### PR TITLE
Add stub clientapi webserver with readers/writers packages

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/clientapi.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/clientapi.go
@@ -16,8 +16,8 @@ import (
 // to clients which need to make outbound HTTP requests.
 func setup(mux *http.ServeMux, httpClient *http.Client) {
 	mux.Handle("/metrics", prometheus.Handler())
-	mux.Handle("/send", prometheus.InstrumentHandler("send_message", util.MakeJSONAPI(&writers.SendMessage{})))
-	mux.Handle("/sync", prometheus.InstrumentHandler("sync", util.MakeJSONAPI(&readers.Sync{})))
+	mux.Handle("/api/send", prometheus.InstrumentHandler("send_message", util.MakeJSONAPI(&writers.SendMessage{})))
+	mux.Handle("/api/sync", prometheus.InstrumentHandler("sync", util.MakeJSONAPI(&readers.Sync{})))
 }
 
 func main() {

--- a/src/github.com/matrix-org/dendrite/clientapi/clientapi.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/clientapi.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"net/http"
+	"os"
+
+	log "github.com/Sirupsen/logrus"
+
+	"github.com/matrix-org/dendrite/clientapi/readers"
+	"github.com/matrix-org/dendrite/clientapi/writers"
+	"github.com/matrix-org/util"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// setup registers HTTP handlers with the given ServeMux. It also supplies the given http.Client
+// to clients which need to make outbound HTTP requests.
+func setup(mux *http.ServeMux, httpClient *http.Client) {
+	mux.Handle("/metrics", prometheus.Handler())
+	mux.Handle("/send", prometheus.InstrumentHandler("send_message", util.MakeJSONAPI(&writers.SendMessage{})))
+	mux.Handle("/sync", prometheus.InstrumentHandler("sync", util.MakeJSONAPI(&readers.Sync{})))
+}
+
+func main() {
+	bindAddr := os.Getenv("BIND_ADDRESS")
+	if bindAddr == "" {
+		log.Panic("No BIND_ADDRESS environment variable found.")
+	}
+	log.Info("Starting clientapi")
+	setup(http.DefaultServeMux, http.DefaultClient)
+	log.Fatal(http.ListenAndServe(bindAddr, nil))
+}

--- a/src/github.com/matrix-org/dendrite/clientapi/readers/sync.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/readers/sync.go
@@ -1,0 +1,19 @@
+package readers
+
+import (
+	"net/http"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/matrix-org/util"
+)
+
+type Sync struct{}
+
+func (s *Sync) OnIncomingRequest(req *http.Request) (interface{}, *util.HTTPError) {
+	logger := req.Context().Value(util.CtxValueLogger).(*log.Entry)
+	logger.Info("Doing stuff...")
+	return nil, &util.HTTPError{
+		Code:    404,
+		Message: "Not implemented yet",
+	}
+}

--- a/src/github.com/matrix-org/dendrite/clientapi/readers/sync.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/readers/sync.go
@@ -7,8 +7,10 @@ import (
 	"github.com/matrix-org/util"
 )
 
+// Sync handles HTTP requests to /sync
 type Sync struct{}
 
+// OnIncomingRequest implements util.JSONRequestHandler
 func (s *Sync) OnIncomingRequest(req *http.Request) (interface{}, *util.HTTPError) {
 	logger := req.Context().Value(util.CtxValueLogger).(*log.Entry)
 	logger.Info("Doing stuff...")

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/sendmessage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/sendmessage.go
@@ -7,9 +7,11 @@ import (
 	"github.com/matrix-org/util"
 )
 
+// SendMessage handles HTTP requests to /rooms/$room_id/send/$event_type
 type SendMessage struct {
 }
 
+// OnIncomingRequest implements util.JSONRequestHandler
 func (s *SendMessage) OnIncomingRequest(req *http.Request) (interface{}, *util.HTTPError) {
 	logger := req.Context().Value(util.CtxValueLogger).(*log.Entry)
 	logger.Info("Doing stuff...")

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/sendmessage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/sendmessage.go
@@ -1,0 +1,20 @@
+package writers
+
+import (
+	"net/http"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/matrix-org/util"
+)
+
+type SendMessage struct {
+}
+
+func (s *SendMessage) OnIncomingRequest(req *http.Request) (interface{}, *util.HTTPError) {
+	logger := req.Context().Value(util.CtxValueLogger).(*log.Entry)
+	logger.Info("Doing stuff...")
+	return nil, &util.HTTPError{
+		Code:    404,
+		Message: "Not implemented yet",
+	}
+}


### PR DESCRIPTION
This automatically does JSON and logs with request IDs because it uses `matrix-org/util`. It looks like:
```
$ BIND_ADDRESS=:7878 ./bin/clientapi 
INFO[0000] Starting clientapi                           
INFO[0005] Incoming request                              req.id=x1slkZ1Mrk3B req.method=GET req.path="/sync"
INFO[0005] Doing stuff...                                req.id=x1slkZ1Mrk3B req.method=GET req.path="/sync"
INFO[0005] Responding with error                         error="Not implemented yet: 404: " req.id=x1slkZ1Mrk3B req.method=GET req.path="/sync"
INFO[0009] Incoming request                              req.id=ioZU9NanGplb req.method=GET req.path="/send"
INFO[0009] Doing stuff...                                req.id=ioZU9NanGplb req.method=GET req.path="/send"
INFO[0009] Responding with error                         error="Not implemented yet: 404: " req.id=ioZU9NanGplb req.method=GET req.path="/send"
```

Obviously the endpoints are stubs for now, but this gives the skeleton for how new APIs will be added.