### PR TITLE
Use gorilla/mux to route HTTP requests

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/clientapi.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/clientapi.go
@@ -1,24 +1,12 @@
 package main
 
 import (
+	"github.com/matrix-org/dendrite/clientapi/routing"
 	"net/http"
 	"os"
 
 	log "github.com/Sirupsen/logrus"
-
-	"github.com/matrix-org/dendrite/clientapi/readers"
-	"github.com/matrix-org/dendrite/clientapi/writers"
-	"github.com/matrix-org/util"
-	"github.com/prometheus/client_golang/prometheus"
 )
-
-// setup registers HTTP handlers with the given ServeMux. It also supplies the given http.Client
-// to clients which need to make outbound HTTP requests.
-func setup(mux *http.ServeMux, httpClient *http.Client) {
-	mux.Handle("/metrics", prometheus.Handler())
-	mux.Handle("/api/send", prometheus.InstrumentHandler("send_message", util.MakeJSONAPI(&writers.SendMessage{})))
-	mux.Handle("/api/sync", prometheus.InstrumentHandler("sync", util.MakeJSONAPI(&readers.Sync{})))
-}
 
 func main() {
 	bindAddr := os.Getenv("BIND_ADDRESS")
@@ -26,6 +14,6 @@ func main() {
 		log.Panic("No BIND_ADDRESS environment variable found.")
 	}
 	log.Info("Starting clientapi")
-	setup(http.DefaultServeMux, http.DefaultClient)
+	routing.Setup(http.DefaultServeMux, http.DefaultClient)
 	log.Fatal(http.ListenAndServe(bindAddr, nil))
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/readers/sync.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/readers/sync.go
@@ -3,7 +3,6 @@ package readers
 import (
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/matrix-org/util"
 )
 
@@ -12,7 +11,7 @@ type Sync struct{}
 
 // OnIncomingRequest implements util.JSONRequestHandler
 func (s *Sync) OnIncomingRequest(req *http.Request) (interface{}, *util.HTTPError) {
-	logger := req.Context().Value(util.CtxValueLogger).(*log.Entry)
+	logger := util.GetLogger(req.Context())
 	logger.Info("Doing stuff...")
 	return nil, &util.HTTPError{
 		Code:    404,

--- a/src/github.com/matrix-org/dendrite/clientapi/readers/sync.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/readers/sync.go
@@ -6,11 +6,8 @@ import (
 	"github.com/matrix-org/util"
 )
 
-// Sync handles HTTP requests to /sync
-type Sync struct{}
-
-// OnIncomingRequest implements util.JSONRequestHandler
-func (s *Sync) OnIncomingRequest(req *http.Request) (interface{}, *util.HTTPError) {
+// Sync implements /sync
+func Sync(req *http.Request) (interface{}, *util.HTTPError) {
 	logger := util.GetLogger(req.Context())
 	logger.Info("Doing stuff...")
 	return nil, &util.HTTPError{

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -12,18 +12,39 @@ import (
 
 const pathPrefixR0 = "/_matrix/client/r0"
 
-func make(metricsName string, h util.JSONRequestHandler) http.Handler {
-	return prometheus.InstrumentHandler(metricsName, util.MakeJSONAPI(h))
-}
-
 // Setup registers HTTP handlers with the given ServeMux. It also supplies the given http.Client
 // to clients which need to make outbound HTTP requests.
 func Setup(servMux *http.ServeMux, httpClient *http.Client) {
 	apiMux := mux.NewRouter()
 	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
 	r0mux.Handle("/sync", make("sync", &readers.Sync{}))
-	r0mux.Handle("/rooms/{roomID}/send/{eventType}", make("send_message", &writers.SendMessage{}))
+	r0mux.Handle("/rooms/{roomID}/send/{eventType}",
+		make("send_message", wrap(func(req *http.Request) (interface{}, *util.HTTPError) {
+			vars := mux.Vars(req)
+			roomID := vars["roomID"]
+			eventType := vars["eventType"]
+			h := &writers.SendMessage{}
+			return h.OnIncomingRequest(req, roomID, eventType)
+		})),
+	)
 
 	servMux.Handle("/metrics", prometheus.Handler())
 	servMux.Handle("/api/", http.StripPrefix("/api", apiMux))
+}
+
+// make a util.JSONRequestHandler into an http.Handler
+func make(metricsName string, h util.JSONRequestHandler) http.Handler {
+	return prometheus.InstrumentHandler(metricsName, util.MakeJSONAPI(h))
+}
+
+// jsonRequestHandlerWrapper is a wrapper to allow in-line functions to conform to util.JSONRequestHandler
+type jsonRequestHandlerWrapper struct {
+	function func(req *http.Request) (interface{}, *util.HTTPError)
+}
+
+func (r *jsonRequestHandlerWrapper) OnIncomingRequest(req *http.Request) (interface{}, *util.HTTPError) {
+	return r.function(req)
+}
+func wrap(f func(req *http.Request) (interface{}, *util.HTTPError)) *jsonRequestHandlerWrapper {
+	return &jsonRequestHandlerWrapper{f}
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -23,9 +23,7 @@ func Setup(servMux *http.ServeMux, httpClient *http.Client) {
 	r0mux.Handle("/rooms/{roomID}/send/{eventType}",
 		make("send_message", wrap(func(req *http.Request) (interface{}, *util.HTTPError) {
 			vars := mux.Vars(req)
-			roomID := vars["roomID"]
-			eventType := vars["eventType"]
-			return writers.SendMessage(req, roomID, eventType)
+			return writers.SendMessage(req, vars["roomID"], vars["eventType"])
 		})),
 	)
 

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -17,14 +17,15 @@ const pathPrefixR0 = "/_matrix/client/r0"
 func Setup(servMux *http.ServeMux, httpClient *http.Client) {
 	apiMux := mux.NewRouter()
 	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
-	r0mux.Handle("/sync", make("sync", &readers.Sync{}))
+	r0mux.Handle("/sync", make("sync", wrap(func(req *http.Request) (interface{}, *util.HTTPError) {
+		return readers.Sync(req)
+	})))
 	r0mux.Handle("/rooms/{roomID}/send/{eventType}",
 		make("send_message", wrap(func(req *http.Request) (interface{}, *util.HTTPError) {
 			vars := mux.Vars(req)
 			roomID := vars["roomID"]
 			eventType := vars["eventType"]
-			h := &writers.SendMessage{}
-			return h.OnIncomingRequest(req, roomID, eventType)
+			return writers.SendMessage(req, roomID, eventType)
 		})),
 	)
 

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -20,7 +20,7 @@ func make(metricsName string, h util.JSONRequestHandler) http.Handler {
 // to clients which need to make outbound HTTP requests.
 func Setup(servMux *http.ServeMux, httpClient *http.Client) {
 	apiMux := mux.NewRouter()
-	r0mux := apiMux.PathPrefix("/_matrix/client/r0").Subrouter()
+	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
 	r0mux.Handle("/sync", make("sync", &readers.Sync{}))
 	r0mux.Handle("/rooms/{roomID}/send/{eventType}", make("send_message", &writers.SendMessage{}))
 

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -1,0 +1,56 @@
+package routing
+
+import (
+	"github.com/matrix-org/dendrite/clientapi/readers"
+	_ "github.com/matrix-org/dendrite/clientapi/writers"
+	"github.com/matrix-org/util"
+	"github.com/prometheus/client_golang/prometheus"
+	"net/http"
+	"strings"
+)
+
+const pathPrefixR0 = "/_matrix/client/r0"
+
+// Return true if this path should be handled by this handler
+type matcher func(path string) bool
+
+type lookup struct {
+	Matches matcher
+	Handler http.Handler
+}
+
+func newLookup(name string, m matcher, h util.JSONRequestHandler) lookup {
+	return lookup{
+		Matches: m,
+		Handler: prometheus.InstrumentHandler(name, util.MakeJSONAPI(h)),
+	}
+}
+
+func matchesString(str string) func(path string) bool {
+	return func(path string) bool {
+		return path == str
+	}
+}
+
+// Setup registers HTTP handlers with the given ServeMux. It also supplies the given http.Client
+// to clients which need to make outbound HTTP requests.
+func Setup(mux *http.ServeMux, httpClient *http.Client) {
+	var r0lookups []lookup
+	r0lookups = append(r0lookups, newLookup("sync", matchesString("/sync"), &readers.Sync{}))
+
+	mux.Handle("/metrics", prometheus.Handler())
+	mux.HandleFunc("/api/", func(w http.ResponseWriter, req *http.Request) {
+		clientServerPath := strings.TrimPrefix(req.URL.Path, "/api")
+		if strings.HasPrefix(clientServerPath, pathPrefixR0) {
+			apiPath := strings.TrimPrefix(clientServerPath, pathPrefixR0)
+			for _, lookup := range r0lookups {
+				if lookup.Matches(apiPath) {
+					lookup.Handler.ServeHTTP(w, req)
+					return
+				}
+			}
+		}
+		w.WriteHeader(404)
+		w.Write([]byte(`{"error":"Not found","errcode":"M_NOT_FOUND"}`))
+	})
+}

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/sendmessage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/sendmessage.go
@@ -3,8 +3,6 @@ package writers
 import (
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
-	"github.com/gorilla/mux"
 	"github.com/matrix-org/util"
 )
 
@@ -12,12 +10,9 @@ import (
 type SendMessage struct {
 }
 
-// OnIncomingRequest implements util.JSONRequestHandler
-func (s *SendMessage) OnIncomingRequest(req *http.Request) (interface{}, *util.HTTPError) {
-	logger := req.Context().Value(util.CtxValueLogger).(*log.Entry)
-	vars := mux.Vars(req)
-	roomID := vars["roomID"]
-	eventType := vars["eventType"]
+// OnIncomingRequest implements /rooms/{roomID}/send/{eventType}
+func (s *SendMessage) OnIncomingRequest(req *http.Request, roomID, eventType string) (interface{}, *util.HTTPError) {
+	logger := util.GetLogger(req.Context())
 	logger.WithField("roomID", roomID).WithField("eventType", eventType).Info("Doing stuff...")
 	return nil, &util.HTTPError{
 		Code:    404,

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/sendmessage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/sendmessage.go
@@ -17,7 +17,8 @@ func (s *SendMessage) OnIncomingRequest(req *http.Request) (interface{}, *util.H
 	logger := req.Context().Value(util.CtxValueLogger).(*log.Entry)
 	vars := mux.Vars(req)
 	roomID := vars["roomID"]
-	logger.WithField("roomID", roomID).Info("Doing stuff...")
+	eventType := vars["eventType"]
+	logger.WithField("roomID", roomID).WithField("eventType", eventType).Info("Doing stuff...")
 	return nil, &util.HTTPError{
 		Code:    404,
 		Message: "Not implemented yet",

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/sendmessage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/sendmessage.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/gorilla/mux"
 	"github.com/matrix-org/util"
 )
 
@@ -14,7 +15,9 @@ type SendMessage struct {
 // OnIncomingRequest implements util.JSONRequestHandler
 func (s *SendMessage) OnIncomingRequest(req *http.Request) (interface{}, *util.HTTPError) {
 	logger := req.Context().Value(util.CtxValueLogger).(*log.Entry)
-	logger.Info("Doing stuff...")
+	vars := mux.Vars(req)
+	roomID := vars["roomID"]
+	logger.WithField("roomID", roomID).Info("Doing stuff...")
 	return nil, &util.HTTPError{
 		Code:    404,
 		Message: "Not implemented yet",

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/sendmessage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/sendmessage.go
@@ -6,12 +6,8 @@ import (
 	"github.com/matrix-org/util"
 )
 
-// SendMessage handles HTTP requests to /rooms/$room_id/send/$event_type
-type SendMessage struct {
-}
-
-// OnIncomingRequest implements /rooms/{roomID}/send/{eventType}
-func (s *SendMessage) OnIncomingRequest(req *http.Request, roomID, eventType string) (interface{}, *util.HTTPError) {
+// SendMessage implements /rooms/{roomID}/send/{eventType}
+func SendMessage(req *http.Request, roomID, eventType string) (interface{}, *util.HTTPError) {
 	logger := util.GetLogger(req.Context())
 	logger.WithField("roomID", roomID).WithField("eventType", eventType).Info("Doing stuff...")
 	return nil, &util.HTTPError{

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -86,7 +86,7 @@
 		{
 			"importpath": "github.com/matrix-org/util",
 			"repository": "https://github.com/matrix-org/util",
-			"revision": "0f4d9cce82badc0741ff1141dcf079312cb4d2f0",
+			"revision": "0bbc3896e02031e7e7338948b73ce891aa73ab2b",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
- Make `/sync` and `/send` use the right API paths.
- Pluck out the `roomID` as an example of how to do it.