### PR TITLE
Add a query API to the roomserver for getting the latest events in a room.

### DIFF
--- a/src/github.com/matrix-org/dendrite/roomserver/api/query.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/api/query.go
@@ -9,8 +9,14 @@ import (
 )
 
 // StateKeyTuple is a pair of an event type and state_key.
+// This is used when requesting parts of the state of a room.
 type StateKeyTuple struct {
-	EventType     string
+	// The "type" key
+	EventType string
+	// The "state_key" of a matrix event.
+	// The empty string is a legitimate value for the "state_key" in matrix
+	// so take care to initialise this field lest you accidentally request a
+	// "state_key" with the go default of the empty string.
 	EventStateKey string
 }
 

--- a/src/github.com/matrix-org/dendrite/roomserver/api/query.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/api/query.go
@@ -27,8 +27,11 @@ type QueryLatestEventsAndStateRequest struct {
 type QueryLatestEventsAndStateResponse struct {
 	// Copy of the request for debugging.
 	QueryLatestEventsAndStateRequest
+	// Does the room exist?
+	// If the room doesn't exist this will be false and LatestEvents will be empty.
+	RoomExists bool
 	// The latest events in the room.
-	LatestEvents gomatrixserverlib.EventReference
+	LatestEvents []gomatrixserverlib.EventReference
 	// The state events requested.
 	StateEvents []gomatrixserverlib.Event
 }
@@ -86,9 +89,8 @@ func postJSON(httpClient http.Client, apiURL string, request, response interface
 		}
 		if err = json.NewDecoder(res.Body).Decode(&errorBody); err != nil {
 			return err
-		} else {
-			return fmt.Errorf("api: %d: %s", res.StatusCode, errorBody.Message)
 		}
+		return fmt.Errorf("api: %d: %s", res.StatusCode, errorBody.Message)
 	}
 	return json.NewDecoder(res.Body).Decode(response)
 }

--- a/src/github.com/matrix-org/dendrite/roomserver/api/query.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/api/query.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"github.com/matrix-org/gomatrixserverlib"
+)
+
+// StateKeyTuple is a pair of an event type and state_key.
+type StateKeyTuple struct {
+	EventType     string
+	EventStateKey string
+}
+
+// QueryLatestEventsAndStateRequest is a request to QueryLatestEventsAndState
+type QueryLatestEventsAndStateRequest struct {
+	// The roomID to query the latest events for.
+	RoomID string
+	// The state key tuples to fetch from the room current state.
+	// If this list is empty or nil then no events are returned.
+	StateToFetch []StateKeyTuple
+}
+
+// QueryLatestEventsAndStateResponse is a response to QueryLatestEventsAndState
+type QueryLatestEventsAndStateResponse struct {
+	// Copy of the request for debugging.
+	QueryLatestEventsAndStateRequest
+	// The latest events in the room.
+	LatestEvents gomatrixserverlib.EventReference
+	// The state events requested.
+	StateEvents []gomatrixserverlib.Event
+}
+
+// RoomserverQueryAPI is used to query information from the room server.
+type RoomserverQueryAPI interface {
+	// Query the latest events and state for a room from the room server.
+	QueryLatestEventsAndState(
+		request *QueryLatestEventsAndStateRequest,
+		response *QueryLatestEventsAndStateResponse,
+	) error
+}
+
+// RPCServer is used to register a roomserver implementation with an RPC server.
+type RPCServer interface {
+	RegisterName(name string, rcvr interface{}) error
+}
+
+// RegisterRoomserverQueryAPI registers a RoomserverQueryAPI implementation with an RPC server.
+func RegisterRoomserverQueryAPI(rpcServer RPCServer, roomserver RoomserverQueryAPI) error {
+	return rpcServer.RegisterName("Roomserver", roomserver)
+}
+
+// RPCClient is used to invoke roomserver APIs on a remote server.
+type RPCClient interface {
+	Call(serviceMethod string, args interface{}, reply interface{}) error
+}
+
+// NewRoomserverQueryAPIFromClient creates a new query API from an RPC client.
+func NewRoomserverQueryAPIFromClient(client RPCClient) RoomserverQueryAPI {
+	return &remoteRoomserver{client}
+}
+
+type remoteRoomserver struct {
+	client RPCClient
+}
+
+// QueryLatestEventsAndState implements RoomserverQueryAPI
+func (r *remoteRoomserver) QueryLatestEventsAndState(
+	request *QueryLatestEventsAndStateRequest,
+	response *QueryLatestEventsAndStateResponse,
+) error {
+	return r.client.Call("Roomserver.QueryLatestEventsAndState", request, response)
+}

--- a/src/github.com/matrix-org/dendrite/roomserver/api/query.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/api/query.go
@@ -19,7 +19,7 @@ type QueryLatestEventsAndStateRequest struct {
 	// The roomID to query the latest events for.
 	RoomID string
 	// The state key tuples to fetch from the room current state.
-	// If this list is empty or nil then no events are returned.
+	// If this list is empty or nil then no state events are returned.
 	StateToFetch []StateKeyTuple
 }
 

--- a/src/github.com/matrix-org/dendrite/roomserver/api/query.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/api/query.go
@@ -46,7 +46,7 @@ type RoomserverQueryAPI interface {
 }
 
 // RoomserverQueryLatestEventsAndStatePath is the HTTP path for the QueryLatestEventsAndState API.
-const RoomserverQueryLatestEventsAndStatePath = "/api/Roomserver/QueryLatestEventsAndState"
+const RoomserverQueryLatestEventsAndStatePath = "/api/roomserver/QueryLatestEventsAndState"
 
 // NewRoomserverQueryAPIHTTP creates a RoomserverQueryAPI implemented by talking to a HTTP POST API.
 // If httpClient is nil then it uses the http.DefaultClient

--- a/src/github.com/matrix-org/dendrite/roomserver/query/query.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/query/query.go
@@ -1,0 +1,18 @@
+package query
+
+import (
+	"fmt"
+	"github.com/matrix-org/dendrite/roomserver/api"
+)
+
+// RoomserverQueryAPI is an implemenation of RoomserverQueryAPI
+type RoomserverQueryAPI struct {
+}
+
+// QueryLatestEventsAndState implements api.RoomserverQueryAPI
+func (r *RoomserverQueryAPI) QueryLatestEventsAndState(
+	request *api.QueryLatestEventsAndStateRequest,
+	response *api.QueryLatestEventsAndStateResponse,
+) error {
+	return fmt.Errorf("Not Implemented")
+}

--- a/src/github.com/matrix-org/dendrite/roomserver/query/query.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/query/query.go
@@ -21,7 +21,7 @@ type RoomserverQueryAPIDatabase interface {
 	LatestEventIDs(roomNID types.RoomNID) ([]gomatrixserverlib.EventReference, error)
 }
 
-// RoomserverQueryAPI is an implemenation of RoomserverQueryAPI
+// RoomserverQueryAPI is an implementation of RoomserverQueryAPI
 type RoomserverQueryAPI struct {
 	DB RoomserverQueryAPIDatabase
 }

--- a/src/github.com/matrix-org/dendrite/roomserver/query/query.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/query/query.go
@@ -1,8 +1,12 @@
 package query
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/util"
+	"github.com/prometheus/client_golang/prometheus"
+	"net/http"
 )
 
 // RoomserverQueryAPI is an implemenation of RoomserverQueryAPI
@@ -15,4 +19,25 @@ func (r *RoomserverQueryAPI) QueryLatestEventsAndState(
 	response *api.QueryLatestEventsAndStateResponse,
 ) error {
 	return fmt.Errorf("Not Implemented")
+}
+
+func (r *RoomserverQueryAPI) SetupHTTP(servMux *http.ServeMux) {
+	servMux.Handle(
+		api.RoomserverQueryLatestEventsAndStatePath,
+		makeAPI("query_latest_events_and_state", func(req *http.Request) util.JSONResponse {
+			var request api.QueryLatestEventsAndStateRequest
+			var response api.QueryLatestEventsAndStateResponse
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.ErrorResponse(err)
+			}
+			if err := r.QueryLatestEventsAndState(&request, &response); err != nil {
+				return util.ErrorResponse(err)
+			}
+			return util.JSONResponse{Code: 200, JSON: &response}
+		}),
+	)
+}
+
+func makeAPI(metric string, apiFunc func(req *http.Request) util.JSONResponse) http.Handler {
+	return prometheus.InstrumentHandler(metric, util.MakeJSONAPI(util.NewJSONRequestHandler(apiFunc)))
 }

--- a/src/github.com/matrix-org/dendrite/roomserver/roomserver-integration-tests/main.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/roomserver-integration-tests/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
-	"net/rpc"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -210,12 +209,8 @@ func testRoomServer(input []string, wantOutput []string) {
 	cmd.Stderr = os.Stderr
 
 	gotOutput, err := runAndReadFromTopic(cmd, outputTopic, 1, func() {
-		client, err := rpc.DialHTTP("tcp", roomserverAddr)
-		if err != nil {
-			panic(err)
-		}
-		queryAPI := api.NewRoomserverQueryAPIFromClient(client)
-		if err = queryAPI.QueryLatestEventsAndState(
+		queryAPI := api.NewRoomserverQueryAPIHTTP("http://"+roomserverAddr, nil)
+		if err := queryAPI.QueryLatestEventsAndState(
 			&api.QueryLatestEventsAndStateRequest{},
 			&api.QueryLatestEventsAndStateResponse{},
 		); err != nil {

--- a/src/github.com/matrix-org/dendrite/roomserver/roomserver-integration-tests/main.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/roomserver-integration-tests/main.go
@@ -21,7 +21,7 @@ var (
 	// The address the roomserver should listen on.
 	roomserverAddr = defaulting(os.Getenv("ROOMSERVER_URI"), "localhost:9876")
 	// How long to wait for the roomserver to write the expected output messages.
-	timeoutString = defaulting(os.Getenv("TIMEOUT"), "10s")
+	timeoutString = defaulting(os.Getenv("TIMEOUT"), "60s")
 	// The name of maintenance database to connect to in order to create the test database.
 	postgresDatabase = defaulting(os.Getenv("POSTGRES_DATABASE"), "postgres")
 	// The name of the test database to create.

--- a/src/github.com/matrix-org/dendrite/roomserver/roomserver/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/roomserver/roomserver.go
@@ -2,13 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/roomserver/input"
 	"github.com/matrix-org/dendrite/roomserver/query"
 	"github.com/matrix-org/dendrite/roomserver/storage"
 	sarama "gopkg.in/Shopify/sarama.v1"
 	"net/http"
-	"net/rpc"
 	"os"
 	"strings"
 )
@@ -51,11 +49,7 @@ func main() {
 
 	queryAPI := query.RoomserverQueryAPI{}
 
-	if err = api.RegisterRoomserverQueryAPI(rpc.DefaultServer, &queryAPI); err != nil {
-		panic(err)
-	}
-
-	rpc.HandleHTTP()
+	queryAPI.SetupHTTP(http.DefaultServeMux)
 
 	fmt.Println("Started roomserver")
 

--- a/src/github.com/matrix-org/dendrite/roomserver/roomserver/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/roomserver/roomserver.go
@@ -2,9 +2,13 @@ package main
 
 import (
 	"fmt"
+	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/roomserver/input"
+	"github.com/matrix-org/dendrite/roomserver/query"
 	"github.com/matrix-org/dendrite/roomserver/storage"
 	sarama "gopkg.in/Shopify/sarama.v1"
+	"net/http"
+	"net/rpc"
 	"os"
 	"strings"
 )
@@ -14,6 +18,7 @@ var (
 	kafkaURIs            = strings.Split(os.Getenv("KAFKA_URIS"), ",")
 	inputRoomEventTopic  = os.Getenv("TOPIC_INPUT_ROOM_EVENT")
 	outputRoomEventTopic = os.Getenv("TOPIC_OUTPUT_ROOM_EVENT")
+	bindAddr             = os.Getenv("BIND_ADDRESS")
 )
 
 func main() {
@@ -44,9 +49,16 @@ func main() {
 		panic(err)
 	}
 
+	queryAPI := query.RoomserverQueryAPI{}
+
+	if err = api.RegisterRoomserverQueryAPI(rpc.DefaultServer, &queryAPI); err != nil {
+		panic(err)
+	}
+
+	rpc.HandleHTTP()
+
 	fmt.Println("Started roomserver")
 
-	// Wait forever.
 	// TODO: Implement clean shutdown.
-	select {}
+	http.ListenAndServe(bindAddr, nil)
 }

--- a/src/github.com/matrix-org/dendrite/roomserver/roomserver/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/roomserver/roomserver.go
@@ -47,7 +47,9 @@ func main() {
 		panic(err)
 	}
 
-	queryAPI := query.RoomserverQueryAPI{}
+	queryAPI := query.RoomserverQueryAPI{
+		DB: db,
+	}
 
 	queryAPI.SetupHTTP(http.DefaultServeMux)
 

--- a/src/github.com/matrix-org/dendrite/roomserver/storage/event_json_table.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/storage/event_json_table.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"database/sql"
-	"github.com/lib/pq"
 	"github.com/matrix-org/dendrite/roomserver/types"
 )
 
@@ -65,11 +64,7 @@ type eventJSONPair struct {
 }
 
 func (s *eventJSONStatements) bulkSelectEventJSON(eventNIDs []types.EventNID) ([]eventJSONPair, error) {
-	nids := make([]int64, len(eventNIDs))
-	for i := range eventNIDs {
-		nids[i] = int64(eventNIDs[i])
-	}
-	rows, err := s.bulkSelectEventJSONStmt.Query(pq.Int64Array(nids))
+	rows, err := s.bulkSelectEventJSONStmt.Query(eventNIDsAsArray(eventNIDs))
 	if err != nil {
 		return nil, err
 	}

--- a/src/github.com/matrix-org/dendrite/roomserver/storage/rooms_table.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/storage/rooms_table.go
@@ -111,10 +111,6 @@ func (s *roomStatements) selectLatestEventsNIDsForUpdate(txn *sql.Tx, roomNID ty
 }
 
 func (s *roomStatements) updateLatestEventNIDs(txn *sql.Tx, roomNID types.RoomNID, eventNIDs []types.EventNID, lastEventSentNID types.EventNID) error {
-	nids := make([]int64, len(eventNIDs))
-	for i := range eventNIDs {
-		nids[i] = int64(eventNIDs[i])
-	}
-	_, err := txn.Stmt(s.updateLatestEventNIDsStmt).Exec(roomNID, pq.Int64Array(nids), int64(lastEventSentNID))
+	_, err := txn.Stmt(s.updateLatestEventNIDsStmt).Exec(roomNID, eventNIDsAsArray(eventNIDs), int64(lastEventSentNID))
 	return err
 }

--- a/src/github.com/matrix-org/dendrite/roomserver/storage/storage.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/storage/storage.go
@@ -280,3 +280,21 @@ func (u *roomRecentEventsUpdater) Commit() error {
 func (u *roomRecentEventsUpdater) Rollback() error {
 	return u.txn.Rollback()
 }
+
+// RoomNID implements query.RoomserverQueryAPIDB
+func (d *Database) RoomNID(roomID string) (types.RoomNID, error) {
+	roomNID, err := d.statements.selectRoomNID(roomID)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	return roomNID, err
+}
+
+// LatestEventIDs implements query.RoomserverQueryAPIDB
+func (d *Database) LatestEventIDs(roomNID types.RoomNID) ([]gomatrixserverlib.EventReference, error) {
+	eventNIDs, err := d.statements.selectLatestEventNIDs(roomNID)
+	if err != nil {
+		return nil, err
+	}
+	return d.statements.bulkSelectEventReference(eventNIDs)
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -98,7 +98,7 @@
 		{
 			"importpath": "github.com/matrix-org/util",
 			"repository": "https://github.com/matrix-org/util",
-			"revision": "ccef6dc7c24a7c896d96b433a9107b7c47ecf828",
+			"revision": "28bd7491c8aafbf346ca23821664f0f9911ef52b",
 			"branch": "master"
 		},
 		{

--- a/vendor/src/github.com/matrix-org/util/context.go
+++ b/vendor/src/github.com/matrix-org/util/context.go
@@ -25,11 +25,13 @@ func GetRequestID(ctx context.Context) string {
 // ctxValueLogger is the key to extract the logrus Logger.
 const ctxValueLogger = contextKeys("logger")
 
-// GetLogger retrieves the logrus logger from the supplied context. Returns nil if there is no logger.
+// GetLogger retrieves the logrus logger from the supplied context. Always returns a logger,
+// even if there wasn't one originally supplied.
 func GetLogger(ctx context.Context) *log.Entry {
 	l := ctx.Value(ctxValueLogger)
 	if l == nil {
-		return nil
+		// Always return a logger so callers don't need to constantly nil check.
+		return log.WithField("context", "missing")
 	}
 	return l.(*log.Entry)
 }

--- a/vendor/src/github.com/matrix-org/util/json.go
+++ b/vendor/src/github.com/matrix-org/util/json.go
@@ -58,6 +58,21 @@ type JSONRequestHandler interface {
 	OnIncomingRequest(req *http.Request) JSONResponse
 }
 
+// jsonRequestHandlerWrapper is a wrapper to allow in-line functions to conform to util.JSONRequestHandler
+type jsonRequestHandlerWrapper struct {
+	function func(req *http.Request) JSONResponse
+}
+
+// OnIncomingRequest implements util.JSONRequestHandler
+func (r *jsonRequestHandlerWrapper) OnIncomingRequest(req *http.Request) JSONResponse {
+	return r.function(req)
+}
+
+// NewJSONRequestHandler converts the given OnIncomingRequest function into a JSONRequestHandler
+func NewJSONRequestHandler(f func(req *http.Request) JSONResponse) JSONRequestHandler {
+	return &jsonRequestHandlerWrapper{f}
+}
+
 // Protect panicking HTTP requests from taking down the entire process, and log them using
 // the correct logger, returning a 500 with a JSON response rather than abruptly closing the
 // connection. The http.Request MUST have a ctxValueLogger.

--- a/vendor/src/github.com/matrix-org/util/json_test.go
+++ b/vendor/src/github.com/matrix-org/util/json_test.go
@@ -164,8 +164,8 @@ func TestGetLogger(t *testing.T) {
 
 	noLoggerInReq, _ := http.NewRequest("GET", "http://example.com/foo", nil)
 	ctxLogger = GetLogger(noLoggerInReq.Context())
-	if ctxLogger != nil {
-		t.Errorf("TestGetLogger wanted nil logger, got '%v'", ctxLogger)
+	if ctxLogger == nil {
+		t.Errorf("TestGetLogger wanted logger, got nil")
 	}
 }
 


### PR DESCRIPTION
Implemented as a JSON POST API.

I briefly considered using net/rpc as the RPC protocol. But gave up since it doesn't handle automatically reconnecting and we have existing infrastructure for monitoring HTTP APIs.
Note that we only return non-200 responses if the input was invalid or if there as an internal error in the server. I'd prefer this as a pattern for internal APIs as it is easier to monitor.

I have kept the functions signature expected by net/rpc. That is two arguments, a request struct and a response struct, and a single error return. That should make it easier to switch to a net/rpc solution if the HTTP JSON overhead ever becomes an issue.