### PR TITLE
Log fatal errors at error level and return generic 500s

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/httputil/httputil.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/httputil/httputil.go
@@ -23,3 +23,11 @@ func UnmarshalJSONRequest(req *http.Request, iface interface{}) *util.JSONRespon
 	}
 	return nil
 }
+
+// LogThenError logs the given error then returns a matrix-compliant 500 internal server error response.
+// This should be used to log fatal errors which require investigation. It should not be used
+// to log client validation errors, etc.
+func LogThenError(req *http.Request, err error) util.JSONResponse {
+	util.GetLogger(req.Context()).WithError(err).Error("request failed")
+	return jsonerror.InternalServerError()
+}

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/createroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/createroom.go
@@ -168,11 +168,11 @@ func createRoom(req *http.Request, cfg config.ClientAPI, roomID string, producer
 		}
 		ev, err := buildEvent(&builder, builtEventMap, cfg)
 		if err != nil {
-			return util.ErrorResponse(err)
+			return httputil.LogThenError(req, err)
 		}
 
 		if err := gomatrixserverlib.Allowed(*ev, &authEvents); err != nil {
-			return util.ErrorResponse(err)
+			return httputil.LogThenError(req, err)
 		}
 
 		// Add the event to the list of auth events
@@ -183,10 +183,10 @@ func createRoom(req *http.Request, cfg config.ClientAPI, roomID string, producer
 	// send events to the room server
 	msgs, err := eventsToMessages(builtEvents, cfg.ClientAPIOutputTopic)
 	if err != nil {
-		return util.ErrorResponse(err)
+		return httputil.LogThenError(req, err)
 	}
 	if err = producer.SendMessages(msgs); err != nil {
-		return util.ErrorResponse(err)
+		return httputil.LogThenError(req, err)
 	}
 
 	return util.JSONResponse{


### PR DESCRIPTION
Previously, the error responses:
 - were not valid matrix errors (no `errcode`)
 - returned the `err.Error()` message which may contain sensitive information.
 - did not get logged (at all, let alone set the level correctly).

Now the error responses:
 - return valid matrix errors (`M_UNKNOWN`)
 - return a generic "Internal Server Error" string
 - get logged at `ERROR` level.