### PR TITLE
Implement /state event sending

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -29,7 +29,21 @@ func Setup(servMux *http.ServeMux, httpClient *http.Client, cfg config.ClientAPI
 	r0mux.Handle("/rooms/{roomID}/send/{eventType}/{txnID}",
 		make("send_message", util.NewJSONRequestHandler(func(req *http.Request) util.JSONResponse {
 			vars := mux.Vars(req)
-			return writers.SendMessage(req, vars["roomID"], vars["eventType"], vars["txnID"], cfg, queryAPI, producer)
+			return writers.SendEvent(req, vars["roomID"], vars["eventType"], vars["txnID"], nil, cfg, queryAPI, producer)
+		})),
+	)
+	r0mux.Handle("/rooms/{roomID}/state/{eventType}",
+		make("send_message", util.NewJSONRequestHandler(func(req *http.Request) util.JSONResponse {
+			vars := mux.Vars(req)
+			emptyString := ""
+			return writers.SendEvent(req, vars["roomID"], vars["eventType"], vars["txnID"], &emptyString, cfg, queryAPI, producer)
+		})),
+	)
+	r0mux.Handle("/rooms/{roomID}/state/{eventType}/{stateKey}",
+		make("send_message", util.NewJSONRequestHandler(func(req *http.Request) util.JSONResponse {
+			vars := mux.Vars(req)
+			stateKey := vars["stateKey"]
+			return writers.SendEvent(req, vars["roomID"], vars["eventType"], vars["txnID"], &stateKey, cfg, queryAPI, producer)
 		})),
 	)
 

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/sendevent.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/sendevent.go
@@ -18,12 +18,15 @@ import (
 )
 
 // http://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-rooms-roomid-send-eventtype-txnid
-type sendMessageResponse struct {
+// http://matrix.org/docs/spec/client_server/r0.2.0.html#put-matrix-client-r0-rooms-roomid-state-eventtype-statekey
+type sendEventResponse struct {
 	EventID string `json:"event_id"`
 }
 
-// SendMessage implements /rooms/{roomID}/send/{eventType}/{txnID}
-func SendMessage(req *http.Request, roomID, eventType, txnID string, cfg config.ClientAPI, queryAPI api.RoomserverQueryAPI, producer *producers.RoomserverProducer) util.JSONResponse {
+// SendEvent implements:
+//   /rooms/{roomID}/send/{eventType}/{txnID}
+//   /rooms/{roomID}/state/{eventType}/{stateKey}
+func SendEvent(req *http.Request, roomID, eventType, txnID string, stateKey *string, cfg config.ClientAPI, queryAPI api.RoomserverQueryAPI, producer *producers.RoomserverProducer) util.JSONResponse {
 	// parse the incoming http request
 	userID, resErr := auth.VerifyAccessToken(req)
 	if resErr != nil {
@@ -40,7 +43,7 @@ func SendMessage(req *http.Request, roomID, eventType, txnID string, cfg config.
 		Sender:   userID,
 		RoomID:   roomID,
 		Type:     eventType,
-		StateKey: nil,
+		StateKey: stateKey,
 	}
 	builder.SetContent(r)
 
@@ -99,7 +102,7 @@ func SendMessage(req *http.Request, roomID, eventType, txnID string, cfg config.
 
 	return util.JSONResponse{
 		Code: 200,
-		JSON: sendMessageResponse{e.EventID()},
+		JSON: sendEventResponse{e.EventID()},
 	}
 }
 


### PR DESCRIPTION
Now people can send state events in addition to message events.

This means you can actually join rooms as different users now and all the auth stuff (not in room, not enough power, etc) works :D