### PR TITLE
Add metrics for the various ways of calculating room state

### DIFF
--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-roomserver/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-roomserver/main.go
@@ -5,6 +5,7 @@ import (
 	"github.com/matrix-org/dendrite/roomserver/input"
 	"github.com/matrix-org/dendrite/roomserver/query"
 	"github.com/matrix-org/dendrite/roomserver/storage"
+	"github.com/prometheus/client_golang/prometheus"
 	sarama "gopkg.in/Shopify/sarama.v1"
 	"net/http"
 	_ "net/http/pprof"
@@ -70,6 +71,8 @@ func main() {
 	}
 
 	queryAPI.SetupHTTP(http.DefaultServeMux)
+
+	http.DefaultServeMux.Handle("/metrics", prometheus.Handler())
 
 	fmt.Println("Started roomserver")
 

--- a/src/github.com/matrix-org/dendrite/roomserver/input/state.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/input/state.go
@@ -19,10 +19,22 @@ var calculateStateDurations = prometheus.NewSummaryVec(
 		Help:      "How long it takes to calculate the state after a list of events",
 	},
 	// Takes two labels:
-	//	algorithm:
-	//		The algorithm used to calculate the state or the step it failed on if it failed.
+	//   algorithm:
+	//      The algorithm used to calculate the state or the step it failed on if it failed.
+	//      Labels starting with "_" are used to indicate when the algorithm fails halfway.
 	//  outcome:
 	//      Whether the state was successfully calculated.
+	//
+	// The possible values for algorithm are:
+	//    empty_state -> The list of events was empty so the state is empty.
+	//    no_change -> The state hasn't changed.
+	//    single_delta -> There was a single event added to the state in a way that can be encoded as a single delta
+	//    full_state_no_conflicts -> We created a new copy of the full room state, but didn't enounter any conflicts
+	//                               while doing so.
+	//    full_state_with_conflicts -> We created a new copy of the full room state and had to resolve conflicts to do so.
+	//    _load_state_block_nids -> Failed loading the state block nids for a single previous state.
+	//    _load_combined_state -> Failed to load the combined state.
+	//    _resolve_conflicts -> Failed to resolve conflicts.
 	[]string{"algorithm", "outcome"},
 )
 


### PR DESCRIPTION
Each code path through the function has a different "algorithm" label since some of the code paths will be a lot faster than others.

Whether the function succeeds or fails is recorded in an "outcome" label since the performance of a failing attempt might be different to a successful attempt.

Might be an idea to check with @leonerd whether "success" and "failure" are sensible values for the "outcome" label.