### PR TITLE
Return events based on 'since' value

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/jsonerror/jsonerror.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/jsonerror/jsonerror.go
@@ -64,6 +64,12 @@ func UnknownToken(msg string) *MatrixError {
 	return &MatrixError{"M_UNKNOWN_TOKEN", msg}
 }
 
+// InvalidSync is an error when the client tries to hit /sync with an invalid
+// ?since= parameter.
+func InvalidSync(msg string) *MatrixError {
+	return &MatrixError{"M_BAD_SYNC", msg}
+}
+
 // LimitExceededError is a rate-limiting error.
 type LimitExceededError struct {
 	MatrixError

--- a/src/github.com/matrix-org/dendrite/clientapi/jsonerror/jsonerror.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/jsonerror/jsonerror.go
@@ -2,6 +2,7 @@ package jsonerror
 
 import (
 	"fmt"
+
 	"github.com/matrix-org/util"
 )
 
@@ -62,12 +63,6 @@ func MissingToken(msg string) *MatrixError {
 // requires authentication and supplies a valid, but out-of-date token.
 func UnknownToken(msg string) *MatrixError {
 	return &MatrixError{"M_UNKNOWN_TOKEN", msg}
-}
-
-// InvalidSync is an error when the client tries to hit /sync with an invalid
-// ?since= parameter.
-func InvalidSync(msg string) *MatrixError {
-	return &MatrixError{"M_BAD_SYNC", msg}
 }
 
 // LimitExceededError is a rate-limiting error.

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -49,7 +49,7 @@ func Setup(servMux *http.ServeMux, httpClient *http.Client, cfg config.ClientAPI
 }
 
 // SetupSyncServerListeners configures the given mux with sync-server listeners
-func SetupSyncServerListeners(servMux *http.ServeMux, httpClient *http.Client, cfg config.Sync, srp sync.RequestPool) {
+func SetupSyncServerListeners(servMux *http.ServeMux, httpClient *http.Client, cfg config.Sync, srp *sync.RequestPool) {
 	apiMux := mux.NewRouter()
 	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
 	r0mux.Handle("/sync", make("sync", util.NewJSONRequestHandler(func(req *http.Request) util.JSONResponse {

--- a/src/github.com/matrix-org/dendrite/clientapi/storage/output_room_events_table.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/storage/output_room_events_table.go
@@ -72,7 +72,11 @@ func (s *outputRoomEventsStatements) prepare(db *sql.DB) (err error) {
 // MaxID returns the ID of the last inserted event in this table. This should only ever be used at startup, as it will
 // race with inserting events if it is done afterwards.
 func (s *outputRoomEventsStatements) MaxID() (id int64, err error) {
-	err = s.selectMaxIDStmt.QueryRow().Scan(&id)
+	var nullableID sql.NullInt64
+	err = s.selectMaxIDStmt.QueryRow().Scan(&nullableID)
+	if nullableID.Valid {
+		id = nullableID.Int64
+	}
 	return
 }
 

--- a/src/github.com/matrix-org/dendrite/clientapi/storage/output_room_events_table.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/storage/output_room_events_table.go
@@ -37,7 +37,7 @@ const selectEventsSQL = "" +
 	"SELECT event_json FROM output_room_events WHERE event_id = ANY($1)"
 
 const selectEventsInRangeSQL = "" +
-	"SELECT event_json FROM output_room_events WHERE id >= $1 AND id <= $2"
+	"SELECT event_json FROM output_room_events WHERE id > $1 AND id <= $2"
 
 const selectMaxIDSQL = "" +
 	"SELECT MAX(id) FROM output_room_events"
@@ -96,8 +96,8 @@ func (s *outputRoomEventsStatements) InRange(oldPos, newPos int64) ([]gomatrixse
 		}
 		result = append(result, ev)
 	}
-	// Expect one event per position, inclusive eg old=3, new=5, expect 3,4,5 so 3 events.
-	wantNum := (1 + newPos - oldPos)
+	// Expect one event per position, exclusive of old. eg old=3, new=5, expect 4,5 so 2 events.
+	wantNum := (newPos - oldPos)
 	if i != wantNum {
 		return nil, fmt.Errorf("failed to map all positions to events: (got %d, wanted, %d)", i, wantNum)
 	}

--- a/src/github.com/matrix-org/dendrite/clientapi/storage/syncserver.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/storage/syncserver.go
@@ -85,7 +85,7 @@ func (d *SyncServerDatabase) SetPartitionOffset(topic string, partition int32, o
 	return d.partitions.UpsertPartitionOffset(topic, partition, offset)
 }
 
-// SyncStreamPosition returns the latest position in the sync stream
+// SyncStreamPosition returns the latest position in the sync stream. Returns 0 if there are no events yet.
 func (d *SyncServerDatabase) SyncStreamPosition() (int64, error) {
 	return d.events.MaxID()
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/storage/syncserver.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/storage/syncserver.go
@@ -90,6 +90,11 @@ func (d *SyncServerDatabase) SyncStreamPosition() (int64, error) {
 	return d.events.MaxID()
 }
 
+// EventsInRange returns all events in the given range, inclusive.
+func (d *SyncServerDatabase) EventsInRange(oldPos, newPos int64) ([]gomatrixserverlib.Event, error) {
+	return d.events.InRange(oldPos, newPos)
+}
+
 func runTransaction(db *sql.DB, fn func(txn *sql.Tx) error) (err error) {
 	txn, err := db.Begin()
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/clientapi/storage/syncserver.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/storage/syncserver.go
@@ -85,6 +85,11 @@ func (d *SyncServerDatabase) SetPartitionOffset(topic string, partition int32, o
 	return d.partitions.UpsertPartitionOffset(topic, partition, offset)
 }
 
+// SyncStreamPosition returns the latest position in the sync stream
+func (d *SyncServerDatabase) SyncStreamPosition() (int64, error) {
+	return d.events.MaxID()
+}
+
 func runTransaction(db *sql.DB, fn func(txn *sql.Tx) error) (err error) {
 	txn, err := db.Begin()
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/clientapi/storage/syncserver.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/storage/syncserver.go
@@ -90,7 +90,7 @@ func (d *SyncServerDatabase) SyncStreamPosition() (int64, error) {
 	return d.events.MaxID()
 }
 
-// EventsInRange returns all events in the given range, inclusive.
+// EventsInRange returns all events in the given range, exclusive of oldPos, inclusive of newPos.
 func (d *SyncServerDatabase) EventsInRange(oldPos, newPos int64) ([]gomatrixserverlib.Event, error) {
 	return d.events.InRange(oldPos, newPos)
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
@@ -134,32 +134,6 @@ func (rp *RequestPool) waitForEvents(req syncRequest) syncStreamPosition {
 func (rp *RequestPool) currentSyncForUser(req syncRequest) ([]gomatrixserverlib.Event, error) {
 	currentPos := rp.waitForEvents(req)
 	return rp.db.EventsInRange(int64(req.since), int64(currentPos))
-
-	// https://github.com/matrix-org/synapse/blob/v0.19.3/synapse/handlers/sync.py#L179
-	// Check if we are going to return immediately and if so, calculate the current
-	// sync for this user and return.
-	// if req.since == 0 || req.timeout == time.Duration(0) || req.wantFullState {
-	// 	return []gomatrixserverlib.Event{}, nil
-	// }
-
-	// Steps: (no token)
-	// - get all rooms the user is joined to.
-	// - f.e room, get room state.
-	// - f.e room, get latest N messages.
-	// - rollback state by N messages.
-
-	// Steps: (up-to-date token)
-	// - Wait for new event.
-	// - Check if event should notify user.
-	// - Notify user or continue waiting, eventually timing out.
-
-	// Steps: (partial token, less than threshold)
-	// - Get rooms the user is joined to.
-	// - Get all events between token and now for those rooms.
-	// - Work out state and message delta and return.
-
-	// Steps: (partial token, more than threshold (too expensive to do the above))
-	// - Ignore for now, meaning this code path will be horrendously slow.
 }
 
 func getTimeout(timeoutMS string) time.Duration {

--- a/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
@@ -1,6 +1,7 @@
 package sync
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -65,8 +66,8 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request) util.JSONRespons
 }
 
 // OnNewEvent is called when a new event is received from the room server
-func (rp *RequestPool) OnNewEvent(ev *gomatrixserverlib.Event) {
-
+func (rp *RequestPool) OnNewEvent(ev *gomatrixserverlib.Event, syncStreamPos int64) {
+	fmt.Println("OnNewEvent =>", ev.EventID(), syncStreamPos)
 }
 
 func (rp *RequestPool) currentSyncForUser(req syncRequest) ([]gomatrixserverlib.Event, error) {

--- a/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
@@ -56,7 +56,7 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request) util.JSONRespons
 	if err != nil {
 		return util.JSONResponse{
 			Code: 400,
-			JSON: jsonerror.InvalidSync(err.Error()),
+			JSON: jsonerror.Unknown(err.Error()),
 		}
 	}
 	timeout := getTimeout(req.URL.Query().Get("timeout"))
@@ -112,8 +112,8 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request) util.JSONRespons
 }
 
 // OnNewEvent is called when a new event is received from the room server. Must only be
-// called from a single goroutine, or else the current position in the stream may be
-// set incorrectly as it is blindly clobbered.
+// called from a single goroutine, to avoid races between updates which could set the
+// current position in the stream incorrectly.
 func (rp *RequestPool) OnNewEvent(ev *gomatrixserverlib.Event, pos syncStreamPosition) {
 	// update the current position in a guard and then notify all /sync streams
 	rp.cond.L.Lock()

--- a/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
@@ -81,12 +81,18 @@ func (rp *RequestPool) OnNewEvent(ev *gomatrixserverlib.Event, pos syncStreamPos
 }
 
 func (rp *RequestPool) currentSyncForUser(req syncRequest) ([]gomatrixserverlib.Event, error) {
+	if req.since == rp.currPos {
+		// wait for new event
+	}
+
+	return rp.db.EventsInRange(int64(req.since), int64(rp.currPos))
+
 	// https://github.com/matrix-org/synapse/blob/v0.19.3/synapse/handlers/sync.py#L179
 	// Check if we are going to return immediately and if so, calculate the current
 	// sync for this user and return.
-	if req.since == 0 || req.timeout == time.Duration(0) || req.wantFullState {
-		return []gomatrixserverlib.Event{}, nil
-	}
+	// if req.since == 0 || req.timeout == time.Duration(0) || req.wantFullState {
+	// 	return []gomatrixserverlib.Event{}, nil
+	// }
 
 	// Steps: (no token)
 	// - get all rooms the user is joined to.

--- a/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
@@ -112,7 +112,8 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request) util.JSONRespons
 }
 
 // OnNewEvent is called when a new event is received from the room server. Must only be
-// called from a single goroutine.
+// called from a single goroutine, or else the current position in the stream may be
+// set incorrectly as it is blindly clobbered.
 func (rp *RequestPool) OnNewEvent(ev *gomatrixserverlib.Event, pos syncStreamPosition) {
 	// update the current position in a guard and then notify all /sync streams
 	rp.cond.L.Lock()

--- a/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
@@ -9,6 +9,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/matrix-org/dendrite/clientapi/auth"
 	"github.com/matrix-org/dendrite/clientapi/httputil"
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/clientapi/storage"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
@@ -19,13 +20,14 @@ const defaultSyncTimeout = time.Duration(30) * time.Second
 type syncRequest struct {
 	userID        string
 	timeout       time.Duration
-	since         string
+	since         syncStreamPosition
 	wantFullState bool
 }
 
 // RequestPool manages HTTP long-poll connections for /sync
 type RequestPool struct {
-	db *storage.SyncServerDatabase
+	db      *storage.SyncServerDatabase
+	currPos syncStreamPosition
 }
 
 // OnIncomingSyncRequest is called when a client makes a /sync request. This function MUST be
@@ -38,7 +40,13 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request) util.JSONRespons
 	if resErr != nil {
 		return *resErr
 	}
-	since := req.URL.Query().Get("since")
+	since, err := getSyncStreamPosition(req.URL.Query().Get("since"))
+	if err != nil {
+		return util.JSONResponse{
+			Code: 400,
+			JSON: jsonerror.InvalidSync(err.Error()),
+		}
+	}
 	timeout := getTimeout(req.URL.Query().Get("timeout"))
 	fullState := req.URL.Query().Get("full_state")
 	wantFullState := fullState != "" && fullState != "false"
@@ -66,15 +74,16 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request) util.JSONRespons
 }
 
 // OnNewEvent is called when a new event is received from the room server
-func (rp *RequestPool) OnNewEvent(ev *gomatrixserverlib.Event, syncStreamPos int64) {
-	fmt.Println("OnNewEvent =>", ev.EventID(), syncStreamPos)
+func (rp *RequestPool) OnNewEvent(ev *gomatrixserverlib.Event, pos syncStreamPosition) {
+	fmt.Println("OnNewEvent =>", ev.EventID(), " pos=", pos, " old_pos=", rp.currPos)
+	rp.currPos = pos
 }
 
 func (rp *RequestPool) currentSyncForUser(req syncRequest) ([]gomatrixserverlib.Event, error) {
 	// https://github.com/matrix-org/synapse/blob/v0.19.3/synapse/handlers/sync.py#L179
 	// Check if we are going to return immediately and if so, calculate the current
 	// sync for this user and return.
-	if req.since == "" || req.timeout == time.Duration(0) || req.wantFullState {
+	if req.since == 0 || req.timeout == time.Duration(0) || req.wantFullState {
 		return []gomatrixserverlib.Event{}, nil
 	}
 
@@ -96,7 +105,22 @@ func getTimeout(timeoutMS string) time.Duration {
 	return time.Duration(i) * time.Millisecond
 }
 
+func getSyncStreamPosition(since string) (syncStreamPosition, error) {
+	if since == "" {
+		return syncStreamPosition(0), nil
+	}
+	i, err := strconv.Atoi(since)
+	if err != nil {
+		return syncStreamPosition(0), err
+	}
+	return syncStreamPosition(i), nil
+}
+
 // NewRequestPool makes a new RequestPool
-func NewRequestPool(db *storage.SyncServerDatabase) RequestPool {
-	return RequestPool{db}
+func NewRequestPool(db *storage.SyncServerDatabase) (*RequestPool, error) {
+	pos, err := db.SyncStreamPosition()
+	if err != nil {
+		return nil, err
+	}
+	return &RequestPool{db, syncStreamPosition(pos)}, nil
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
@@ -1,7 +1,6 @@
 package sync
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 	"sync"
@@ -117,7 +116,6 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request) util.JSONRespons
 func (rp *RequestPool) OnNewEvent(ev *gomatrixserverlib.Event, pos syncStreamPosition) {
 	// update the current position in a guard and then notify all /sync streams
 	rp.cond.L.Lock()
-	fmt.Println("OnNewEvent =>", ev.EventID(), " pos=", pos, " old_pos=", rp.currPos)
 	rp.currPos = pos
 	rp.cond.L.Unlock()
 

--- a/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
@@ -35,6 +35,15 @@ type RequestPool struct {
 	cond *sync.Cond
 }
 
+// NewRequestPool makes a new RequestPool
+func NewRequestPool(db *storage.SyncServerDatabase) (*RequestPool, error) {
+	pos, err := db.SyncStreamPosition()
+	if err != nil {
+		return nil, err
+	}
+	return &RequestPool{db, syncStreamPosition(pos), sync.NewCond(&sync.Mutex{})}, nil
+}
+
 // OnIncomingSyncRequest is called when a client makes a /sync request. This function MUST be
 // called in a dedicated goroutine for this request. This function will block the goroutine
 // until a response is ready, or it times out.
@@ -160,13 +169,4 @@ func getSyncStreamPosition(since string) (syncStreamPosition, error) {
 		return syncStreamPosition(0), err
 	}
 	return syncStreamPosition(i), nil
-}
-
-// NewRequestPool makes a new RequestPool
-func NewRequestPool(db *storage.SyncServerDatabase) (*RequestPool, error) {
-	pos, err := db.SyncStreamPosition()
-	if err != nil {
-		return nil, err
-	}
-	return &RequestPool{db, syncStreamPosition(pos), sync.NewCond(&sync.Mutex{})}, nil
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
@@ -74,7 +74,6 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request) util.JSONRespons
 		"userID":  userID,
 		"since":   since,
 		"timeout": timeout,
-		"current": rp.currPos,
 	}).Info("Incoming /sync request")
 
 	// Set up a timer based on the provided timeout value.
@@ -93,6 +92,9 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request) util.JSONRespons
 			timer.Stop()
 		}
 	}()
+
+	// TODO: Spawn off a 3rd goroutine to do this work so we can simply race
+	// with the timeout to determine what to return to the client.
 
 	res, err := rp.currentSyncForUser(syncReq)
 	close(done) // signal that the work is complete

--- a/src/github.com/matrix-org/dendrite/clientapi/sync/syncserver.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/sync/syncserver.go
@@ -49,6 +49,9 @@ func (s *Server) Start() error {
 	return s.roomServerConsumer.Start()
 }
 
+// onMessage is called when the sync server receives a new event from the room server output log.
+// It is not safe for this function to be called from multiple goroutines, or else the
+// sync stream position may race and be incorrectly calculated.
 func (s *Server) onMessage(msg *sarama.ConsumerMessage) error {
 	// Parse out the event JSON
 	var output api.OutputRoomEvent

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-sync-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-sync-server/main.go
@@ -74,7 +74,10 @@ func main() {
 		log.Panicf("startup: failed to create sync server database with data source %s : %s", cfg.DataSource, err)
 	}
 
-	rp := sync.NewRequestPool(db)
+	rp, err := sync.NewRequestPool(db)
+	if err != nil {
+		log.Panicf("startup: Failed to create request pool : %s", err)
+	}
 
 	server, err := sync.NewServer(cfg, rp, db)
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/common/consumers.go
+++ b/src/github.com/matrix-org/dendrite/common/consumers.go
@@ -67,8 +67,8 @@ func (c *ContinualConsumer) Start() error {
 	}
 	for _, offset := range storedOffsets {
 		// We've already processed events from this partition so advance the offset to where we got to.
-		// Offsets are provided with each message, so if we use the same offset on startup then we'll
-		// get the same message a 2nd time, so increment 1 to indicate the next offset.
+		// ConsumePartition will start streaming from the message with the given offset (inclusive),
+		// so increment 1 to avoid getting the same message a second time.
 		offsets[offset.Partition] = 1 + offset.Offset
 	}
 

--- a/src/github.com/matrix-org/dendrite/common/consumers.go
+++ b/src/github.com/matrix-org/dendrite/common/consumers.go
@@ -67,7 +67,7 @@ func (c *ContinualConsumer) Start() error {
 	}
 	for _, offset := range storedOffsets {
 		// We've already processed events from this partition so advance the offset to where we got to.
-		offsets[offset.Partition] = offset.Offset
+		offsets[offset.Partition] = 1 + offset.Offset
 	}
 
 	var partitionConsumers []sarama.PartitionConsumer

--- a/src/github.com/matrix-org/dendrite/common/consumers.go
+++ b/src/github.com/matrix-org/dendrite/common/consumers.go
@@ -67,6 +67,8 @@ func (c *ContinualConsumer) Start() error {
 	}
 	for _, offset := range storedOffsets {
 		// We've already processed events from this partition so advance the offset to where we got to.
+		// Offsets are provided with each message, so if we use the same offset on startup then we'll
+		// get the same message a 2nd time, so increment 1 to indicate the next offset.
 		offsets[offset.Partition] = 1 + offset.Offset
 	}
 


### PR DESCRIPTION
This PR implements sync tokens as an integer offset from the stream of events received from the room server. If the offset is in the future, the HTTP request is blocked until that event arrives or the timeout expires.

This PR doesn't concern itself with:
 - Visibility of events.
 - Format of HTTP response.
 - Optimisations when servicing very old offsets.

Those will come in a different PR.