### PR TITLE
Add /sync API response structs

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/storage/syncserver.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/storage/syncserver.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	// Import the postgres database driver.
 	_ "github.com/lib/pq"
+	"github.com/matrix-org/dendrite/clientapi/sync/syncapi"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/gomatrixserverlib"
 )
@@ -41,13 +42,14 @@ func NewSyncServerDatabase(dataSourceName string) (*SyncServerDatabase, error) {
 // WriteEvent into the database. It is not safe to call this function from multiple goroutines, as it would create races
 // when generating the stream position for this event. Returns the sync stream position for the inserted event.
 // Returns an error if there was a problem inserting this event.
-func (d *SyncServerDatabase) WriteEvent(ev *gomatrixserverlib.Event, addStateEventIDs, removeStateEventIDs []string) (streamPos int64, returnErr error) {
+func (d *SyncServerDatabase) WriteEvent(ev *gomatrixserverlib.Event, addStateEventIDs, removeStateEventIDs []string) (streamPos syncapi.StreamPosition, returnErr error) {
 	returnErr = runTransaction(d.db, func(txn *sql.Tx) error {
 		var err error
-		streamPos, err = d.events.InsertEvent(txn, ev, addStateEventIDs, removeStateEventIDs)
+		pos, err := d.events.InsertEvent(txn, ev, addStateEventIDs, removeStateEventIDs)
 		if err != nil {
 			return err
 		}
+		streamPos = syncapi.StreamPosition(pos)
 
 		if len(addStateEventIDs) == 0 && len(removeStateEventIDs) == 0 {
 			// Nothing to do, the event may have just been a message event.
@@ -86,8 +88,12 @@ func (d *SyncServerDatabase) SetPartitionOffset(topic string, partition int32, o
 }
 
 // SyncStreamPosition returns the latest position in the sync stream. Returns 0 if there are no events yet.
-func (d *SyncServerDatabase) SyncStreamPosition() (int64, error) {
-	return d.events.MaxID()
+func (d *SyncServerDatabase) SyncStreamPosition() (syncapi.StreamPosition, error) {
+	id, err := d.events.MaxID()
+	if err != nil {
+		return syncapi.StreamPosition(0), err
+	}
+	return syncapi.StreamPosition(id), nil
 }
 
 // EventsInRange returns all events in the given range, exclusive of oldPos, inclusive of newPos.

--- a/src/github.com/matrix-org/dendrite/clientapi/storage/syncserver.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/storage/syncserver.go
@@ -97,8 +97,8 @@ func (d *SyncServerDatabase) SyncStreamPosition() (syncapi.StreamPosition, error
 }
 
 // EventsInRange returns all events in the given range, exclusive of oldPos, inclusive of newPos.
-func (d *SyncServerDatabase) EventsInRange(oldPos, newPos int64) ([]gomatrixserverlib.Event, error) {
-	return d.events.InRange(oldPos, newPos)
+func (d *SyncServerDatabase) EventsInRange(oldPos, newPos syncapi.StreamPosition) ([]gomatrixserverlib.Event, error) {
+	return d.events.InRange(int64(oldPos), int64(newPos))
 }
 
 func runTransaction(db *sql.DB, fn func(txn *sql.Tx) error) (err error) {

--- a/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
@@ -139,6 +139,19 @@ func (rp *RequestPool) waitForEvents(req syncRequest) syncStreamPosition {
 
 func (rp *RequestPool) currentSyncForUser(req syncRequest) ([]gomatrixserverlib.Event, error) {
 	currentPos := rp.waitForEvents(req)
+
+	// TODO: ignored users
+
+	// Implement https://github.com/matrix-org/synapse/blob/v0.19.3/synapse/handlers/sync.py#L821
+	// 1) Get the CURRENT joined room list for this user
+	// 2) Get membership list changes for this user between the provided stream position and now.
+	// 3) For each room which has membership list changes:
+	//   a) Check if the room is 'newly joined' (insufficient to just check for a join event because we allow dupe joins).
+	//      If it is, then we need to send the full room state down (and 'limited' is always true).
+	//   b) Check if user is still CURRENTLY invited to the room. If so, add room to 'invited' block.
+	//   c) Check if the user is CURRENTLY left/banned. If so, add room to 'archived' block. // This has a TODO: How do we handle ban -> leave in same batch?
+	// 4) Add joined rooms (joined room list)
+
 	return rp.db.EventsInRange(int64(req.since), int64(currentPos))
 }
 

--- a/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/sync/requestpool.go
@@ -153,7 +153,7 @@ func (rp *RequestPool) currentSyncForUser(req syncRequest) (*syncapi.Response, e
 	//   c) Check if the user is CURRENTLY left/banned. If so, add room to 'archived' block. // Synapse has a TODO: How do we handle ban -> leave in same batch?
 	// 4) Add joined rooms (joined room list)
 
-	events, err := rp.db.EventsInRange(int64(req.since), int64(currentPos))
+	events, err := rp.db.EventsInRange(req.since, currentPos)
 	if err != nil {
 		return nil, err
 	}

--- a/src/github.com/matrix-org/dendrite/clientapi/sync/syncapi/syncapi.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/sync/syncapi/syncapi.go
@@ -1,4 +1,112 @@
 package syncapi
 
+import (
+	"strconv"
+
+	"github.com/matrix-org/gomatrixserverlib"
+)
+
 // StreamPosition represents the offset in the sync stream a client is at.
 type StreamPosition int64
+
+// String implements the Stringer interface.
+func (sp StreamPosition) String() string {
+	return strconv.FormatInt(int64(sp), 10)
+}
+
+// Response represents a /sync API response. See https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-sync
+type Response struct {
+	NextBatch   string `json:"next_batch"`
+	AccountData struct {
+		Events []gomatrixserverlib.Event `json:"events"`
+	} `json:"account_data"`
+	Presence struct {
+		Events []gomatrixserverlib.Event `json:"events"`
+	} `json:"presence"`
+	Rooms struct {
+		Join   map[string]JoinResponse   `json:"join"`
+		Invite map[string]InviteResponse `json:"invite"`
+		Leave  map[string]LeaveResponse  `json:"leave"`
+	} `json:"rooms"`
+}
+
+// NewResponse creates an empty response with initialised maps.
+func NewResponse() *Response {
+	res := Response{}
+	// Pre-initalise the maps. Synapse will return {} even if there are no rooms under a specific section,
+	// so let's do the same thing. Bonus: this means we can't get dreaded 'assignment to entry in nil map' errors.
+	res.Rooms.Join = make(map[string]JoinResponse)
+	res.Rooms.Invite = make(map[string]InviteResponse)
+	res.Rooms.Leave = make(map[string]LeaveResponse)
+
+	// Also pre-intialise empty slices or else we'll insert 'null' instead of '[]' for the value.
+	// TODO: We really shouldn't have to do all this to coerce encoding/json to Do The Right Thing. We should
+	//       really be using our own Marshal/Unmarshal implementations otherwise this may prove to be a CPU bottleneck.
+	//       This also applies to NewJoinResponse, NewInviteResponse and NewLeaveResponse.
+	res.AccountData.Events = make([]gomatrixserverlib.Event, 0)
+	res.Presence.Events = make([]gomatrixserverlib.Event, 0)
+
+	return &res
+}
+
+// JoinResponse represents a /sync response for a room which is under the 'join' key.
+type JoinResponse struct {
+	State struct {
+		Events []gomatrixserverlib.Event `json:"events"`
+	} `json:"state"`
+	Timeline struct {
+		Events    []gomatrixserverlib.Event `json:"events"`
+		Limited   bool                      `json:"limited"`
+		PrevBatch string                    `json:"prev_batch"`
+	} `json:"timeline"`
+	Ephemeral struct {
+		Events []gomatrixserverlib.Event `json:"events"`
+	} `json:"ephemeral"`
+	AccountData struct {
+		Events []gomatrixserverlib.Event `json:"events"`
+	} `json:"account_data"`
+}
+
+// NewJoinResponse creates an empty response with initialised arrays.
+func NewJoinResponse() *JoinResponse {
+	res := JoinResponse{}
+	res.State.Events = make([]gomatrixserverlib.Event, 0)
+	res.Timeline.Events = make([]gomatrixserverlib.Event, 0)
+	res.Ephemeral.Events = make([]gomatrixserverlib.Event, 0)
+	res.AccountData.Events = make([]gomatrixserverlib.Event, 0)
+	return &res
+}
+
+// InviteResponse represents a /sync response for a room which is under the 'invite' key.
+type InviteResponse struct {
+	InviteState struct {
+		Events []gomatrixserverlib.Event
+	} `json:"invite_state"`
+}
+
+// NewInviteResponse creates an empty response with initialised arrays.
+func NewInviteResponse() *InviteResponse {
+	res := InviteResponse{}
+	res.InviteState.Events = make([]gomatrixserverlib.Event, 0)
+	return &res
+}
+
+// LeaveResponse represents a /sync response for a room which is under the 'leave' key.
+type LeaveResponse struct {
+	State struct {
+		Events []gomatrixserverlib.Event `json:"events"`
+	} `json:"state"`
+	Timeline struct {
+		Events    []gomatrixserverlib.Event `json:"events"`
+		Limited   bool                      `json:"limited"`
+		PrevBatch string                    `json:"prev_batch"`
+	} `json:"timeline"`
+}
+
+// NewLeaveResponse creates an empty response with initialised arrays.
+func NewLeaveResponse() *LeaveResponse {
+	res := LeaveResponse{}
+	res.State.Events = make([]gomatrixserverlib.Event, 0)
+	res.Timeline.Events = make([]gomatrixserverlib.Event, 0)
+	return &res
+}

--- a/src/github.com/matrix-org/dendrite/clientapi/sync/syncapi/syncapi.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/sync/syncapi/syncapi.go
@@ -1,0 +1,4 @@
+package syncapi
+
+// StreamPosition represents the offset in the sync stream a client is at.
+type StreamPosition int64

--- a/src/github.com/matrix-org/dendrite/clientapi/sync/syncserver.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/sync/syncserver.go
@@ -6,14 +6,12 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/matrix-org/dendrite/clientapi/config"
 	"github.com/matrix-org/dendrite/clientapi/storage"
+	"github.com/matrix-org/dendrite/clientapi/sync/syncapi"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
 	sarama "gopkg.in/Shopify/sarama.v1"
 )
-
-// syncStreamPosition represents the offset in the sync stream a client is at.
-type syncStreamPosition int64
 
 // Server contains all the logic for running a sync server
 type Server struct {
@@ -83,7 +81,7 @@ func (s *Server) onMessage(msg *sarama.ConsumerMessage) error {
 		}).Panicf("roomserver output log: write event failure")
 		return nil
 	}
-	s.rp.OnNewEvent(&ev, syncStreamPosition(syncStreamPos))
+	s.rp.OnNewEvent(&ev, syncapi.StreamPosition(syncStreamPos))
 
 	return nil
 }


### PR DESCRIPTION
Response structs live in a `syncapi` package, which also now has `StreamPosition` so we can actually reference this type in the database layer without creating circular `import` graphs.

Currently, the response looks like:
```json
{
	"next_batch": "7",
	"account_data": {
		"events": []
	},
	"presence": {
		"events": []
	},
	"rooms": {
		"join": {
			"!LB07hAXJaqz3MwTC:localhost": {
				"state": {
					"events": null
				},
				"timeline": {
					"events": [{
						"auth_events": [
							["$AfaQS85NizUAJBS3:localhost", {
								"sha256": "v2XvxbxiiQMJmJXXbKUTsy20uJSUYjQHWnuC1nwqido"
							}],
							["$XZQUHcjOs0c5E7iU:localhost", {
								"sha256": "4u3VQqzIik4yTimhFF7InqnWhqi205ZXPx2pmIksYOo"
							}],
							["$UNs4N0ivMNZeLngy:localhost", {
								"sha256": "FS5Dh84M1/1Vev+ZK2rvmIy0tW9v7RX2ifDFjj8G6Vs"
							}]
						],
						"content": {
							"content": {
								"body": "Hello World"
							},
							"msgtype": "m.text"
						},
						"depth": 0,
						"event_id": "$0O9Ate3BDbmBhuWu:localhost",
						"hashes": {
							"sha256": "Urq+U/eAM6l3FNvm8syxNySx2wBanD70f1OnKr+4X+w"
						},
						"origin": "localhost",
						"origin_server_ts": 1491840394757,
						"prev_events": [
							["$PXICPRLZdPBmcgMs:localhost", {
								"sha256": "GTc01inNaOVR1g/uNEEBxt/K4Xo0/r71Uux427nZnPE"
							}]
						],
						"room_id": "!LB07hAXJaqz3MwTC:localhost",
						"sender": "@alice:localhost",
						"signatures": {
							"localhost": {
								"ed25519:something": "SnLw3FR/OPzm0PYPhXJjy0eeSgi0fzC6yN39Ue+jexIDlyHIM/+ZTbhYYbKgpLxZ7rSnPbMTLKETWlxqw0PJDg"
							}
						},
						"type": "m.room.message"
					}],
					"limited": false,
					"prev_batch": ""
				},
				"ephemeral": {
					"events": null
				},
				"account_data": {
					"events": null
				}
			}
		},
		"invite": {},
		"leave": {}
	}
}
```

This has the following known failings:
 - It doesn't remove federation keys.
 - It doesn't put things anywhere but the timeline events section.
 - It has `"events": null` when it should have `"events":[]`.

But it's a start.