### PR TITLE
Fix a race with sync server integration tests

### DIFF
--- a/src/github.com/matrix-org/dendrite/cmd/syncserver-integration-tests/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/syncserver-integration-tests/main.go
@@ -237,9 +237,9 @@ func testSyncServer(input, want []string, since string) {
 			panic(err)
 		}
 		panic("dendrite-sync-api-server timed out")
-	case err := <-done:
+	case err, open := <-done:
 		cmd.Process.Kill() // ensure server is dead, only cleaning up so don't care about errors this returns.
-		if err != nil {
+		if open {          // channel is closed on success
 			fmt.Println("=============================================================================================")
 			fmt.Println("sync server failed to run. If failing with 'pq: password authentication failed for user' try:")
 			fmt.Println("    export PGHOST=/var/run/postgresql\n")


### PR DESCRIPTION
Tidy things up so stdout looks sensible for:
 - Success
 - Failure (mismatch)
 - Failure (db configuration)

Success:
```
$ ./bin/syncserver-integration-tests 
==TESTING== ./bin/syncserver-integration-tests
Topic syncserverInput is marked for deletion.
Note: This will have no impact if delete.topic.enable is not set to true.
Created topic "syncserverInput".
DROP DATABASE
CREATE DATABASE
INFO[2017-05-09T12:27:14.730373083Z] sync server config: &{syncserverInput [localhost:9092] dbname=syncserver_test sslmode=disable binary_parameters=yes} 
INFO[2017-05-09T12:27:14.767718174Z] Starting sync server on localhost:9876       
INFO[2017-05-09T12:27:14.768972166Z] received event from roomserver                event_id="$rOaxKSu6K1s0nOsW:localhost" room_id="!gnrFfNAK7yGBWXFd:localhost"
INFO[2017-05-09T12:27:14.771643865Z] received event from roomserver                event_id="$uEDYwFpBO936HTfM:localhost" room_id="!gnrFfNAK7yGBWXFd:localhost"
INFO[2017-05-09T12:27:14.773570877Z] received event from roomserver                event_id="$Axp7qdQXf0bz7zBy:localhost" room_id="!gnrFfNAK7yGBWXFd:localhost"
INFO[2017-05-09T12:27:14.775430143Z] received event from roomserver                event_id="$zCgCrw3aZwVaKm34:localhost" room_id="!gnrFfNAK7yGBWXFd:localhost"
INFO[2017-05-09T12:27:14.777261670Z] received event from roomserver                event_id="$0NUtdnY7KWMhOR9E:localhost" room_id="!gnrFfNAK7yGBWXFd:localhost"
INFO[2017-05-09T12:27:15.728391875Z] Incoming request                              req.id=7DEnpXGvYPUr req.method=GET req.path="/_matrix/client/r0/sync"
INFO[2017-05-09T12:27:15.728538251Z] Incoming /sync request                        req.id=7DEnpXGvYPUr req.method=GET req.path="/_matrix/client/r0/sync" since=3 timeout=30s userID="@alice:localhost"
INFO[2017-05-09T12:27:15.737723061Z] Responding (832 bytes)                        code=200 req.id=7DEnpXGvYPUr req.method=GET req.path="/_matrix/client/r0/sync"
```

Failure (db configuration error):
```
$ ./bin/syncserver-integration-tests 
==TESTING== ./bin/syncserver-integration-tests
Topic syncserverInput is marked for deletion.
Note: This will have no impact if delete.topic.enable is not set to true.
Created topic "syncserverInput".
DROP DATABASE
CREATE DATABASE
INFO[2017-05-09T12:25:50.568398131Z] sync server config: &{syncserverInput [localhost:9092] dbname=aasyncserver_test sslmode=disable binary_parameters=yes} 
PANI[2017-05-09T12:25:50.571765762Z] startup: failed to create sync server database with data source dbname=aasyncserver_test sslmode=disable binary_parameters=yes : pq: database "aasyncserver_test" does not exist 
panic: (*logrus.Entry) (0x49f4a0,0xc42000c8c0)

goroutine 1 [running]:
panic(0x49f4a0, 0xc42000c8c0)
	/usr/local/go/src/runtime/panic.go:500 +0x1a1
github.com/Sirupsen/logrus.Entry.log(0xc4200948c0, 0xc420018690, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc42004fc00, ...)
	/Users/kegan/github/dendrite/vendor/src/github.com/Sirupsen/logrus/entry.go:124 +0x423
github.com/Sirupsen/logrus.(*Entry).Panic(0xc42000c640, 0xc42004fd00, 0x1, 0x1)
	/Users/kegan/github/dendrite/vendor/src/github.com/Sirupsen/logrus/entry.go:169 +0x124
github.com/Sirupsen/logrus.(*Entry).Panicf(0xc42000c640, 0x4c4c43, 0x47, 0xc42004fef8, 0x2, 0x2)
	/Users/kegan/github/dendrite/vendor/src/github.com/Sirupsen/logrus/entry.go:217 +0x101
github.com/Sirupsen/logrus.(*Logger).Panicf(0xc4200948c0, 0x4c4c43, 0x47, 0xc42004fef8, 0x2, 0x2)
	/Users/kegan/github/dendrite/vendor/src/github.com/Sirupsen/logrus/logger.go:172 +0x86
github.com/Sirupsen/logrus.Panicf(0x4c4c43, 0x47, 0xc42004fef8, 0x2, 0x2)
	/Users/kegan/github/dendrite/vendor/src/github.com/Sirupsen/logrus/exported.go:147 +0x5f
main.main()
	/Users/kegan/github/dendrite/src/github.com/matrix-org/dendrite/cmd/dendrite-sync-api-server/main.go:71 +0x67b
=============================================================================================
sync server failed to run. If failing with 'pq: password authentication failed for user' try:
    export PGHOST=/var/run/postgresql

=============================================================================================
panic: exit status 2

goroutine 1 [running]:
panic(0x257820, 0xc42010ab40)
	/usr/local/go/src/runtime/panic.go:500 +0x1a1
main.testSyncServer(0xc42004fee8, 0x5, 0x5, 0xc42004feb8, 0x1, 0x1, 0x268cff, 0x1)
	/Users/kegan/github/dendrite/src/github.com/matrix-org/dendrite/cmd/syncserver-integration-tests/main.go:247 +0x59d
main.main()
	/Users/kegan/github/dendrite/src/github.com/matrix-org/dendrite/cmd/syncserver-integration-tests/main.go:532 +0x1ac
```

Failure (data mismatch):
```
$ ./bin/syncserver-integration-tests 
==TESTING== ./bin/syncserver-integration-tests
Topic syncserverInput is marked for deletion.
Note: This will have no impact if delete.topic.enable is not set to true.
Created topic "syncserverInput".
DROP DATABASE
CREATE DATABASE
INFO[2017-05-09T12:26:44.233987745Z] sync server config: &{syncserverInput [localhost:9092] dbname=syncserver_test sslmode=disable binary_parameters=yes} 
INFO[2017-05-09T12:26:44.275024779Z] Starting sync server on localhost:9876       
INFO[2017-05-09T12:26:44.276154983Z] received event from roomserver                event_id="$rOaxKSu6K1s0nOsW:localhost" room_id="!gnrFfNAK7yGBWXFd:localhost"
INFO[2017-05-09T12:26:44.278758706Z] received event from roomserver                event_id="$uEDYwFpBO936HTfM:localhost" room_id="!gnrFfNAK7yGBWXFd:localhost"
INFO[2017-05-09T12:26:44.280801779Z] received event from roomserver                event_id="$Axp7qdQXf0bz7zBy:localhost" room_id="!gnrFfNAK7yGBWXFd:localhost"
INFO[2017-05-09T12:26:44.282482791Z] received event from roomserver                event_id="$zCgCrw3aZwVaKm34:localhost" room_id="!gnrFfNAK7yGBWXFd:localhost"
INFO[2017-05-09T12:26:44.284096724Z] received event from roomserver                event_id="$0NUtdnY7KWMhOR9E:localhost" room_id="!gnrFfNAK7yGBWXFd:localhost"
INFO[2017-05-09T12:26:45.235681014Z] Incoming request                              req.id=0JK6XYozoDiq req.method=GET req.path="/_matrix/client/r0/sync"
INFO[2017-05-09T12:26:45.235806213Z] Incoming /sync request                        req.id=0JK6XYozoDiq req.method=GET req.path="/_matrix/client/r0/sync" since=3 timeout=30s userID="@alice:localhost"
INFO[2017-05-09T12:26:45.244800935Z] Responding (832 bytes)                        code=200 req.id=0JK6XYozoDiq req.method=GET req.path="/_matrix/client/r0/sync"
INFO[2017-05-09T12:26:46.249733399Z] Incoming request                              req.id=oXAKH9nfCpFV req.method=GET req.path="/_matrix/client/r0/sync"
INFO[2017-05-09T12:26:46.249801704Z] Incoming /sync request                        req.id=oXAKH9nfCpFV req.method=GET req.path="/_matrix/client/r0/sync" since=3 timeout=30s userID="@alice:localhost"
INFO[2017-05-09T12:26:46.252682258Z] Responding (832 bytes)                        code=200 req.id=oXAKH9nfCpFV req.method=GET req.path="/_matrix/client/r0/sync"
INFO[2017-05-09T12:26:47.257469246Z] Incoming request                              req.id=oVSV5JdW4Ciz req.method=GET req.path="/_matrix/client/r0/sync"
INFO[2017-05-09T12:26:47.257547392Z] Incoming /sync request                        req.id=oVSV5JdW4Ciz req.method=GET req.path="/_matrix/client/r0/sync" since=3 timeout=30s userID="@alice:localhost"
INFO[2017-05-09T12:26:47.260034957Z] Responding (832 bytes)                        code=200 req.id=oVSV5JdW4Ciz req.method=GET req.path="/_matrix/client/r0/sync"
INFO[2017-05-09T12:26:48.265071055Z] Incoming request                              req.id=Tf0MW8SCzMiU req.method=GET req.path="/_matrix/client/r0/sync"
INFO[2017-05-09T12:26:48.265130176Z] Incoming /sync request                        req.id=Tf0MW8SCzMiU req.method=GET req.path="/_matrix/client/r0/sync" since=3 timeout=30s userID="@alice:localhost"
INFO[2017-05-09T12:26:48.268039206Z] Responding (832 bytes)                        code=200 req.id=Tf0MW8SCzMiU req.method=GET req.path="/_matrix/client/r0/sync"
INFO[2017-05-09T12:26:49.273938247Z] Incoming request                              req.id=LzAORlJvaRCM req.method=GET req.path="/_matrix/client/r0/sync"
INFO[2017-05-09T12:26:49.274005733Z] Incoming /sync request                        req.id=LzAORlJvaRCM req.method=GET req.path="/_matrix/client/r0/sync" since=3 timeout=30s userID="@alice:localhost"
INFO[2017-05-09T12:26:49.276847803Z] Responding (832 bytes)                        code=200 req.id=LzAORlJvaRCM req.method=GET req.path="/_matrix/client/r0/sync"
INFO[2017-05-09T12:26:50.281482680Z] Incoming request                              req.id=PLw8MbCxoNb2 req.method=GET req.path="/_matrix/client/r0/sync"
INFO[2017-05-09T12:26:50.281532242Z] Incoming /sync request                        req.id=PLw8MbCxoNb2 req.method=GET req.path="/_matrix/client/r0/sync" since=3 timeout=30s userID="@alice:localhost"
INFO[2017-05-09T12:26:50.283998270Z] Responding (832 bytes)                        code=200 req.id=PLw8MbCxoNb2 req.method=GET req.path="/_matrix/client/r0/sync"
INFO[2017-05-09T12:26:51.288412000Z] Incoming request                              req.id=lwWG4grfQT7t req.method=GET req.path="/_matrix/client/r0/sync"
INFO[2017-05-09T12:26:51.288463000Z] Incoming /sync request                        req.id=lwWG4grfQT7t req.method=GET req.path="/_matrix/client/r0/sync" since=3 timeout=30s userID="@alice:localhost"
INFO[2017-05-09T12:26:51.290758000Z] Responding (832 bytes)                        code=200 req.id=lwWG4grfQT7t req.method=GET req.path="/_matrix/client/r0/sync"
INFO[2017-05-09T12:26:52.295865563Z] Incoming request                              req.id=GFSkmwbORRpt req.method=GET req.path="/_matrix/client/r0/sync"
INFO[2017-05-09T12:26:52.295928575Z] Incoming /sync request                        req.id=GFSkmwbORRpt req.method=GET req.path="/_matrix/client/r0/sync" since=3 timeout=30s userID="@alice:localhost"
INFO[2017-05-09T12:26:52.298720958Z] Responding (832 bytes)                        code=200 req.id=GFSkmwbORRpt req.method=GET req.path="/_matrix/client/r0/sync"
INFO[2017-05-09T12:26:53.303378458Z] Incoming request                              req.id=1h55TJB0036T req.method=GET req.path="/_matrix/client/r0/sync"
INFO[2017-05-09T12:26:53.303427999Z] Incoming /sync request                        req.id=1h55TJB0036T req.method=GET req.path="/_matrix/client/r0/sync" since=3 timeout=30s userID="@alice:localhost"
INFO[2017-05-09T12:26:53.305447112Z] Responding (832 bytes)                        code=200 req.id=1h55TJB0036T req.method=GET req.path="/_matrix/client/r0/sync"
Last /sync request error:
/sync returned wrong bytes. Expected:
{"account_data":{"events":[]},"next_batch":"I AM NOT A TOKEN","presence":{"events":[]},"rooms":{"invite":{},"join":{"!gnrFfNAK7yGBWXFd:localhost":{"account_data":{"events":[]},"ephemeral":{"events":[]},"state":{"events":[{"content":{"join_rule":"public"},"event_id":"$zCgCrw3aZwVaKm34:localhost","origin_server_ts":1493908927172,"sender":"@alice:localhost","state_key":"","type":"m.room.join_rules"}]},"timeline":{"events":[{"content":{"join_rule":"public"},"event_id":"$zCgCrw3aZwVaKm34:localhost","origin_server_ts":1493908927172,"sender":"@alice:localhost","state_key":"","type":"m.room.join_rules"},{"content":{"history_visibility":"joined"},"event_id":"$0NUtdnY7KWMhOR9E:localhost","origin_server_ts":1493908927174,"sender":"@alice:localhost","state_key":"","type":"m.room.history_visibility"}],"limited":false,"prev_batch":""}}},"leave":{}}}

Got:
{"account_data":{"events":[]},"next_batch":"5","presence":{"events":[]},"rooms":{"invite":{},"join":{"!gnrFfNAK7yGBWXFd:localhost":{"account_data":{"events":[]},"ephemeral":{"events":[]},"state":{"events":[{"content":{"join_rule":"public"},"event_id":"$zCgCrw3aZwVaKm34:localhost","origin_server_ts":1493908927172,"sender":"@alice:localhost","state_key":"","type":"m.room.join_rules"}]},"timeline":{"events":[{"content":{"join_rule":"public"},"event_id":"$zCgCrw3aZwVaKm34:localhost","origin_server_ts":1493908927172,"sender":"@alice:localhost","state_key":"","type":"m.room.join_rules"},{"content":{"history_visibility":"joined"},"event_id":"$0NUtdnY7KWMhOR9E:localhost","origin_server_ts":1493908927174,"sender":"@alice:localhost","state_key":"","type":"m.room.history_visibility"}],"limited":false,"prev_batch":""}}},"leave":{}}}
panic: dendrite-sync-api-server timed out

goroutine 1 [running]:
panic(0x2129c0, 0xc42014b680)
	/usr/local/go/src/runtime/panic.go:500 +0x1a1
main.testSyncServer(0xc42004fee8, 0x5, 0x5, 0xc42004feb8, 0x1, 0x1, 0x268cff, 0x1)
	/Users/kegan/github/dendrite/src/github.com/matrix-org/dendrite/cmd/syncserver-integration-tests/main.go:239 +0x678
main.main()
	/Users/kegan/github/dendrite/src/github.com/matrix-org/dendrite/cmd/syncserver-integration-tests/main.go:532 +0x1ac
```