### PR TITLE
Send the entire room state down when transitioning to 'join' on a /sync response

### DIFF
--- a/src/github.com/matrix-org/dendrite/cmd/syncserver-integration-tests/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/syncserver-integration-tests/main.go
@@ -392,7 +392,6 @@ func main() {
 	}
 
 	// Make sure alice sees it TODO: prev_batch
-	// TODO: Make sure bob sees it AND all the current room state
 	testSyncServer(syncServerCmdChan, "@alice:localhost", "9", `{
 		"account_data": {
 			"events": []
@@ -418,6 +417,46 @@ func main() {
 						"limited": false,
 						"prev_batch": "",
 						"events": [`+clientEventTestData[9]+`]
+					}
+				}
+			},
+			"leave": {}
+		}
+	}`)
+
+	// Make sure bob sees the room AND all the current room state TODO: history visibility
+	testSyncServer(syncServerCmdChan, "@bob:localhost", "9", `{
+		"account_data": {
+			"events": []
+		},
+		"next_batch": "10",
+		"presence": {
+			"events": []
+		},
+		"rooms": {
+			"invite": {},
+			"join": {
+				"!PjrbIMW2cIiaYF4t:localhost": {
+					"account_data": {
+						"events": []
+					},
+					"ephemeral": {
+						"events": []
+					},
+					"state": {
+						"events": [`+
+		clientEventTestData[0]+","+
+		clientEventTestData[1]+","+
+		clientEventTestData[2]+","+
+		clientEventTestData[3]+","+
+		clientEventTestData[4]+","+
+		clientEventTestData[8]+`]
+					},
+					"timeline": {
+						"limited": false,
+						"prev_batch": "",
+						"events": [`+
+		clientEventTestData[9]+`]
 					}
 				}
 			},

--- a/src/github.com/matrix-org/dendrite/syncapi/storage/output_room_events_table.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/storage/output_room_events_table.go
@@ -64,7 +64,7 @@ const selectMaxIDSQL = "" +
 // In order for us to apply the state updates correctly, rows need to be ordered in the order they were received (id).
 const selectStateInRangeSQL = "" +
 	"SELECT event_json, add_state_ids, remove_state_ids FROM output_room_events" +
-	" WHERE (id > $1 AND id < $2) AND (add_state_ids IS NOT NULL OR remove_state_ids IS NOT NULL)" +
+	" WHERE (id > $1 AND id <= $2) AND (add_state_ids IS NOT NULL OR remove_state_ids IS NOT NULL)" +
 	" ORDER BY id ASC"
 
 type outputRoomEventsStatements struct {
@@ -102,7 +102,7 @@ func (s *outputRoomEventsStatements) prepare(db *sql.DB) (err error) {
 	return
 }
 
-// StateBetween returns the state events between the two given stream positions, exclusive of both.
+// StateBetween returns the state events between the two given stream positions, exclusive of oldPos, inclusive of newPos.
 // Results are bucketed based on the room ID. If the same state is overwritten multiple times between the
 // two positions, only the most recent state is returned.
 func (s *outputRoomEventsStatements) StateBetween(txn *sql.Tx, oldPos, newPos types.StreamPosition) (map[string][]gomatrixserverlib.Event, error) {


### PR DESCRIPTION
This means that when a client joins a room, they will now be told things like
the membership list, room name, etc for the room.

This is only 'mostly' correct currently, because what should be no-op dupe
joins will actually trigger the entire room state to be re-sent. Bizarrely, it's
significantly easier to just do that than work out if we should, and there
are no client-visible effects to doing so, so we just do it for now.

Also fix an off-by-one error which appeared when testing this.
