### PR TITLE
Only wake up /sync requests which the event is for

### DIFF
--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-sync-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-sync-api-server/main.go
@@ -78,6 +78,9 @@ func main() {
 	}
 
 	n := sync.NewNotifier(types.StreamPosition(pos))
+	if err := n.Load(db); err != nil {
+		log.Panicf("startup: failed to set up notifier: %s", err)
+	}
 	server, err := consumers.NewServer(cfg, n, db)
 	if err != nil {
 		log.Panicf("startup: failed to create sync server: %s", err)

--- a/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
@@ -53,6 +53,11 @@ func NewSyncServerDatabase(dataSourceName string) (*SyncServerDatabase, error) {
 	return &SyncServerDatabase{db, partitions, events, state}, nil
 }
 
+// AllJoinedUsersInRooms returns a map of room ID to a list of all joined user IDs.
+func (d *SyncServerDatabase) AllJoinedUsersInRooms() (map[string][]string, error) {
+	return d.roomstate.JoinedMemberLists()
+}
+
 // WriteEvent into the database. It is not safe to call this function from multiple goroutines, as it would create races
 // when generating the stream position for this event. Returns the sync stream position for the inserted event.
 // Returns an error if there was a problem inserting this event.

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
@@ -122,7 +122,7 @@ func (n *Notifier) WaitForEvents(req syncRequest) types.StreamPosition {
 	// give up the stream lock prior to waiting on the user lock
 	stream := n.fetchUserStream(req.userID, true)
 	n.streamLock.Unlock()
-	return stream.Wait()
+	return stream.Wait(currentPos)
 }
 
 // Load the membership states required to notify users correctly.

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
@@ -84,7 +84,7 @@ func (n *Notifier) OnNewEvent(ev *gomatrixserverlib.Event, pos types.StreamPosit
 			case "invite":
 				userIDs = append(userIDs, userID)
 			case "join":
-				n.userJoined(ev.RoomID(), userID)
+				n.addJoinedUser(ev.RoomID(), userID)
 			case "leave":
 				fallthrough
 			case "ban":
@@ -131,14 +131,14 @@ func (n *Notifier) Load(db *storage.SyncServerDatabase) error {
 	if err != nil {
 		return err
 	}
-	n.usersJoinedToRooms(roomToUsers)
+	n.setUsersJoinedToRooms(roomToUsers)
 	return nil
 }
 
-// usersJoinedToRooms marks the given users as 'joined' to the given rooms, such that new events from
+// setUsersJoinedToRooms marks the given users as 'joined' to the given rooms, such that new events from
 // these rooms will wake the given users /sync requests. This should be called prior to ANY calls to
 // OnNewEvent (eg on startup) to prevent racing.
-func (n *Notifier) usersJoinedToRooms(roomIDToUserIDs map[string][]string) {
+func (n *Notifier) setUsersJoinedToRooms(roomIDToUserIDs map[string][]string) {
 	// This is just the bulk form of userJoined where we only lock once.
 	n.roomIDToJoinedUsersMutex.Lock()
 	defer n.roomIDToJoinedUsersMutex.Unlock()
@@ -180,7 +180,7 @@ func (n *Notifier) fetchUserStream(userID string, makeIfNotExists bool) *UserStr
 	return stream
 }
 
-func (n *Notifier) userJoined(roomID, userID string) {
+func (n *Notifier) addJoinedUser(roomID, userID string) {
 	n.roomIDToJoinedUsersMutex.Lock()
 	defer n.roomIDToJoinedUsersMutex.Unlock()
 	if _, ok := n.roomIDToJoinedUsers[roomID]; !ok {

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
@@ -15,27 +15,46 @@
 package sync
 
 import (
+	"encoding/json"
 	"sync"
 
+	log "github.com/Sirupsen/logrus"
+	"github.com/matrix-org/dendrite/clientapi/events"
 	"github.com/matrix-org/dendrite/syncapi/types"
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
-// Notifier will wake up sleeping requests in the request pool when there
-// is some new data. It does not tell requests what that data is, only the
-// stream position which they can use to get at it.
+// Notifier will wake up sleeping requests when there is some new data.
+// It does not tell requests what that data is, only the stream position which
+// they can use to get at it. This is done to prevent races whereby we tell the caller
+// the event, but the token has already advanced by the time they fetch it, resulting
+// in missed events.
 type Notifier struct {
-	// The latest sync stream position: guarded by 'cond'.
-	currPos types.StreamPosition
-	// A condition variable to notify all waiting goroutines of a new sync stream position
-	cond *sync.Cond
+	// The latest sync stream position: guarded by 'currPosMutex' which is RW to allow
+	// for concurrent reads on /sync requests
+	currPos      types.StreamPosition
+	currPosMutex *sync.RWMutex
+	// A map of RoomID => Set<UserID> : Map access is guarded by roomIDToJoinedUsersMutex.
+	roomIDToJoinedUsers      map[string]set
+	roomIDToJoinedUsersMutex *sync.Mutex
+	// A map of user_id => Cond which can be used to wake a given user's /sync request.
+	// Because this is a Cond, we can notify all waiting goroutines so this works
+	// across devices. Map access is guarded by userIDCondsMutex.
+	userIDConds      map[string]*sync.Cond
+	userIDCondsMutex *sync.Mutex
 }
 
 // NewNotifier creates a new notifier set to the given stream position.
+// In order for this to be of any use, the Notifier needs to be told all rooms and
+// the joined users within each of them by calling Notifier.UsersJoinedToRooms().
 func NewNotifier(pos types.StreamPosition) *Notifier {
 	return &Notifier{
-		pos,
-		sync.NewCond(&sync.Mutex{}),
+		currPos:                  pos,
+		currPosMutex:             &sync.RWMutex{},
+		roomIDToJoinedUsers:      make(map[string]set),
+		roomIDToJoinedUsersMutex: &sync.Mutex{},
+		userIDConds:              make(map[string]*sync.Cond),
+		userIDCondsMutex:         &sync.Mutex{},
 	}
 }
 
@@ -43,25 +62,166 @@ func NewNotifier(pos types.StreamPosition) *Notifier {
 // called from a single goroutine, to avoid races between updates which could set the
 // current position in the stream incorrectly.
 func (n *Notifier) OnNewEvent(ev *gomatrixserverlib.Event, pos types.StreamPosition) {
-	// update the current position in a guard and then notify all /sync streams
-	n.cond.L.Lock()
+	// update the current position in a guard and then notify relevant /sync streams.
+	// This needs to be done PRIOR to waking up users as they will read this value.
+	n.currPosMutex.Lock()
 	n.currPos = pos
-	n.cond.L.Unlock()
+	n.currPosMutex.Unlock()
 
-	n.cond.Broadcast() // notify ALL waiting goroutines
+	// Map this event's room_id to a list of joined users, and wake them up.
+	userIDs := n.joinedUsers(ev.RoomID())
+	// If this is an invite, also add in the invitee to this list.
+	if ev.Type() == "m.room.member" && ev.StateKey() != nil {
+		userID := *ev.StateKey()
+		var memberContent events.MemberContent
+		if err := json.Unmarshal(ev.Content(), &memberContent); err != nil {
+			log.WithError(err).WithField("event_id", ev.EventID()).Errorf(
+				"Notifier.OnNewEvent: Failed to unmarshal member event",
+			)
+		} else {
+			// Keep the joined user map up-to-date
+			switch memberContent.Membership {
+			case "invite":
+				userIDs = append(userIDs, userID)
+			case "join":
+				n.userJoined(ev.RoomID(), userID)
+			case "leave":
+				fallthrough
+			case "ban":
+				n.userLeft(ev.RoomID(), userID)
+			}
+		}
+	}
+
+	for _, userID := range userIDs {
+		n.wakeupUser(userID)
+	}
 }
 
 // WaitForEvents blocks until there are new events for this request.
 func (n *Notifier) WaitForEvents(req syncRequest) types.StreamPosition {
-	// In a guard, check if the /sync request should block, and block it until we get a new position
-	n.cond.L.Lock()
-	currentPos := n.currPos
-	for req.since == currentPos {
-		// we need to wait for a new event.
-		// TODO: This waits for ANY new event, we need to only wait for events which we care about.
-		n.cond.Wait() // atomically unlocks and blocks goroutine, then re-acquires lock on unblock
-		currentPos = n.currPos
+	// Do what synapse does: https://github.com/matrix-org/synapse/blob/v0.20.0/synapse/notifier.py#L298
+	// - Bucket request into a lookup map keyed off a list of joined room IDs and separately a user ID
+	// - Incoming events wake requests for a matching room ID
+	// - Incoming events wake requests for a matching user ID (needed for invites)
+
+	// TODO: v1 /events 'peeking' has an 'explicit room ID' which is also tracked,
+	//       but given we don't do /events, let's pretend it doesn't exist.
+
+	for {
+		// In a guard, check if the /sync request should block, and block it until we get woken up
+		n.currPosMutex.RLock()
+		currentPos := n.currPos
+		n.currPosMutex.RUnlock()
+
+		// TODO: We increment the stream position for any event, so it's possible that we return immediately
+		//       with a pos which contains no new events for this user. We should probably re-wait for events
+		//       automatically in this case.
+		if req.since != currentPos {
+			return currentPos
+		}
+
+		// wait to be woken up, and then re-check the stream position
+		req.log.WithField("user_id", req.userID).Info("Waiting for event")
+		n.blockUser(req.userID)
 	}
-	n.cond.L.Unlock()
-	return currentPos
+}
+
+// UsersJoinedToRooms marks the given users as 'joined' to the given rooms, such that new events from
+// these rooms will wake the given users /sync requests. This should be called prior to ANY calls to
+// OnNewEvent (eg on startup) to prevent racing.
+func (n *Notifier) UsersJoinedToRooms(roomIDToUserIDs map[string][]string) {
+	// This is just the bulk form of userJoined where we only lock once.
+	n.roomIDToJoinedUsersMutex.Lock()
+	defer n.roomIDToJoinedUsersMutex.Unlock()
+	for roomID, userIDs := range roomIDToUserIDs {
+		if _, ok := n.roomIDToJoinedUsers[roomID]; !ok {
+			n.roomIDToJoinedUsers[roomID] = make(set)
+		}
+		for _, userID := range userIDs {
+			n.roomIDToJoinedUsers[roomID].add(userID)
+		}
+	}
+}
+
+func (n *Notifier) wakeupUser(userID string) {
+	cond := n.fetchUserCond(userID, false)
+	if cond == nil {
+		return
+	}
+	cond.Broadcast() // wakeup all goroutines Wait()ing on this Cond
+}
+
+func (n *Notifier) blockUser(userID string) {
+	cond := n.fetchUserCond(userID, true)
+	cond.L.Lock()
+	cond.Wait()
+	cond.L.Unlock()
+}
+
+// fetchUserCond retrieves a Cond unique to the given user. If makeIfNotExists is true,
+// a Cond will be made for this user if one doesn't exist and it will be returned. This
+// function does not lock the Cond.
+func (n *Notifier) fetchUserCond(userID string, makeIfNotExists bool) *sync.Cond {
+	// There is a bit of a locking dance here, we want to lock the mutex protecting the map
+	// but NOT the Cond that we may be returning/creating.
+	n.userIDCondsMutex.Lock()
+	defer n.userIDCondsMutex.Unlock()
+	cond, ok := n.userIDConds[userID]
+	if !ok {
+		// TODO: Unbounded growth of locks (1 per user)
+		cond = sync.NewCond(&sync.Mutex{})
+		n.userIDConds[userID] = cond
+	}
+	return cond
+}
+
+func (n *Notifier) userJoined(roomID, userID string) {
+	n.roomIDToJoinedUsersMutex.Lock()
+	defer n.roomIDToJoinedUsersMutex.Unlock()
+	if _, ok := n.roomIDToJoinedUsers[roomID]; !ok {
+		n.roomIDToJoinedUsers[roomID] = make(set)
+	}
+	n.roomIDToJoinedUsers[roomID].add(userID)
+}
+
+func (n *Notifier) userLeft(roomID, userID string) {
+	n.roomIDToJoinedUsersMutex.Lock()
+	defer n.roomIDToJoinedUsersMutex.Unlock()
+	if _, ok := n.roomIDToJoinedUsers[roomID]; !ok {
+		n.roomIDToJoinedUsers[roomID] = make(set)
+	}
+	n.roomIDToJoinedUsers[roomID].remove(userID)
+}
+
+func (n *Notifier) joinedUsers(roomID string) (userIDs []string) {
+	n.roomIDToJoinedUsersMutex.Lock()
+	defer n.roomIDToJoinedUsersMutex.Unlock()
+	if _, ok := n.roomIDToJoinedUsers[roomID]; !ok {
+		return
+	}
+	return n.roomIDToJoinedUsers[roomID].values()
+}
+
+// A string set, mainly existing for improving clarity of structs in this file.
+type set map[string]bool
+
+func (s set) add(str string) {
+	s[str] = true
+}
+
+func (s set) remove(str string) {
+	delete(s, str)
+}
+
+func (s set) has(str string) bool {
+	_, ok := s[str]
+	return ok
+}
+
+func (s set) values() (vals []string) {
+	for str := range s {
+		vals = append(vals, str)
+	}
+	return
 }

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/notifier_test.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/notifier_test.go
@@ -1,0 +1,137 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sync
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/matrix-org/dendrite/syncapi/types"
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/util"
+)
+
+var randomMessageEvent gomatrixserverlib.Event
+
+func init() {
+	var err error
+	randomMessageEvent, err = gomatrixserverlib.NewEventFromTrustedJSON([]byte(`{
+		"type": "m.room.message",
+		"content": {
+			"body": "Hello World",
+			"msgtype": "m.text"
+		},
+		"sender": "@noone:localhost",
+		"room_id": "!test:localhost",
+		"origin_server_ts": 12345,
+		"event_id": "$something:localhost"
+	}`), false)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// Test that the current position is returned if a request is already behind.
+func TestImmediateNotification(t *testing.T) {
+	currPos := types.StreamPosition(11)
+	n := NewNotifier(currPos)
+	pos, err := waitForEvents(n, newTestSyncRequest("@alice:localhost", types.StreamPosition(9)))
+	if err != nil {
+		t.Fatalf("TestImmediateNotification error: %s", err)
+	}
+	if pos != currPos {
+		t.Fatalf("TestImmediateNotification want %d, got %d", currPos, pos)
+	}
+}
+
+// Test that new events to a joined room unblocks the request.
+func TestNewEventAndJoinedToRoom(t *testing.T) {
+	currPos := types.StreamPosition(11)
+	newPos := types.StreamPosition(12)
+	n := NewNotifier(currPos)
+	n.usersJoinedToRooms(map[string][]string{
+		"!test:localhost": []string{"@alice:localhost", "@bob:localhost"},
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		pos, err := waitForEvents(n, newTestSyncRequest("@bob:localhost", types.StreamPosition(11)))
+		if err != nil {
+			t.Errorf("TestNewEventAndJoinedToRoom error: %s", err)
+		}
+		if pos != newPos {
+			t.Errorf("TestNewEventAndJoinedToRoom want %d, got %d", newPos, pos)
+		}
+		wg.Done()
+	}()
+	time.Sleep(1 * time.Millisecond)
+
+	n.OnNewEvent(&randomMessageEvent, types.StreamPosition(12))
+
+	wg.Wait()
+}
+
+// Test that new events to a not joined room does not unblock the request.
+func TestNewEventAndNotJoinedToRoom(t *testing.T) {
+
+}
+
+// Test that an invite unblocks the request
+func TestNewInviteEventForUser(t *testing.T) {
+
+}
+
+// Test that all blocked requests get woken up on a new event.
+func TestMultipleRequestWakeup(t *testing.T) {
+
+}
+
+// Test that you stop getting unblocked when you leave a room.
+func TestNewEventAndWasPreviouslyJoinedToRoom(t *testing.T) {
+
+}
+
+// same as Notifier.WaitForEvents but with a timeout.
+func waitForEvents(n *Notifier, req syncRequest) (types.StreamPosition, error) {
+	done := make(chan types.StreamPosition, 1)
+	go func() {
+		newPos := n.WaitForEvents(req)
+		done <- newPos
+		close(done)
+	}()
+	select {
+	case <-time.After(5 * time.Second):
+		return types.StreamPosition(0), fmt.Errorf(
+			"waitForEvents timed out waiting for %s (pos=%d)", req.userID, req.since,
+		)
+	case p := <-done:
+		return p, nil
+	}
+}
+
+func newTestSyncRequest(userID string, since types.StreamPosition) syncRequest {
+	return syncRequest{
+		userID:        userID,
+		timeout:       1 * time.Minute,
+		since:         since,
+		wantFullState: false,
+		limit:         defaultTimelineLimit,
+		log:           util.GetLogger(context.TODO()),
+	}
+}

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/notifier_test.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/notifier_test.go
@@ -103,7 +103,7 @@ func TestImmediateNotification(t *testing.T) {
 // Test that new events to a joined room unblocks the request.
 func TestNewEventAndJoinedToRoom(t *testing.T) {
 	n := NewNotifier(streamPositionBefore)
-	n.usersJoinedToRooms(map[string][]string{
+	n.setUsersJoinedToRooms(map[string][]string{
 		roomID: []string{alice, bob},
 	})
 
@@ -131,7 +131,7 @@ func TestNewEventAndJoinedToRoom(t *testing.T) {
 // Test that an invite unblocks the request
 func TestNewInviteEventForUser(t *testing.T) {
 	n := NewNotifier(streamPositionBefore)
-	n.usersJoinedToRooms(map[string][]string{
+	n.setUsersJoinedToRooms(map[string][]string{
 		roomID: []string{alice, bob},
 	})
 
@@ -159,7 +159,7 @@ func TestNewInviteEventForUser(t *testing.T) {
 // Test that all blocked requests get woken up on a new event.
 func TestMultipleRequestWakeup(t *testing.T) {
 	n := NewNotifier(streamPositionBefore)
-	n.usersJoinedToRooms(map[string][]string{
+	n.setUsersJoinedToRooms(map[string][]string{
 		roomID: []string{alice, bob},
 	})
 
@@ -197,7 +197,7 @@ func TestNewEventAndWasPreviouslyJoinedToRoom(t *testing.T) {
 	// listen as bob. Make bob leave room. Make alice send event to room.
 	// Make sure alice gets woken up only and not bob as well.
 	n := NewNotifier(streamPositionBefore)
-	n.usersJoinedToRooms(map[string][]string{
+	n.setUsersJoinedToRooms(map[string][]string{
 		roomID: []string{alice, bob},
 	})
 

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/notifier_test.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/notifier_test.go
@@ -80,7 +80,9 @@ func TestNewEventAndJoinedToRoom(t *testing.T) {
 		}
 		wg.Done()
 	}()
-	time.Sleep(1 * time.Millisecond)
+
+	stream := n.fetchUserStream("@bob:localhost", true)
+	waitForBlocking(stream, 1)
 
 	n.OnNewEvent(&randomMessageEvent, types.StreamPosition(12))
 
@@ -122,6 +124,14 @@ func waitForEvents(n *Notifier, req syncRequest) (types.StreamPosition, error) {
 		)
 	case p := <-done:
 		return p, nil
+	}
+}
+
+// Wait until something is Wait()ing on the user stream.
+func waitForBlocking(s *UserStream, numBlocking int) {
+	for numBlocking != s.NumWaiting() {
+		// This is horrible but I don't want to add a signalling mechanism JUST for testing.
+		time.Sleep(1 * time.Microsecond)
 	}
 }
 

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/request.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/request.go
@@ -15,10 +15,13 @@
 package sync
 
 import (
-	"github.com/matrix-org/dendrite/syncapi/types"
 	"net/http"
 	"strconv"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/matrix-org/dendrite/syncapi/types"
+	"github.com/matrix-org/util"
 )
 
 const defaultSyncTimeout = time.Duration(30) * time.Second
@@ -31,6 +34,7 @@ type syncRequest struct {
 	timeout       time.Duration
 	since         types.StreamPosition
 	wantFullState bool
+	log           *log.Entry
 }
 
 func newSyncRequest(req *http.Request, userID string) (*syncRequest, error) {
@@ -48,6 +52,7 @@ func newSyncRequest(req *http.Request, userID string) (*syncRequest, error) {
 		since:         since,
 		wantFullState: wantFullState,
 		limit:         defaultTimelineLimit, // TODO: read from filter
+		log:           util.GetLogger(req.Context()),
 	}, nil
 }
 

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
@@ -99,7 +99,7 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request) util.JSONRespons
 }
 
 func (rp *RequestPool) currentSyncForUser(req syncRequest) (*types.Response, error) {
-	currentPos := rp.notifier.WaitForEvents(req, false)
+	currentPos := rp.notifier.WaitForEvents(req)
 
 	if req.since == types.StreamPosition(0) {
 		pos, data, err := rp.db.CompleteSync(req.userID, req.limit)

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
@@ -99,7 +99,7 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request) util.JSONRespons
 }
 
 func (rp *RequestPool) currentSyncForUser(req syncRequest) (*types.Response, error) {
-	currentPos := rp.notifier.WaitForEvents(req)
+	currentPos := rp.notifier.WaitForEvents(req, false)
 
 	if req.since == types.StreamPosition(0) {
 		pos, data, err := rp.db.CompleteSync(req.userID, req.limit)

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/userstream.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/userstream.go
@@ -1,0 +1,57 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package sync
+
+import (
+	"sync"
+
+	"github.com/matrix-org/dendrite/syncapi/types"
+)
+
+// UserStream represents a communication mechanism between the /sync request goroutine
+// and the underlying sync server goroutines. Goroutines can Wait() for a stream position and
+// goroutines can Broadcast(streamPosition) to other goroutines.
+type UserStream struct {
+	UserID string
+	// Because this is a Cond, we can notify all waiting goroutines so this works
+	// across devices. Protects pos.
+	cond *sync.Cond
+	// The position to broadcast to callers of Wait().
+	pos types.StreamPosition
+}
+
+// NewUserStream creates a new user stream
+func NewUserStream(userID string) *UserStream {
+	return &UserStream{
+		UserID: userID,
+		cond:   sync.NewCond(&sync.Mutex{}),
+	}
+}
+
+// Wait blocks until there is a new stream position for this user, which is then returned.
+func (s *UserStream) Wait() (pos types.StreamPosition) {
+	s.cond.L.Lock()
+	s.cond.Wait()
+	pos = s.pos
+	s.cond.L.Unlock()
+	return
+}
+
+// Broadcast a new stream position for this user.
+func (s *UserStream) Broadcast(pos types.StreamPosition) {
+	s.cond.L.Lock()
+	s.pos = pos
+	s.cond.L.Unlock()
+	s.cond.Broadcast()
+}

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/userstream.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/userstream.go
@@ -45,10 +45,10 @@ func NewUserStream(userID string) *UserStream {
 // Wait blocks until there is a new stream position for this user, which is then returned.
 func (s *UserStream) Wait() (pos types.StreamPosition) {
 	s.cond.L.Lock()
-	s.numWaiting += 1
+	s.numWaiting++
 	s.cond.Wait()
 	pos = s.pos
-	s.numWaiting -= 1
+	s.numWaiting--
 	s.cond.L.Unlock()
 	return
 }


### PR DESCRIPTION
Really long PR, sorry :disappointed: 

The gist is:
 - Add logic to `Notifier` to determine which /sync streams to wake up (based on who is joined to which room)
 - Add `database.AllJoinedUsersInRooms()` so the `Notifier` can know who is joined to which rooms at startup. Kept up-to-date by the Kafka consumer.

In my defence, 300 lines are purely for unit tests :(