### PR TITLE
Remove intermediary /sync response struct

### DIFF
--- a/src/github.com/matrix-org/dendrite/syncapi/types/types.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/types/types.go
@@ -28,12 +28,6 @@ func (sp StreamPosition) String() string {
 	return strconv.FormatInt(int64(sp), 10)
 }
 
-// RoomData represents the data for a room suitable for building a sync response from.
-type RoomData struct {
-	State        []gomatrixserverlib.Event
-	RecentEvents []gomatrixserverlib.Event
-}
-
 // Response represents a /sync API response. See https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-sync
 type Response struct {
 	NextBatch   string `json:"next_batch"`


### PR DESCRIPTION
The logic required to populate the right bits of `RoomData` tends towards
the complete `/sync` response struct, so just use the actual response struct
and save the hassle of mapping between the two. It may not make much difference
in its current form, but the next PR will make use of this.

This PR has no functional changes.