### PR TITLE
Minor refactoring

### DIFF
--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-sync-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-sync-api-server/main.go
@@ -81,12 +81,12 @@ func main() {
 	if err := n.Load(db); err != nil {
 		log.Panicf("startup: failed to set up notifier: %s", err)
 	}
-	server, err := consumers.NewServer(cfg, n, db)
+	consumer, err := consumers.NewRoomserver(cfg, n, db)
 	if err != nil {
-		log.Panicf("startup: failed to create sync server: %s", err)
+		log.Panicf("startup: failed to create room server consumer: %s", err)
 	}
-	if err = server.Start(); err != nil {
-		log.Panicf("startup: failed to start sync server")
+	if err = consumer.Start(); err != nil {
+		log.Panicf("startup: failed to start room server consumer")
 	}
 
 	log.Info("Starting sync server on ", *bindAddr)

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-sync-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-sync-api-server/main.go
@@ -81,7 +81,7 @@ func main() {
 	if err := n.Load(db); err != nil {
 		log.Panicf("startup: failed to set up notifier: %s", err)
 	}
-	consumer, err := consumers.NewRoomserver(cfg, n, db)
+	consumer, err := consumers.NewOutputRoomEvent(cfg, n, db)
 	if err != nil {
 		log.Panicf("startup: failed to create room server consumer: %s", err)
 	}

--- a/src/github.com/matrix-org/dendrite/syncapi/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/consumers/roomserver.go
@@ -28,15 +28,15 @@ import (
 	sarama "gopkg.in/Shopify/sarama.v1"
 )
 
-// Roomserver consumes events that originated in the room server.
-type Roomserver struct {
+// OutputRoomEvent consumes events that originated in the room server.
+type OutputRoomEvent struct {
 	roomServerConsumer *common.ContinualConsumer
 	db                 *storage.SyncServerDatabase
 	notifier           *sync.Notifier
 }
 
-// NewRoomserver creates a new room server consumer. Call Start() to begin consuming from room servers.
-func NewRoomserver(cfg *config.Sync, n *sync.Notifier, store *storage.SyncServerDatabase) (*Roomserver, error) {
+// NewOutputRoomEvent creates a new OutputRoomEvent consumer. Call Start() to begin consuming from room servers.
+func NewOutputRoomEvent(cfg *config.Sync, n *sync.Notifier, store *storage.SyncServerDatabase) (*OutputRoomEvent, error) {
 	kafkaConsumer, err := sarama.NewConsumer(cfg.KafkaConsumerURIs, nil)
 	if err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ func NewRoomserver(cfg *config.Sync, n *sync.Notifier, store *storage.SyncServer
 		Consumer:       kafkaConsumer,
 		PartitionStore: store,
 	}
-	s := &Roomserver{
+	s := &OutputRoomEvent{
 		roomServerConsumer: &consumer,
 		db:                 store,
 		notifier:           n,
@@ -58,14 +58,14 @@ func NewRoomserver(cfg *config.Sync, n *sync.Notifier, store *storage.SyncServer
 }
 
 // Start consuming from room servers
-func (s *Roomserver) Start() error {
+func (s *OutputRoomEvent) Start() error {
 	return s.roomServerConsumer.Start()
 }
 
 // onMessage is called when the sync server receives a new event from the room server output log.
 // It is not safe for this function to be called from multiple goroutines, or else the
 // sync stream position may race and be incorrectly calculated.
-func (s *Roomserver) onMessage(msg *sarama.ConsumerMessage) error {
+func (s *OutputRoomEvent) onMessage(msg *sarama.ConsumerMessage) error {
 	// Parse out the event JSON
 	var output api.OutputRoomEvent
 	if err := json.Unmarshal(msg.Value, &output); err != nil {

--- a/src/github.com/matrix-org/dendrite/syncapi/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/consumers/roomserver.go
@@ -28,15 +28,15 @@ import (
 	sarama "gopkg.in/Shopify/sarama.v1"
 )
 
-// Server contains all the logic for running a sync server
-type Server struct {
+// Roomserver consumes events that originated in the room server.
+type Roomserver struct {
 	roomServerConsumer *common.ContinualConsumer
 	db                 *storage.SyncServerDatabase
 	notifier           *sync.Notifier
 }
 
-// NewServer creates a new sync server. Call Start() to begin consuming from room servers.
-func NewServer(cfg *config.Sync, n *sync.Notifier, store *storage.SyncServerDatabase) (*Server, error) {
+// NewRoomserver creates a new room server consumer. Call Start() to begin consuming from room servers.
+func NewRoomserver(cfg *config.Sync, n *sync.Notifier, store *storage.SyncServerDatabase) (*Roomserver, error) {
 	kafkaConsumer, err := sarama.NewConsumer(cfg.KafkaConsumerURIs, nil)
 	if err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ func NewServer(cfg *config.Sync, n *sync.Notifier, store *storage.SyncServerData
 		Consumer:       kafkaConsumer,
 		PartitionStore: store,
 	}
-	s := &Server{
+	s := &Roomserver{
 		roomServerConsumer: &consumer,
 		db:                 store,
 		notifier:           n,
@@ -58,14 +58,14 @@ func NewServer(cfg *config.Sync, n *sync.Notifier, store *storage.SyncServerData
 }
 
 // Start consuming from room servers
-func (s *Server) Start() error {
+func (s *Roomserver) Start() error {
 	return s.roomServerConsumer.Start()
 }
 
 // onMessage is called when the sync server receives a new event from the room server output log.
 // It is not safe for this function to be called from multiple goroutines, or else the
 // sync stream position may race and be incorrectly calculated.
-func (s *Server) onMessage(msg *sarama.ConsumerMessage) error {
+func (s *Roomserver) onMessage(msg *sarama.ConsumerMessage) error {
 	// Parse out the event JSON
 	var output api.OutputRoomEvent
 	if err := json.Unmarshal(msg.Value, &output); err != nil {


### PR DESCRIPTION
- `s/Server/Roomserver/` in `consumers` to accurately reflect what is being consumed.
- `s/set/userIDSet/` in `notifier.go` for clarity.
- Removed lying comments.