### PR TITLE
.travis.yml: Bump golang to 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
- - 1.7
+ - 1.8
 
 sudo: false
 


### PR DESCRIPTION
@NegativeMjark says he's started using 1.8 in gomatrixserverlib and I've used it in #107. This just bumps the version used by travis. Is there anything else to be done, aside from if errors are detected?