### PR TITLE
Rename "make" to "makeAPI" and factor out some more common code into it

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -148,6 +148,6 @@ func Setup(servMux *http.ServeMux, httpClient *http.Client, cfg config.ClientAPI
 
 // make a util.JSONRequestHandler function into an http.Handler.
 func makeAPI(metricsName string, f func(*http.Request) util.JSONResponse) http.Handler {
-	h := util.NewJSONRequestHander(f)
+	h := util.NewJSONRequestHandler(f)
 	return prometheus.InstrumentHandler(metricsName, util.MakeJSONAPI(h))
 }


### PR DESCRIPTION
Naming a function the same as a go builtin function seems like a bad
idea. Also move the call to `NewJSONRequestHander` inside the function
rather than calling it everywhere.