### PR TITLE
Rename packages under /auth

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/accounts_table.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/accounts_table.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storage
+package accounts
 
 import (
 	"database/sql"

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package storage
+package accounts
 
 import (
 	"database/sql"
@@ -23,14 +23,14 @@ import (
 	_ "github.com/lib/pq"
 )
 
-// AccountDatabase represents an account database
-type AccountDatabase struct {
+// Database represents an account database
+type Database struct {
 	db       *sql.DB
 	accounts accountsStatements
 }
 
-// NewAccountDatabase creates a new accounts database
-func NewAccountDatabase(dataSourceName string, serverName gomatrixserverlib.ServerName) (*AccountDatabase, error) {
+// NewDatabase creates a new accounts database
+func NewDatabase(dataSourceName string, serverName gomatrixserverlib.ServerName) (*Database, error) {
 	var db *sql.DB
 	var err error
 	if db, err = sql.Open("postgres", dataSourceName); err != nil {
@@ -40,12 +40,12 @@ func NewAccountDatabase(dataSourceName string, serverName gomatrixserverlib.Serv
 	if err = a.prepare(db, serverName); err != nil {
 		return nil, err
 	}
-	return &AccountDatabase{db, a}, nil
+	return &Database{db, a}, nil
 }
 
 // GetAccountByPassword returns the account associated with the given localpart and password.
 // Returns sql.ErrNoRows if no account exists which matches the given credentials.
-func (d *AccountDatabase) GetAccountByPassword(localpart, plaintextPassword string) (*types.Account, error) {
+func (d *Database) GetAccountByPassword(localpart, plaintextPassword string) (*types.Account, error) {
 	hash, err := d.accounts.selectPasswordHash(localpart)
 	if err != nil {
 		return nil, err
@@ -58,7 +58,7 @@ func (d *AccountDatabase) GetAccountByPassword(localpart, plaintextPassword stri
 
 // CreateAccount makes a new account with the given login name and password. If no password is supplied,
 // the account will be a passwordless account.
-func (d *AccountDatabase) CreateAccount(localpart, plaintextPassword string) (*types.Account, error) {
+func (d *Database) CreateAccount(localpart, plaintextPassword string) (*types.Account, error) {
 	hash, err := hashPassword(plaintextPassword)
 	if err != nil {
 		return nil, err

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/devices/storage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/devices/storage.go
@@ -12,18 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package types
+package devices
 
-import (
-	"github.com/matrix-org/gomatrixserverlib"
-)
+// Database represents a device database.
+type Database struct {
+	// TODO
+}
 
-// Account represents a Matrix account on this home server.
-type Account struct {
-	UserID     string
-	Localpart  string
-	ServerName gomatrixserverlib.ServerName
-	// TODO: Other flags like IsAdmin, IsGuest
-	// TODO: Devices
-	// TODO: Associations (e.g. with application services)
+// NewDatabase creates a new device database
+func NewDatabase() *Database {
+	return &Database{}
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/types/device.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/types/device.go
@@ -14,16 +14,10 @@
 
 package types
 
-import (
-	"github.com/matrix-org/gomatrixserverlib"
-)
-
-// Account represents a Matrix account on this home server.
-type Account struct {
-	UserID     string
-	Localpart  string
-	ServerName gomatrixserverlib.ServerName
-	// TODO: Other flags like IsAdmin, IsGuest
-	// TODO: Devices
-	// TODO: Associations (e.g. with application services)
+// Device represents a client's device (mobile, web, etc)
+type Device struct {
+	ID          string
+	UserID      string
+	AccessToken string
+	// TODO: display name, last used timestamp, keys, etc
 }

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-client-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-client-api-server/main.go
@@ -19,7 +19,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/matrix-org/dendrite/clientapi/auth/storage"
+	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
 	"github.com/matrix-org/dendrite/clientapi/config"
 	"github.com/matrix-org/dendrite/clientapi/producers"
 	"github.com/matrix-org/dendrite/clientapi/routing"
@@ -81,7 +81,7 @@ func main() {
 	}
 
 	queryAPI := api.NewRoomserverQueryAPIHTTP(cfg.RoomserverURL, nil)
-	accountDB, err := storage.NewAccountDatabase(accountDataSource, serverName)
+	accountDB, err := accounts.NewDatabase(accountDataSource, serverName)
 	if err != nil {
 		log.Panicf("Failed to setup account database(%s): %s", accountDataSource, err.Error())
 	}


### PR DESCRIPTION
Previously, all database stuff was under the helpfully named
package 'storage'. However, this convention is used throughout all
of dendrite, which will clash the moment we want to add auth to all
the CS API endpoints. To prevent the package name clash, add
sub-directories which represent what is being stored so the final
usage ends up being:

```
func doThing(db *storage.SyncServerDatabase, authDB *accounts.Database)
{
    // ...
}
```

Add a stub `devices.Database` which will be used in the next PR for storing access tokens.