### PR TITLE
Start implementing /join for room aliases for rooms the server is not in.

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/producers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/producers/roomserver.go
@@ -92,6 +92,7 @@ func (c *RoomserverProducer) SendEventWithState(state gomatrixserverlib.RespStat
 	return c.SendInputRoomEvents(ires, eventIDs)
 }
 
+// TODO Make this a method on gomatrixserverlib.Event
 func authEventIDs(event gomatrixserverlib.Event) (ids []string) {
 	for _, ref := range event.AuthEvents() {
 		ids = append(ids, ref.EventID)

--- a/src/github.com/matrix-org/dendrite/clientapi/producers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/producers/roomserver.go
@@ -57,7 +57,7 @@ func (c *RoomserverProducer) SendEvents(events []gomatrixserverlib.Event) error 
 }
 
 // SendEventWithState writes an event with KindNew to the roomserver input log
-// preceeded by the state at the event as KindOutlier.
+// with the state at the event as KindOutlier before it.
 func (c *RoomserverProducer) SendEventWithState(state gomatrixserverlib.RespState, event gomatrixserverlib.Event) error {
 	outliers, err := state.Events()
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/clientapi/producers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/producers/roomserver.go
@@ -45,20 +45,58 @@ func NewRoomserverProducer(kafkaURIs []string, topic string) (*RoomserverProduce
 func (c *RoomserverProducer) SendEvents(events []gomatrixserverlib.Event) error {
 	eventIDs := make([]string, len(events))
 	ires := make([]api.InputRoomEvent, len(events))
-	for i := range events {
-		var authEventIDs []string
-		for _, ref := range events[i].AuthEvents() {
-			authEventIDs = append(authEventIDs, ref.EventID)
-		}
-		ire := api.InputRoomEvent{
+	for i, event := range events {
+		ires[i] = api.InputRoomEvent{
 			Kind:         api.KindNew,
-			Event:        events[i].JSON(),
-			AuthEventIDs: authEventIDs,
+			Event:        event.JSON(),
+			AuthEventIDs: authEventIDs(event),
 		}
-		ires[i] = ire
-		eventIDs[i] = events[i].EventID()
+		eventIDs[i] = event.EventID()
 	}
 	return c.SendInputRoomEvents(ires, eventIDs)
+}
+
+// SendEventWithState writes an event with KindNew to the roomserver input log
+// preceeded by the state at the event as KindOutlier.
+func (c *RoomserverProducer) SendEventWithState(state gomatrixserverlib.RespState, event gomatrixserverlib.Event) error {
+	outliers, err := state.Events()
+	if err != nil {
+		return err
+	}
+
+	eventIDs := make([]string, len(outliers)+1)
+	ires := make([]api.InputRoomEvent, len(outliers)+1)
+	for i, outlier := range outliers {
+		ires[i] = api.InputRoomEvent{
+			Kind:         api.KindOutlier,
+			Event:        outlier.JSON(),
+			AuthEventIDs: authEventIDs(outlier),
+		}
+		eventIDs[i] = outlier.EventID()
+	}
+
+	stateEventIDs := make([]string, len(state.StateEvents))
+	for i := range state.StateEvents {
+		stateEventIDs[i] = state.StateEvents[i].EventID()
+	}
+
+	ires[len(outliers)] = api.InputRoomEvent{
+		Kind:          api.KindNew,
+		Event:         event.JSON(),
+		AuthEventIDs:  authEventIDs(event),
+		HasState:      true,
+		StateEventIDs: stateEventIDs,
+	}
+	eventIDs[len(outliers)] = event.EventID()
+
+	return c.SendInputRoomEvents(ires, eventIDs)
+}
+
+func authEventIDs(event gomatrixserverlib.Event) (ids []string) {
+	for _, ref := range event.AuthEvents() {
+		ids = append(ids, ref.EventID)
+	}
+	return
 }
 
 // SendInputRoomEvents writes the given input room events to the roomserver input log. The length of both

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -40,9 +40,10 @@ const pathPrefixR0 = "/_matrix/client/r0"
 func Setup(
 	servMux *http.ServeMux, httpClient *http.Client, cfg config.ClientAPI,
 	producer *producers.RoomserverProducer, queryAPI api.RoomserverQueryAPI,
-	accountDB *storage.AccountDatabase,
+	accountDB *accounts.Database,
 	deviceDB *devices.Database,
 	federation *gomatrixserverlib.FederationClient,
+	keyRing gomatrixserverlib.KeyRing,
 ) {
 	apiMux := mux.NewRouter()
 	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
@@ -52,10 +53,10 @@ func Setup(
 		}),
 	)
 	r0mux.Handle("/join/{roomIDOrAlias}",
-		makeAPI("join", func(req *http.Request) util.JSONResponse {
+		common.MakeAuthAPI("join", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return writers.JoinRoomByIDOrAlias(
-				req, vars["roomIDOrAlias"], cfg, federation, producer, queryAPI,
+				req, device, vars["roomIDOrAlias"], cfg, federation, producer, queryAPI, keyRing,
 			)
 		}),
 	)

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -28,6 +28,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/writers"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -36,13 +37,26 @@ const pathPrefixR0 = "/_matrix/client/r0"
 
 // Setup registers HTTP handlers with the given ServeMux. It also supplies the given http.Client
 // to clients which need to make outbound HTTP requests.
-func Setup(servMux *http.ServeMux, httpClient *http.Client, cfg config.ClientAPI, producer *producers.RoomserverProducer,
-	queryAPI api.RoomserverQueryAPI, accountDB *accounts.Database, deviceDB *devices.Database) {
+func Setup(
+	servMux *http.ServeMux, httpClient *http.Client, cfg config.ClientAPI,
+	producer *producers.RoomserverProducer, queryAPI api.RoomserverQueryAPI,
+	accountDB *storage.AccountDatabase,
+	deviceDB *devices.Database,
+	federation *gomatrixserverlib.FederationClient,
+) {
 	apiMux := mux.NewRouter()
 	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
 	r0mux.Handle("/createRoom",
 		common.MakeAuthAPI("createRoom", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			return writers.CreateRoom(req, device, cfg, producer)
+		}),
+	)
+	r0mux.Handle("/join/{roomIDOrAlias}",
+		makeAPI("join", func(req *http.Request) util.JSONResponse {
+			vars := mux.Vars(req)
+			return writers.JoinRoomByIDOrAlias(
+				req, vars["roomIDOrAlias"], cfg, federation, producer, queryAPI,
+			)
 		}),
 	)
 	r0mux.Handle("/rooms/{roomID}/send/{eventType}/{txnID}",

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/joinroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/joinroom.go
@@ -167,12 +167,13 @@ func (r joinRoomReq) joinRoomUsingServers(
 		}
 	}
 
+	var lastErr error
 	for _, server := range servers {
 		var response *util.JSONResponse
-		response, err = r.joinRoomUsingServer(roomID, server)
-		if err != nil {
+		response, lastErr = r.joinRoomUsingServer(roomID, server)
+		if lastErr != nil {
 			// There was a problem talking to one of the servers.
-			util.GetLogger(r.req.Context()).WithError(err).WithField("server", server).Warn("Failed to join room using server")
+			util.GetLogger(r.req.Context()).WithError(lastErr).WithField("server", server).Warn("Failed to join room using server")
 			// Try the next server.
 			continue
 		}
@@ -192,7 +193,7 @@ func (r joinRoomReq) joinRoomUsingServers(
 	//   4) We couldn't fetch the public keys needed to verify the
 	//      signatures on the state events.
 	//   5) ...
-	return httputil.LogThenError(r.req, err)
+	return httputil.LogThenError(r.req, lastErr)
 }
 
 // joinRoomUsingServer tries to join a remote room using a given matrix server.

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/joinroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/joinroom.go
@@ -1,0 +1,223 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package writers
+
+import (
+	"fmt"
+	"github.com/matrix-org/dendrite/clientapi/auth"
+	"github.com/matrix-org/dendrite/clientapi/config"
+	"github.com/matrix-org/dendrite/clientapi/httputil"
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"github.com/matrix-org/dendrite/clientapi/producers"
+	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/gomatrix"
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/util"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// JoinRoomByIDOrAlias implements the "/join/{roomIDOrAlias}" API.
+// https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-join-roomidoralias
+func JoinRoomByIDOrAlias(
+	req *http.Request,
+	roomIDOrAlias string,
+	cfg config.ClientAPI,
+	federation *gomatrixserverlib.FederationClient,
+	producer *producers.RoomserverProducer,
+	queryAPI api.RoomserverQueryAPI,
+) util.JSONResponse {
+	userID, resErr := auth.VerifyAccessToken(req)
+	if resErr != nil {
+		return *resErr
+	}
+	var content map[string]interface{} // must be a JSON object
+	if resErr := httputil.UnmarshalJSONRequest(req, &content); resErr != nil {
+		return *resErr
+	}
+
+	content["membership"] = "join"
+
+	r := joinRoomReq{req, content, userID, cfg, federation, producer, queryAPI}
+
+	if strings.HasPrefix(roomIDOrAlias, "!") {
+		return r.joinRoomByID()
+	}
+	if strings.HasPrefix(roomIDOrAlias, "#") {
+		return r.joinRoomByAlias(roomIDOrAlias)
+	}
+	return util.JSONResponse{
+		Code: 400,
+		JSON: jsonerror.BadJSON("Invalid first character for room ID or alias"),
+	}
+}
+
+type joinRoomReq struct {
+	req        *http.Request
+	content    map[string]interface{}
+	userID     string
+	cfg        config.ClientAPI
+	federation *gomatrixserverlib.FederationClient
+	producer   *producers.RoomserverProducer
+	queryAPI   api.RoomserverQueryAPI
+}
+
+// joinRoomByID joins a room by roomID
+func (r joinRoomReq) joinRoomByID() util.JSONResponse {
+	// TODO: Implement joining rooms by ID.
+	// A client should only join a room by roomID when it has an invite
+	// to the room. If the server is already in the room then we can
+	// lookup the invite and process the request as a normal state event.
+	// If the server is not in the room the we will need to look up the
+	// remote server the invite came from in order to request a join event
+	// from that server.
+	panic(fmt.Errorf("Joining rooms by ID is not implemented"))
+}
+
+// joinRoomByAlias joins a room using a room alias.
+func (r joinRoomReq) joinRoomByAlias(roomAlias string) util.JSONResponse {
+	domain, err := domainFromID(roomAlias)
+	if err != nil {
+		return util.JSONResponse{
+			Code: 400,
+			JSON: jsonerror.BadJSON("Room alias must be in the form '#localpart:domain'"),
+		}
+	}
+	if domain == r.cfg.ServerName {
+		// TODO: Implement joining local room aliases.
+		panic(fmt.Errorf("Joining local room aliases is not implemented"))
+	} else {
+		return r.joinRoomByRemoteAlias(domain, roomAlias)
+	}
+}
+
+func (r joinRoomReq) joinRoomByRemoteAlias(
+	domain gomatrixserverlib.ServerName, roomAlias string,
+) util.JSONResponse {
+	resp, err := r.federation.LookupRoomAlias(domain, roomAlias)
+	if err != nil {
+		switch x := err.(type) {
+		case gomatrix.HTTPError:
+			if x.Code == 404 {
+				return util.JSONResponse{
+					Code: 404,
+					JSON: jsonerror.NotFound("Room alias not found"),
+				}
+			}
+		}
+		return util.ErrorResponse(err)
+	}
+
+	return r.joinRoomUsingServers(resp.RoomID, resp.Servers)
+}
+
+func (r joinRoomReq) writeToBuilder(eb *gomatrixserverlib.EventBuilder, roomID string) {
+	eb.Type = "m.room.member"
+	eb.SetContent(r.content) // TODO: Set avatar_url / displayname
+	eb.SetUnsigned(struct{}{})
+	eb.Sender = r.userID
+	eb.StateKey = &r.userID
+	eb.RoomID = roomID
+	eb.Redacts = ""
+}
+
+func (r joinRoomReq) joinRoomUsingServers(
+	roomID string, servers []gomatrixserverlib.ServerName,
+) util.JSONResponse {
+	var eb gomatrixserverlib.EventBuilder
+	r.writeToBuilder(&eb, roomID)
+
+	needed, err := gomatrixserverlib.StateNeededForEventBuilder(&eb)
+	if err != nil {
+		return httputil.LogThenError(r.req, err)
+	}
+
+	// Ask the roomserver for information about this room
+	queryReq := api.QueryLatestEventsAndStateRequest{
+		RoomID:       roomID,
+		StateToFetch: needed.Tuples(),
+	}
+	var queryRes api.QueryLatestEventsAndStateResponse
+	if queryErr := r.queryAPI.QueryLatestEventsAndState(&queryReq, &queryRes); queryErr != nil {
+		return httputil.LogThenError(r.req, queryErr)
+	}
+
+	if queryRes.RoomExists {
+		// TODO: Implement joining rooms that already the server is already in.
+		// This should just fall through to the usual event sending code.
+		panic(fmt.Errorf("Joining rooms that the server already in is not implemented"))
+	}
+
+	var event gomatrixserverlib.Event
+	var respMakeJoin gomatrixserverlib.RespMakeJoin
+	//var respSendJoin gomatrixserverlib.RespSendJoin
+	for _, server := range servers {
+		respMakeJoin, err = r.federation.MakeJoin(server, roomID, r.userID)
+		if err != nil {
+			// TODO: Check if the user was not allowed to join the room.
+
+			// Try the next server in the list.
+			continue
+		}
+
+		// Set all the fields to be what they should be, this should be a no-op
+		// but it's possible that the remote server returned us something "odd"
+		r.writeToBuilder(&respMakeJoin.JoinEvent, roomID)
+
+		now := time.Now()
+		eventID := fmt.Sprintf("$%s:%s", util.RandomString(16), r.cfg.ServerName)
+		if event, err = respMakeJoin.JoinEvent.Build(
+			eventID, now, r.cfg.ServerName, r.cfg.KeyID, r.cfg.PrivateKey,
+		); err != nil {
+			return util.ErrorResponse(err)
+		}
+
+		_, err = r.federation.SendJoin(server, event)
+		if err != nil {
+			// Try the next server in the list.
+			continue
+		}
+
+		// TODO: validate the state response.
+		// TODO: check that the join event passes auth against the state response.
+		// TODO: send the state and the join event to the room server.
+	}
+
+	if err != nil {
+		return util.ErrorResponse(err)
+	}
+
+	return util.JSONResponse{
+		Code: 404,
+		JSON: jsonerror.NotFound("No candidate servers found for room"),
+	}
+}
+
+// domainFromID returns everything after the first ":" character to extract
+// the domain part of a matrix ID.
+// TODO: duplicated from gomatrixserverlib.
+func domainFromID(id string) (gomatrixserverlib.ServerName, error) {
+	// IDs have the format: SIGIL LOCALPART ":" DOMAIN
+	// Split on the first ":" character since the domain can contain ":"
+	// characters.
+	parts := strings.SplitN(id, ":", 2)
+	if len(parts) != 2 {
+		// The ID must have a ":" character.
+		return "", fmt.Errorf("invalid ID: %q", id)
+	}
+	// Return everything after the first ":" character.
+	return gomatrixserverlib.ServerName(parts[1]), nil
+}

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/joinroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/joinroom.go
@@ -74,10 +74,10 @@ type joinRoomReq struct {
 	keyRing    gomatrixserverlib.KeyRing
 }
 
-// joinRoomByID joins a room by roomID
+// joinRoomByID joins a room by room ID
 func (r joinRoomReq) joinRoomByID() util.JSONResponse {
 	// TODO: Implement joining rooms by ID.
-	// A client should only join a room by roomID when it has an invite
+	// A client should only join a room by room ID when it has an invite
 	// to the room. If the server is already in the room then we can
 	// lookup the invite and process the request as a normal state event.
 	// If the server is not in the room the we will need to look up the

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/joinroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/joinroom.go
@@ -194,6 +194,14 @@ func (r joinRoomReq) joinRoomUsingServers(
 		// TODO: validate the state response.
 		// TODO: check that the join event passes auth against the state response.
 		// TODO: send the state and the join event to the room server.
+
+		return util.JSONResponse{
+			Code: 200,
+			// TODO: Put the response struct somewhere common.
+			JSON: struct {
+				RoomID string `json:"room_id"`
+			}{roomID},
+		}
 	}
 
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/cmd/client-api-proxy/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/client-api-proxy/main.go
@@ -76,7 +76,11 @@ func makeProxy(targetURL string) (*httputil.ReverseProxy, error) {
 				"url":    targetURL,
 				"method": req.Method,
 			}).Print("proxying request")
-			newURL, err := url.Parse(targetURL + path)
+			newURL, err := url.Parse(targetURL)
+			// Set the path separately as we need to preserve '#' characters
+			// that would otherwise be interpreted as being the start of a URL
+			// fragment.
+			newURL.Path += path
 			if err != nil {
 				// We already checked that we can parse the URL
 				// So this shouldn't ever get hit.

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-client-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-client-api-server/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/routing"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/roomserver/api"
+
 	"github.com/matrix-org/gomatrixserverlib"
 
 	log "github.com/Sirupsen/logrus"
@@ -81,6 +82,8 @@ func main() {
 		log.Panicf("Failed to setup kafka producers(%s): %s", cfg.KafkaProducerURIs, err)
 	}
 
+	federation := gomatrixserverlib.NewFederationClient(cfg.ServerName, cfg.KeyID, cfg.PrivateKey)
+
 	queryAPI := api.NewRoomserverQueryAPIHTTP(cfg.RoomserverURL, nil)
 	accountDB, err := accounts.NewDatabase(accountDataSource, serverName)
 	if err != nil {
@@ -91,6 +94,6 @@ func main() {
 		log.Panicf("Failed to setup device database(%s): %s", accountDataSource, err.Error())
 	}
 
-	routing.Setup(http.DefaultServeMux, http.DefaultClient, cfg, roomserverProducer, queryAPI, accountDB, deviceDB)
+	routing.Setup(http.DefaultServeMux, http.DefaultClient, cfg, roomserverProducer, queryAPI, accountDB, deviceDB, federation)
 	log.Fatal(http.ListenAndServe(bindAddr, nil))
 }

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-federation-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-federation-api-server/main.go
@@ -49,6 +49,9 @@ func main() {
 		// TODO: make the validity period configurable.
 		ValidityPeriod: 24 * time.Hour,
 	}
+	cfg.TLSFingerPrints = []gomatrixserverlib.TLSFingerprint{
+		{[]byte("o\xe2\xd1\x05A7g\xd6=\x10\xdfq\x9e4\xb1:/\x9co>\x01g\x1d\xb8\xbebFf]\xf0\x89N")},
+	}
 
 	var err error
 	cfg.KeyID, cfg.PrivateKey, err = common.ReadKey(serverKey)

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-federation-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-federation-api-server/main.go
@@ -38,7 +38,7 @@ var (
 	// Can be generated from a PEM certificate called "server.crt" using:
 	//
 	//  openssl x509 -noout -fingerprint -sha256 -inform pem -in server.crt |\
-	//	python -c 'print raw_input()[19:].replace(":","").decode("hex").encode("base64").rstrip("=\n")'
+	//     python -c 'print raw_input()[19:].replace(":","").decode("hex").encode("base64").rstrip("=\n")'
 	//
 	tlsFingerprint = os.Getenv("TLS_FINGERPRINT")
 )

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
@@ -36,6 +36,10 @@ func Setup(servMux *http.ServeMux, cfg config.FederationAPI) {
 		return readers.LocalKeys(req, cfg)
 	})
 
+	// Ignore the {keyID} argument as we only have a single server key so we always
+	// return that key.
+	// Even if we had more than one server key, we would probably still ignore the
+	// {keyID} argument and always return a response containing all of the keys.
 	v2keysmux.Handle("/server/{keyID}", localKeys)
 	v2keysmux.Handle("/server/", localKeys)
 

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	pathPrefixV2Keys = "/_matrix/keys/v2"
+	pathPrefixV2Keys = "/_matrix/key/v2"
 )
 
 // Setup registers HTTP handlers with the given ServeMux.
@@ -32,11 +32,12 @@ func Setup(servMux *http.ServeMux, cfg config.FederationAPI) {
 	apiMux := mux.NewRouter()
 	v2keysmux := apiMux.PathPrefix(pathPrefixV2Keys).Subrouter()
 
-	v2keysmux.Handle("/server/",
-		makeAPI("localkeys", func(req *http.Request) util.JSONResponse {
-			return readers.LocalKeys(req, cfg)
-		}),
-	)
+	localKeys := makeAPI("localkeys", func(req *http.Request) util.JSONResponse {
+		return readers.LocalKeys(req, cfg)
+	})
+
+	v2keysmux.Handle("/server/{keyID}", localKeys)
+	v2keysmux.Handle("/server/", localKeys)
 
 	servMux.Handle("/metrics", prometheus.Handler())
 	servMux.Handle("/api/", http.StripPrefix("/api", apiMux))

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -98,7 +98,7 @@
 		{
 			"importpath": "github.com/matrix-org/gomatrixserverlib",
 			"repository": "https://github.com/matrix-org/gomatrixserverlib",
-			"revision": "9cefcd6c3a00bff51e719a33e19a16edf52cdd6f",
+			"revision": "c396ef3cc1e546729f7052f1f48e345cc59269f4",
 			"branch": "master"
 		},
 		{

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/event.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/event.go
@@ -386,7 +386,7 @@ func (e Event) CheckFields() error {
 		// are allowed to have a different sender because they have the same
 		// sender as the "m.room.third_party_invite" event they derived from.
 		// https://github.com/matrix-org/synapse/blob/v0.21.0/synapse/event_auth.py#L58-L64
-		if e.fields.Type != "m.room.member" {
+		if e.fields.Type != MRoomMember {
 			return fmt.Errorf(
 				"gomatrixserverlib: sender domain doesn't match origin: %q != %q",
 				eventDomain, e.fields.Origin,

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/eventcontent.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/eventcontent.go
@@ -191,7 +191,7 @@ func (c *powerLevelContent) userLevel(userID string) int64 {
 
 // eventLevel returns the power level needed to send an event in the room.
 func (c *powerLevelContent) eventLevel(eventType string, isState bool) int64 {
-	if eventType == "m.room.third_party_invite" {
+	if eventType == MRoomThirdPartyInvite {
 		// Special case third_party_invite events to have the same level as
 		// m.room.member invite events.
 		// https://github.com/matrix-org/synapse/blob/v0.18.5/synapse/api/auth.py#L182

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/eventcrypto.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/eventcrypto.go
@@ -201,9 +201,9 @@ func VerifyEventSignatures(events []Event, keyRing KeyRing) error {
 		}
 		toVerify = append(toVerify, v)
 
-		// "m.room.member" invite events are signed by both the server sending
+		// MRoomMember invite events are signed by both the server sending
 		// the invite and the server the invite is for.
-		if event.Type() == "m.room.member" && event.StateKey() != nil {
+		if event.Type() == MRoomMember && event.StateKey() != nil {
 			targetDomain, err := domainFromID(*event.StateKey())
 			if err != nil {
 				return err

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/redactevent.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/redactevent.go
@@ -140,17 +140,17 @@ func redactEvent(eventJSON []byte) ([]byte, error) {
 	// Copy the content fields that we should keep for the event type.
 	// By default we copy nothing leaving the content object empty.
 	switch event.Type {
-	case "m.room.create":
+	case MRoomCreate:
 		newContent.createContent = event.Content.createContent
-	case "m.room.member":
+	case MRoomMember:
 		newContent.memberContent = event.Content.memberContent
-	case "m.room.join_rules":
+	case MRoomJoinRules:
 		newContent.joinRulesContent = event.Content.joinRulesContent
-	case "m.room.power_levels":
+	case MRoomPowerLevels:
 		newContent.powerLevelContent = event.Content.powerLevelContent
-	case "m.room.history_visibility":
+	case MRoomHistoryVisibility:
 		newContent.historyVisibilityContent = event.Content.historyVisibilityContent
-	case "m.room.aliases":
+	case MRoomAliases:
 		newContent.aliasesContent = event.Content.aliasesContent
 	}
 	// Replace the content with our new filtered content.

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/stateresolution.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/stateresolution.go
@@ -114,24 +114,24 @@ func (r *stateResolver) addConflicted(events []Event) {
 		// By default we add the event to a block in the others list.
 		blockList := &r.others
 		switch key.eventType {
-		case "m.room.create":
+		case MRoomCreate:
 			if key.stateKey == "" {
 				r.creates = append(r.creates, event)
 				continue
 			}
-		case "m.room.power_levels":
+		case MRoomPowerLevels:
 			if key.stateKey == "" {
 				r.powerLevels = append(r.powerLevels, event)
 				continue
 			}
-		case "m.room.join_rules":
+		case MRoomJoinRules:
 			if key.stateKey == "" {
 				r.joinRules = append(r.joinRules, event)
 				continue
 			}
-		case "m.room.member":
+		case MRoomMember:
 			blockList = &r.members
-		case "m.room.third_party_invite":
+		case MRoomThirdPartyInvite:
 			blockList = &r.thirdPartyInvites
 		}
 		// We need to find an entry for the state key in a block list.
@@ -153,21 +153,21 @@ func (r *stateResolver) addConflicted(events []Event) {
 // Add an event to the resolved auth events.
 func (r *stateResolver) addAuthEvent(event *Event) {
 	switch event.Type() {
-	case "m.room.create":
+	case MRoomCreate:
 		if event.StateKeyEquals("") {
 			r.resolvedCreate = event
 		}
-	case "m.room.power_levels":
+	case MRoomPowerLevels:
 		if event.StateKeyEquals("") {
 			r.resolvedPowerLevels = event
 		}
-	case "m.room.join_rules":
+	case MRoomJoinRules:
 		if event.StateKeyEquals("") {
 			r.resolvedJoinRules = event
 		}
-	case "m.room.member":
+	case MRoomMember:
 		r.resolvedMembers[*event.StateKey()] = event
-	case "m.room.third_party_invite":
+	case MRoomThirdPartyInvite:
 		r.resolvedThirdPartyInvites[*event.StateKey()] = event
 	default:
 		panic(fmt.Errorf("Unexpected auth event with type %q", event.Type()))
@@ -177,21 +177,21 @@ func (r *stateResolver) addAuthEvent(event *Event) {
 // Remove the auth event with the given type and state key.
 func (r *stateResolver) removeAuthEvent(eventType, stateKey string) {
 	switch eventType {
-	case "m.room.create":
+	case MRoomCreate:
 		if stateKey == "" {
 			r.resolvedCreate = nil
 		}
-	case "m.room.power_levels":
+	case MRoomPowerLevels:
 		if stateKey == "" {
 			r.resolvedPowerLevels = nil
 		}
-	case "m.room.join_rules":
+	case MRoomJoinRules:
 		if stateKey == "" {
 			r.resolvedJoinRules = nil
 		}
-	case "m.room.member":
+	case MRoomMember:
 		r.resolvedMembers[stateKey] = nil
-	case "m.room.third_party_invite":
+	case MRoomThirdPartyInvite:
 		r.resolvedThirdPartyInvites[stateKey] = nil
 	default:
 		panic(fmt.Errorf("Unexpected auth event with type %q", eventType))


### PR DESCRIPTION
This PR just creates the join event and sends it to the remote server. This is enough for the remote server to think that dendrite is a member of the room and to involve it in federation.

Notably it doesn't send anything to the roomserver, so the client won't actually think that it has joined the room.