### PR TITLE
Call 'go build' from the pre-commit hook to check that everything builds

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -9,7 +9,7 @@ gocyclo -over 12 src/
 gb test
 
 # Check that all the packages can build.
-# When go build is given multiple packages it won't output anything, and just
-# checks that everything build. This seems to do a better job of handling
+# When `go build` is given multiple packages it won't output anything, and just
+# checks that everything builds. This seems to do a better job of handling
 # missing imports than `gb build` does.
 GOPATH=$(pwd):$(pwd)/vendor go build github.com/matrix-org/dendrite/cmd/...

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -7,3 +7,9 @@ go fmt ./src/...
 go tool vet --all --shadow ./src
 gocyclo -over 12 src/
 gb test
+
+# Check that all the packages can build.
+# When go build is given multiple packages it won't output anything, and just
+# checks that everything build. This seems to do a better job of handling
+# missing imports than `gb build` does.
+GOPATH=$(pwd):$(pwd)/vendor go build github.com/matrix-org/dendrite/cmd/...


### PR DESCRIPTION
This would have caught the problem in #114 that necessitated  a7acfa5

A possible concern is that it takes a couple of seconds to build. One option would be to use `go install` instead, which would write object files in `/pkg` and `/vendor/pkg` that can be reused by subsequent checks. The name of the directory inside `/pkg` doesn't seem to conflict with the name used by gb so it should be safe to do.

