### PR TITLE
Glue together devices and auth with the current HTTP code

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/auth/auth.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/auth.go
@@ -20,30 +20,16 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
-	"github.com/matrix-org/dendrite/clientapi/auth/types"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/util"
 )
 
-// VerifyAccessToken TODO: Remove me.
-func VerifyAccessToken(req *http.Request) (userID string, resErr *util.JSONResponse) {
-	token, err := extractAccessToken(req)
-	if err != nil {
-		resErr = &util.JSONResponse{
-			Code: 401,
-			JSON: jsonerror.MissingToken(err.Error()),
-		}
-		return
-	}
-	userID = token
-	return
-}
-
-// VerifyAccessTokenNew verifies that an access token was supplied in the given HTTP request
+// VerifyAccessToken verifies that an access token was supplied in the given HTTP request
 // and returns the device it corresponds to. Returns resErr (an error response which can be
 // sent to the client) if the token is invalid or there was a problem querying the database.
-func VerifyAccessTokenNew(req *http.Request, deviceDB *devices.Database) (device *types.Device, resErr *util.JSONResponse) {
+func VerifyAccessToken(req *http.Request, deviceDB *devices.Database) (device *authtypes.Device, resErr *util.JSONResponse) {
 	token, err := extractAccessToken(req)
 	if err != nil {
 		resErr = &util.JSONResponse{

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/auth.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/auth.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package auth implements authentication checks and storage.
 package auth
 
 import (
@@ -19,28 +20,45 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
+	"github.com/matrix-org/dendrite/clientapi/auth/types"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/util"
 )
 
-// VerifyAccessToken verifies that an access token was supplied in the given HTTP request
-// and returns the user ID it corresponds to. Returns resErr (an error response which can be
-// sent to the client) if the token is invalid or there was a problem querying the database.
+// VerifyAccessToken TODO: Remove me.
 func VerifyAccessToken(req *http.Request) (userID string, resErr *util.JSONResponse) {
-	token, tokenErr := extractAccessToken(req)
-	if tokenErr != nil {
+	token, err := extractAccessToken(req)
+	if err != nil {
 		resErr = &util.JSONResponse{
 			Code: 401,
-			JSON: jsonerror.MissingToken(tokenErr.Error()),
+			JSON: jsonerror.MissingToken(err.Error()),
 		}
 		return
 	}
-	if token == "fail" {
-		res := util.ErrorResponse(fmt.Errorf("Fatal error"))
-		resErr = &res
-	}
-	// TODO: Check the token against the database
 	userID = token
+	return
+}
+
+// VerifyAccessTokenNew verifies that an access token was supplied in the given HTTP request
+// and returns the device it corresponds to. Returns resErr (an error response which can be
+// sent to the client) if the token is invalid or there was a problem querying the database.
+func VerifyAccessTokenNew(req *http.Request, deviceDB *devices.Database) (device *types.Device, resErr *util.JSONResponse) {
+	token, err := extractAccessToken(req)
+	if err != nil {
+		resErr = &util.JSONResponse{
+			Code: 401,
+			JSON: jsonerror.MissingToken(err.Error()),
+		}
+		return
+	}
+	device, err = deviceDB.GetDeviceByAccessToken(token)
+	if err != nil {
+		resErr = &util.JSONResponse{
+			Code: 500,
+			JSON: jsonerror.Unknown("Failed to check access token"),
+		}
+	}
 	return
 }
 

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/authtypes/account.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/authtypes/account.go
@@ -12,12 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package types
+package authtypes
 
-// Device represents a client's device (mobile, web, etc)
-type Device struct {
-	ID          string
-	UserID      string
-	AccessToken string
-	// TODO: display name, last used timestamp, keys, etc
+import (
+	"github.com/matrix-org/gomatrixserverlib"
+)
+
+// Account represents a Matrix account on this home server.
+type Account struct {
+	UserID     string
+	Localpart  string
+	ServerName gomatrixserverlib.ServerName
+	// TODO: Other flags like IsAdmin, IsGuest
+	// TODO: Devices
+	// TODO: Associations (e.g. with application services)
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/authtypes/device.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/authtypes/device.go
@@ -12,18 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package types
+package authtypes
 
-import (
-	"github.com/matrix-org/gomatrixserverlib"
-)
-
-// Account represents a Matrix account on this home server.
-type Account struct {
-	UserID     string
-	Localpart  string
-	ServerName gomatrixserverlib.ServerName
-	// TODO: Other flags like IsAdmin, IsGuest
-	// TODO: Devices
-	// TODO: Associations (e.g. with application services)
+// Device represents a client's device (mobile, web, etc)
+type Device struct {
+	ID          string
+	UserID      string
+	AccessToken string
+	// TODO: display name, last used timestamp, keys, etc
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/authtypes/logintypes.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/authtypes/logintypes.go
@@ -1,4 +1,4 @@
-package types
+package authtypes
 
 // LoginType are specified by http://matrix.org/docs/spec/client_server/r0.2.0.html#login-types
 type LoginType string

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/accounts_table.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/accounts_table.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matrix-org/dendrite/clientapi/auth/types"
+	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
@@ -76,10 +76,10 @@ func (s *accountsStatements) prepare(db *sql.DB, server gomatrixserverlib.Server
 // insertAccount creates a new account. 'hash' should be the password hash for this account. If it is missing,
 // this account will be passwordless. Returns an error if this account already exists. Returns the account
 // on success.
-func (s *accountsStatements) insertAccount(localpart, hash string) (acc *types.Account, err error) {
+func (s *accountsStatements) insertAccount(localpart, hash string) (acc *authtypes.Account, err error) {
 	createdTimeMS := time.Now().UnixNano() / 1000000
 	if _, err = s.insertAccountStmt.Exec(localpart, createdTimeMS, hash); err == nil {
-		acc = &types.Account{
+		acc = &authtypes.Account{
 			Localpart:  localpart,
 			UserID:     makeUserID(localpart, s.serverName),
 			ServerName: s.serverName,
@@ -93,8 +93,8 @@ func (s *accountsStatements) selectPasswordHash(localpart string) (hash string, 
 	return
 }
 
-func (s *accountsStatements) selectAccountByLocalpart(localpart string) (*types.Account, error) {
-	var acc types.Account
+func (s *accountsStatements) selectAccountByLocalpart(localpart string) (*authtypes.Account, error) {
+	var acc authtypes.Account
 	err := s.selectAccountByLocalpartStmt.QueryRow(localpart).Scan(&acc.Localpart)
 	if err != nil {
 		acc.UserID = makeUserID(localpart, s.serverName)

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
@@ -16,7 +16,7 @@ package accounts
 
 import (
 	"database/sql"
-	"github.com/matrix-org/dendrite/clientapi/auth/types"
+	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/gomatrixserverlib"
 	"golang.org/x/crypto/bcrypt"
 	// Import the postgres database driver.
@@ -45,7 +45,7 @@ func NewDatabase(dataSourceName string, serverName gomatrixserverlib.ServerName)
 
 // GetAccountByPassword returns the account associated with the given localpart and password.
 // Returns sql.ErrNoRows if no account exists which matches the given credentials.
-func (d *Database) GetAccountByPassword(localpart, plaintextPassword string) (*types.Account, error) {
+func (d *Database) GetAccountByPassword(localpart, plaintextPassword string) (*authtypes.Account, error) {
 	hash, err := d.accounts.selectPasswordHash(localpart)
 	if err != nil {
 		return nil, err
@@ -58,7 +58,7 @@ func (d *Database) GetAccountByPassword(localpart, plaintextPassword string) (*t
 
 // CreateAccount makes a new account with the given login name and password. If no password is supplied,
 // the account will be a passwordless account.
-func (d *Database) CreateAccount(localpart, plaintextPassword string) (*types.Account, error) {
+func (d *Database) CreateAccount(localpart, plaintextPassword string) (*authtypes.Account, error) {
 	hash, err := hashPassword(plaintextPassword)
 	if err != nil {
 		return nil, err

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/devices/storage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/devices/storage.go
@@ -15,7 +15,7 @@
 package devices
 
 import (
-	"github.com/matrix-org/dendrite/clientapi/auth/types"
+	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 )
 
 // Database represents a device database.
@@ -24,14 +24,14 @@ type Database struct {
 }
 
 // NewDatabase creates a new device database
-func NewDatabase() *Database {
-	return &Database{}
+func NewDatabase(dataSource string) (*Database, error) {
+	return &Database{}, nil
 }
 
 // GetDeviceByAccessToken returns the device matching the given access token.
-func (d *Database) GetDeviceByAccessToken(token string) (*types.Device, error) {
+func (d *Database) GetDeviceByAccessToken(token string) (*authtypes.Device, error) {
 	// TODO: Actual implementation
-	return &types.Device{
+	return &authtypes.Device{
 		UserID: token,
 	}, nil
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/devices/storage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/devices/storage.go
@@ -14,6 +14,10 @@
 
 package devices
 
+import (
+	"github.com/matrix-org/dendrite/clientapi/auth/types"
+)
+
 // Database represents a device database.
 type Database struct {
 	// TODO
@@ -22,4 +26,12 @@ type Database struct {
 // NewDatabase creates a new device database
 func NewDatabase() *Database {
 	return &Database{}
+}
+
+// GetDeviceByAccessToken returns the device matching the given access token.
+func (d *Database) GetDeviceByAccessToken(token string) (*types.Device, error) {
+	// TODO: Actual implementation
+	return &types.Device{
+		UserID: token,
+	}, nil
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/createroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/createroom.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/matrix-org/dendrite/clientapi/auth"
+	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/clientapi/config"
 	"github.com/matrix-org/dendrite/clientapi/events"
 	"github.com/matrix-org/dendrite/clientapi/httputil"
@@ -91,22 +91,19 @@ type fledglingEvent struct {
 }
 
 // CreateRoom implements /createRoom
-func CreateRoom(req *http.Request, cfg config.ClientAPI, producer *producers.RoomserverProducer) util.JSONResponse {
+func CreateRoom(req *http.Request, device *authtypes.Device, cfg config.ClientAPI, producer *producers.RoomserverProducer) util.JSONResponse {
 	// TODO: Check room ID doesn't clash with an existing one, and we
 	//       probably shouldn't be using pseudo-random strings, maybe GUIDs?
 	roomID := fmt.Sprintf("!%s:%s", util.RandomString(16), cfg.ServerName)
-	return createRoom(req, cfg, roomID, producer)
+	return createRoom(req, device, cfg, roomID, producer)
 }
 
 // createRoom implements /createRoom
-func createRoom(req *http.Request, cfg config.ClientAPI, roomID string, producer *producers.RoomserverProducer) util.JSONResponse {
+func createRoom(req *http.Request, device *authtypes.Device, cfg config.ClientAPI, roomID string, producer *producers.RoomserverProducer) util.JSONResponse {
 	logger := util.GetLogger(req.Context())
-	userID, resErr := auth.VerifyAccessToken(req)
-	if resErr != nil {
-		return *resErr
-	}
+	userID := device.UserID
 	var r createRoomRequest
-	resErr = httputil.UnmarshalJSONRequest(req, &r)
+	resErr := httputil.UnmarshalJSONRequest(req, &r)
 	if resErr != nil {
 		return *resErr
 	}

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/register.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/register.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
-	"github.com/matrix-org/dendrite/clientapi/auth/types"
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -34,15 +34,15 @@ type registerRequest struct {
 }
 
 type authDict struct {
-	Type    types.LoginType `json:"type"`
-	Session string          `json:"session"`
+	Type    authtypes.LoginType `json:"type"`
+	Session string              `json:"session"`
 	// TODO: Lots of custom keys depending on the type
 }
 
 // http://matrix.org/speculator/spec/HEAD/client_server/unstable.html#user-interactive-authentication-api
 type userInteractiveResponse struct {
 	Flows     []authFlow             `json:"flows"`
-	Completed []types.LoginType      `json:"completed"`
+	Completed []authtypes.LoginType  `json:"completed"`
 	Params    map[string]interface{} `json:"params"`
 	Session   string                 `json:"session"`
 }
@@ -50,12 +50,12 @@ type userInteractiveResponse struct {
 // authFlow represents one possible way that the client can authenticate a request.
 // http://matrix.org/speculator/spec/HEAD/client_server/unstable.html#user-interactive-authentication-api
 type authFlow struct {
-	Stages []types.LoginType `json:"stages"`
+	Stages []authtypes.LoginType `json:"stages"`
 }
 
 func newUserInteractiveResponse(sessionID string, fs []authFlow) userInteractiveResponse {
 	return userInteractiveResponse{
-		fs, []types.LoginType{}, make(map[string]interface{}), sessionID,
+		fs, []authtypes.LoginType{}, make(map[string]interface{}), sessionID,
 	}
 }
 
@@ -119,7 +119,7 @@ func Register(req *http.Request, accountDB *accounts.Database) util.JSONResponse
 			// TODO: Hard-coded 'dummy' auth for now with a bogus session ID.
 			//       Server admins should be able to change things around (eg enable captcha)
 			JSON: newUserInteractiveResponse("totallyuniquesessionid", []authFlow{
-				{[]types.LoginType{types.LoginTypeDummy}},
+				{[]authtypes.LoginType{authtypes.LoginTypeDummy}},
 			}),
 		}
 	}
@@ -129,7 +129,7 @@ func Register(req *http.Request, accountDB *accounts.Database) util.JSONResponse
 
 	// TODO: email / msisdn / recaptcha auth types.
 	switch r.Auth.Type {
-	case types.LoginTypeDummy:
+	case authtypes.LoginTypeDummy:
 		// there is nothing to do
 		return completeRegistration(accountDB, r.Username, r.Password)
 	default:

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/sendevent.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/sendevent.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/matrix-org/dendrite/clientapi/auth"
+	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/clientapi/config"
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
@@ -39,14 +39,11 @@ type sendEventResponse struct {
 // SendEvent implements:
 //   /rooms/{roomID}/send/{eventType}/{txnID}
 //   /rooms/{roomID}/state/{eventType}/{stateKey}
-func SendEvent(req *http.Request, roomID, eventType, txnID string, stateKey *string, cfg config.ClientAPI, queryAPI api.RoomserverQueryAPI, producer *producers.RoomserverProducer) util.JSONResponse {
+func SendEvent(req *http.Request, device *authtypes.Device, roomID, eventType, txnID string, stateKey *string, cfg config.ClientAPI, queryAPI api.RoomserverQueryAPI, producer *producers.RoomserverProducer) util.JSONResponse {
 	// parse the incoming http request
-	userID, resErr := auth.VerifyAccessToken(req)
-	if resErr != nil {
-		return *resErr
-	}
+	userID := device.UserID
 	var r map[string]interface{} // must be a JSON object
-	resErr = httputil.UnmarshalJSONRequest(req, &r)
+	resErr := httputil.UnmarshalJSONRequest(req, &r)
 	if resErr != nil {
 		return *resErr
 	}

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-client-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-client-api-server/main.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
+	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
 	"github.com/matrix-org/dendrite/clientapi/config"
 	"github.com/matrix-org/dendrite/clientapi/producers"
 	"github.com/matrix-org/dendrite/clientapi/routing"
@@ -85,7 +86,11 @@ func main() {
 	if err != nil {
 		log.Panicf("Failed to setup account database(%s): %s", accountDataSource, err.Error())
 	}
+	deviceDB, err := devices.NewDatabase(accountDataSource)
+	if err != nil {
+		log.Panicf("Failed to setup device database(%s): %s", accountDataSource, err.Error())
+	}
 
-	routing.Setup(http.DefaultServeMux, http.DefaultClient, cfg, roomserverProducer, queryAPI, accountDB)
+	routing.Setup(http.DefaultServeMux, http.DefaultClient, cfg, roomserverProducer, queryAPI, accountDB, deviceDB)
 	log.Fatal(http.ListenAndServe(bindAddr, nil))
 }

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-sync-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-sync-api-server/main.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/syncapi/config"
 	"github.com/matrix-org/dendrite/syncapi/consumers"
@@ -72,6 +73,12 @@ func main() {
 		log.Panicf("startup: failed to create sync server database with data source %s : %s", cfg.DataSource, err)
 	}
 
+	// TODO: DO NOT USE THIS DATABASE
+	deviceDB, err := devices.NewDatabase(cfg.DataSource)
+	if err != nil {
+		log.Panicf("startup: failed to create device database with data source %s : %s", cfg.DataSource, err)
+	}
+
 	pos, err := db.SyncStreamPosition()
 	if err != nil {
 		log.Panicf("startup: failed to get latest sync stream position : %s", err)
@@ -90,6 +97,6 @@ func main() {
 	}
 
 	log.Info("Starting sync server on ", *bindAddr)
-	routing.SetupSyncServerListeners(http.DefaultServeMux, http.DefaultClient, *cfg, sync.NewRequestPool(db, n))
+	routing.SetupSyncServerListeners(http.DefaultServeMux, http.DefaultClient, *cfg, sync.NewRequestPool(db, n), deviceDB)
 	log.Fatal(http.ListenAndServe(*bindAddr, nil))
 }

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-sync-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-sync-api-server/main.go
@@ -73,7 +73,7 @@ func main() {
 		log.Panicf("startup: failed to create sync server database with data source %s : %s", cfg.DataSource, err)
 	}
 
-	// TODO: DO NOT USE THIS DATABASE
+	// TODO: DO NOT USE THIS DATA SOURCE (it's the sync one, not devices!)
 	deviceDB, err := devices.NewDatabase(cfg.DataSource)
 	if err != nil {
 		log.Panicf("startup: failed to create device database with data source %s : %s", cfg.DataSource, err)

--- a/src/github.com/matrix-org/dendrite/common/httpapi.go
+++ b/src/github.com/matrix-org/dendrite/common/httpapi.go
@@ -1,0 +1,28 @@
+package common
+
+import (
+	"github.com/matrix-org/dendrite/clientapi/auth"
+	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
+	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
+	"github.com/matrix-org/util"
+	"github.com/prometheus/client_golang/prometheus"
+	"net/http"
+)
+
+// MakeAuthAPI turns a util.JSONRequestHandler function into an http.Handler which checks the access token in the request.
+func MakeAuthAPI(metricsName string, deviceDB *devices.Database, f func(*http.Request, *authtypes.Device) util.JSONResponse) http.Handler {
+	h := util.NewJSONRequestHandler(func(req *http.Request) util.JSONResponse {
+		device, resErr := auth.VerifyAccessToken(req, deviceDB)
+		if resErr != nil {
+			return *resErr
+		}
+		return f(req, device)
+	})
+	return prometheus.InstrumentHandler(metricsName, util.MakeJSONAPI(h))
+}
+
+// MakeAPI turns a util.JSONRequestHandler function into an http.Handler.
+func MakeAPI(metricsName string, f func(*http.Request) util.JSONResponse) http.Handler {
+	h := util.NewJSONRequestHandler(f)
+	return prometheus.InstrumentHandler(metricsName, util.MakeJSONAPI(h))
+}

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/matrix-org/dendrite/clientapi/auth"
+	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/syncapi/storage"
@@ -41,13 +41,10 @@ func NewRequestPool(db *storage.SyncServerDatabase, n *Notifier) *RequestPool {
 // OnIncomingSyncRequest is called when a client makes a /sync request. This function MUST be
 // called in a dedicated goroutine for this request. This function will block the goroutine
 // until a response is ready, or it times out.
-func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request) util.JSONResponse {
+func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request, device *authtypes.Device) util.JSONResponse {
 	// Extract values from request
 	logger := util.GetLogger(req.Context())
-	userID, resErr := auth.VerifyAccessToken(req)
-	if resErr != nil {
-		return *resErr
-	}
+	userID := device.UserID
 	syncReq, err := newSyncRequest(req, userID)
 	if err != nil {
 		return util.JSONResponse{


### PR DESCRIPTION
- Renamed `clientapi/auth/types` to `clientapi/auth/authtypes` for the same
  horrible namespace clashing reasons as `storage`.
- Factored out `makeAPI` to `common`.
- Added in `makeAuthAPI`.

I mulled for ages over how best to do this so I'll summarise here.
 - Auth is huge cross-cutting concern for all of Dendrite. Lots of things need it (sync server, client API, content repo, etc).
 - People will understandably be upset with me if I force them to thread EVERYTHING EVER through functions.
 - I need a solution which I can unit test easily in isolation.

As for the solutions:
 - Make a singleton in `func init()`. Can't stub it out in tests. It means we don't need to thread things through though.
 - Make a singleton with a setter/getter. We can stub it out in tests now. But it means that our dependencies are obscured. You don't know what needs auth and what doesn't.
 - We could thread things through and make people sad as they constantly need to pass in account/device databases and do queries on them for each HTTP request.
 - We could do the threading for people and get the best of both worlds by hooking into the routing logic instead.

I went for the last one. So the general "how do I make a process and write an API which checks access tokens" looks like:
```go
dataSource = os.Getenv("ACCOUNT_DATABASE")

deviceDB, err := devices.NewDatabase(dataSource)
if err != nil {
	log.Panicf("Failed to setup device database(%s): %s", dataSource, err.Error())
}

someMux := http.DefaultServeMux
someMux.Handle("/some/path", common.MakeAuthAPI("some_name", deviceDB,
    func(req *http.Request, device *authtypes.Device) util.JSONResponse {
        authedUserID := device.UserID
        // do stuff
    }
)
```

Which I feel is transparent enough to be self-explanatory. You know where it is looking when doing auth for incoming requests, but you don't need to write the threading yourself aside from passing it the `deviceDB`.