### PR TITLE
Hook up registration/login APIs and implement access token generation

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/auth/auth.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/auth.go
@@ -30,6 +30,10 @@ import (
 )
 
 // UnknownDeviceID is the default device id if one is not specified.
+// This deviates from Synapse which generates a new device ID if one is not specified.
+// It's preferable to not amass a huge list of valid access tokens for an account,
+// so limiting it to 1 unknown device for now limits the number of valid tokens.
+// Clients should be giving us device IDs.
 var UnknownDeviceID = "unknown-device"
 
 // OWASP recommends at least 128 bits of entropy for tokens: https://www.owasp.org/index.php/Insufficient_Session-ID_Length

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
@@ -16,6 +16,7 @@ package accounts
 
 import (
 	"database/sql"
+
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/gomatrixserverlib"
 	"golang.org/x/crypto/bcrypt"
@@ -44,7 +45,7 @@ func NewDatabase(dataSourceName string, serverName gomatrixserverlib.ServerName)
 }
 
 // GetAccountByPassword returns the account associated with the given localpart and password.
-// Returns sql.ErrNoRows if no account exists which matches the given credentials.
+// Returns sql.ErrNoRows if no account exists which matches the given localpart.
 func (d *Database) GetAccountByPassword(localpart, plaintextPassword string) (*authtypes.Account, error) {
 	hash, err := d.accounts.selectPasswordHash(localpart)
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/devices/devices_table.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/devices/devices_table.go
@@ -86,7 +86,7 @@ func (s *devicesStatements) prepare(db *sql.DB, server gomatrixserverlib.ServerN
 // Returns the device on success.
 func (s *devicesStatements) insertDevice(txn *sql.Tx, id, localpart, accessToken string) (dev *authtypes.Device, err error) {
 	createdTimeMS := time.Now().UnixNano() / 1000000
-	if _, err = s.insertDeviceStmt.Exec(id, localpart, accessToken, createdTimeMS); err == nil {
+	if _, err = txn.Stmt(s.insertDeviceStmt).Exec(id, localpart, accessToken, createdTimeMS); err == nil {
 		dev = &authtypes.Device{
 			ID:          id,
 			UserID:      makeUserID(localpart, s.serverName),

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -82,14 +82,14 @@ func Setup(
 	)
 
 	r0mux.Handle("/register", common.MakeAPI("register", func(req *http.Request) util.JSONResponse {
-		return writers.Register(req, accountDB)
+		return writers.Register(req, accountDB, deviceDB)
 	}))
 
 	// Stub endpoints required by Riot
 
 	r0mux.Handle("/login",
 		common.MakeAPI("login", func(req *http.Request) util.JSONResponse {
-			return readers.Login(req, cfg)
+			return readers.Login(req, accountDB, deviceDB, cfg)
 		}),
 	)
 

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/register.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/register.go
@@ -5,8 +5,10 @@ import (
 	"net/http"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/matrix-org/dendrite/clientapi/auth"
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
+	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -90,7 +92,7 @@ func (r *registerRequest) Validate() *util.JSONResponse {
 }
 
 // Register processes a /register request. http://matrix.org/speculator/spec/HEAD/client_server/unstable.html#post-matrix-client-unstable-register
-func Register(req *http.Request, accountDB *accounts.Database) util.JSONResponse {
+func Register(req *http.Request, accountDB *accounts.Database, deviceDB *devices.Database) util.JSONResponse {
 	var r registerRequest
 	resErr := httputil.UnmarshalJSONRequest(req, &r)
 	if resErr != nil {
@@ -131,7 +133,7 @@ func Register(req *http.Request, accountDB *accounts.Database) util.JSONResponse
 	switch r.Auth.Type {
 	case authtypes.LoginTypeDummy:
 		// there is nothing to do
-		return completeRegistration(accountDB, r.Username, r.Password)
+		return completeRegistration(accountDB, deviceDB, r.Username, r.Password)
 	default:
 		return util.JSONResponse{
 			Code: 501,
@@ -140,7 +142,20 @@ func Register(req *http.Request, accountDB *accounts.Database) util.JSONResponse
 	}
 }
 
-func completeRegistration(accountDB *accounts.Database, username, password string) util.JSONResponse {
+func completeRegistration(accountDB *accounts.Database, deviceDB *devices.Database, username, password string) util.JSONResponse {
+	if username == "" {
+		return util.JSONResponse{
+			Code: 400,
+			JSON: jsonerror.BadJSON("missing username"),
+		}
+	}
+	if password == "" {
+		return util.JSONResponse{
+			Code: 400,
+			JSON: jsonerror.BadJSON("missing password"),
+		}
+	}
+
 	acc, err := accountDB.CreateAccount(username, password)
 	if err != nil {
 		return util.JSONResponse{
@@ -148,15 +163,31 @@ func completeRegistration(accountDB *accounts.Database, username, password strin
 			JSON: jsonerror.Unknown("failed to create account: " + err.Error()),
 		}
 	}
-	// TODO: Make and store a proper access_token
-	// TODO: Store the client's device information?
+
+	token, err := auth.GenerateAccessToken()
+	if err != nil {
+		return util.JSONResponse{
+			Code: 500,
+			JSON: jsonerror.Unknown("Failed to generate access token"),
+		}
+	}
+
+	// // TODO: Use the device ID in the request.
+	dev, err := deviceDB.CreateDevice(username, auth.UnknownDeviceID, token)
+	if err != nil {
+		return util.JSONResponse{
+			Code: 500,
+			JSON: jsonerror.Unknown("failed to create device: " + err.Error()),
+		}
+	}
+
 	return util.JSONResponse{
 		Code: 200,
 		JSON: registerResponse{
-			UserID:      acc.UserID,
-			AccessToken: acc.UserID, // FIXME
+			UserID:      dev.UserID,
+			AccessToken: dev.AccessToken, // FIXME
 			HomeServer:  acc.ServerName,
-			DeviceID:    "kindauniquedeviceid",
+			DeviceID:    dev.ID,
 		},
 	}
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/register.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/register.go
@@ -185,7 +185,7 @@ func completeRegistration(accountDB *accounts.Database, deviceDB *devices.Databa
 		Code: 200,
 		JSON: registerResponse{
 			UserID:      dev.UserID,
-			AccessToken: dev.AccessToken, // FIXME
+			AccessToken: dev.AccessToken,
 			HomeServer:  acc.ServerName,
 			DeviceID:    dev.ID,
 		},


### PR DESCRIPTION
This finishes feature work on registration/login for now.

Registration:
```
$ curl -XPOST -d '{"username":"alice","password":"12345678"}' "http://localhost:7778/api/_matrix/client/r0/register"
{
	"flows": [{
		"stages": ["m.login.dummy"]
	}],
	"completed": [],
	"params": {},
	"session": "totallyuniquesessionid"
}

$ curl -XPOST -d '{"username":"alice","password":"12345678","auth":{"type":"m.login.dummy"}}' "http://localhost:7778/api/_matrix/client/r0/register"
{
	"user_id": "@alice:localhost",
	"access_token": "mV8NAhs90FwKISo5_dlSVqxnqn0AYkS11YnW4faVLxc",
	"home_server": "localhost",
	"device_id": "unknown-device"
}

$ curl -XPOST -d '{"username":"bob","password":"1","auth":{"type":"m.login.dummy"}}' "http://localhost:7778/api/_matrix/client/r0/register"
{"errcode":"M_WEAK_PASSWORD","error":"password too weak: min 8 chars"}
```

Login:
```
$ curl -XGET  "http://localhost:7778/api/_matrix/client/r0/login"
{
	"flows": [{
		"type": "m.login.password",
		"stages": ["m.login.password"]
	}]
}

$ curl -XPOST -d '{"user":"alice","password":"invalid","type":"m.login.password"}' "http://localhost:7778/api/_matrix/client/r0/login"
{"errcode":"M_BAD_JSON","error":"username or password was incorrect, or the account does not exist"}

$ curl -XPOST -d '{"user":"alice","password":"12345678","type":"m.login.password"}' "http://localhost:7778/api/_matrix/client/r0/login"
{
	"user_id": "@alice:localhost",
	"access_token": "d_4_PLGDSRdVXv4-r0b1xhU8VGhNvV1LcsYkx2nOLLI",
	"home_server": "localhost"
}

$ curl -XPOST -d '{}' "http://localhost:7778/api/_matrix/client/r0/createRoom?access_token=@alice:localhost"
{"errcode":"M_FORBIDDEN","error":"Invalid access token"}

$ curl -XPOST -d '{}' "http://localhost:7778/api/_matrix/client/r0/createRoom?access_token=d_4_PLGDSRdVXv4-r0b1xhU8VGhNvV1LcsYkx2nOLLI"
{ .... }
```

Repeated logins clobber access tokens for now (so there is only ever 1 valid access_token at any one time, meaning multi-device doesn't work). This is keyed off the device ID, which we don't yet parse out the request.