### PR TITLE
Add support for downloading of remote files

### DIFF
--- a/src/github.com/matrix-org/dendrite/mediaapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/mediaapi/routing/routing.go
@@ -16,7 +16,6 @@ package routing
 
 import (
 	"net/http"
-	"sync"
 
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/common"
@@ -42,7 +41,7 @@ func Setup(servMux *http.ServeMux, httpClient *http.Client, cfg *config.MediaAPI
 	}))
 
 	activeRemoteRequests := &types.ActiveRemoteRequests{
-		MXCToCond: map[string]*sync.Cond{},
+		MXCToResult: map[string]*types.RemoteRequestResult{},
 	}
 	r0mux.Handle("/download/{serverName}/{mediaId}",
 		prometheus.InstrumentHandler("download", http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/src/github.com/matrix-org/dendrite/mediaapi/types/types.go
+++ b/src/github.com/matrix-org/dendrite/mediaapi/types/types.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/util"
 )
 
 // FileSizeBytes is a file size in bytes
@@ -63,8 +64,10 @@ type MediaMetadata struct {
 type RemoteRequestResult struct {
 	// Condition used for the requester to signal the result to all other routines waiting on this condition
 	Cond *sync.Cond
-	// Resulting HTTP status code from the request
-	Result int
+	// MediaMetadata of the requested file to avoid querying the database for every waiting routine
+	MediaMetadata *MediaMetadata
+	// An error in util.JSONResponse form. nil in case of no error.
+	ErrorResponse *util.JSONResponse
 }
 
 // ActiveRemoteRequests is a lockable map of media URIs requested from remote homeservers

--- a/src/github.com/matrix-org/dendrite/mediaapi/types/types.go
+++ b/src/github.com/matrix-org/dendrite/mediaapi/types/types.go
@@ -59,10 +59,18 @@ type MediaMetadata struct {
 	UserID            MatrixUserID
 }
 
+// RemoteRequestResult is used for broadcasting the result of a request for a remote file to routines waiting on the condition
+type RemoteRequestResult struct {
+	// Condition used for the requester to signal the result to all other routines waiting on this condition
+	Cond *sync.Cond
+	// Resulting HTTP status code from the request
+	Result int
+}
+
 // ActiveRemoteRequests is a lockable map of media URIs requested from remote homeservers
 // It is used for ensuring multiple requests for the same file do not clobber each other.
 type ActiveRemoteRequests struct {
 	sync.Mutex
 	// The string key is an mxc:// URL
-	MXCToCond map[string]*sync.Cond
+	MXCToResult map[string]*RemoteRequestResult
 }

--- a/src/github.com/matrix-org/dendrite/mediaapi/writers/download.go
+++ b/src/github.com/matrix-org/dendrite/mediaapi/writers/download.go
@@ -253,10 +253,8 @@ func (r *downloadRequest) getMediaMetadataForRemoteFile(db *storage.Database, ac
 	if activeRemoteRequestResult, ok := activeRemoteRequests.MXCToResult[mxcURL]; ok {
 		r.Logger.Info("Waiting for another goroutine to fetch the remote file.")
 
+		// NOTE: Wait unlocks and locks again internally. There is still a deferred Unlock() that will unlock this.
 		activeRemoteRequestResult.Cond.Wait()
-		activeRemoteRequests.Unlock()
-		// NOTE: there is still a deferred Unlock() that will unlock this
-		activeRemoteRequests.Lock()
 
 		// check if we have a record of the media in our database
 		mediaMetadata, err := db.GetMediaMetadata(r.MediaMetadata.MediaID, r.MediaMetadata.Origin)

--- a/src/github.com/matrix-org/dendrite/mediaapi/writers/download.go
+++ b/src/github.com/matrix-org/dendrite/mediaapi/writers/download.go
@@ -229,6 +229,11 @@ func (r *downloadRequest) getRemoteFile(cfg *config.MediaAPI, db *storage.Databa
 		// Note: broadcastMediaMetadata uses mutexes and conditions from activeRemoteRequests
 		defer func() {
 			// Note: errorResponse is the named return variable so we wrap this in a closure to re-evaluate the arguments at defer-time
+			if err := recover(); err != nil {
+				resErr := jsonerror.InternalServerError()
+				r.broadcastMediaMetadata(activeRemoteRequests, &resErr)
+				panic(err)
+			}
 			r.broadcastMediaMetadata(activeRemoteRequests, errorResponse)
 		}()
 

--- a/src/github.com/matrix-org/dendrite/mediaapi/writers/download.go
+++ b/src/github.com/matrix-org/dendrite/mediaapi/writers/download.go
@@ -226,9 +226,11 @@ func (r *downloadRequest) getRemoteFile(cfg *config.MediaAPI, db *storage.Databa
 		r.MediaMetadata = mediaMetadata
 	} else {
 		// Note: This is an active request that MUST broadcastMediaMetadata to wake up waiting goroutines!
-		// Note: errorResponse is the named return variable
 		// Note: broadcastMediaMetadata uses mutexes and conditions from activeRemoteRequests
-		defer r.broadcastMediaMetadata(activeRemoteRequests, errorResponse)
+		defer func() {
+			// Note: errorResponse is the named return variable so we wrap this in a closure to re-evaluate the arguments at defer-time
+			r.broadcastMediaMetadata(activeRemoteRequests, errorResponse)
+		}()
 
 		// check if we have a record of the media in our database
 		mediaMetadata, err := db.GetMediaMetadata(r.MediaMetadata.MediaID, r.MediaMetadata.Origin)

--- a/src/github.com/matrix-org/dendrite/mediaapi/writers/download.go
+++ b/src/github.com/matrix-org/dendrite/mediaapi/writers/download.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"strings"
 	"sync"
 
 	log "github.com/Sirupsen/logrus"
@@ -431,7 +430,7 @@ func (r *downloadRequest) createRemoteRequest() (*http.Response, *util.JSONRespo
 		resErr := jsonerror.InternalServerError()
 		return nil, &resErr
 	}
-	url := "https://" + strings.Trim(dnsResult.SRVRecords[0].Target, ".") + ":" + strconv.Itoa(int(dnsResult.SRVRecords[0].Port))
+	url := "https://" + dnsResult.Addrs[0]
 
 	r.Logger.WithField("URL", url).Info("Connecting to remote")
 

--- a/src/github.com/matrix-org/dendrite/mediaapi/writers/upload.go
+++ b/src/github.com/matrix-org/dendrite/mediaapi/writers/upload.go
@@ -136,10 +136,8 @@ func (r *uploadRequest) doUpload(reqReader io.Reader, cfg *config.MediaAPI, db *
 	mediaMetadata, err := db.GetMediaMetadata(r.MediaMetadata.MediaID, r.MediaMetadata.Origin)
 	if err != nil {
 		r.Logger.WithError(err).Error("Error querying the database.")
-		return &util.JSONResponse{
-			Code: 500,
-			JSON: jsonerror.InternalServerError(),
-		}
+		resErr := jsonerror.InternalServerError()
+		return &resErr
 	}
 
 	if mediaMetadata != nil {

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -98,7 +98,7 @@
 		{
 			"importpath": "github.com/matrix-org/gomatrixserverlib",
 			"repository": "https://github.com/matrix-org/gomatrixserverlib",
-			"revision": "c396ef3cc1e546729f7052f1f48e345cc59269f4",
+			"revision": "b1dfcb3b345cc8410f1a03fec0a1ffe6bd002dcd",
 			"branch": "master"
 		},
 		{

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/client.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/client.go
@@ -220,3 +220,14 @@ func (fc *Client) LookupServerKeys(
 	}
 	return result, nil
 }
+
+// CreateMediaDownloadRequest creates a request for media on a homeserver and returns the http.Response or an error
+func (fc *Client) CreateMediaDownloadRequest(matrixServer ServerName, mediaID string) (*http.Response, error) {
+	requestURL := "matrix://" + string(matrixServer) + "/_matrix/media/v1/download/" + string(matrixServer) + "/" + mediaID
+	resp, err := fc.client.Get(requestURL)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}


### PR DESCRIPTION
There is some synchronisation to pay attention to around ActiveRemoteRequests to ensure that we only have one download request for remote media which gets cached and then served to all the incoming download requests from clients.