### PR TITLE
Clean up syncapi storage to match the coding style

### DIFF
--- a/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
@@ -72,7 +72,7 @@ func NewSyncServerDatabase(dataSourceName string) (*SyncServerDatabase, error) {
 
 // AllJoinedUsersInRooms returns a map of room ID to a list of all joined user IDs.
 func (d *SyncServerDatabase) AllJoinedUsersInRooms() (map[string][]string, error) {
-	return d.roomstate.JoinedMemberLists()
+	return d.roomstate.selectJoinedUsers()
 }
 
 // WriteEvent into the database. It is not safe to call this function from multiple goroutines, as it would create races
@@ -81,7 +81,7 @@ func (d *SyncServerDatabase) AllJoinedUsersInRooms() (map[string][]string, error
 func (d *SyncServerDatabase) WriteEvent(ev *gomatrixserverlib.Event, addStateEventIDs, removeStateEventIDs []string) (streamPos types.StreamPosition, returnErr error) {
 	returnErr = runTransaction(d.db, func(txn *sql.Tx) error {
 		var err error
-		pos, err := d.events.InsertEvent(txn, ev, addStateEventIDs, removeStateEventIDs)
+		pos, err := d.events.insertEvent(txn, ev, addStateEventIDs, removeStateEventIDs)
 		if err != nil {
 			return err
 		}
@@ -97,20 +97,47 @@ func (d *SyncServerDatabase) WriteEvent(ev *gomatrixserverlib.Event, addStateEve
 		// However, conflict resolution may result in there being different events being added, or even some removed.
 		if len(removeStateEventIDs) == 0 && len(addStateEventIDs) == 1 && addStateEventIDs[0] == ev.EventID() {
 			// common case
-			if err = d.roomstate.UpdateRoomState(txn, []gomatrixserverlib.Event{*ev}, nil); err != nil {
-				return err
-			}
-			return nil
+			return d.updateRoomState(txn, nil, []gomatrixserverlib.Event{*ev})
 		}
 
 		// uncommon case: we need to fetch the full event for each event ID mentioned, then update room state
-		added, err := d.events.Events(txn, addStateEventIDs)
+		added, err := d.events.selectEvents(txn, addStateEventIDs)
 		if err != nil {
 			return err
 		}
-		return d.roomstate.UpdateRoomState(txn, streamEventsToEvents(added), removeStateEventIDs)
+
+		return d.updateRoomState(txn, removeStateEventIDs, streamEventsToEvents(added))
 	})
 	return
+}
+
+func (d *SyncServerDatabase) updateRoomState(txn *sql.Tx, removedEventIDs []string, addedEvents []gomatrixserverlib.Event) error {
+	// remove first, then add, as we do not ever delete state, but do replace state which is a remove followed by an add.
+	for _, eventID := range removedEventIDs {
+		if err := d.roomstate.deleteRoomStateByEventID(txn, eventID); err != nil {
+			return err
+		}
+	}
+
+	for _, event := range addedEvents {
+		if event.StateKey() == nil {
+			// ignore non state events
+			continue
+		}
+		var membership *string
+		if event.Type() == "m.room.member" {
+			var memberContent events.MemberContent
+			if err := json.Unmarshal(event.Content(), &memberContent); err != nil {
+				return err
+			}
+			membership = &memberContent.Membership
+		}
+		if err := d.roomstate.upsertRoomState(txn, event, membership); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // PartitionOffsets implements common.PartitionStorer
@@ -125,7 +152,7 @@ func (d *SyncServerDatabase) SetPartitionOffset(topic string, partition int32, o
 
 // SyncStreamPosition returns the latest position in the sync stream. Returns 0 if there are no events yet.
 func (d *SyncServerDatabase) SyncStreamPosition() (types.StreamPosition, error) {
-	id, err := d.events.MaxID(nil)
+	id, err := d.events.selectMaxID(nil)
 	if err != nil {
 		return types.StreamPosition(0), err
 	}
@@ -156,7 +183,7 @@ func (d *SyncServerDatabase) IncrementalSync(userID string, fromPos, toPos types
 				// This is all "okay" assuming history_visibility == "shared" which it is by default.
 				endPos = delta.membershipPos
 			}
-			recentStreamEvents, err := d.events.RecentEventsInRoom(txn, delta.roomID, fromPos, endPos, numRecentEventsPerRoom)
+			recentStreamEvents, err := d.events.selectRecentEvents(txn, delta.roomID, fromPos, endPos, numRecentEventsPerRoom)
 			if err != nil {
 				return err
 			}
@@ -197,14 +224,14 @@ func (d *SyncServerDatabase) CompleteSync(userID string, numRecentEventsPerRoom 
 	// but it's better to not hide the fact that this is being done in a transaction.
 	returnErr = runTransaction(d.db, func(txn *sql.Tx) error {
 		// Get the current stream position which we will base the sync response on.
-		id, err := d.events.MaxID(txn)
+		id, err := d.events.selectMaxID(txn)
 		if err != nil {
 			return err
 		}
 		pos := types.StreamPosition(id)
 
 		// Extract room state and recent events for all rooms the user is joined to.
-		roomIDs, err := d.roomstate.SelectRoomIDsWithMembership(txn, userID, "join")
+		roomIDs, err := d.roomstate.selectRoomIDsWithMembership(txn, userID, "join")
 		if err != nil {
 			return err
 		}
@@ -212,13 +239,15 @@ func (d *SyncServerDatabase) CompleteSync(userID string, numRecentEventsPerRoom 
 		// Build up a /sync response. Add joined rooms.
 		res = types.NewResponse(pos)
 		for _, roomID := range roomIDs {
-			stateEvents, err := d.roomstate.CurrentState(txn, roomID)
+			stateEvents, err := d.roomstate.selectCurrentState(txn, roomID)
 			if err != nil {
 				return err
 			}
 			// TODO: When filters are added, we may need to call this multiple times to get enough events.
 			//       See: https://github.com/matrix-org/synapse/blob/v0.19.3/synapse/handlers/sync.py#L316
-			recentStreamEvents, err := d.events.RecentEventsInRoom(txn, roomID, types.StreamPosition(0), pos, numRecentEventsPerRoom)
+			recentStreamEvents, err := d.events.selectRecentEvents(
+				txn, roomID, types.StreamPosition(0), pos, numRecentEventsPerRoom,
+			)
 			if err != nil {
 				return err
 			}
@@ -239,7 +268,7 @@ func (d *SyncServerDatabase) CompleteSync(userID string, numRecentEventsPerRoom 
 
 func (d *SyncServerDatabase) addInvitesToResponse(txn *sql.Tx, userID string, res *types.Response) error {
 	// Add invites - TODO: This will break over federation as they won't be in the current state table according to Mark.
-	roomIDs, err := d.roomstate.SelectRoomIDsWithMembership(txn, userID, "invite")
+	roomIDs, err := d.roomstate.selectRoomIDsWithMembership(txn, userID, "invite")
 	if err != nil {
 		return err
 	}
@@ -249,6 +278,49 @@ func (d *SyncServerDatabase) addInvitesToResponse(txn *sql.Tx, userID string, re
 		res.Rooms.Invite[roomID] = *ir
 	}
 	return nil
+}
+
+// fetchStateEvents converts the set of event IDs into a set of events. It will fetch any which are missing from the database.
+// Returns a map of room ID to list of events.
+func (d *SyncServerDatabase) fetchStateEvents(txn *sql.Tx, roomIDToEventIDSet map[string]map[string]bool, eventIDToEvent map[string]streamEvent) (map[string][]streamEvent, error) {
+	stateBetween := make(map[string][]streamEvent)
+	missingEvents := make(map[string][]string)
+	for roomID, ids := range roomIDToEventIDSet {
+		events := stateBetween[roomID]
+		for id, need := range ids {
+			if !need {
+				continue // deleted state
+			}
+			e, ok := eventIDToEvent[id]
+			if ok {
+				events = append(events, e)
+			} else {
+				m := missingEvents[roomID]
+				m = append(m, id)
+				missingEvents[roomID] = m
+			}
+		}
+		stateBetween[roomID] = events
+	}
+
+	if len(missingEvents) > 0 {
+		// This happens when add_state_ids has an event ID which is not in the provided range.
+		// We need to explicitly fetch them.
+		allMissingEventIDs := []string{}
+		for _, missingEvIDs := range missingEvents {
+			allMissingEventIDs = append(allMissingEventIDs, missingEvIDs...)
+		}
+		evs, err := d.events.selectEvents(txn, allMissingEventIDs)
+		if err != nil {
+			return nil, err
+		}
+		// we know we got them all otherwise an error would've been returned, so just loop the events
+		for _, ev := range evs {
+			roomID := ev.RoomID()
+			stateBetween[roomID] = append(stateBetween[roomID], ev)
+		}
+	}
+	return stateBetween, nil
 }
 
 func (d *SyncServerDatabase) getStateDeltas(txn *sql.Tx, fromPos, toPos types.StreamPosition, userID string) ([]stateDelta, error) {
@@ -263,10 +335,15 @@ func (d *SyncServerDatabase) getStateDeltas(txn *sql.Tx, fromPos, toPos types.St
 	var deltas []stateDelta
 
 	// get all the state events ever between these two positions
-	state, err := d.events.StateBetween(txn, fromPos, toPos)
+	stateNeeded, eventMap, err := d.events.selectStateInRange(txn, fromPos, toPos)
 	if err != nil {
 		return nil, err
 	}
+	state, err := d.fetchStateEvents(txn, stateNeeded, eventMap)
+	if err != nil {
+		return nil, err
+	}
+
 	for roomID, stateStreamEvents := range state {
 		for _, ev := range stateStreamEvents {
 			// TODO: Currently this will incorrectly add rooms which were ALREADY joined but they sent another no-op join event.
@@ -278,7 +355,7 @@ func (d *SyncServerDatabase) getStateDeltas(txn *sql.Tx, fromPos, toPos types.St
 				if membership == "join" {
 					// send full room state down instead of a delta
 					var allState []gomatrixserverlib.Event
-					allState, err = d.roomstate.CurrentState(txn, roomID)
+					allState, err = d.roomstate.selectCurrentState(txn, roomID)
 					if err != nil {
 						return nil, err
 					}
@@ -302,7 +379,7 @@ func (d *SyncServerDatabase) getStateDeltas(txn *sql.Tx, fromPos, toPos types.St
 	}
 
 	// Add in currently joined rooms
-	joinedRoomIDs, err := d.roomstate.SelectRoomIDsWithMembership(txn, userID, "join")
+	joinedRoomIDs, err := d.roomstate.selectRoomIDsWithMembership(txn, userID, "join")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The expected coding style is that the table.go files only contain functions whose name begins with a single SQL verb wrapping a single SQL statement with the same name. The only other functions in those files should be utility functions to help execute individual queries.

The main storage file which implements the component storage interface is the only place where multiple statements can be executed in a single function.

This makes it a bit easier to read the code as it will only leave the main storage file to execute a single statement, and because the functions are prefixed with the SQL verb it's usually possible to guess what is going to happen.