### PR TITLE
Fetching missing state from the roomserver.

### DIFF
--- a/src/github.com/matrix-org/dendrite/syncapi/config/config.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/config/config.go
@@ -20,6 +20,8 @@ import (
 
 // Sync contains the config information necessary to spin up a sync-server process.
 type Sync struct {
+	// Where the room server is listening for queries.
+	RoomserverURL string `yaml:"roomserver_url"`
 	// The topic for events which are written by the room server output log.
 	RoomserverOutputTopic string `yaml:"roomserver_topic"`
 	// A list of URIs to consume events from. These kafka logs should be produced by a Room Server.

--- a/src/github.com/matrix-org/dendrite/syncapi/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/consumers/roomserver.go
@@ -87,7 +87,7 @@ func (s *OutputRoomEvent) onMessage(msg *sarama.ConsumerMessage) error {
 		"room_id":  ev.RoomID(),
 	}).Info("received event from roomserver")
 
-	addsStateEvents, err := s.addsStateEvents(output.AddsStateEventIDs, ev)
+	addsStateEvents, err := s.lookupStateEvents(output.AddsStateEventIDs, ev)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"event":      string(ev.JSON()),
@@ -116,8 +116,8 @@ func (s *OutputRoomEvent) onMessage(msg *sarama.ConsumerMessage) error {
 	return nil
 }
 
-// addsStateEvents looks up the state events that are added by a new event.
-func (s *OutputRoomEvent) addsStateEvents(
+// lookupStateEvents looks up the state events that are added by a new event.
+func (s *OutputRoomEvent) lookupStateEvents(
 	addsStateEventIDs []string, event gomatrixserverlib.Event,
 ) ([]gomatrixserverlib.Event, error) {
 	// Fast path if there aren't any new state events.

--- a/src/github.com/matrix-org/dendrite/syncapi/storage/current_room_state_table.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/storage/current_room_state_table.go
@@ -36,9 +36,9 @@ CREATE TABLE IF NOT EXISTS current_room_state (
     -- The 'content.membership' value if this event is an m.room.member event. For other
     -- events, this will be NULL.
     membership TEXT,
-	-- The serial ID of the output_room_events table when this event became
-	-- part of the current state of the room.
-	added_at BIGINT,
+    -- The serial ID of the output_room_events table when this event became
+    -- part of the current state of the room.
+    added_at BIGINT,
     -- Clobber based on 3-uple of room_id, type and state_key
     CONSTRAINT room_state_unique UNIQUE (room_id, type, state_key)
 );
@@ -49,10 +49,10 @@ CREATE INDEX IF NOT EXISTS membership_idx ON current_room_state(type, state_key,
 `
 
 const upsertRoomStateSQL = "" +
-	"INSERT INTO current_room_state (room_id, event_id, type, state_key, event_json, membership, added_at_id)" +
+	"INSERT INTO current_room_state (room_id, event_id, type, state_key, event_json, membership, added_at)" +
 	" VALUES ($1, $2, $3, $4, $5, $6, $7)" +
 	" ON CONFLICT ON CONSTRAINT room_state_unique" +
-	" DO UPDATE SET event_id = $2, event_json = $5, membership = $6, added_at_id = $7"
+	" DO UPDATE SET event_id = $2, event_json = $5, membership = $6, added_at = $7"
 
 const deleteRoomStateByEventIDSQL = "" +
 	"DELETE FROM current_room_state WHERE event_id = $1"

--- a/src/github.com/matrix-org/dendrite/syncapi/storage/current_room_state_table.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/storage/current_room_state_table.go
@@ -36,6 +36,9 @@ CREATE TABLE IF NOT EXISTS current_room_state (
     -- The 'content.membership' value if this event is an m.room.member event. For other
     -- events, this will be NULL.
     membership TEXT,
+	-- The serial ID of the output_room_events table when this event became
+	-- part of the current state of the room.
+	added_at BIGINT,
     -- Clobber based on 3-uple of room_id, type and state_key
     CONSTRAINT room_state_unique UNIQUE (room_id, type, state_key)
 );
@@ -46,9 +49,10 @@ CREATE INDEX IF NOT EXISTS membership_idx ON current_room_state(type, state_key,
 `
 
 const upsertRoomStateSQL = "" +
-	"INSERT INTO current_room_state (room_id, event_id, type, state_key, event_json, membership) VALUES ($1, $2, $3, $4, $5, $6)" +
+	"INSERT INTO current_room_state (room_id, event_id, type, state_key, event_json, membership, added_at_id)" +
+	" VALUES ($1, $2, $3, $4, $5, $6, $7)" +
 	" ON CONFLICT ON CONSTRAINT room_state_unique" +
-	" DO UPDATE SET event_id = $2, event_json = $5, membership = $6"
+	" DO UPDATE SET event_id = $2, event_json = $5, membership = $6, added_at_id = $7"
 
 const deleteRoomStateByEventIDSQL = "" +
 	"DELETE FROM current_room_state WHERE event_id = $1"
@@ -63,7 +67,7 @@ const selectJoinedUsersSQL = "" +
 	"SELECT room_id, state_key FROM current_room_state WHERE type = 'm.room.member' AND membership = 'join'"
 
 const selectEventsWithEventIDsSQL = "" +
-	"SELECT event_json FROM current_room_state WHERE event_id = ANY($1)"
+	"SELECT added_at, event_json FROM current_room_state WHERE event_id = ANY($1)"
 
 type currentRoomStateStatements struct {
 	upsertRoomStateStmt             *sql.Stmt
@@ -157,20 +161,22 @@ func (s *currentRoomStateStatements) deleteRoomStateByEventID(txn *sql.Tx, event
 	return err
 }
 
-func (s *currentRoomStateStatements) upsertRoomState(txn *sql.Tx, event gomatrixserverlib.Event, membership *string) error {
+func (s *currentRoomStateStatements) upsertRoomState(
+	txn *sql.Tx, event gomatrixserverlib.Event, membership *string, addedAt int64,
+) error {
 	_, err := txn.Stmt(s.upsertRoomStateStmt).Exec(
-		event.RoomID(), event.EventID(), event.Type(), *event.StateKey(), event.JSON(), membership,
+		event.RoomID(), event.EventID(), event.Type(), *event.StateKey(), event.JSON(), membership, addedAt,
 	)
 	return err
 }
 
-func (s *currentRoomStateStatements) selectEventsWithEventIDs(txn *sql.Tx, eventIDs []string) ([]gomatrixserverlib.Event, error) {
+func (s *currentRoomStateStatements) selectEventsWithEventIDs(txn *sql.Tx, eventIDs []string) ([]streamEvent, error) {
 	rows, err := txn.Stmt(s.selectEventsWithEventIDsStmt).Query(pq.StringArray(eventIDs))
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	return rowsToEvents(rows)
+	return rowsToStreamEvents(rows)
 }
 
 func rowsToEvents(rows *sql.Rows) ([]gomatrixserverlib.Event, error) {

--- a/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
@@ -360,10 +360,6 @@ func (d *SyncServerDatabase) fetchMissingStateEvents(txn *sql.Tx, eventIDs []str
 		return nil, fmt.Errorf("failed to map all event IDs to events: (got %d, wanted %d)", len(stateEvents), len(missing))
 	}
 	for _, e := range stateEvents {
-		// Set the stream position to 0 since these events occurred outside the
-		// stream so probably happened before it.
-		// TOOD: What happens if we receive a state event from outside the
-		// timeline associated with an event in the middle of the timeline?
 		events = append(events, e)
 	}
 	return events, nil

--- a/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
@@ -317,7 +317,7 @@ func (d *SyncServerDatabase) fetchStateEvents(txn *sql.Tx, roomIDToEventIDSet ma
 		}
 		for _, ev := range evs {
 			roomID := ev.RoomID()
-			stateBetween[roomID] = append(stateBetween[roomID])
+			stateBetween[roomID] = append(stateBetween[roomID], ev)
 		}
 	}
 	return stateBetween, nil

--- a/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
@@ -358,7 +358,7 @@ func (d *SyncServerDatabase) fetchMissingStateEvents(txn *sql.Tx, eventIDs []str
 		return nil, fmt.Errorf("failed to map all event IDs to events: (got %d, wanted %d)", len(stateEvents), len(missing))
 	}
 	for _, e := range stateEvents {
-		// Set the stream position to 0 since these events occured outside the
+		// Set the stream position to 0 since these events occurred outside the
 		// stream so probably happened before it.
 		// TOOD: What happens if we receive a state event from outside the
 		// timeline associated with an event in the middle of the timeline?

--- a/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
@@ -315,6 +315,7 @@ func (d *SyncServerDatabase) fetchStateEvents(txn *sql.Tx, roomIDToEventIDSet ma
 		if err != nil {
 			return nil, err
 		}
+		// we know we got them all otherwise an error would've been returned, so just loop the events
 		for _, ev := range evs {
 			roomID := ev.RoomID()
 			stateBetween[roomID] = append(stateBetween[roomID], ev)


### PR DESCRIPTION
Whenever the syncserver receives an event from the room server that adds
state that isn't in the syncserver's local database it should fetch
those state events from the roomserver.