### PR TITLE
Set depth of events and whether they need to be federated.

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/producers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/producers/roomserver.go
@@ -42,7 +42,7 @@ func NewRoomserverProducer(kafkaURIs []string, topic string) (*RoomserverProduce
 }
 
 // SendEvents writes the given events to the roomserver input log. The events are written with KindNew.
-func (c *RoomserverProducer) SendEvents(events []gomatrixserverlib.Event) error {
+func (c *RoomserverProducer) SendEvents(events []gomatrixserverlib.Event, sendAsServer gomatrixserverlib.ServerName) error {
 	eventIDs := make([]string, len(events))
 	ires := make([]api.InputRoomEvent, len(events))
 	for i, event := range events {
@@ -50,6 +50,7 @@ func (c *RoomserverProducer) SendEvents(events []gomatrixserverlib.Event) error 
 			Kind:         api.KindNew,
 			Event:        event.JSON(),
 			AuthEventIDs: authEventIDs(event),
+			SendAsServer: string(sendAsServer),
 		}
 		eventIDs[i] = event.EventID()
 	}

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/createroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/createroom.go
@@ -188,7 +188,7 @@ func createRoom(req *http.Request, device *authtypes.Device, cfg config.Dendrite
 	}
 
 	// send events to the room server
-	if err := producer.SendEvents(builtEvents); err != nil {
+	if err := producer.SendEvents(builtEvents, cfg.Matrix.ServerName); err != nil {
 		return httputil.LogThenError(req, err)
 	}
 

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/sendevent.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/sendevent.go
@@ -93,6 +93,7 @@ func SendEvent(
 		refs = append(refs, e.EventReference())
 	}
 	builder.AuthEvents = refs
+	builder.Depth = queryRes.Depth
 	eventID := fmt.Sprintf("$%s:%s", util.RandomString(16), cfg.Matrix.ServerName)
 	e, err := builder.Build(
 		eventID, time.Now(), cfg.Matrix.ServerName, cfg.Matrix.KeyID, cfg.Matrix.PrivateKey,
@@ -115,7 +116,7 @@ func SendEvent(
 	}
 
 	// pass the new event to the roomserver
-	if err := producer.SendEvents([]gomatrixserverlib.Event{e}); err != nil {
+	if err := producer.SendEvents([]gomatrixserverlib.Event{e}, cfg.Matrix.ServerName); err != nil {
 		return httputil.LogThenError(req, err)
 	}
 

--- a/src/github.com/matrix-org/dendrite/cmd/roomserver-integration-tests/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/roomserver-integration-tests/main.go
@@ -340,7 +340,8 @@ func main() {
 				"state_key":"@richvdh:matrix.org",
 				"type":"m.room.member"
 			},
-			"VisibilityEventIDs":null,
+			"StateBeforeRemovesEventIDs":["$1463671339126270PnVwC:matrix.org"],
+			"StateBeforeAddsEventIDs":null,
 			"LatestEventIDs":["$1463671339126270PnVwC:matrix.org"],
 			"AddsStateEventIDs":["$1463671337126266wrSBX:matrix.org", "$1463671339126270PnVwC:matrix.org"],
 			"RemovesStateEventIDs":null,

--- a/src/github.com/matrix-org/dendrite/cmd/roomserver-integration-tests/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/roomserver-integration-tests/main.go
@@ -345,7 +345,8 @@ func main() {
 			"LatestEventIDs":["$1463671339126270PnVwC:matrix.org"],
 			"AddsStateEventIDs":["$1463671337126266wrSBX:matrix.org", "$1463671339126270PnVwC:matrix.org"],
 			"RemovesStateEventIDs":null,
-			"LastSentEventID":""
+			"LastSentEventID":"",
+			"SendAsServer":""
 		}`,
 	}
 

--- a/src/github.com/matrix-org/dendrite/federationapi/writers/send.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/writers/send.go
@@ -159,7 +159,7 @@ func (t *txnReq) processEvent(e gomatrixserverlib.Event) error {
 	// TODO: Check that the event is allowed by its auth_events.
 
 	// pass the event to the roomserver
-	if err := t.producer.SendEvents([]gomatrixserverlib.Event{e}); err != nil {
+	if err := t.producer.SendEvents([]gomatrixserverlib.Event{e}, ""); err != nil {
 		return err
 	}
 

--- a/src/github.com/matrix-org/dendrite/federationapi/writers/send.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/writers/send.go
@@ -159,7 +159,7 @@ func (t *txnReq) processEvent(e gomatrixserverlib.Event) error {
 	// TODO: Check that the event is allowed by its auth_events.
 
 	// pass the event to the roomserver
-	if err := t.producer.SendEvents([]gomatrixserverlib.Event{e}, ""); err != nil {
+	if err := t.producer.SendEvents([]gomatrixserverlib.Event{e}, api.DoNotSendToOtherServers); err != nil {
 		return err
 	}
 

--- a/src/github.com/matrix-org/dendrite/roomserver/api/input.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/api/input.go
@@ -40,6 +40,10 @@ const (
 	KindBackfill = 4
 )
 
+// DoNotSendToOtherServers tells us not to send the event to other matrix
+// servers.
+const DoNotSendToOtherServers = ""
+
 // InputRoomEvent is a matrix room event to add to the room server database.
 // TODO: Implement UnmarshalJSON/MarshalJSON in a way that does something sensible with the event JSON.
 type InputRoomEvent struct {

--- a/src/github.com/matrix-org/dendrite/roomserver/api/input.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/api/input.go
@@ -62,6 +62,9 @@ type InputRoomEvent struct {
 	// These are only used if HasState is true.
 	// The list can be empty, for example when storing the first event in a room.
 	StateEventIDs []string
+	// The server name to use to push this event to other servers.
+	// Or empty if this event shouldn't be pushed to other servers.
+	SendAsServer string
 }
 
 // UnmarshalJSON implements json.Unmarshaller
@@ -76,6 +79,7 @@ func (ire *InputRoomEvent) UnmarshalJSON(data []byte) error {
 		AuthEventIDs  []string
 		StateEventIDs []string
 		HasState      bool
+		SendAsServer  string
 	}
 	if err := json.Unmarshal(data, &content); err != nil {
 		return err
@@ -84,6 +88,7 @@ func (ire *InputRoomEvent) UnmarshalJSON(data []byte) error {
 	ire.AuthEventIDs = content.AuthEventIDs
 	ire.StateEventIDs = content.StateEventIDs
 	ire.HasState = content.HasState
+	ire.SendAsServer = content.SendAsServer
 	if content.Event != nil {
 		ire.Event = []byte(*content.Event)
 	}
@@ -103,12 +108,14 @@ func (ire InputRoomEvent) MarshalJSON() ([]byte, error) {
 		AuthEventIDs  []string
 		StateEventIDs []string
 		HasState      bool
+		SendAsServer  string
 	}{
 		Kind:          ire.Kind,
 		AuthEventIDs:  ire.AuthEventIDs,
 		StateEventIDs: ire.StateEventIDs,
 		Event:         &event,
 		HasState:      ire.HasState,
+		SendAsServer:  ire.SendAsServer,
 	}
 	return json.Marshal(&content)
 }

--- a/src/github.com/matrix-org/dendrite/roomserver/api/output.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/api/output.go
@@ -70,7 +70,7 @@ type OutputRoomEvent struct {
 	// Or empty if this event shouldn't be pushed to other servers.
 	//
 	// This is used by the federation sender component. We need to tell it what
-	// event is needs to send because it can't tell on its own. Normally if an
+	// event it needs to send because it can't tell on its own. Normally if an
 	// event was created on this server then we are responsible for sending it.
 	// However there are a couple of exceptions. The first is that when the
 	// server joins a remote room through another matrix server, it is the job

--- a/src/github.com/matrix-org/dendrite/roomserver/api/output.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/api/output.go
@@ -70,14 +70,14 @@ type OutputRoomEvent struct {
 	// Or empty if this event shouldn't be pushed to other servers.
 	//
 	// This is used by the federation sender component. We need to tell it what
-	// event is needs to send because it can't tell on its own. Normally we
-	// if an event was created on this server then we are responsible for
-	// sending. However there are a couple of exceptions. The first is that
-	// when the server joins a remote room through another matrix server, it
-	// is the job of the other matrix server to send the event over federation.
-	// The second is the reverse of the first, that is when a remote server
-	// joins a room that we are in over federation using our server it is our
-	// responsibility to send the join event to other matrix server.
+	// event is needs to send because it can't tell on its own. Normally if an
+	// event was created on this server then we are responsible for sending it.
+	// However there are a couple of exceptions. The first is that when the
+	// server joins a remote room through another matrix server, it is the job
+	// of the other matrix server to send the event over federation. The second
+	// is the reverse of the first, that is when a remote server joins a room
+	// that we are in over federation using our server it is our responsibility
+	// to send the join event to other matrix servers.
 	//
 	// We encode the server name that the event should be sent using here to
 	// future proof the API for virtual hosting.

--- a/src/github.com/matrix-org/dendrite/roomserver/api/query.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/api/query.go
@@ -43,6 +43,9 @@ type QueryLatestEventsAndStateResponse struct {
 	// The state events requested.
 	// This list will be in an arbitrary order.
 	StateEvents []gomatrixserverlib.Event
+	// The depth of the latest events.
+	// This is one greater than the depths of the latest events.
+	Depth int64
 }
 
 // QueryStateAfterEventsRequest is a request to QueryStateAfterEvents

--- a/src/github.com/matrix-org/dendrite/roomserver/api/query.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/api/query.go
@@ -32,6 +32,8 @@ type QueryLatestEventsAndStateRequest struct {
 }
 
 // QueryLatestEventsAndStateResponse is a response to QueryLatestEventsAndState
+// This is used when sending events to set the prev_events, auth_events and depth.
+// It is also used to tell whether the event is allowed by the event auth rules.
 type QueryLatestEventsAndStateResponse struct {
 	// Copy of the request for debugging.
 	QueryLatestEventsAndStateRequest
@@ -39,12 +41,16 @@ type QueryLatestEventsAndStateResponse struct {
 	// If the room doesn't exist this will be false and LatestEvents will be empty.
 	RoomExists bool
 	// The latest events in the room.
+	// These are used to set the prev_events when sending an event.
 	LatestEvents []gomatrixserverlib.EventReference
 	// The state events requested.
 	// This list will be in an arbitrary order.
+	// These are used to set the auth_events when sending an event.
+	// These are used to check whether the event is allowed.
 	StateEvents []gomatrixserverlib.Event
 	// The depth of the latest events.
-	// This is one greater than the depths of the latest events.
+	// This is one greater than the maximum depth of the latest events.
+	// This is used to set the depth when sending an event.
 	Depth int64
 }
 

--- a/src/github.com/matrix-org/dendrite/roomserver/input/events.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/input/events.go
@@ -102,7 +102,7 @@ func processRoomEvent(db RoomEventDatabase, ow OutputRoomEventWriter, input api.
 	}
 
 	// Update the extremities of the event graph for the room
-	if err := updateLatestEvents(db, ow, roomNID, stateAtEvent, event); err != nil {
+	if err := updateLatestEvents(db, ow, roomNID, stateAtEvent, event, input.SendAsServer); err != nil {
 		return err
 	}
 

--- a/src/github.com/matrix-org/dendrite/roomserver/query/query.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/query/query.go
@@ -34,7 +34,7 @@ type RoomserverQueryAPIDatabase interface {
 	RoomNID(roomID string) (types.RoomNID, error)
 	// Lookup event references for the latest events in the room and the current state snapshot.
 	// Returns an error if there was a problem talking to the database.
-	LatestEventIDs(roomNID types.RoomNID) ([]gomatrixserverlib.EventReference, types.StateSnapshotNID, error)
+	LatestEventIDs(roomNID types.RoomNID) ([]gomatrixserverlib.EventReference, types.StateSnapshotNID, int64, error)
 	// Lookup the numeric IDs for a list of events.
 	// Returns an error if there was a problem talking to the database.
 	EventNIDs(eventIDs []string) (map[string]types.EventNID, error)
@@ -60,7 +60,7 @@ func (r *RoomserverQueryAPI) QueryLatestEventsAndState(
 	}
 	response.RoomExists = true
 	var currentStateSnapshotNID types.StateSnapshotNID
-	response.LatestEvents, currentStateSnapshotNID, err = r.DB.LatestEventIDs(roomNID)
+	response.LatestEvents, currentStateSnapshotNID, response.Depth, err = r.DB.LatestEventIDs(roomNID)
 	if err != nil {
 		return err
 	}

--- a/src/github.com/matrix-org/dendrite/roomserver/query/query.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/query/query.go
@@ -33,6 +33,7 @@ type RoomserverQueryAPIDatabase interface {
 	// Returns an error if there was a problem talking to the database.
 	RoomNID(roomID string) (types.RoomNID, error)
 	// Lookup event references for the latest events in the room and the current state snapshot.
+	// Returns the latest events, the current state and the maximum depth of the latest events plus 1.
 	// Returns an error if there was a problem talking to the database.
 	LatestEventIDs(roomNID types.RoomNID) ([]gomatrixserverlib.EventReference, types.StateSnapshotNID, int64, error)
 	// Lookup the numeric IDs for a list of events.


### PR DESCRIPTION
Builds on #143

Set the depth of each new event to one greater than the maximum depth
of it's direct ancestors.

Add a flag to each event passing through the roomserver that tells us
whether the event needs to be sent over federation.

We do this by passing the name of the server to send the event as.
We will need this capability if we want to support vhosting as it is
not possible to tell from the event alone which server to send it as.

(The reason for this is that sometimes a event needs to be sent on
behalf of a different remote matrix server)

