### PR TITLE
Response to createRoom is now the room's ID

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/writers/createroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/createroom.go
@@ -192,9 +192,13 @@ func createRoom(req *http.Request, device *authtypes.Device, cfg config.Dendrite
 		return httputil.LogThenError(req, err)
 	}
 
+	response := createRoomResponse{
+		RoomID: roomID,
+	}
+
 	return util.JSONResponse{
 		Code: 200,
-		JSON: builtEvents,
+		JSON: response,
 	}
 }
 


### PR DESCRIPTION
Previous response to `POST /_matrix/client/r0/createRoom` was a bunch of events related to the room's creation, changed it to the room's ID to match with Synapse's current behaviour and Riot's expectations.