### PR TITLE
Improve room creation

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/events/eventcontent.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/events/eventcontent.go
@@ -28,6 +28,21 @@ type MemberContent struct {
 	// TODO: ThirdPartyInvite string `json:"third_party_invite,omitempty"`
 }
 
+// NameContent is the event content for https://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-name
+type NameContent struct {
+	Name string `json:"name"`
+}
+
+// TopicContent is the event content for https://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-topic
+type TopicContent struct {
+	Topic string `json:"topic"`
+}
+
+// GuestAccessContent is the event content for https://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-guest-access
+type GuestAccessContent struct {
+	GuestAccess string `json:"guest_access"`
+}
+
 // JoinRulesContent is the event content for http://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-join-rules
 type JoinRulesContent struct {
 	JoinRule string `json:"join_rule"`

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/createroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/createroom.go
@@ -124,7 +124,7 @@ func createRoom(req *http.Request, device *authtypes.Device, cfg config.Dendrite
 	//  4- m.room.canonical_alias (opt) TODO
 	//  5- m.room.join_rules
 	//  6- m.room.history_visibility
-	//  7- m.room.guest_access (opt) TODO
+	//  7- m.room.guest_access (opt)
 	//  8- other initial state items TODO
 	//  9- m.room.name (opt)
 	//  10- m.room.topic (opt)
@@ -142,13 +142,13 @@ func createRoom(req *http.Request, device *authtypes.Device, cfg config.Dendrite
 		// TODO: m.room.canonical_alias
 		{"m.room.join_rules", "", events.JoinRulesContent{"public"}},                 // FIXME: Allow this to be changed
 		{"m.room.history_visibility", "", events.HistoryVisibilityContent{"joined"}}, // FIXME: Allow this to be changed
-		// TODO: m.room.guest_access
+		{"m.room.guest_access", "", events.GuestAccessContent{"can_join"}},           // FIXME: Allow this to be changed
 		// TODO: Other initial state items
-		// TODO: m.room.name
-		// TODO: m.room.topic
+		{"m.room.name", "", events.NameContent{r.Name}}, // FIXME: Only send the name event if a name is supplied, to avoid sending a false room name removal event
+		{"m.room.topic", "", events.TopicContent{r.Topic}},
 		// TODO: invite events
 		// TODO: 3pid invite events
-		// TODO m.room.aliases
+		// TODO: m.room.aliases
 	}
 
 	authEvents := gomatrixserverlib.NewAuthEvents(nil)


### PR DESCRIPTION
Not a full implementation of the spec, but small improvements to room creation:

* Set `guest_access` (to a hardcoded value, same way as `join_rules` or `history_visibility`)
* Set room name
* Set room topic