### PR TITLE
Move setting up the api mux to outside the routing.Setup functions.

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -31,7 +31,6 @@ import (
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 const pathPrefixR0 = "/_matrix/client/r0"
@@ -40,7 +39,7 @@ const pathPrefixUnstable = "/_matrix/client/unstable"
 // Setup registers HTTP handlers with the given ServeMux. It also supplies the given http.Client
 // to clients which need to make outbound HTTP requests.
 func Setup(
-	servMux *http.ServeMux, httpClient *http.Client, cfg config.Dendrite,
+	apiMux *mux.Router, httpClient *http.Client, cfg config.Dendrite,
 	producer *producers.RoomserverProducer, queryAPI api.RoomserverQueryAPI,
 	aliasAPI api.RoomserverAliasAPI,
 	accountDB *accounts.Database,
@@ -50,7 +49,6 @@ func Setup(
 	userUpdateProducer *producers.UserUpdateProducer,
 	syncProducer *producers.SyncAPIProducer,
 ) {
-	apiMux := mux.NewRouter()
 
 	apiMux.Handle("/_matrix/client/versions",
 		common.MakeAPI("versions", func(req *http.Request) util.JSONResponse {
@@ -316,7 +314,4 @@ func Setup(
 			return util.JSONResponse{Code: 200, JSON: struct{}{}}
 		}),
 	)
-
-	servMux.Handle("/metrics", prometheus.Handler())
-	servMux.Handle("/api/", http.StripPrefix("/api", apiMux))
 }

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-client-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-client-api-server/main.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
 	"github.com/matrix-org/dendrite/clientapi/consumers"
@@ -102,10 +103,14 @@ func main() {
 	}
 
 	log.Info("Starting client API server on ", cfg.Listen.ClientAPI)
+
+	api := mux.NewRouter()
 	routing.Setup(
-		http.DefaultServeMux, http.DefaultClient, *cfg, roomserverProducer,
+		api, http.DefaultClient, *cfg, roomserverProducer,
 		queryAPI, aliasAPI, accountDB, deviceDB, federation, keyRing,
 		userUpdateProducer, syncProducer,
 	)
+	common.SetupHTTPAPI(http.DefaultServeMux, api)
+
 	log.Fatal(http.ListenAndServe(string(cfg.Listen.ClientAPI), nil))
 }

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-federation-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-federation-api-server/main.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/clientapi/producers"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/config"
@@ -75,6 +76,9 @@ func main() {
 
 	log.Info("Starting federation API server on ", cfg.Listen.FederationAPI)
 
-	routing.Setup(http.DefaultServeMux, *cfg, queryAPI, roomserverProducer, keyRing, federation)
+	api := mux.NewRouter()
+	routing.Setup(api, *cfg, queryAPI, roomserverProducer, keyRing, federation)
+	common.SetupHTTPAPI(http.DefaultServeMux, api)
+
 	log.Fatal(http.ListenAndServe(string(cfg.Listen.FederationAPI), nil))
 }

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-federation-sender-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-federation-sender-server/main.go
@@ -19,13 +19,13 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/config"
 	"github.com/matrix-org/dendrite/federationsender/consumers"
 	"github.com/matrix-org/dendrite/federationsender/queue"
 	"github.com/matrix-org/dendrite/federationsender/storage"
 	"github.com/matrix-org/gomatrixserverlib"
-	"github.com/prometheus/client_golang/prometheus"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -66,7 +66,8 @@ func main() {
 		log.WithError(err).Panicf("startup: failed to start room server consumer")
 	}
 
-	http.DefaultServeMux.Handle("/metrics", prometheus.Handler())
+	api := mux.NewRouter()
+	common.SetupHTTPAPI(http.DefaultServeMux, api)
 
 	if err := http.ListenAndServe(string(cfg.Listen.FederationSender), nil); err != nil {
 		panic(err)

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-media-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-media-api-server/main.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/config"
 	"github.com/matrix-org/dendrite/mediaapi/routing"
@@ -52,6 +53,9 @@ func main() {
 
 	log.Info("Starting media API server on ", cfg.Listen.MediaAPI)
 
-	routing.Setup(http.DefaultServeMux, http.DefaultClient, cfg, db)
+	api := mux.NewRouter()
+	routing.Setup(api, http.DefaultClient, cfg, db)
+	common.SetupHTTPAPI(http.DefaultServeMux, api)
+
 	log.Fatal(http.ListenAndServe(string(cfg.Listen.MediaAPI), nil))
 }

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-sync-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-sync-api-server/main.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
 	"github.com/matrix-org/dendrite/common"
@@ -89,6 +90,10 @@ func main() {
 	}
 
 	log.Info("Starting sync server on ", cfg.Listen.SyncAPI)
-	routing.SetupSyncServerListeners(http.DefaultServeMux, http.DefaultClient, sync.NewRequestPool(db, n, adb), deviceDB)
+
+	api := mux.NewRouter()
+	routing.Setup(api, sync.NewRequestPool(db, n, adb), deviceDB)
+	common.SetupHTTPAPI(http.DefaultServeMux, api)
+
 	log.Fatal(http.ListenAndServe(string(cfg.Listen.SyncAPI), nil))
 }

--- a/src/github.com/matrix-org/dendrite/common/httpapi.go
+++ b/src/github.com/matrix-org/dendrite/common/httpapi.go
@@ -3,6 +3,7 @@ package common
 import (
 	"net/http"
 
+	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/clientapi/auth"
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/util"
@@ -25,4 +26,11 @@ func MakeAuthAPI(metricsName string, deviceDB auth.DeviceDatabase, f func(*http.
 func MakeAPI(metricsName string, f func(*http.Request) util.JSONResponse) http.Handler {
 	h := util.NewJSONRequestHandler(f)
 	return prometheus.InstrumentHandler(metricsName, util.MakeJSONAPI(h))
+}
+
+// SetupHTTPAPI registers an HTTP API mux under /api and sets up a metrics
+// listener.
+func SetupHTTPAPI(servMux *http.ServeMux, apiMux *mux.Router) {
+	servMux.Handle("/metrics", prometheus.Handler())
+	servMux.Handle("/api/", http.StripPrefix("/api", apiMux))
 }

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
@@ -15,6 +15,9 @@
 package routing
 
 import (
+	"net/http"
+	"time"
+
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/clientapi/producers"
 	"github.com/matrix-org/dendrite/common/config"
@@ -24,8 +27,6 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 	"github.com/prometheus/client_golang/prometheus"
-	"net/http"
-	"time"
 )
 
 const (
@@ -35,14 +36,13 @@ const (
 
 // Setup registers HTTP handlers with the given ServeMux.
 func Setup(
-	servMux *http.ServeMux,
+	apiMux *mux.Router,
 	cfg config.Dendrite,
 	query api.RoomserverQueryAPI,
 	producer *producers.RoomserverProducer,
 	keys gomatrixserverlib.KeyRing,
 	federation *gomatrixserverlib.FederationClient,
 ) {
-	apiMux := mux.NewRouter()
 	v2keysmux := apiMux.PathPrefix(pathPrefixV2Keys).Subrouter()
 	v1fedmux := apiMux.PathPrefix(pathPrefixV1Federation).Subrouter()
 
@@ -67,9 +67,6 @@ func Setup(
 			)
 		},
 	))
-
-	servMux.Handle("/metrics", prometheus.Handler())
-	servMux.Handle("/api/", http.StripPrefix("/api", apiMux))
 }
 
 func makeAPI(metricsName string, f func(*http.Request) util.JSONResponse) http.Handler {

--- a/src/github.com/matrix-org/dendrite/mediaapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/mediaapi/routing/routing.go
@@ -30,10 +30,8 @@ import (
 
 const pathPrefixR0 = "/_matrix/media/v1"
 
-// Setup registers HTTP handlers with the given ServeMux. It also supplies the given http.Client
-// to clients which need to make outbound HTTP requests.
-func Setup(servMux *http.ServeMux, httpClient *http.Client, cfg *config.Dendrite, db *storage.Database) {
-	apiMux := mux.NewRouter()
+// Setup registers the media API HTTP handlers
+func Setup(apiMux *mux.Router, httpClient *http.Client, cfg *config.Dendrite, db *storage.Database) {
 	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
 
 	activeThumbnailGeneration := &types.ActiveThumbnailGeneration{
@@ -54,9 +52,6 @@ func Setup(servMux *http.ServeMux, httpClient *http.Client, cfg *config.Dendrite
 	r0mux.Handle("/thumbnail/{serverName}/{mediaId}",
 		makeDownloadAPI("thumbnail", cfg, db, activeRemoteRequests, activeThumbnailGeneration),
 	)
-
-	servMux.Handle("/metrics", prometheus.Handler())
-	servMux.Handle("/api/", http.StripPrefix("/api", apiMux))
 }
 
 func makeDownloadAPI(name string, cfg *config.Dendrite, db *storage.Database, activeRemoteRequests *types.ActiveRemoteRequests, activeThumbnailGeneration *types.ActiveThumbnailGeneration) http.HandlerFunc {

--- a/src/github.com/matrix-org/dendrite/syncapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/routing/routing.go
@@ -23,18 +23,14 @@ import (
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/syncapi/sync"
 	"github.com/matrix-org/util"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 const pathPrefixR0 = "/_matrix/client/r0"
 
-// SetupSyncServerListeners configures the given mux with sync-server listeners
-func SetupSyncServerListeners(servMux *http.ServeMux, httpClient *http.Client, srp *sync.RequestPool, deviceDB *devices.Database) {
-	apiMux := mux.NewRouter()
+// Setup configures the given mux with sync-server listeners
+func Setup(apiMux *mux.Router, srp *sync.RequestPool, deviceDB *devices.Database) {
 	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
 	r0mux.Handle("/sync", common.MakeAuthAPI("sync", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 		return srp.OnIncomingSyncRequest(req, device)
 	}))
-	servMux.Handle("/metrics", prometheus.Handler())
-	servMux.Handle("/api/", http.StripPrefix("/api", apiMux))
 }


### PR DESCRIPTION
This makes it possible to setup all the component APIs on a single http
listener which is necessary if we want to combine all the components
into a single monolith.