### PR TITLE
Membership viewing API

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/auth/authtypes/membership.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/authtypes/membership.go
@@ -17,7 +17,8 @@ package authtypes
 // Membership represents the relationship between a user and a room they're a
 // member of
 type Membership struct {
-	Localpart string
-	RoomID    string
-	EventID   string
+	Localpart   string
+	RoomID      string
+	EventID     string
+	StillInRoom bool
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
@@ -156,12 +156,20 @@ func (d *Database) UpdateMemberships(eventsToAdd []gomatrixserverlib.Event, idsT
 	})
 }
 
-// GetMembershipsByLocalpart returns an array containing the IDs of all the rooms
-// a user matching a given localpart is a member of
+// GetMembershipsByLocalpart returns an array containing the memberships for all
+// the rooms a user matching a given localpart is a member of
 // If no membership match the given localpart, returns an empty array
 // If there was an issue during the retrieval, returns the SQL error
 func (d *Database) GetMembershipsByLocalpart(localpart string) (memberships []authtypes.Membership, err error) {
 	return d.memberships.selectMembershipsByLocalpart(localpart)
+}
+
+// GetMembershipsByRoomID returns an array containing the memberships for all
+// the users that are member of a given room
+// If no membership match the given localpart, returns an empty array
+// If there was an issue during the retrieval, returns the SQL error
+func (d *Database) GetMembershipsByRoomID(roomID string) (memberships []authtypes.Membership, err error) {
+	return d.memberships.selectMembershipsByRoomID(roomID)
 }
 
 // UpdateMembership update the "join" membership event ID of a membership.

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
@@ -157,6 +157,13 @@ func (d *Database) UpdateMemberships(eventsToAdd []gomatrixserverlib.Event, idsT
 	})
 }
 
+// GetMembership returns the membership for the given localpart and room ID
+// If no membership match the given localpart, returns nil
+// If there was an issue during the retrieval, returns the SQL error
+func (d *Database) GetMembership(localpart string, roomID string) (*authtypes.Membership, error) {
+	return d.memberships.selectMembership(localpart, roomID)
+}
+
 // GetMembershipsByLocalpart returns an array containing the memberships for all
 // the rooms a user matching a given localpart is a member of
 // If no membership match the given localpart, returns an empty array

--- a/src/github.com/matrix-org/dendrite/clientapi/readers/memberships.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/readers/memberships.go
@@ -29,9 +29,8 @@ func GetMemberships(
 	req *http.Request, roomID string, accountDB *accounts.Database,
 	queryAPI api.RoomserverQueryAPI,
 ) util.JSONResponse {
-	// TODO: Check if the user is or has been in the room, and respond with
-	// M_FORBIDDEN if not. If the user has been in the room before but isn't
-	// anymore, send the members list as it was before they left.
+	// TODO: If the user has been in the room before but isn't
+	// anymore, only send the members list as it was before they left.
 
 	memberships, err := accountDB.GetMembershipsByRoomID(roomID)
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/clientapi/readers/memberships.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/readers/memberships.go
@@ -1,0 +1,64 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package readers
+
+import (
+	"net/http"
+
+	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
+	"github.com/matrix-org/dendrite/clientapi/httputil"
+	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/util"
+)
+
+// GetMemberships implements GET /rooms/{roomId}/members
+func GetMemberships(
+	req *http.Request, roomID string, accountDB *accounts.Database,
+	queryAPI api.RoomserverQueryAPI,
+) util.JSONResponse {
+	// TODO: Check if the user is or has been in the room, and respond with
+	// M_FORBIDDEN if not. If the user has been in the room before but isn't
+	// anymore, send the members list as it was before they left.
+
+	memberships, err := accountDB.GetMembershipsByRoomID(roomID)
+	if err != nil {
+		return httputil.LogThenError(req, err)
+	}
+
+	eventIDs := []string{}
+	for _, membership := range memberships {
+		eventIDs = append(eventIDs, membership.EventID)
+	}
+
+	queryReq := api.QueryEventsByIDRequest{
+		EventIDs: eventIDs,
+	}
+	var queryRes api.QueryEventsByIDResponse
+	if err := queryAPI.QueryEventsByID(&queryReq, &queryRes); err != nil {
+		return httputil.LogThenError(req, err)
+	}
+
+	events := []gomatrixserverlib.ClientEvent{}
+	for _, event := range queryRes.Events {
+		ev := gomatrixserverlib.ToClientEvent(event, gomatrixserverlib.FormatAll)
+		events = append(events, ev)
+	}
+
+	return util.JSONResponse{
+		Code: 200,
+		JSON: events,
+	}
+}

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -304,7 +304,7 @@ func Setup(
 	r0mux.Handle("/rooms/{roomID}/members",
 		common.MakeAuthAPI("rooms_members", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
-			return readers.GetMemberships(req, vars["roomID"], accountDB, queryAPI)
+			return readers.GetMemberships(req, device, vars["roomID"], accountDB, cfg, queryAPI)
 		}),
 	)
 

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -303,6 +303,13 @@ func Setup(
 		}),
 	)
 
+	r0mux.Handle("/rooms/{roomID}/members",
+		common.MakeAuthAPI("rooms_members", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+			vars := mux.Vars(req)
+			return readers.GetMemberships(req, vars["roomID"], accountDB, queryAPI)
+		}),
+	)
+
 	r0mux.Handle("/rooms/{roomID}/read_markers",
 		common.MakeAPI("rooms_read_markers", func(req *http.Request) util.JSONResponse {
 			// TODO: return the read_markers.


### PR DESCRIPTION
This PR implements `GET /_matrix/client/r0/rooms/{roomID}/members`

Still left to do:
* If the user was previously in the room but has left since, send the memberships list as it was before they left instead of the current one
* If the room isn't local, retrieve the list of memberships through federation

But I'm not sure either of them are currently doable.