### PR TITLE
Add prefixes to namespace the SQL tables.

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/accounts_table.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/accounts_table.go
@@ -25,7 +25,7 @@ import (
 
 const accountsSchema = `
 -- Stores data about accounts.
-CREATE TABLE IF NOT EXISTS accounts (
+CREATE TABLE IF NOT EXISTS account_accounts (
     -- The Matrix user ID localpart for this account
     localpart TEXT NOT NULL PRIMARY KEY,
     -- When this account was first created, as a unix timestamp (ms resolution).
@@ -38,13 +38,13 @@ CREATE TABLE IF NOT EXISTS accounts (
 `
 
 const insertAccountSQL = "" +
-	"INSERT INTO accounts(localpart, created_ts, password_hash) VALUES ($1, $2, $3)"
+	"INSERT INTO account_accounts(localpart, created_ts, password_hash) VALUES ($1, $2, $3)"
 
 const selectAccountByLocalpartSQL = "" +
-	"SELECT localpart FROM accounts WHERE localpart = $1"
+	"SELECT localpart FROM account_accounts WHERE localpart = $1"
 
 const selectPasswordHashSQL = "" +
-	"SELECT password_hash FROM accounts WHERE localpart = $1"
+	"SELECT password_hash FROM account_accounts WHERE localpart = $1"
 
 // TODO: Update password
 

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/membership_table.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/membership_table.go
@@ -23,7 +23,7 @@ import (
 
 const membershipSchema = `
 -- Stores data about users memberships to rooms.
-CREATE TABLE IF NOT EXISTS memberships (
+CREATE TABLE IF NOT EXISTS account_memberships (
     -- The Matrix user ID localpart for the member
     localpart TEXT NOT NULL,
     -- The room this user is a member of
@@ -36,25 +36,25 @@ CREATE TABLE IF NOT EXISTS memberships (
 );
 
 -- Use index to process deletion by ID more efficiently
-CREATE UNIQUE INDEX IF NOT EXISTS membership_event_id ON memberships(event_id);
+CREATE UNIQUE INDEX IF NOT EXISTS account_membership_event_id ON account_memberships(event_id);
 `
 
 const insertMembershipSQL = `
-	INSERT INTO memberships(localpart, room_id, event_id) VALUES ($1, $2, $3)
+	INSERT INTO account_memberships(localpart, room_id, event_id) VALUES ($1, $2, $3)
 	ON CONFLICT (localpart, room_id) DO UPDATE SET event_id = EXCLUDED.event_id
 `
 
 const selectMembershipSQL = "" +
-	"SELECT * from memberships WHERE localpart = $1 AND room_id = $2"
+	"SELECT * from account_memberships WHERE localpart = $1 AND room_id = $2"
 
 const selectMembershipsByLocalpartSQL = "" +
-	"SELECT room_id, event_id FROM memberships WHERE localpart = $1"
+	"SELECT room_id, event_id FROM account_memberships WHERE localpart = $1"
 
 const deleteMembershipsByEventIDsSQL = "" +
-	"DELETE FROM memberships WHERE event_id = ANY($1)"
+	"DELETE FROM account_memberships WHERE event_id = ANY($1)"
 
 const updateMembershipByEventIDSQL = "" +
-	"UPDATE memberships SET event_id = $2 WHERE event_id = $1"
+	"UPDATE account_memberships SET event_id = $2 WHERE event_id = $1"
 
 type membershipStatements struct {
 	deleteMembershipsByEventIDsStmt  *sql.Stmt

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/profile_table.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/profile_table.go
@@ -22,7 +22,7 @@ import (
 
 const profilesSchema = `
 -- Stores data about accounts profiles.
-CREATE TABLE IF NOT EXISTS profiles (
+CREATE TABLE IF NOT EXISTS account_profiles (
     -- The Matrix user ID localpart for this account
     localpart TEXT NOT NULL PRIMARY KEY,
     -- The display name for this account
@@ -33,16 +33,16 @@ CREATE TABLE IF NOT EXISTS profiles (
 `
 
 const insertProfileSQL = "" +
-	"INSERT INTO profiles(localpart, display_name, avatar_url) VALUES ($1, $2, $3)"
+	"INSERT INTO account_profiles(localpart, display_name, avatar_url) VALUES ($1, $2, $3)"
 
 const selectProfileByLocalpartSQL = "" +
-	"SELECT localpart, display_name, avatar_url FROM profiles WHERE localpart = $1"
+	"SELECT localpart, display_name, avatar_url FROM account_profiles WHERE localpart = $1"
 
 const setAvatarURLSQL = "" +
-	"UPDATE profiles SET avatar_url = $1 WHERE localpart = $2"
+	"UPDATE account_profiles SET avatar_url = $1 WHERE localpart = $2"
 
 const setDisplayNameSQL = "" +
-	"UPDATE profiles SET display_name = $1 WHERE localpart = $2"
+	"UPDATE account_profiles SET display_name = $1 WHERE localpart = $2"
 
 type profilesStatements struct {
 	insertProfileStmt            *sql.Stmt

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
@@ -44,7 +44,7 @@ func NewDatabase(dataSourceName string, serverName gomatrixserverlib.ServerName)
 		return nil, err
 	}
 	partitions := common.PartitionOffsetStatements{}
-	if err = partitions.Prepare(db); err != nil {
+	if err = partitions.Prepare(db, "account"); err != nil {
 		return nil, err
 	}
 	a := accountsStatements{}

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/devices/devices_table.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/devices/devices_table.go
@@ -25,7 +25,7 @@ import (
 
 const devicesSchema = `
 -- Stores data about devices.
-CREATE TABLE IF NOT EXISTS devices (
+CREATE TABLE IF NOT EXISTS device_devices (
     -- The access token granted to this device. This has to be the primary key
     -- so we can distinguish which device is making a given request.
     access_token TEXT NOT NULL PRIMARY KEY,
@@ -42,17 +42,17 @@ CREATE TABLE IF NOT EXISTS devices (
 );
 
 -- Device IDs must be unique for a given user.
-CREATE UNIQUE INDEX IF NOT EXISTS localpart_id_idx ON devices(localpart, device_id);
+CREATE UNIQUE INDEX IF NOT EXISTS device_localpart_id_idx ON device_devices(localpart, device_id);
 `
 
 const insertDeviceSQL = "" +
-	"INSERT INTO devices(device_id, localpart, access_token, created_ts) VALUES ($1, $2, $3, $4)"
+	"INSERT INTO device_devices(device_id, localpart, access_token, created_ts) VALUES ($1, $2, $3, $4)"
 
 const selectDeviceByTokenSQL = "" +
-	"SELECT device_id, localpart FROM devices WHERE access_token = $1"
+	"SELECT device_id, localpart FROM device_devices WHERE access_token = $1"
 
 const deleteDeviceSQL = "" +
-	"DELETE FROM devices WHERE device_id = $1 AND localpart = $2"
+	"DELETE FROM device_devices WHERE device_id = $1 AND localpart = $2"
 
 // TODO: List devices?
 

--- a/src/github.com/matrix-org/dendrite/common/keydb/server_key_table.go
+++ b/src/github.com/matrix-org/dendrite/common/keydb/server_key_table.go
@@ -17,13 +17,14 @@ package keydb
 import (
 	"database/sql"
 	"encoding/json"
+
 	"github.com/lib/pq"
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
 const serverKeysSchema = `
 -- A cache of server keys downloaded from remote servers.
-CREATE TABLE IF NOT EXISTS server_keys (
+CREATE TABLE IF NOT EXISTS keydb_server_keys (
 	-- The name of the matrix server the key is for.
 	server_name TEXT NOT NULL,
 	-- The ID of the server key.
@@ -35,21 +36,21 @@ CREATE TABLE IF NOT EXISTS server_keys (
 	valid_until_ts BIGINT NOT NULL,
 	-- The raw JSON for the server key.
 	server_key_json TEXT NOT NULL,
-	CONSTRAINT server_keys_unique UNIQUE (server_name, server_key_id)
+	CONSTRAINT keydb_server_keys_unique UNIQUE (server_name, server_key_id)
 );
 
-CREATE INDEX IF NOT EXISTS server_name_and_key_id ON server_keys (server_name_and_key_id);
+CREATE INDEX IF NOT EXISTS keydb_server_name_and_key_id ON keydb_server_keys (server_name_and_key_id);
 `
 
 const bulkSelectServerKeysSQL = "" +
-	"SELECT server_name, server_key_id, server_key_json FROM server_keys" +
+	"SELECT server_name, server_key_id, server_key_json FROM keydb_server_keys" +
 	" WHERE server_name_and_key_id = ANY($1)"
 
 const upsertServerKeysSQL = "" +
-	"INSERT INTO server_keys (server_name, server_key_id," +
+	"INSERT INTO keydb_server_keys (server_name, server_key_id," +
 	" server_name_and_key_id, valid_until_ts, server_key_json)" +
 	" VALUES ($1, $2, $3, $4, $5)" +
-	" ON CONFLICT ON CONSTRAINT server_keys_unique" +
+	" ON CONFLICT ON CONSTRAINT keydb_server_keys_unique" +
 	" DO UPDATE SET valid_until_ts = $4, server_key_json = $5"
 
 type serverKeyStatements struct {

--- a/src/github.com/matrix-org/dendrite/common/partition_offset_table.go
+++ b/src/github.com/matrix-org/dendrite/common/partition_offset_table.go
@@ -45,6 +45,8 @@ type PartitionOffsetStatements struct {
 }
 
 // Prepare converts the raw SQL statements into prepared statements.
+// Takes a prefix to prepend to the table name used to store the partition offsets.
+// This allows multiple components to share the same database schema.
 func (s *PartitionOffsetStatements) Prepare(db *sql.DB, prefix string) (err error) {
 	_, err = db.Exec(strings.Replace(partitionOffsetsSchema, "${prefix}", prefix, -1))
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/federationsender/storage/joined_hosts_table.go
+++ b/src/github.com/matrix-org/dendrite/federationsender/storage/joined_hosts_table.go
@@ -26,7 +26,7 @@ const joinedHostsSchema = `
 -- The joined_hosts table stores a list of m.room.member event ids in the
 -- current state for each room where the membership is "join".
 -- There will be an entry for every user that is joined to the room.
-CREATE TABLE IF NOT EXISTS joined_hosts (
+CREATE TABLE IF NOT EXISTS federationsender_joined_hosts (
     -- The string ID of the room.
     room_id TEXT NOT NULL,
     -- The event ID of the m.room.member join event.
@@ -35,22 +35,22 @@ CREATE TABLE IF NOT EXISTS joined_hosts (
     server_name TEXT NOT NULL
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS joined_hosts_event_id_idx
-    ON joined_hosts (event_id);
+CREATE UNIQUE INDEX IF NOT EXISTS federatonsender_joined_hosts_event_id_idx
+    ON federationsender_joined_hosts (event_id);
 
-CREATE INDEX IF NOT EXISTS joined_hosts_room_id_idx
-    ON joined_hosts (room_id)
+CREATE INDEX IF NOT EXISTS federatonsender_joined_hosts_room_id_idx
+    ON federationsender_joined_hosts (room_id)
 `
 
 const insertJoinedHostsSQL = "" +
-	"INSERT INTO joined_hosts (room_id, event_id, server_name)" +
+	"INSERT INTO federationsender_joined_hosts (room_id, event_id, server_name)" +
 	" VALUES ($1, $2, $3)"
 
 const deleteJoinedHostsSQL = "" +
-	"DELETE FROM joined_hosts WHERE event_id = ANY($1)"
+	"DELETE FROM federationsender_joined_hosts WHERE event_id = ANY($1)"
 
 const selectJoinedHostsSQL = "" +
-	"SELECT event_id, server_name FROM joined_hosts" +
+	"SELECT event_id, server_name FROM federationsender_joined_hosts" +
 	" WHERE room_id = $1"
 
 type joinedHostsStatements struct {

--- a/src/github.com/matrix-org/dendrite/federationsender/storage/room_table.go
+++ b/src/github.com/matrix-org/dendrite/federationsender/storage/room_table.go
@@ -19,7 +19,7 @@ import (
 )
 
 const roomSchema = `
-CREATE TABLE IF NOT EXISTS rooms (
+CREATE TABLE IF NOT EXISTS federationsender_rooms (
     -- The string ID of the room
     room_id TEXT PRIMARY KEY,
     -- The most recent event state by the room server.
@@ -29,14 +29,14 @@ CREATE TABLE IF NOT EXISTS rooms (
 );`
 
 const insertRoomSQL = "" +
-	"INSERT INTO rooms (room_id, last_event_id) VALUES ($1, '')" +
+	"INSERT INTO federationsender_rooms (room_id, last_event_id) VALUES ($1, '')" +
 	" ON CONFLICT DO NOTHING"
 
 const selectRoomForUpdateSQL = "" +
-	"SELECT last_event_id FROM rooms WHERE room_id = $1 FOR UPDATE"
+	"SELECT last_event_id FROM federationsender_rooms WHERE room_id = $1 FOR UPDATE"
 
 const updateRoomSQL = "" +
-	"UPDATE rooms SET last_event_id = $2 WHERE room_id = $1"
+	"UPDATE federationsender_rooms SET last_event_id = $2 WHERE room_id = $1"
 
 type roomStatements struct {
 	insertRoomStmt          *sql.Stmt

--- a/src/github.com/matrix-org/dendrite/federationsender/storage/storage.go
+++ b/src/github.com/matrix-org/dendrite/federationsender/storage/storage.go
@@ -53,7 +53,7 @@ func (d *Database) prepare() error {
 		return err
 	}
 
-	if err = d.PartitionOffsetStatements.Prepare(d.db); err != nil {
+	if err = d.PartitionOffsetStatements.Prepare(d.db, "federationsender"); err != nil {
 		return err
 	}
 

--- a/src/github.com/matrix-org/dendrite/mediaapi/storage/media_repository_table.go
+++ b/src/github.com/matrix-org/dendrite/mediaapi/storage/media_repository_table.go
@@ -25,7 +25,7 @@ import (
 const mediaSchema = `
 -- The media_repository table holds metadata for each media file stored and accessible to the local server,
 -- the actual file is stored separately.
-CREATE TABLE IF NOT EXISTS media_repository (
+CREATE TABLE IF NOT EXISTS mediaapi_media_repository (
     -- The id used to refer to the media.
     -- For uploads to this server this is a base64-encoded sha256 hash of the file data
     -- For media from remote servers, this can be any unique identifier string
@@ -45,16 +45,16 @@ CREATE TABLE IF NOT EXISTS media_repository (
     -- The user who uploaded the file. Should be a Matrix user ID.
     user_id TEXT NOT NULL
 );
-CREATE UNIQUE INDEX IF NOT EXISTS media_repository_index ON media_repository (media_id, media_origin);
+CREATE UNIQUE INDEX IF NOT EXISTS mediaapi_media_repository_index ON mediaapi_media_repository (media_id, media_origin);
 `
 
 const insertMediaSQL = `
-INSERT INTO media_repository (media_id, media_origin, content_type, file_size_bytes, creation_ts, upload_name, base64hash, user_id)
+INSERT INTO mediaapi_media_repository (media_id, media_origin, content_type, file_size_bytes, creation_ts, upload_name, base64hash, user_id)
     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 `
 
 const selectMediaSQL = `
-SELECT content_type, file_size_bytes, creation_ts, upload_name, base64hash, user_id FROM media_repository WHERE media_id = $1 AND media_origin = $2
+SELECT content_type, file_size_bytes, creation_ts, upload_name, base64hash, user_id FROM mediaapi_media_repository WHERE media_id = $1 AND media_origin = $2
 `
 
 type mediaStatements struct {

--- a/src/github.com/matrix-org/dendrite/mediaapi/storage/thumbnail_table.go
+++ b/src/github.com/matrix-org/dendrite/mediaapi/storage/thumbnail_table.go
@@ -23,9 +23,9 @@ import (
 )
 
 const thumbnailSchema = `
--- The thumbnail table holds metadata for each thumbnail file stored and accessible to the local server,
+-- The mediaapi_thumbnail table holds metadata for each thumbnail file stored and accessible to the local server,
 -- the actual file is stored separately.
-CREATE TABLE IF NOT EXISTS thumbnail (
+CREATE TABLE IF NOT EXISTS mediaapi_thumbnail (
     -- The id used to refer to the media.
     -- For uploads to this server this is a base64-encoded sha256 hash of the file data
     -- For media from remote servers, this can be any unique identifier string
@@ -45,22 +45,22 @@ CREATE TABLE IF NOT EXISTS thumbnail (
     -- The resize method used to generate the thumbnail. Can be crop or scale.
     resize_method TEXT NOT NULL
 );
-CREATE UNIQUE INDEX IF NOT EXISTS thumbnail_index ON thumbnail (media_id, media_origin, width, height, resize_method);
+CREATE UNIQUE INDEX IF NOT EXISTS mediaapi_thumbnail_index ON mediaapi_thumbnail (media_id, media_origin, width, height, resize_method);
 `
 
 const insertThumbnailSQL = `
-INSERT INTO thumbnail (media_id, media_origin, content_type, file_size_bytes, creation_ts, width, height, resize_method)
+INSERT INTO mediaapi_thumbnail (media_id, media_origin, content_type, file_size_bytes, creation_ts, width, height, resize_method)
     VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 `
 
 // Note: this selects one specific thumbnail
 const selectThumbnailSQL = `
-SELECT content_type, file_size_bytes, creation_ts FROM thumbnail WHERE media_id = $1 AND media_origin = $2 AND width = $3 AND height = $4 AND resize_method = $5
+SELECT content_type, file_size_bytes, creation_ts FROM mediaapi_thumbnail WHERE media_id = $1 AND media_origin = $2 AND width = $3 AND height = $4 AND resize_method = $5
 `
 
 // Note: this selects all thumbnails for a media_origin and media_id
 const selectThumbnailsSQL = `
-SELECT content_type, file_size_bytes, creation_ts, width, height, resize_method FROM thumbnail WHERE media_id = $1 AND media_origin = $2
+SELECT content_type, file_size_bytes, creation_ts, width, height, resize_method FROM mediaapi_thumbnail WHERE media_id = $1 AND media_origin = $2
 `
 
 type thumbnailStatements struct {

--- a/src/github.com/matrix-org/dendrite/roomserver/storage/event_json_table.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/storage/event_json_table.go
@@ -16,13 +16,14 @@ package storage
 
 import (
 	"database/sql"
+
 	"github.com/matrix-org/dendrite/roomserver/types"
 )
 
 const eventJSONSchema = `
 -- Stores the JSON for each event. This kept separate from the main events
 -- table to keep the rows in the main events table small.
-CREATE TABLE IF NOT EXISTS event_json (
+CREATE TABLE IF NOT EXISTS roomserver_event_json (
     -- Local numeric ID for the event.
     event_nid BIGINT NOT NULL PRIMARY KEY,
     -- The JSON for the event.
@@ -37,14 +38,14 @@ CREATE TABLE IF NOT EXISTS event_json (
 `
 
 const insertEventJSONSQL = "" +
-	"INSERT INTO event_json (event_nid, event_json) VALUES ($1, $2)" +
+	"INSERT INTO roomserver_event_json (event_nid, event_json) VALUES ($1, $2)" +
 	" ON CONFLICT DO NOTHING"
 
 // Bulk event JSON lookup by numeric event ID.
 // Sort by the numeric event ID.
 // This means that we can use binary search to lookup by numeric event ID.
 const bulkSelectEventJSONSQL = "" +
-	"SELECT event_nid, event_json FROM event_json" +
+	"SELECT event_nid, event_json FROM roomserver_event_json" +
 	" WHERE event_nid = ANY($1)" +
 	" ORDER BY event_nid ASC"
 

--- a/src/github.com/matrix-org/dendrite/roomserver/storage/event_state_keys_table.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/storage/event_state_keys_table.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"database/sql"
+
 	"github.com/lib/pq"
 	"github.com/matrix-org/dendrite/roomserver/types"
 )
@@ -31,29 +32,30 @@ const eventStateKeysSchema = `
 -- Other state keys are automatically assigned numeric IDs starting from 2**16.
 -- This leaves room to add more pre-assigned numeric IDs and clearly separates
 -- the automatically assigned IDs from the pre-assigned IDs.
-CREATE SEQUENCE IF NOT EXISTS event_state_key_nid_seq START 65536;
-CREATE TABLE IF NOT EXISTS event_state_keys (
+CREATE SEQUENCE IF NOT EXISTS roomserver_event_state_key_nid_seq START 65536;
+CREATE TABLE IF NOT EXISTS roomserver_event_state_keys (
     -- Local numeric ID for the state key.
-    event_state_key_nid BIGINT PRIMARY KEY DEFAULT nextval('event_state_key_nid_seq'),
-    event_state_key TEXT NOT NULL CONSTRAINT event_state_key_unique UNIQUE
+    event_state_key_nid BIGINT PRIMARY KEY DEFAULT nextval('roomserver_event_state_key_nid_seq'),
+    event_state_key TEXT NOT NULL CONSTRAINT roomserver_event_state_key_unique UNIQUE
 );
-INSERT INTO event_state_keys (event_state_key_nid, event_state_key) VALUES
+INSERT INTO roomserver_event_state_keys (event_state_key_nid, event_state_key) VALUES
     (1, '') ON CONFLICT DO NOTHING;
 `
 
 // Same as insertEventTypeNIDSQL
 const insertEventStateKeyNIDSQL = "" +
-	"INSERT INTO event_state_keys (event_state_key) VALUES ($1)" +
-	" ON CONFLICT ON CONSTRAINT event_state_key_unique" +
+	"INSERT INTO roomserver_event_state_keys (event_state_key) VALUES ($1)" +
+	" ON CONFLICT ON CONSTRAINT roomserver_event_state_key_unique" +
 	" DO NOTHING RETURNING (event_state_key_nid)"
 
 const selectEventStateKeyNIDSQL = "" +
-	"SELECT event_state_key_nid FROM event_state_keys WHERE event_state_key = $1"
+	"SELECT event_state_key_nid FROM roomserver_event_state_keys" +
+	" WHERE event_state_key = $1"
 
 // Bulk lookup from string state key to numeric ID for that state key.
 // Takes an array of strings as the query parameter.
 const bulkSelectEventStateKeyNIDSQL = "" +
-	"SELECT event_state_key, event_state_key_nid FROM event_state_keys" +
+	"SELECT event_state_key, event_state_key_nid FROM roomserver_event_state_keys" +
 	" WHERE event_state_key = ANY($1)"
 
 type eventStateKeyStatements struct {

--- a/src/github.com/matrix-org/dendrite/roomserver/storage/event_types_table.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/storage/event_types_table.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"database/sql"
+
 	"github.com/lib/pq"
 	"github.com/matrix-org/dendrite/roomserver/types"
 )
@@ -43,14 +44,14 @@ const eventTypesSchema = `
 -- Other event types are automatically assigned numeric IDs starting from 2**16.
 -- This leaves room to add more pre-assigned numeric IDs and clearly separates
 -- the automatically assigned IDs from the pre-assigned IDs.
-CREATE SEQUENCE IF NOT EXISTS event_type_nid_seq START 65536;
-CREATE TABLE IF NOT EXISTS event_types (
+CREATE SEQUENCE IF NOT EXISTS roomserver_event_type_nid_seq START 65536;
+CREATE TABLE IF NOT EXISTS roomserver_event_types (
     -- Local numeric ID for the event type.
-    event_type_nid BIGINT PRIMARY KEY DEFAULT nextval('event_type_nid_seq'),
+    event_type_nid BIGINT PRIMARY KEY DEFAULT nextval('roomserver_event_type_nid_seq'),
     -- The string event_type.
-    event_type TEXT NOT NULL CONSTRAINT event_type_unique UNIQUE
+    event_type TEXT NOT NULL CONSTRAINT roomserver_event_type_unique UNIQUE
 );
-INSERT INTO event_types (event_type_nid, event_type) VALUES
+INSERT INTO roomserver_event_types (event_type_nid, event_type) VALUES
     (1, 'm.room.create'),
     (2, 'm.room.power_levels'),
     (3, 'm.room.join_rules'),
@@ -74,17 +75,17 @@ INSERT INTO event_types (event_type_nid, event_type) VALUES
 // row even though the data doesn't change resulting in unncesssary modifications
 // to the indexes.
 const insertEventTypeNIDSQL = "" +
-	"INSERT INTO event_types (event_type) VALUES ($1)" +
-	" ON CONFLICT ON CONSTRAINT event_type_unique" +
+	"INSERT INTO roomserver_event_types (event_type) VALUES ($1)" +
+	" ON CONFLICT ON CONSTRAINT roomserver_event_type_unique" +
 	" DO NOTHING RETURNING (event_type_nid)"
 
 const selectEventTypeNIDSQL = "" +
-	"SELECT event_type_nid FROM event_types WHERE event_type = $1"
+	"SELECT event_type_nid FROM roomserver_event_types WHERE event_type = $1"
 
 // Bulk lookup from string event type to numeric ID for that event type.
 // Takes an array of strings as the query parameter.
 const bulkSelectEventTypeNIDSQL = "" +
-	"SELECT event_type, event_type_nid FROM event_types" +
+	"SELECT event_type, event_type_nid FROM roomserver_event_types" +
 	" WHERE event_type = ANY($1)"
 
 type eventTypeStatements struct {

--- a/src/github.com/matrix-org/dendrite/roomserver/storage/room_aliases_table.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/storage/room_aliases_table.go
@@ -20,27 +20,27 @@ import (
 
 const roomAliasesSchema = `
 -- Stores room aliases and room IDs they refer to
-CREATE TABLE IF NOT EXISTS room_aliases (
+CREATE TABLE IF NOT EXISTS roomserver_room_aliases (
     -- Alias of the room
     alias TEXT NOT NULL PRIMARY KEY,
     -- Room ID the alias refers to
     room_id TEXT NOT NULL
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS room_id_idx ON room_aliases(room_id);
+CREATE UNIQUE INDEX IF NOT EXISTS roomserver_room_id_idx ON roomserver_room_aliases(room_id);
 `
 
 const insertRoomAliasSQL = "" +
-	"INSERT INTO room_aliases (alias, room_id) VALUES ($1, $2)"
+	"INSERT INTO roomserver_room_aliases (alias, room_id) VALUES ($1, $2)"
 
 const selectRoomIDFromAliasSQL = "" +
-	"SELECT room_id FROM room_aliases WHERE alias = $1"
+	"SELECT room_id FROM roomserver_room_aliases WHERE alias = $1"
 
 const selectAliasesFromRoomIDSQL = "" +
-	"SELECT alias FROM room_aliases WHERE room_id = $1"
+	"SELECT alias FROM roomserver_room_aliases WHERE room_id = $1"
 
 const deleteRoomAliasSQL = "" +
-	"DELETE FROM room_aliases WHERE alias = $1"
+	"DELETE FROM roomserver_room_aliases WHERE alias = $1"
 
 type roomAliasesStatements struct {
 	insertRoomAliasStmt         *sql.Stmt

--- a/src/github.com/matrix-org/dendrite/roomserver/storage/rooms_table.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/storage/rooms_table.go
@@ -16,17 +16,18 @@ package storage
 
 import (
 	"database/sql"
+
 	"github.com/lib/pq"
 	"github.com/matrix-org/dendrite/roomserver/types"
 )
 
 const roomsSchema = `
-CREATE SEQUENCE IF NOT EXISTS room_nid_seq;
-CREATE TABLE IF NOT EXISTS rooms (
+CREATE SEQUENCE IF NOT EXISTS roomserver_room_nid_seq;
+CREATE TABLE IF NOT EXISTS roomserver_rooms (
     -- Local numeric ID for the room.
-    room_nid BIGINT PRIMARY KEY DEFAULT nextval('room_nid_seq'),
+    room_nid BIGINT PRIMARY KEY DEFAULT nextval('roomserver_room_nid_seq'),
     -- Textual ID for the room.
-    room_id TEXT NOT NULL CONSTRAINT room_id_unique UNIQUE,
+    room_id TEXT NOT NULL CONSTRAINT roomserver_room_id_unique UNIQUE,
     -- The most recent events in the room that aren't referenced by another event.
     -- This list may empty if the server hasn't joined the room yet.
     -- (The server will be in that state while it stores the events for the initial state of the room)
@@ -41,21 +42,21 @@ CREATE TABLE IF NOT EXISTS rooms (
 
 // Same as insertEventTypeNIDSQL
 const insertRoomNIDSQL = "" +
-	"INSERT INTO rooms (room_id) VALUES ($1)" +
-	" ON CONFLICT ON CONSTRAINT room_id_unique" +
+	"INSERT INTO roomserver_rooms (room_id) VALUES ($1)" +
+	" ON CONFLICT ON CONSTRAINT roomserver_room_id_unique" +
 	" DO NOTHING RETURNING (room_nid)"
 
 const selectRoomNIDSQL = "" +
-	"SELECT room_nid FROM rooms WHERE room_id = $1"
+	"SELECT room_nid FROM roomserver_rooms WHERE room_id = $1"
 
 const selectLatestEventNIDsSQL = "" +
-	"SELECT latest_event_nids, state_snapshot_nid FROM rooms WHERE room_nid = $1"
+	"SELECT latest_event_nids, state_snapshot_nid FROM roomserver_rooms WHERE room_nid = $1"
 
 const selectLatestEventNIDsForUpdateSQL = "" +
-	"SELECT latest_event_nids, last_event_sent_nid, state_snapshot_nid FROM rooms WHERE room_nid = $1 FOR UPDATE"
+	"SELECT latest_event_nids, last_event_sent_nid, state_snapshot_nid FROM roomserver_rooms WHERE room_nid = $1 FOR UPDATE"
 
 const updateLatestEventNIDsSQL = "" +
-	"UPDATE rooms SET latest_event_nids = $2, last_event_sent_nid = $3, state_snapshot_nid = $4 WHERE room_nid = $1"
+	"UPDATE roomserver_rooms SET latest_event_nids = $2, last_event_sent_nid = $3, state_snapshot_nid = $4 WHERE room_nid = $1"
 
 type roomStatements struct {
 	insertRoomNIDStmt                  *sql.Stmt

--- a/src/github.com/matrix-org/dendrite/roomserver/storage/state_snapshot_table.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/storage/state_snapshot_table.go
@@ -17,6 +17,7 @@ package storage
 import (
 	"database/sql"
 	"fmt"
+
 	"github.com/lib/pq"
 	"github.com/matrix-org/dendrite/roomserver/types"
 )
@@ -32,10 +33,10 @@ const stateSnapshotSchema = `
 -- because room state tends to accumulate small changes over time. Although if
 -- the list of deltas becomes too long it becomes more efficient to encode
 -- the full state under single state_block_nid.
-CREATE SEQUENCE IF NOT EXISTS state_snapshot_nid_seq;
-CREATE TABLE IF NOT EXISTS state_snapshots (
+CREATE SEQUENCE IF NOT EXISTS roomserver_state_snapshot_nid_seq;
+CREATE TABLE IF NOT EXISTS roomserver_state_snapshots (
     -- Local numeric ID for the state.
-    state_snapshot_nid bigint PRIMARY KEY DEFAULT nextval('state_snapshot_nid_seq'),
+    state_snapshot_nid bigint PRIMARY KEY DEFAULT nextval('roomserver_state_snapshot_nid_seq'),
     -- Local numeric ID of the room this state is for.
     -- Unused in normal operation, but useful for background work or ad-hoc debugging.
     room_nid bigint NOT NULL,
@@ -45,7 +46,7 @@ CREATE TABLE IF NOT EXISTS state_snapshots (
 `
 
 const insertStateSQL = "" +
-	"INSERT INTO state_snapshots (room_nid, state_block_nids)" +
+	"INSERT INTO roomserver_state_snapshots (room_nid, state_block_nids)" +
 	" VALUES ($1, $2)" +
 	" RETURNING state_snapshot_nid"
 
@@ -53,7 +54,7 @@ const insertStateSQL = "" +
 // Sorting by state_snapshot_nid means we can use binary search over the result
 // to lookup the state data NIDs for a state snapshot NID.
 const bulkSelectStateBlockNIDsSQL = "" +
-	"SELECT state_snapshot_nid, state_block_nids FROM state_snapshots" +
+	"SELECT state_snapshot_nid, state_block_nids FROM roomserver_state_snapshots" +
 	" WHERE state_snapshot_nid = ANY($1) ORDER BY state_snapshot_nid ASC"
 
 type stateSnapshotStatements struct {

--- a/src/github.com/matrix-org/dendrite/syncapi/storage/account_data_table.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/storage/account_data_table.go
@@ -22,7 +22,7 @@ import (
 
 const accountDataSchema = `
 -- Stores the users account data
-CREATE TABLE IF NOT EXISTS account_data_type (
+CREATE TABLE IF NOT EXISTS syncapi_account_data_type (
     -- The highest numeric ID from the output_room_events at the time of saving the data
     id BIGINT,
     -- ID of the user the data belongs to
@@ -35,19 +35,19 @@ CREATE TABLE IF NOT EXISTS account_data_type (
     PRIMARY KEY(user_id, room_id, type),
 
     -- We don't want two entries of the same type for the same user
-    CONSTRAINT account_data_unique UNIQUE (user_id, room_id, type)
+    CONSTRAINT syncapi_account_data_unique UNIQUE (user_id, room_id, type)
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS account_data_id_idx ON account_data_type(id);
+CREATE UNIQUE INDEX IF NOT EXISTS syncapi_account_data_id_idx ON syncapi_account_data_type(id);
 `
 
 const insertAccountDataSQL = "" +
-	"INSERT INTO account_data_type (id, user_id, room_id, type) VALUES ($1, $2, $3, $4)" +
-	" ON CONFLICT ON CONSTRAINT account_data_unique" +
+	"INSERT INTO syncapi_account_data_type (id, user_id, room_id, type) VALUES ($1, $2, $3, $4)" +
+	" ON CONFLICT ON CONSTRAINT syncapi_account_data_unique" +
 	" DO UPDATE SET id = EXCLUDED.id"
 
 const selectAccountDataInRangeSQL = "" +
-	"SELECT room_id, type FROM account_data_type" +
+	"SELECT room_id, type FROM syncapi_account_data_type" +
 	" WHERE user_id = $1 AND id > $2 AND id <= $3" +
 	" ORDER BY id ASC"
 

--- a/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
@@ -56,7 +56,7 @@ func NewSyncServerDatabase(dataSourceName string) (*SyncServerDatabase, error) {
 		return nil, err
 	}
 	partitions := common.PartitionOffsetStatements{}
-	if err = partitions.Prepare(db); err != nil {
+	if err = partitions.Prepare(db, "syncapi"); err != nil {
 		return nil, err
 	}
 	accountData := accountDataStatements{}


### PR DESCRIPTION
This means that multiple components can share a single database schema
without colliding with each other.

Once this lands it will be possible to run a single monolithic dendrite
against a single postgresql schema.

Hopefully this will make trivial deployments and development easier.

The result ends up looking something like:
```
test=# \d
                        List of relations
 Schema |                Name                |   Type   | Owner  
--------+------------------------------------+----------+--------
 public | account_accounts                   | table    | markjh
 public | account_data                       | table    | markjh
 public | account_memberships                | table    | markjh
 public | account_partition_offsets          | table    | markjh
 public | account_profiles                   | table    | markjh
 public | device_devices                     | table    | markjh
 public | federationsender_joined_hosts      | table    | markjh
 public | federationsender_partition_offsets | table    | markjh
 public | federationsender_rooms             | table    | markjh
 public | keydb_server_keys                  | table    | markjh
 public | mediaapi_media_repository          | table    | markjh
 public | mediaapi_thumbnail                 | table    | markjh
 public | roomserver_event_json              | table    | markjh
 public | roomserver_event_nid_seq           | sequence | markjh
 public | roomserver_event_state_key_nid_seq | sequence | markjh
 public | roomserver_event_state_keys        | table    | markjh
 public | roomserver_event_type_nid_seq      | sequence | markjh
 public | roomserver_event_types             | table    | markjh
 public | roomserver_events                  | table    | markjh
 public | roomserver_previous_events         | table    | markjh
 public | roomserver_room_aliases            | table    | markjh
 public | roomserver_room_nid_seq            | sequence | markjh
 public | roomserver_rooms                   | table    | markjh
 public | roomserver_state_block             | table    | markjh
 public | roomserver_state_block_nid_seq     | sequence | markjh
 public | roomserver_state_snapshot_nid_seq  | sequence | markjh
 public | roomserver_state_snapshots         | table    | markjh
 public | syncapi_account_data_type          | table    | markjh
 public | syncapi_current_room_state         | table    | markjh
 public | syncapi_output_room_events         | table    | markjh
 public | syncapi_output_room_events_id_seq  | sequence | markjh
 public | syncapi_partition_offsets          | table    | markjh

```