### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml}]
+indent_style = space


### PR DESCRIPTION
By default GitHub renders tabs as 8 characters wide, which is really annoying. Adding this `.editorconfig` changes that to 4 chars wide.

`.editorconfig` is not only recognized by GitHub, but also basically every editor (hence the name, and all the settings that aren't the indent size) although many require an extra plugin / package. Details can be found on http://editorconfig.org/.