### PR TITLE
Add a route matching the trailing slash on the state event sending route

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -100,6 +100,13 @@ func Setup(
 			return writers.SendEvent(req, device, vars["roomID"], vars["eventType"], vars["txnID"], &emptyString, cfg, queryAPI, producer)
 		}),
 	)
+	r0mux.Handle("/rooms/{roomID}/state/{eventType}/",
+		common.MakeAuthAPI("send_message", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+			vars := mux.Vars(req)
+			emptyString := ""
+			return writers.SendEvent(req, device, vars["roomID"], vars["eventType"], vars["txnID"], &emptyString, cfg, queryAPI, producer)
+		}),
+	)
 	r0mux.Handle("/rooms/{roomID}/state/{eventType}/{stateKey}",
 		common.MakeAuthAPI("send_message", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -94,7 +94,7 @@ func Setup(
 			return writers.SendEvent(req, device, vars["roomID"], vars["eventType"], vars["txnID"], nil, cfg, queryAPI, producer)
 		}),
 	)
-	r0mux.Handle("/rooms/{roomID}/state/{eventType:[a-z._-]+(?:\\/)?}",
+	r0mux.Handle("/rooms/{roomID}/state/{eventType:[^/]+/?}",
 		common.MakeAuthAPI("send_message", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			emptyString := ""

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -17,6 +17,7 @@ package routing
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
@@ -93,18 +94,16 @@ func Setup(
 			return writers.SendEvent(req, device, vars["roomID"], vars["eventType"], vars["txnID"], nil, cfg, queryAPI, producer)
 		}),
 	)
-	r0mux.Handle("/rooms/{roomID}/state/{eventType}",
+	r0mux.Handle("/rooms/{roomID}/state/{eventType:[a-z._-]+(?:\\/)?}",
 		common.MakeAuthAPI("send_message", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			emptyString := ""
-			return writers.SendEvent(req, device, vars["roomID"], vars["eventType"], vars["txnID"], &emptyString, cfg, queryAPI, producer)
-		}),
-	)
-	r0mux.Handle("/rooms/{roomID}/state/{eventType}/",
-		common.MakeAuthAPI("send_message", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
-			vars := mux.Vars(req)
-			emptyString := ""
-			return writers.SendEvent(req, device, vars["roomID"], vars["eventType"], vars["txnID"], &emptyString, cfg, queryAPI, producer)
+			eventType := vars["eventType"]
+			// If there's a trailing slash, remove it
+			if strings.HasSuffix(eventType, "/") {
+				eventType = eventType[:len(eventType)-1]
+			}
+			return writers.SendEvent(req, device, vars["roomID"], eventType, vars["txnID"], &emptyString, cfg, queryAPI, producer)
 		}),
 	)
 	r0mux.Handle("/rooms/{roomID}/state/{eventType}/{stateKey}",


### PR DESCRIPTION
I know it looks like a nasty solution (code duplication and stuff), but after many tries and a bit of research it looks like it's [the official way of solving this problem](https://github.com/gorilla/mux/issues/30#issuecomment-21254225).

FTR, the issue here is that `PUT` requests on `/_matrix/client/r0/rooms/{roomID}/state/{eventType}/` aren't supported by Dendrite because of the trailing slash, despite being implicitly allowed in the Matrix spec. This causes some functionalities in Riot to not work with Dendrite (such as changing a room's avatar) because it's using the route with the trailing slash.