### PR TITLE
Optionally use naffka in the monolithic server

### DIFF
--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -75,6 +75,7 @@ database:
 
 # The TCP host:port pairs to bind the internal HTTP APIs to.
 # These shouldn't be exposed to the public internet.
+# These aren't needed when running dendrite as a monolithic server.
 listen:
     room_server: "localhost:7770"
     client_api: "localhost:7771"

--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -52,9 +52,13 @@ media:
 kafka:
     # Where the kafka servers are running.
     addresses: ["localhost:9092"]
+    # Whether to use naffka instead of kafka.
+    # Naffka can only be used when running dendrite as a single monolithic server.
+    # Kafka can be used both with a monolithic server and when running the
+    # components as separate servers.
+    use_naffka: false
     # The names of the kafka topics to use.
     topics:
-        input_room_event: roomserverInput
         output_room_event: roomserverOutput
         output_client_data: clientapiOutput
         user_updates: userUpdates

--- a/src/github.com/matrix-org/dendrite/clientapi/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/consumers/roomserver.go
@@ -17,13 +17,13 @@ package consumers
 import (
 	"encoding/json"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/config"
-
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
+
+	log "github.com/Sirupsen/logrus"
 	sarama "gopkg.in/Shopify/sarama.v1"
 )
 

--- a/src/github.com/matrix-org/dendrite/clientapi/producers/syncapi.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/producers/syncapi.go
@@ -28,18 +28,6 @@ type SyncAPIProducer struct {
 	Producer sarama.SyncProducer
 }
 
-// NewSyncAPIProducer creates a new SyncAPIProducer
-func NewSyncAPIProducer(kafkaURIs []string, topic string) (*SyncAPIProducer, error) {
-	producer, err := sarama.NewSyncProducer(kafkaURIs, nil)
-	if err != nil {
-		return nil, err
-	}
-	return &SyncAPIProducer{
-		Topic:    topic,
-		Producer: producer,
-	}, nil
-}
-
 // SendData sends account data to the sync API server
 func (p *SyncAPIProducer) SendData(userID string, roomID string, dataType string) error {
 	var m sarama.ProducerMessage

--- a/src/github.com/matrix-org/dendrite/clientapi/producers/userupdate.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/producers/userupdate.go
@@ -34,18 +34,6 @@ type profileUpdate struct {
 	NewValue string `json:"new_value"` // The attribute's value after the update
 }
 
-// NewUserUpdateProducer creates a new UserUpdateProducer
-func NewUserUpdateProducer(kafkaURIs []string, topic string) (*UserUpdateProducer, error) {
-	producer, err := sarama.NewSyncProducer(kafkaURIs, nil)
-	if err != nil {
-		return nil, err
-	}
-	return &UserUpdateProducer{
-		Topic:    topic,
-		Producer: producer,
-	}, nil
-}
-
 // SendUpdate sends an update using kafka to notify the roomserver of the
 // profile update. Returns an error if the update failed to send.
 func (p *UserUpdateProducer) SendUpdate(

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
@@ -81,6 +81,7 @@ func main() {
 	m := newMonolith(cfg)
 	m.setupDatabases()
 	m.setupFederation()
+	m.setupKafka()
 	m.setupRoomServer()
 	m.setupProducers()
 	m.setupNotifiers()

--- a/src/github.com/matrix-org/dendrite/common/config/config.go
+++ b/src/github.com/matrix-org/dendrite/common/config/config.go
@@ -94,6 +94,11 @@ type Dendrite struct {
 	Kafka struct {
 		// A list of kafka addresses to connect to.
 		Addresses []string `yaml:"addresses"`
+		// Whether to use naffka instead of kafka.
+		// Naffka can only be used when running dendrite as a single monolithic server.
+		// Kafka can be used both with a monolithic server and when running the
+		// components as separate servers.
+		UseNaffka bool `yaml:"use_naffka,omitempty"`
 		// The names of the topics to use when reading and writing from kafka.
 		Topics struct {
 			// Topic for roomserver/api.OutputRoomEvent events.
@@ -169,7 +174,10 @@ type ThumbnailSize struct {
 	ResizeMethod string `yaml:"method,omitempty"`
 }
 
-// Load a yaml config file
+// Load a yaml config file for a server run as multiple processes.
+// Checks the config to ensure that it is valid.
+// The checks are different if the server is run as a monolithic process instead
+// of being split into multiple components
 func Load(configPath string) (*Dendrite, error) {
 	configData, err := ioutil.ReadFile(configPath)
 	if err != nil {
@@ -181,7 +189,27 @@ func Load(configPath string) (*Dendrite, error) {
 	}
 	// Pass the current working directory and ioutil.ReadFile so that they can
 	// be mocked in the tests
-	return loadConfig(basePath, configData, ioutil.ReadFile)
+	monolithic := false
+	return loadConfig(basePath, configData, ioutil.ReadFile, monolithic)
+}
+
+// LoadMonolithic loads a yaml config file for a server run as a single monolith.
+// Checks the config to ensure that it is valid.
+// The checks are different if the server is run as a monolithic process instead
+// of being split into multiple components
+func LoadMonolithic(configPath string) (*Dendrite, error) {
+	configData, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+	basePath, err := filepath.Abs(".")
+	if err != nil {
+		return nil, err
+	}
+	// Pass the current working directory and ioutil.ReadFile so that they can
+	// be mocked in the tests
+	monolithic := true
+	return loadConfig(basePath, configData, ioutil.ReadFile, monolithic)
 }
 
 // An Error indicates a problem parsing the config.
@@ -194,6 +222,7 @@ func loadConfig(
 	basePath string,
 	configData []byte,
 	readFile func(string) ([]byte, error),
+	monolithic bool,
 ) (*Dendrite, error) {
 	var config Dendrite
 	var err error
@@ -203,7 +232,7 @@ func loadConfig(
 
 	config.setDefaults()
 
-	if err = config.check(); err != nil {
+	if err = config.check(monolithic); err != nil {
 		return nil, err
 	}
 
@@ -259,7 +288,7 @@ func (e Error) Error() string {
 	)
 }
 
-func (config *Dendrite) check() error {
+func (config *Dendrite) check(monolithic bool) error {
 	var problems []string
 
 	if config.Version != Version {
@@ -297,21 +326,32 @@ func (config *Dendrite) check() error {
 		checkPositive(fmt.Sprintf("media.thumbnail_sizes[%d].width", i), int64(size.Width))
 		checkPositive(fmt.Sprintf("media.thumbnail_sizes[%d].height", i), int64(size.Height))
 	}
-
-	checkNotZero("kafka.addresses", int64(len(config.Kafka.Addresses)))
+	if config.Kafka.UseNaffka {
+		if !monolithic {
+			problems = append(problems, fmt.Sprintf("naffka can only be used in a monolithic server"))
+		}
+	} else {
+		// If we aren't using naffka then we need to have at least one kafka
+		// server to talk to.
+		checkNotZero("kafka.addresses", int64(len(config.Kafka.Addresses)))
+	}
 	checkNotEmpty("kafka.topics.output_room_event", string(config.Kafka.Topics.OutputRoomEvent))
 	checkNotEmpty("kafka.topics.output_client_data", string(config.Kafka.Topics.OutputClientData))
+	checkNotEmpty("kafka.topics.user_updates", string(config.Kafka.Topics.UserUpdates))
 	checkNotEmpty("database.account", string(config.Database.Account))
 	checkNotEmpty("database.device", string(config.Database.Device))
 	checkNotEmpty("database.server_key", string(config.Database.ServerKey))
 	checkNotEmpty("database.media_api", string(config.Database.MediaAPI))
 	checkNotEmpty("database.sync_api", string(config.Database.SyncAPI))
 	checkNotEmpty("database.room_server", string(config.Database.RoomServer))
-	checkNotEmpty("listen.media_api", string(config.Listen.MediaAPI))
-	checkNotEmpty("listen.client_api", string(config.Listen.ClientAPI))
-	checkNotEmpty("listen.federation_api", string(config.Listen.FederationAPI))
-	checkNotEmpty("listen.sync_api", string(config.Listen.SyncAPI))
-	checkNotEmpty("listen.room_server", string(config.Listen.RoomServer))
+
+	if !monolithic {
+		checkNotEmpty("listen.media_api", string(config.Listen.MediaAPI))
+		checkNotEmpty("listen.client_api", string(config.Listen.ClientAPI))
+		checkNotEmpty("listen.federation_api", string(config.Listen.FederationAPI))
+		checkNotEmpty("listen.sync_api", string(config.Listen.SyncAPI))
+		checkNotEmpty("listen.room_server", string(config.Listen.RoomServer))
+	}
 
 	if problems != nil {
 		return Error{problems}

--- a/src/github.com/matrix-org/dendrite/common/config/config_test.go
+++ b/src/github.com/matrix-org/dendrite/common/config/config_test.go
@@ -25,6 +25,7 @@ func TestLoadConfigRelative(t *testing.T) {
 			"/my/config/dir/matrix_key.pem": testKey,
 			"/my/config/dir/tls_cert.pem":   testCert,
 		}.readFile,
+		false,
 	)
 	if err != nil {
 		t.Error("failed to load config:", err)
@@ -42,9 +43,9 @@ media:
 kafka:
   addresses: ["localhost:9092"]
   topics:
-    input_room_event: input.room
     output_room_event: output.room
     output_client_data: output.client
+    user_updates: output.user
 database:
   media_api: "postgresql:///media_api"
   account: "postgresql:///account"

--- a/src/github.com/matrix-org/dendrite/common/test/config.go
+++ b/src/github.com/matrix-org/dendrite/common/test/config.go
@@ -83,6 +83,7 @@ func MakeConfig(configDir, kafkaURI, database, host string, startPort int) (*con
 	// Make this configurable somehow?
 	cfg.Kafka.Topics.OutputRoomEvent = "test.room.output"
 	cfg.Kafka.Topics.OutputClientData = "test.clientapi.output"
+	cfg.Kafka.Topics.UserUpdates = "test.user.output"
 
 	// TODO: Use different databases for the different schemas.
 	// Using the same database for every schema currently works because

--- a/src/github.com/matrix-org/dendrite/federationsender/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/federationsender/consumers/roomserver.go
@@ -38,13 +38,13 @@ type OutputRoomEvent struct {
 }
 
 // NewOutputRoomEvent creates a new OutputRoomEvent consumer. Call Start() to begin consuming from room servers.
-func NewOutputRoomEvent(cfg *config.Dendrite, queues *queue.OutgoingQueues, store *storage.Database) (*OutputRoomEvent, error) {
-	kafkaConsumer, err := sarama.NewConsumer(cfg.Kafka.Addresses, nil)
-	if err != nil {
-		return nil, err
-	}
-	roomServerURL := cfg.RoomServerURL()
-
+func NewOutputRoomEvent(
+	cfg *config.Dendrite,
+	kafkaConsumer sarama.Consumer,
+	queues *queue.OutgoingQueues,
+	store *storage.Database,
+	queryAPI api.RoomserverQueryAPI,
+) *OutputRoomEvent {
 	consumer := common.ContinualConsumer{
 		Topic:          string(cfg.Kafka.Topics.OutputRoomEvent),
 		Consumer:       kafkaConsumer,
@@ -54,11 +54,11 @@ func NewOutputRoomEvent(cfg *config.Dendrite, queues *queue.OutgoingQueues, stor
 		roomServerConsumer: &consumer,
 		db:                 store,
 		queues:             queues,
-		query:              api.NewRoomserverQueryAPIHTTP(roomServerURL, nil),
+		query:              queryAPI,
 	}
 	consumer.ProcessMessage = s.onMessage
 
-	return s, nil
+	return s
 }
 
 // Start consuming from room servers

--- a/src/github.com/matrix-org/dendrite/syncapi/consumers/clientapi.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/consumers/clientapi.go
@@ -33,11 +33,12 @@ type OutputClientData struct {
 }
 
 // NewOutputClientData creates a new OutputClientData consumer. Call Start() to begin consuming from room servers.
-func NewOutputClientData(cfg *config.Dendrite, n *sync.Notifier, store *storage.SyncServerDatabase) (*OutputClientData, error) {
-	kafkaConsumer, err := sarama.NewConsumer(cfg.Kafka.Addresses, nil)
-	if err != nil {
-		return nil, err
-	}
+func NewOutputClientData(
+	cfg *config.Dendrite,
+	kafkaConsumer sarama.Consumer,
+	n *sync.Notifier,
+	store *storage.SyncServerDatabase,
+) *OutputClientData {
 
 	consumer := common.ContinualConsumer{
 		Topic:          string(cfg.Kafka.Topics.OutputClientData),
@@ -51,7 +52,7 @@ func NewOutputClientData(cfg *config.Dendrite, n *sync.Notifier, store *storage.
 	}
 	consumer.ProcessMessage = s.onMessage
 
-	return s, nil
+	return s
 }
 
 // Start consuming from room servers

--- a/src/github.com/matrix-org/dendrite/syncapi/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/consumers/roomserver.go
@@ -44,12 +44,13 @@ type prevEventRef struct {
 }
 
 // NewOutputRoomEvent creates a new OutputRoomEvent consumer. Call Start() to begin consuming from room servers.
-func NewOutputRoomEvent(cfg *config.Dendrite, n *sync.Notifier, store *storage.SyncServerDatabase) (*OutputRoomEvent, error) {
-	kafkaConsumer, err := sarama.NewConsumer(cfg.Kafka.Addresses, nil)
-	if err != nil {
-		return nil, err
-	}
-	roomServerURL := cfg.RoomServerURL()
+func NewOutputRoomEvent(
+	cfg *config.Dendrite,
+	kafkaConsumer sarama.Consumer,
+	n *sync.Notifier,
+	store *storage.SyncServerDatabase,
+	queryAPI api.RoomserverQueryAPI,
+) *OutputRoomEvent {
 
 	consumer := common.ContinualConsumer{
 		Topic:          string(cfg.Kafka.Topics.OutputRoomEvent),
@@ -60,11 +61,11 @@ func NewOutputRoomEvent(cfg *config.Dendrite, n *sync.Notifier, store *storage.S
 		roomServerConsumer: &consumer,
 		db:                 store,
 		notifier:           n,
-		query:              api.NewRoomserverQueryAPIHTTP(roomServerURL, nil),
+		query:              queryAPI,
 	}
 	consumer.ProcessMessage = s.onMessage
 
-	return s, nil
+	return s
 }
 
 // Start consuming from room servers


### PR DESCRIPTION
This PR chases down all the places where we create a kafka consumer or producer and replaces them with dependency injected versions, this means that we can optionally replace the kafka consumer or producers objects with a naffka versions in the monolithic server.