### PR TITLE
Implement public rooms APIs

### DIFF
--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -68,6 +68,7 @@ database:
     room_server: "postgres://dendrite:itsasecret@localhost/dendrite_roomserver?sslmode=disable"
     server_key: "postgres://dendrite:itsasecret@localhost/dendrite_serverkey?sslmode=disable"
     federation_sender: "postgres://dendrite:itsasecret@localhost/dendrite_federationsender?sslmode=disable"
+    public_rooms_api: "postgres://dendrite:itsasecret@localhost/dendrite_publicroomsapi?sslmode=disable"
 
 # The TCP host:port pairs to bind the internal HTTP APIs to.
 # These shouldn't be exposed to the public internet.

--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -78,3 +78,4 @@ listen:
     federation_api: "localhost:7772"
     sync_api: "localhost:7773"
     media_api: "localhost:7774"
+    public_rooms_api: "localhost:7775"

--- a/src/github.com/matrix-org/dendrite/clientapi/readers/profile.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/readers/profile.go
@@ -23,6 +23,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/clientapi/producers"
+	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/config"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -271,7 +272,7 @@ func buildMembershipEvents(
 			StateKey: &userID,
 		}
 
-		content := events.MemberContent{
+		content := common.MemberContent{
 			Membership: "join",
 		}
 

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -100,6 +100,13 @@ func Setup(
 			return writers.SendEvent(req, device, vars["roomID"], vars["eventType"], vars["txnID"], &emptyString, cfg, queryAPI, producer)
 		}),
 	)
+	r0mux.Handle("/rooms/{roomID}/state/{eventType}/",
+		common.MakeAuthAPI("send_message", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+			vars := mux.Vars(req)
+			emptyString := ""
+			return writers.SendEvent(req, device, vars["roomID"], vars["eventType"], vars["txnID"], &emptyString, cfg, queryAPI, producer)
+		}),
+	)
 	r0mux.Handle("/rooms/{roomID}/state/{eventType}/{stateKey}",
 		common.MakeAuthAPI("send_message", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -100,13 +100,6 @@ func Setup(
 			return writers.SendEvent(req, device, vars["roomID"], vars["eventType"], vars["txnID"], &emptyString, cfg, queryAPI, producer)
 		}),
 	)
-	r0mux.Handle("/rooms/{roomID}/state/{eventType}/",
-		common.MakeAuthAPI("send_message", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
-			vars := mux.Vars(req)
-			emptyString := ""
-			return writers.SendEvent(req, device, vars["roomID"], vars["eventType"], vars["txnID"], &emptyString, cfg, queryAPI, producer)
-		}),
-	)
 	r0mux.Handle("/rooms/{roomID}/state/{eventType}/{stateKey}",
 		common.MakeAuthAPI("send_message", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
@@ -262,20 +255,6 @@ func Setup(
 			return util.JSONResponse{
 				Code: 200,
 				JSON: struct{}{},
-			}
-		}),
-	)
-
-	r0mux.Handle("/publicRooms",
-		common.MakeAPI("public_rooms", func(req *http.Request) util.JSONResponse {
-			// TODO: Return a list of public rooms
-			return util.JSONResponse{
-				Code: 200,
-				JSON: struct {
-					Chunk []struct{} `json:"chunk"`
-					Start string     `json:"start"`
-					End   string     `json:"end"`
-				}{[]struct{}{}, "", ""},
 			}
 		}),
 	)

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/createroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/createroom.go
@@ -24,10 +24,10 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
-	"github.com/matrix-org/dendrite/clientapi/events"
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/clientapi/producers"
+	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/config"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
@@ -132,7 +132,7 @@ func createRoom(req *http.Request, device *authtypes.Device,
 		return httputil.LogThenError(req, err)
 	}
 
-	membershipContent := events.MemberContent{
+	membershipContent := common.MemberContent{
 		Membership:  "join",
 		DisplayName: profile.DisplayName,
 		AvatarURL:   profile.AvatarURL,
@@ -159,16 +159,16 @@ func createRoom(req *http.Request, device *authtypes.Device,
 	// harder to reason about, hence sticking to a strict static ordering.
 	// TODO: Synapse has txn/token ID on each event. Do we need to do this here?
 	eventsToMake := []fledglingEvent{
-		{"m.room.create", "", events.CreateContent{Creator: userID}},
+		{"m.room.create", "", common.CreateContent{Creator: userID}},
 		{"m.room.member", userID, membershipContent},
-		{"m.room.power_levels", "", events.InitialPowerLevelsContent(userID)},
+		{"m.room.power_levels", "", common.InitialPowerLevelsContent(userID)},
 		// TODO: m.room.canonical_alias
-		{"m.room.join_rules", "", events.JoinRulesContent{"public"}},                 // FIXME: Allow this to be changed
-		{"m.room.history_visibility", "", events.HistoryVisibilityContent{"joined"}}, // FIXME: Allow this to be changed
-		{"m.room.guest_access", "", events.GuestAccessContent{"can_join"}},           // FIXME: Allow this to be changed
+		{"m.room.join_rules", "", common.JoinRulesContent{"public"}},                 // FIXME: Allow this to be changed
+		{"m.room.history_visibility", "", common.HistoryVisibilityContent{"joined"}}, // FIXME: Allow this to be changed
+		{"m.room.guest_access", "", common.GuestAccessContent{"can_join"}},           // FIXME: Allow this to be changed
 		// TODO: Other initial state items
-		{"m.room.name", "", events.NameContent{r.Name}}, // FIXME: Only send the name event if a name is supplied, to avoid sending a false room name removal event
-		{"m.room.topic", "", events.TopicContent{r.Topic}},
+		{"m.room.name", "", common.NameContent{r.Name}}, // FIXME: Only send the name event if a name is supplied, to avoid sending a false room name removal event
+		{"m.room.topic", "", common.TopicContent{r.Topic}},
 		// TODO: invite events
 		// TODO: 3pid invite events
 		// TODO: m.room.aliases

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/membership.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/membership.go
@@ -23,6 +23,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/clientapi/producers"
+	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/config"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -69,7 +70,7 @@ func SendMembership(
 		membership = "leave"
 	}
 
-	content := events.MemberContent{
+	content := common.MemberContent{
 		Membership:  membership,
 		DisplayName: profile.DisplayName,
 		AvatarURL:   profile.AvatarURL,

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
@@ -300,7 +300,7 @@ func (m *monolith) setupConsumers() {
 	}
 
 	publicRoomsAPIConsumer := publicroomsapi_consumers.NewOutputRoomEvent(
-		m.cfg, m.kafkaConsumer(), m.publicRoomsAPIDB,
+		m.cfg, m.kafkaConsumer(), m.publicRoomsAPIDB, m.queryAPI,
 	)
 	if err = publicRoomsAPIConsumer.Start(); err != nil {
 		log.Panicf("startup: failed to start room server consumer: %s", err)

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
@@ -300,7 +300,7 @@ func (m *monolith) setupConsumers() {
 	}
 
 	publicRoomsAPIConsumer := publicroomsapi_consumers.NewOutputRoomEvent(
-		m.cfg, m.kafkaConsumer, m.publicRoomsAPIDB,
+		m.cfg, m.kafkaConsumer(), m.publicRoomsAPIDB,
 	)
 	if err = publicRoomsAPIConsumer.Start(); err != nil {
 		log.Panicf("startup: failed to start room server consumer: %s", err)

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
@@ -52,6 +52,10 @@ import (
 	"github.com/matrix-org/dendrite/federationsender/queue"
 	federationsender_storage "github.com/matrix-org/dendrite/federationsender/storage"
 
+	publicroomsapi_consumers "github.com/matrix-org/dendrite/publicroomsapi/consumers"
+	publicroomsapi_routing "github.com/matrix-org/dendrite/publicroomsapi/routing"
+	publicroomsapi_storage "github.com/matrix-org/dendrite/publicroomsapi/storage"
+
 	log "github.com/Sirupsen/logrus"
 	sarama "gopkg.in/Shopify/sarama.v1"
 )
@@ -119,6 +123,7 @@ type monolith struct {
 	mediaAPIDB         *mediaapi_storage.Database
 	syncAPIDB          *syncapi_storage.SyncServerDatabase
 	federationSenderDB *federationsender_storage.Database
+	publicRoomsAPIDB   *publicroomsapi_storage.PublicRoomsServerDatabase
 
 	federation *gomatrixserverlib.FederationClient
 	keyRing    gomatrixserverlib.KeyRing
@@ -170,6 +175,10 @@ func (m *monolith) setupDatabases() {
 	m.federationSenderDB, err = federationsender_storage.NewDatabase(string(m.cfg.Database.FederationSender))
 	if err != nil {
 		log.Panicf("startup: failed to create federation sender database with data source %s : %s", m.cfg.Database.FederationSender, err)
+	}
+	m.publicRoomsAPIDB, err = publicroomsapi_storage.NewPublicRoomsServerDatabase(string(m.cfg.Database.PublicRoomsAPI))
+	if err != nil {
+		log.Panicf("startup: failed to setup public rooms api database with data source %s : %s", m.cfg.Database.PublicRoomsAPI, err)
 	}
 }
 
@@ -283,6 +292,13 @@ func (m *monolith) setupConsumers() {
 		log.Panicf("startup: failed to start client API server consumer: %s", err)
 	}
 
+	publicRoomsAPIConsumer := publicroomsapi_consumers.NewOutputRoomEvent(
+		m.cfg, m.kafkaConsumer, m.publicRoomsAPIDB,
+	)
+	if err = publicRoomsAPIConsumer.Start(); err != nil {
+		log.Panicf("startup: failed to start room server consumer: %s", err)
+	}
+
 	federationSenderQueues := queue.NewOutgoingQueues(m.cfg.Matrix.ServerName, m.federation)
 
 	federationSenderRoomConsumer := federationsender_consumers.NewOutputRoomEvent(
@@ -311,4 +327,6 @@ func (m *monolith) setupAPIs() {
 	federationapi_routing.Setup(
 		m.api, *m.cfg, m.queryAPI, m.roomServerProducer, m.keyRing, m.federation,
 	)
+
+	publicroomsapi_routing.Setup(m.api, m.deviceDB, m.publicRoomsAPIDB)
 }

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-public-rooms-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-public-rooms-api-server/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/config"
+	"github.com/matrix-org/dendrite/publicroomsapi/consumers"
 	"github.com/matrix-org/dendrite/publicroomsapi/routing"
 	"github.com/matrix-org/dendrite/publicroomsapi/storage"
 
@@ -46,6 +47,14 @@ func main() {
 	db, err := storage.NewPublicRoomsServerDatabase(string(cfg.Database.PublicRoomsAPI))
 	if err != nil {
 		log.Panicf("startup: failed to create public rooms server database with data source %s : %s", cfg.Database.PublicRoomsAPI, err)
+	}
+
+	roomConsumer, err := consumers.NewOutputRoomEvent(cfg, db)
+	if err != nil {
+		log.Panicf("startup: failed to create room server consumer: %s", err)
+	}
+	if err = roomConsumer.Start(); err != nil {
+		log.Panicf("startup: failed to start room server consumer: %s", err)
 	}
 
 	log.Info("Starting public rooms server on ", cfg.Listen.PublicRoomsAPI)

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-public-rooms-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-public-rooms-api-server/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/matrix-org/dendrite/publicroomsapi/consumers"
 	"github.com/matrix-org/dendrite/publicroomsapi/routing"
 	"github.com/matrix-org/dendrite/publicroomsapi/storage"
+	"github.com/matrix-org/dendrite/roomserver/api"
 
 	log "github.com/Sirupsen/logrus"
 	sarama "gopkg.in/Shopify/sarama.v1"
@@ -46,6 +47,8 @@ func main() {
 		log.Fatalf("Invalid config file: %s", err)
 	}
 
+	queryAPI := api.NewRoomserverQueryAPIHTTP(cfg.RoomServerURL(), nil)
+
 	db, err := storage.NewPublicRoomsServerDatabase(string(cfg.Database.PublicRoomsAPI))
 	if err != nil {
 		log.Panicf("startup: failed to create public rooms server database with data source %s : %s", cfg.Database.PublicRoomsAPI, err)
@@ -64,7 +67,7 @@ func main() {
 		}).Panic("Failed to setup kafka consumers")
 	}
 
-	roomConsumer := consumers.NewOutputRoomEvent(cfg, kafkaConsumer, db)
+	roomConsumer := consumers.NewOutputRoomEvent(cfg, kafkaConsumer, db, queryAPI)
 	if err != nil {
 		log.Panicf("startup: failed to create room server consumer: %s", err)
 	}

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-public-rooms-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-public-rooms-api-server/main.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"github.com/gorilla/mux"
+	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/config"
 	"github.com/matrix-org/dendrite/publicroomsapi/consumers"
@@ -49,6 +50,11 @@ func main() {
 		log.Panicf("startup: failed to create public rooms server database with data source %s : %s", cfg.Database.PublicRoomsAPI, err)
 	}
 
+	deviceDB, err := devices.NewDatabase(string(cfg.Database.Device), cfg.Matrix.ServerName)
+	if err != nil {
+		log.Panicf("startup: failed to create device database with data source %s : %s", cfg.Database.Device, err)
+	}
+
 	roomConsumer, err := consumers.NewOutputRoomEvent(cfg, db)
 	if err != nil {
 		log.Panicf("startup: failed to create room server consumer: %s", err)
@@ -60,7 +66,7 @@ func main() {
 	log.Info("Starting public rooms server on ", cfg.Listen.PublicRoomsAPI)
 
 	api := mux.NewRouter()
-	routing.Setup(api, db)
+	routing.Setup(api, deviceDB, db)
 	common.SetupHTTPAPI(http.DefaultServeMux, api)
 
 	log.Fatal(http.ListenAndServe(string(cfg.Listen.PublicRoomsAPI), nil))

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-public-rooms-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-public-rooms-api-server/main.go
@@ -1,0 +1,58 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"net/http"
+	"os"
+
+	"github.com/gorilla/mux"
+	"github.com/matrix-org/dendrite/common"
+	"github.com/matrix-org/dendrite/common/config"
+	"github.com/matrix-org/dendrite/publicroomsapi/routing"
+	"github.com/matrix-org/dendrite/publicroomsapi/storage"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+var configPath = flag.String("config", "dendrite.yaml", "The path to the config file. For more information, see the config file in this repository.")
+
+func main() {
+	common.SetupLogging(os.Getenv("LOG_DIR"))
+
+	flag.Parse()
+
+	if *configPath == "" {
+		log.Fatal("--config must be supplied")
+	}
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		log.Fatalf("Invalid config file: %s", err)
+	}
+
+	db, err := storage.NewPublicRoomsServerDatabase(string(cfg.Database.PublicRoomsAPI))
+	if err != nil {
+		log.Panicf("startup: failed to create public rooms server database with data source %s : %s", cfg.Database.PublicRoomsAPI, err)
+	}
+
+	log.Info("Starting public rooms server on ", cfg.Listen.PublicRoomsAPI)
+
+	api := mux.NewRouter()
+	routing.Setup(api, db)
+	common.SetupHTTPAPI(http.DefaultServeMux, api)
+
+	log.Fatal(http.ListenAndServe(string(cfg.Listen.PublicRoomsAPI), nil))
+}

--- a/src/github.com/matrix-org/dendrite/common/config/config.go
+++ b/src/github.com/matrix-org/dendrite/common/config/config.go
@@ -128,6 +128,9 @@ type Dendrite struct {
 		// The FederationSender database stores information used by the FederationSender
 		// It is only accessed by the FederationSender.
 		FederationSender DataSource `yaml:"federation_sender"`
+		// The PublicRoomsAPI database stores information used to compute the public
+		// room directory. It is only accessed by the PublicRoomsAPI server.
+		PublicRoomsAPI DataSource `yaml:"public_rooms_api"`
 	} `yaml:"database"`
 
 	// The internal addresses the components will listen on.

--- a/src/github.com/matrix-org/dendrite/common/config/config.go
+++ b/src/github.com/matrix-org/dendrite/common/config/config.go
@@ -142,6 +142,7 @@ type Dendrite struct {
 		SyncAPI          Address `yaml:"sync_api"`
 		RoomServer       Address `yaml:"room_server"`
 		FederationSender Address `yaml:"federation_sender"`
+		PublicRoomsAPI   Address `yaml:"public_rooms_api"`
 	} `yaml:"listen"`
 }
 

--- a/src/github.com/matrix-org/dendrite/common/eventcontent.go
+++ b/src/github.com/matrix-org/dendrite/common/eventcontent.go
@@ -100,3 +100,19 @@ type AliasesContent struct {
 type CanonicalAliasContent struct {
 	Alias string `json:"alias"`
 }
+
+// AvatarContent is the event content for http://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-avatar
+type AvatarContent struct {
+	Info          ImageInfo `json:"info,omitempty"`
+	URL           string    `json:"url"`
+	ThumbnailURL  string    `json:"thumbnail_url,omitempty"`
+	ThumbnailInfo ImageInfo `json:"thumbnail_info,omitempty"`
+}
+
+// ImageInfo implements the ImageInfo structure from http://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-avatar
+type ImageInfo struct {
+	Mimetype string `json:"mimetype"`
+	Height   int64  `json:"h"`
+	Width    int64  `json:"w"`
+	Size     int64  `json:"size"`
+}

--- a/src/github.com/matrix-org/dendrite/common/eventcontent.go
+++ b/src/github.com/matrix-org/dendrite/common/eventcontent.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package events
+package common
 
 // CreateContent is the event content for http://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-create
 type CreateContent struct {

--- a/src/github.com/matrix-org/dendrite/common/eventcontent.go
+++ b/src/github.com/matrix-org/dendrite/common/eventcontent.go
@@ -90,3 +90,13 @@ func InitialPowerLevelsContent(roomCreator string) PowerLevelContent {
 		Users: map[string]int{roomCreator: 100},
 	}
 }
+
+// AliasesContent is the event content for http://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-aliases
+type AliasesContent struct {
+	Aliases []string `json:"aliases"`
+}
+
+// CanonicalAliasContent is the event content for http://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-canonical-alias
+type CanonicalAliasContent struct {
+	Alias string `json:"alias"`
+}

--- a/src/github.com/matrix-org/dendrite/common/test/config.go
+++ b/src/github.com/matrix-org/dendrite/common/test/config.go
@@ -94,12 +94,14 @@ func MakeConfig(configDir, kafkaURI, database, host string, startPort int) (*con
 	cfg.Database.RoomServer = config.DataSource(database)
 	cfg.Database.ServerKey = config.DataSource(database)
 	cfg.Database.SyncAPI = config.DataSource(database)
+	cfg.Database.PublicRoomsAPI = config.DataSource(database)
 
 	cfg.Listen.ClientAPI = assignAddress()
 	cfg.Listen.FederationAPI = assignAddress()
 	cfg.Listen.MediaAPI = assignAddress()
 	cfg.Listen.RoomServer = assignAddress()
 	cfg.Listen.SyncAPI = assignAddress()
+	cfg.Listen.PublicRoomsAPI = assignAddress()
 
 	return &cfg, port, nil
 }

--- a/src/github.com/matrix-org/dendrite/common/test/server.go
+++ b/src/github.com/matrix-org/dendrite/common/test/server.go
@@ -94,6 +94,7 @@ func StartProxy(bindAddr string, cfg *config.Dendrite) (*exec.Cmd, chan error) {
 		"--sync-api-server-url", "http://" + string(cfg.Listen.SyncAPI),
 		"--client-api-server-url", "http://" + string(cfg.Listen.ClientAPI),
 		"--media-api-server-url", "http://" + string(cfg.Listen.MediaAPI),
+		"--public-rooms-api-server-url", "http://" + string(cfg.Listen.PublicRoomsAPI),
 	}
 	return CreateBackgroundCommand(
 		filepath.Join(filepath.Dir(os.Args[0]), "client-api-proxy"),

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/README.md
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/README.md
@@ -1,0 +1,5 @@
+# Public rooms API
+
+This server is responsible for serving requests hitting `/publicRooms` and `/directory/list/room/{roomID}` as per:
+
+https://matrix.org/docs/spec/client_server/r0.2.0.html#listing-rooms

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/consumers/roomserver.go
@@ -33,12 +33,11 @@ type OutputRoomEvent struct {
 }
 
 // NewOutputRoomEvent creates a new OutputRoomEvent consumer. Call Start() to begin consuming from room servers.
-func NewOutputRoomEvent(cfg *config.Dendrite, store *storage.PublicRoomsServerDatabase) (*OutputRoomEvent, error) {
-	kafkaConsumer, err := sarama.NewConsumer(cfg.Kafka.Addresses, nil)
-	if err != nil {
-		return nil, err
-	}
-	roomServerURL := cfg.RoomServerURL()
+func NewOutputRoomEvent(
+	cfg *config.Dendrite,
+	kafkaConsumer sarama.Consumer,
+	store *storage.PublicRoomsServerDatabase,
+) *OutputRoomEvent {
 
 	consumer := common.ContinualConsumer{
 		Topic:          string(cfg.Kafka.Topics.OutputRoomEvent),
@@ -48,11 +47,10 @@ func NewOutputRoomEvent(cfg *config.Dendrite, store *storage.PublicRoomsServerDa
 	s := &OutputRoomEvent{
 		roomServerConsumer: &consumer,
 		db:                 store,
-		query:              api.NewRoomserverQueryAPIHTTP(roomServerURL, nil),
 	}
 	consumer.ProcessMessage = s.onMessage
 
-	return s, nil
+	return s
 }
 
 // Start consuming from room servers

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/consumers/roomserver.go
@@ -1,0 +1,88 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package consumers
+
+import (
+	"encoding/json"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/matrix-org/dendrite/common"
+	"github.com/matrix-org/dendrite/common/config"
+	"github.com/matrix-org/dendrite/publicroomsapi/storage"
+	"github.com/matrix-org/dendrite/roomserver/api"
+	sarama "gopkg.in/Shopify/sarama.v1"
+)
+
+// OutputRoomEvent consumes events that originated in the room server.
+type OutputRoomEvent struct {
+	roomServerConsumer *common.ContinualConsumer
+	db                 *storage.PublicRoomsServerDatabase
+	query              api.RoomserverQueryAPI
+}
+
+// NewOutputRoomEvent creates a new OutputRoomEvent consumer. Call Start() to begin consuming from room servers.
+func NewOutputRoomEvent(cfg *config.Dendrite, store *storage.PublicRoomsServerDatabase) (*OutputRoomEvent, error) {
+	kafkaConsumer, err := sarama.NewConsumer(cfg.Kafka.Addresses, nil)
+	if err != nil {
+		return nil, err
+	}
+	roomServerURL := cfg.RoomServerURL()
+
+	consumer := common.ContinualConsumer{
+		Topic:          string(cfg.Kafka.Topics.OutputRoomEvent),
+		Consumer:       kafkaConsumer,
+		PartitionStore: store,
+	}
+	s := &OutputRoomEvent{
+		roomServerConsumer: &consumer,
+		db:                 store,
+		query:              api.NewRoomserverQueryAPIHTTP(roomServerURL, nil),
+	}
+	consumer.ProcessMessage = s.onMessage
+
+	return s, nil
+}
+
+// Start consuming from room servers
+func (s *OutputRoomEvent) Start() error {
+	return s.roomServerConsumer.Start()
+}
+
+// onMessage is called when the sync server receives a new event from the room server output log.
+func (s *OutputRoomEvent) onMessage(msg *sarama.ConsumerMessage) error {
+	// Parse out the event JSON
+	var output api.OutputEvent
+	if err := json.Unmarshal(msg.Value, &output); err != nil {
+		// If the message was invalid, log it and move on to the next message in the stream
+		log.WithError(err).Errorf("roomserver output log: message parse failure")
+		return nil
+	}
+
+	if output.Type != api.OutputTypeNewRoomEvent {
+		log.WithField("type", output.Type).Debug(
+			"roomserver output log: ignoring unknown output type",
+		)
+		return nil
+	}
+
+	ev := output.NewRoomEvent.Event
+	log.WithFields(log.Fields{
+		"event_id": ev.EventID(),
+		"room_id":  ev.RoomID(),
+		"type":     ev.Type(),
+	}).Info("received event from roomserver")
+
+	return s.db.UpdateRoomFromEvent(ev)
+}

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/directory/directory.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/directory/directory.go
@@ -1,0 +1,73 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package directory
+
+import (
+	"net/http"
+
+	"github.com/matrix-org/dendrite/clientapi/httputil"
+	"github.com/matrix-org/dendrite/publicroomsapi/storage"
+
+	"github.com/matrix-org/util"
+)
+
+type roomVisibility struct {
+	Visibility string `json:"visibility"`
+}
+
+// GetVisibility implements GET /directory/list/room/{roomID}
+func GetVisibility(
+	req *http.Request, publicRoomsDatabase storage.PublicRoomsServerDatabase,
+	roomID string,
+) util.JSONResponse {
+	isPublic, err := publicRoomsDatabase.GetRoomVisibility(roomID)
+	if err != nil {
+		return httputil.LogThenError(req, err)
+	}
+
+	var v roomVisibility
+	if isPublic {
+		v.Visibility = "public"
+	} else {
+		v.Visibility = "private"
+	}
+
+	return util.JSONResponse{
+		Code: 200,
+		JSON: v,
+	}
+}
+
+// SetVisibility implements PUT /directory/list/room/{roomID}
+// TODO: Check if user has the power level to edit the room visibility
+func SetVisibility(
+	req *http.Request, publicRoomsDatabase storage.PublicRoomsServerDatabase,
+	roomID string,
+) util.JSONResponse {
+	var v roomVisibility
+	if reqErr := httputil.UnmarshalJSONRequest(req, &v); reqErr != nil {
+		return *reqErr
+	}
+
+	isPublic := v.Visibility == "public"
+	if err := publicRoomsDatabase.SetRoomVisibility(isPublic, roomID); err != nil {
+		return httputil.LogThenError(req, err)
+	}
+
+	return util.JSONResponse{
+		Code: 200,
+		JSON: struct{}{},
+	}
+}

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/directory/directory.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/directory/directory.go
@@ -29,7 +29,7 @@ type roomVisibility struct {
 
 // GetVisibility implements GET /directory/list/room/{roomID}
 func GetVisibility(
-	req *http.Request, publicRoomsDatabase storage.PublicRoomsServerDatabase,
+	req *http.Request, publicRoomsDatabase *storage.PublicRoomsServerDatabase,
 	roomID string,
 ) util.JSONResponse {
 	isPublic, err := publicRoomsDatabase.GetRoomVisibility(roomID)
@@ -53,7 +53,7 @@ func GetVisibility(
 // SetVisibility implements PUT /directory/list/room/{roomID}
 // TODO: Check if user has the power level to edit the room visibility
 func SetVisibility(
-	req *http.Request, publicRoomsDatabase storage.PublicRoomsServerDatabase,
+	req *http.Request, publicRoomsDatabase *storage.PublicRoomsServerDatabase,
 	roomID string,
 ) util.JSONResponse {
 	var v roomVisibility

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/directory/public_rooms.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/directory/public_rooms.go
@@ -70,8 +70,9 @@ func GetPublicRooms(
 	if offset > 0 {
 		response.PrevBatch = strconv.Itoa(int(offset) - 1)
 	}
-	if response.Estimate > int64(limit) {
-		response.NextBatch = strconv.Itoa(int(offset) + int(limit))
+	nextIndex := int(offset) + int(limit)
+	if response.Estimate > int64(nextIndex) {
+		response.NextBatch = strconv.Itoa(nextIndex)
 	}
 
 	if response.Chunk, err = publicRoomDatabase.GetPublicRooms(offset, limit, request.Filter.SearchTerms); err != nil {

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/directory/public_rooms.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/directory/public_rooms.go
@@ -1,0 +1,108 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package directory
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/matrix-org/dendrite/clientapi/httputil"
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"github.com/matrix-org/dendrite/publicroomsapi/storage"
+	"github.com/matrix-org/dendrite/publicroomsapi/types"
+	"github.com/matrix-org/util"
+)
+
+type publicRoomReq struct {
+	Since  string `json:"since,omitempty"`
+	Limit  int16  `json:"limit,omitempty"`
+	Filter string `json:"filter,omitempty"`
+}
+
+type publicRoomRes struct {
+	Chunk     []types.PublicRoom `json:"chunk"`
+	NextBatch string             `json:"next_batch,omitempty"`
+	PrevBatch string             `json:"prev_batch,omitempty"`
+	Estimate  int64              `json:"total_room_count_estimate,omitempty"`
+}
+
+// GetPublicRooms implements GET /publicRooms
+func GetPublicRooms(
+	req *http.Request, publicRoomDatabase *storage.PublicRoomsServerDatabase,
+) util.JSONResponse {
+	var limit int16
+	var offset int64
+	var request publicRoomReq
+	var response publicRoomRes
+
+	if fillErr := fillPublicRoomsReq(req, &request); fillErr != nil {
+		return *fillErr
+	}
+
+	limit = request.Limit
+	offset, err := strconv.ParseInt(request.Since, 10, 64)
+	// ParseInt returns 0 and an error when trying to parse an empty string
+	// In that case, we want to assign 0 so we ignore the error
+	if err != nil && len(request.Since) > 0 {
+		return httputil.LogThenError(req, err)
+	}
+
+	if response.Estimate, err = publicRoomDatabase.CountPublicRooms(); err != nil {
+		return httputil.LogThenError(req, err)
+	}
+
+	if offset > 0 {
+		response.PrevBatch = strconv.Itoa(int(offset) - 1)
+	}
+	if response.Estimate > int64(limit) {
+		response.NextBatch = strconv.Itoa(int(offset) + int(limit))
+	}
+
+	if response.Chunk, err = publicRoomDatabase.GetPublicRooms(offset, limit); err != nil {
+		return httputil.LogThenError(req, err)
+	}
+
+	return util.JSONResponse{
+		Code: 200,
+		JSON: response,
+	}
+}
+
+// fillPublicRoomsReq fills the Limit, Since and Filter attributes of a GET or POST request
+// on /publicRooms by parsing the incoming HTTP request
+func fillPublicRoomsReq(httpReq *http.Request, request *publicRoomReq) *util.JSONResponse {
+	if httpReq.Method == "GET" {
+		limit, err := strconv.Atoi(httpReq.FormValue("limit"))
+		// Atoi returns 0 and an error when trying to parse an empty string
+		// In that case, we want to assign 0 so we ignore the error
+		if err != nil && len(httpReq.FormValue("limit")) > 0 {
+			reqErr := httputil.LogThenError(httpReq, err)
+			return &reqErr
+		}
+		request.Limit = int16(limit)
+		request.Since = httpReq.FormValue("since")
+		return nil
+	} else if httpReq.Method == "POST" {
+		if reqErr := httputil.UnmarshalJSONRequest(httpReq, request); reqErr != nil {
+			return reqErr
+		}
+		return nil
+	}
+
+	return &util.JSONResponse{
+		Code: 405,
+		JSON: jsonerror.NotFound("Bad method"),
+	}
+}

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/directory/public_rooms.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/directory/public_rooms.go
@@ -28,7 +28,11 @@ import (
 type publicRoomReq struct {
 	Since  string `json:"since,omitempty"`
 	Limit  int16  `json:"limit,omitempty"`
-	Filter string `json:"filter,omitempty"`
+	Filter filter `json:"filter,omitempty"`
+}
+
+type filter struct {
+	SearchTerms string `json:"generic_search_term,omitempty"`
 }
 
 type publicRoomRes struct {
@@ -70,7 +74,7 @@ func GetPublicRooms(
 		response.NextBatch = strconv.Itoa(int(offset) + int(limit))
 	}
 
-	if response.Chunk, err = publicRoomDatabase.GetPublicRooms(offset, limit); err != nil {
+	if response.Chunk, err = publicRoomDatabase.GetPublicRooms(offset, limit, request.Filter.SearchTerms); err != nil {
 		return httputil.LogThenError(req, err)
 	}
 

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/routing/routing.go
@@ -18,6 +18,8 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
+	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/publicroomsapi/directory"
 	"github.com/matrix-org/dendrite/publicroomsapi/storage"
@@ -27,7 +29,7 @@ import (
 const pathPrefixR0 = "/_matrix/client/r0"
 
 // Setup configures the given mux with publicroomsapi server listeners
-func Setup(apiMux *mux.Router, publicRoomsDB *storage.PublicRoomsServerDatabase) {
+func Setup(apiMux *mux.Router, deviceDB *devices.Database, publicRoomsDB *storage.PublicRoomsServerDatabase) {
 	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
 	r0mux.Handle("/directory/list/room/{roomID}",
 		common.MakeAPI("directory_list", func(req *http.Request) util.JSONResponse {
@@ -36,7 +38,7 @@ func Setup(apiMux *mux.Router, publicRoomsDB *storage.PublicRoomsServerDatabase)
 		}),
 	).Methods("GET")
 	r0mux.Handle("/directory/list/room/{roomID}",
-		common.MakeAPI("directory_list", func(req *http.Request) util.JSONResponse {
+		common.MakeAuthAPI("directory_list", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return directory.SetVisibility(req, publicRoomsDB, vars["roomID"])
 		}),

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/routing/routing.go
@@ -1,0 +1,44 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/matrix-org/dendrite/common"
+	"github.com/matrix-org/dendrite/publicroomsapi/directory"
+	"github.com/matrix-org/dendrite/publicroomsapi/storage"
+	"github.com/matrix-org/util"
+)
+
+const pathPrefixR0 = "/_matrix/client/r0"
+
+// Setup configures the given mux with publicroomsapi server listeners
+func Setup(apiMux *mux.Router, publicRoomsDB storage.PublicRoomsServerDatabase) {
+	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
+	r0mux.Handle("/directory/list/room/{roomID}",
+		common.MakeAPI("directory_list", func(req *http.Request) util.JSONResponse {
+			vars := mux.Vars(req)
+			return directory.GetVisibility(req, publicRoomsDB, vars["roomID"])
+		}),
+	).Methods("GET")
+	r0mux.Handle("/directory/list/room/{roomID}",
+		common.MakeAPI("directory_list", func(req *http.Request) util.JSONResponse {
+			vars := mux.Vars(req)
+			return directory.SetVisibility(req, publicRoomsDB, vars["roomID"])
+		}),
+	).Methods("PUT", "OPTIONS")
+}

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/routing/routing.go
@@ -41,4 +41,9 @@ func Setup(apiMux *mux.Router, publicRoomsDB *storage.PublicRoomsServerDatabase)
 			return directory.SetVisibility(req, publicRoomsDB, vars["roomID"])
 		}),
 	).Methods("PUT", "OPTIONS")
+	r0mux.Handle("/publicRooms",
+		common.MakeAPI("public_rooms", func(req *http.Request) util.JSONResponse {
+			return directory.GetPublicRooms(req, publicRoomsDB)
+		}),
+	).Methods("GET", "POST", "OPTIONS")
 }

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/routing/routing.go
@@ -27,7 +27,7 @@ import (
 const pathPrefixR0 = "/_matrix/client/r0"
 
 // Setup configures the given mux with publicroomsapi server listeners
-func Setup(apiMux *mux.Router, publicRoomsDB storage.PublicRoomsServerDatabase) {
+func Setup(apiMux *mux.Router, publicRoomsDB *storage.PublicRoomsServerDatabase) {
 	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
 	r0mux.Handle("/directory/list/room/{roomID}",
 		common.MakeAPI("directory_list", func(req *http.Request) util.JSONResponse {

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/storage/prepare.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/storage/prepare.go
@@ -1,0 +1,35 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"database/sql"
+)
+
+// a statementList is a list of SQL statements to prepare and a pointer to where to store the resulting prepared statement.
+type statementList []struct {
+	statement **sql.Stmt
+	sql       string
+}
+
+// prepare the SQL for each statement in the list and assign the result to the prepared statement.
+func (s statementList) prepare(db *sql.DB) (err error) {
+	for _, statement := range s {
+		if *statement.statement, err = db.Prepare(statement.sql); err != nil {
+			return
+		}
+	}
+	return
+}

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/storage/public_rooms_table.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/storage/public_rooms_table.go
@@ -226,10 +226,12 @@ func (s *publicRoomsStatements) updateRoomAttribute(attrName string, attrValue a
 	var value interface{}
 	if attrName == "aliases" {
 		// Aliases need a special conversion
-		if value, err = pq.StringArray(attrValue.([]string)); err != nil {
+		valueAsSlice, isSlice := attrValue.([]string)
+		if !isSlice {
 			// attrValue isn't a slice of strings
-			return err
+			return errors.New("New list of aliases is of the wrong type")
 		}
+		value = pq.StringArray(valueAsSlice)
 	} else {
 		value = attrValue
 	}

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/storage/public_rooms_table.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/storage/public_rooms_table.go
@@ -44,7 +44,7 @@ CREATE TABLE IF NOT EXISTS publicroomsapi_public_rooms(
 	-- Aliases of the room (empty array if none)
 	aliases TEXT[] NOT NULL DEFAULT '{}'::TEXT[],
 	-- Canonical alias of the room (empty string if none)
-	canonical_alias TEXT,
+	canonical_alias TEXT NOT NULL DEFAULT '',
 	-- Name of the room (empty string if none)
 	name TEXT NOT NULL DEFAULT '',
 	-- Topic of the room (empty string if none)

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/storage/public_rooms_table.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/storage/public_rooms_table.go
@@ -226,7 +226,10 @@ func (s *publicRoomsStatements) updateRoomAttribute(attrName string, attrValue a
 	var value interface{}
 	if attrName == "aliases" {
 		// Aliases need a special conversion
-		value = pq.StringArray(attrValue.([]string))
+		if value, err = pq.StringArray(attrValue.([]string)); err != nil {
+			// attrValue isn't a slice of strings
+			return err
+		}
 	} else {
 		value = attrValue
 	}

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/storage/public_rooms_table.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/storage/public_rooms_table.go
@@ -31,6 +31,7 @@ var editableAttributes = []string{
 	"world_readable",
 	"guest_can_join",
 	"avatar_url",
+	"visibility",
 }
 
 const publicRoomsSchema = `

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/storage/public_rooms_table.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/storage/public_rooms_table.go
@@ -1,0 +1,194 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"database/sql"
+
+	"github.com/lib/pq"
+	"github.com/matrix-org/dendrite/publicroomsapi/types"
+)
+
+const publicRoomsSchema = `
+-- Stores all of the rooms with data needed to create the server's room directory
+CREATE TABLE IF NOT EXISTS publicroomsapi_public_rooms(
+	-- The room's ID
+	room_id TEXT NOT NULL PRIMARY KEY,
+	-- Number of joined members in the room
+	joined_members INTEGER NOT NULL DEFAULT 0,
+	-- Aliases of the room (empty array if none)
+	aliases TEXT[] NOT NULL DEFAULT DEFAULT '{}'::TEXT[],
+	-- Canonical alias of the room (empty string if none)
+	canonical_alias TEXT,
+	-- Name of the room (empty string if none)
+	name TEXT NOT NULL DEFAULT '',
+	-- Topic of the room (empty string if none)
+	topic TEXT NOT NULL DEFAULT '',
+	-- Is the room world readable?
+	world_readable BOOLEAN NOT NULL DEFAULT false,
+	-- Can guest join the room?
+	guest_can_join BOOLEAN NOT NULL DEFAULT false,
+	-- URL of the room avatar (empty string if none)
+	avatar_url TEXT NOT NULL DEFAULT '',
+	-- Visibility of the room: true means the room is publicly visible, false
+	-- means the room is private
+	visibility BOOLEAN NOT NULL DEFAULT false
+);
+`
+
+const countPublicRoomsSQL = "" +
+	"SELECT COUNT(*) FROM publicroomsapi_public_rooms" +
+	" WHERE visibility = true"
+
+const selectPublicRoomsSQL = "" +
+	"SELECT room_id, joined_members, aliases, canonical_alias, name, topic, world_readable, guest_can_join, avatar_url" +
+	" FROM publicroomsapi_public_rooms WHERE visibility = true" +
+	" ORDER BY joined_members DESC" +
+	" OFFSET $1"
+
+const selectPublicRoomswithLimitSQL = "" +
+	"SELECT room_id, joined_members, aliases, canonical_alias, name, topic, world_readable, guest_can_join, avatar_url" +
+	" FROM publicroomsapi_public_rooms WHERE visibility = true" +
+	" ORDER BY joined_members DESC" +
+	" OFFSET $1 LIMIT $2"
+
+const insertNewRoomSQL = "" +
+	"INSERT INTO publicroomsapi_public_rooms(room_id)" +
+	" VALUES ($1)"
+
+const incrementJoinedMembersInRoomSQL = "" +
+	"UPDATE publicroomsapi_public_rooms" +
+	" SET joined_members = joined_members + 1" +
+	" WHERE room_id = $1"
+
+const decrementJoinedMembersInRoomSQL = "" +
+	"UPDATE publicroomsapi_public_rooms" +
+	" SET joined_members = joined_members - 1" +
+	" WHERE room_id = $1"
+
+const updateRoomAttributeSQL = "" +
+	"UPDATE publicroomsapi_public_rooms" +
+	" SET $1 = $2" +
+	" WHERE room_id = $3"
+
+type publicRoomsStatements struct {
+	countPublicRoomsStmt             *sql.Stmt
+	selectPublicRoomsStmt            *sql.Stmt
+	selectPublicRoomswithLimitStmt   *sql.Stmt
+	insertNewRoomStmt                *sql.Stmt
+	incrementJoinedMembersInRoomStmt *sql.Stmt
+	decrementJoinedMembersInRoomStmt *sql.Stmt
+	updateRoomAttributeStmt          *sql.Stmt
+}
+
+func (s *publicRoomsStatements) prepare(db *sql.DB) (err error) {
+	_, err = db.Exec(publicRoomsSchema)
+	if err != nil {
+		return
+	}
+	if s.countPublicRoomsStmt, err = db.Prepare(countPublicRoomsSQL); err != nil {
+		return
+	}
+	if s.selectPublicRoomsStmt, err = db.Prepare(selectPublicRoomsSQL); err != nil {
+		return
+	}
+	if s.selectPublicRoomswithLimitStmt, err = db.Prepare(selectPublicRoomswithLimitSQL); err != nil {
+		return
+	}
+	if s.insertNewRoomStmt, err = db.Prepare(insertNewRoomSQL); err != nil {
+		return
+	}
+	if s.incrementJoinedMembersInRoomStmt, err = db.Prepare(incrementJoinedMembersInRoomSQL); err != nil {
+		return
+	}
+	if s.decrementJoinedMembersInRoomStmt, err = db.Prepare(decrementJoinedMembersInRoomSQL); err != nil {
+		return
+	}
+	if s.updateRoomAttributeStmt, err = db.Prepare(updateRoomAttributeSQL); err != nil {
+		return
+	}
+	return
+}
+
+func (s *publicRoomsStatements) countPublicRooms() (nb int64, err error) {
+	err = s.countPublicRoomsStmt.QueryRow().Scan(&nb)
+	return
+}
+
+func (s *publicRoomsStatements) selectPublicRooms(offset int64, limit int16) ([]types.PublicRoom, error) {
+	var rows *sql.Rows
+	var err error
+
+	if limit == 0 {
+		rows, err = s.selectPublicRoomsStmt.Query(offset)
+	} else {
+		rows, err = s.selectPublicRoomswithLimitStmt.Query(offset, limit)
+	}
+
+	if err != nil {
+		return []types.PublicRoom{}, nil
+	}
+
+	rooms := []types.PublicRoom{}
+	for rows.Next() {
+		var r types.PublicRoom
+		var aliases pq.StringArray
+
+		err = rows.Scan(
+			&r.RoomID, &r.NumJoinedMembers, &aliases, &r.CanonicalAlias,
+			&r.Name, &r.Topic, &r.WorldReadable, &r.GuestCanJoin, &r.AvatarURL,
+		)
+		if err != nil {
+			return rooms, err
+		}
+
+		r.Aliases = make([]string, len(aliases))
+		for i := range aliases {
+			r.Aliases[i] = aliases[i]
+		}
+
+		rooms = append(rooms, r)
+	}
+
+	return rooms, nil
+}
+
+func (s *publicRoomsStatements) insertNewRoom(roomID string) error {
+	_, err := s.insertNewRoomStmt.Exec(roomID)
+	return err
+}
+
+func (s *publicRoomsStatements) incrementJoinedMembersInRoom(roomID string) error {
+	_, err := s.incrementJoinedMembersInRoomStmt.Exec(roomID)
+	return err
+}
+
+func (s *publicRoomsStatements) decrementJoinedMembersInRoom(roomID string) error {
+	_, err := s.decrementJoinedMembersInRoomStmt.Exec(roomID)
+	return err
+}
+
+func (s *publicRoomsStatements) updateRoomAttribute(attrName string, attrValue attributeValue, roomID string) error {
+	var value interface{}
+	if attrName == "aliases" {
+		// Aliases need a special conversion
+		value = pq.StringArray(attrValue.([]string))
+	} else {
+		value = attrValue
+	}
+
+	_, err := s.updateRoomAttributeStmt.Exec(attrName, value, roomID)
+	return err
+}

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/storage/public_rooms_table.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/storage/public_rooms_table.go
@@ -64,6 +64,10 @@ const selectPublicRoomswithLimitSQL = "" +
 	" ORDER BY joined_members DESC" +
 	" OFFSET $1 LIMIT $2"
 
+const selectRoomVisibilitySQL = "" +
+	"SELECT visibility FROM publicroomsapi_public_rooms" +
+	" WHERE room_id = $1"
+
 const insertNewRoomSQL = "" +
 	"INSERT INTO publicroomsapi_public_rooms(room_id)" +
 	" VALUES ($1)"
@@ -87,6 +91,7 @@ type publicRoomsStatements struct {
 	countPublicRoomsStmt             *sql.Stmt
 	selectPublicRoomsStmt            *sql.Stmt
 	selectPublicRoomswithLimitStmt   *sql.Stmt
+	selectRoomVisibilityStmt         *sql.Stmt
 	insertNewRoomStmt                *sql.Stmt
 	incrementJoinedMembersInRoomStmt *sql.Stmt
 	decrementJoinedMembersInRoomStmt *sql.Stmt
@@ -105,6 +110,9 @@ func (s *publicRoomsStatements) prepare(db *sql.DB) (err error) {
 		return
 	}
 	if s.selectPublicRoomswithLimitStmt, err = db.Prepare(selectPublicRoomswithLimitSQL); err != nil {
+		return
+	}
+	if s.selectRoomVisibilityStmt, err = db.Prepare(selectRoomVisibilitySQL); err != nil {
 		return
 	}
 	if s.insertNewRoomStmt, err = db.Prepare(insertNewRoomSQL); err != nil {
@@ -163,6 +171,11 @@ func (s *publicRoomsStatements) selectPublicRooms(offset int64, limit int16) ([]
 	}
 
 	return rooms, nil
+}
+
+func (s *publicRoomsStatements) selectRoomVisibility(roomID string) (v bool, err error) {
+	err = s.selectRoomVisibilityStmt.QueryRow(roomID).Scan(&v)
+	return
 }
 
 func (s *publicRoomsStatements) insertNewRoom(roomID string) error {

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/storage/storage.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/storage/storage.go
@@ -93,13 +93,14 @@ func (d *PublicRoomsServerDatabase) GetPublicRooms(offset int64, limit int16, fi
 // UpdateRoomFromEvents iterate over a slice of state events and call
 // UpdateRoomFromEvent on each of them to update the database representation of
 // the rooms updated by each event.
+// The slice of events to remove is used to process membership events.
 // If the update triggered by one of the events failed, aborts the process and
 // returns an error.
 func (d *PublicRoomsServerDatabase) UpdateRoomFromEvents(
-	eventsToAdd []gomatrixserverlib.Event, iDsToRemove []string,
+	eventsToAdd []gomatrixserverlib.Event, eventsToRemove []gomatrixserverlib.Event,
 ) error {
 	for _, event := range eventsToAdd {
-		if err := d.UpdateRoomFromEvent(event, iDsToRemove); err != nil {
+		if err := d.UpdateRoomFromEvent(event, eventsToRemove); err != nil {
 			return err
 		}
 	}
@@ -110,11 +111,12 @@ func (d *PublicRoomsServerDatabase) UpdateRoomFromEvents(
 // UpdateRoomFromEvent updates the database representation of a room from a Matrix event, by
 // checking the event's type to know which attribute to change and using the event's content
 // to define the new value of the attribute.
+// The slice of events to remove is used to process membership events.
 // If the event doesn't match with any property used to compute the public room directory,
 // does nothing.
 // If something went wrong during the process, returns an error.
 func (d *PublicRoomsServerDatabase) UpdateRoomFromEvent(
-	event gomatrixserverlib.Event, iDsToRemove []string,
+	event gomatrixserverlib.Event, eventsToRemove []gomatrixserverlib.Event,
 ) error {
 	roomID := event.RoomID()
 
@@ -123,7 +125,7 @@ func (d *PublicRoomsServerDatabase) UpdateRoomFromEvent(
 	case "m.room.create":
 		return d.statements.insertNewRoom(roomID)
 	case "m.room.member":
-		return d.updateNumJoinedUsers(event, iDsToRemove, roomID)
+		return d.updateNumJoinedUsers(event, eventsToRemove, roomID)
 	case "m.room.aliases":
 		return d.updateRoomAliases(event, roomID)
 	case "m.room.canonical_alias":
@@ -166,10 +168,11 @@ func (d *PublicRoomsServerDatabase) UpdateRoomFromEvent(
 
 // updateNumJoinedUsers updates the number of joined user in the database representation
 // of the room identified by a given room ID, using a given Matrix event.
-// If the event's membership is "join", increments the value, if not, decrements it.
+// If the event's membership is "join", increments the value if the event isn't an update,
+// if not, decrements it.
 // Returns an error if the update failed.
 func (d *PublicRoomsServerDatabase) updateNumJoinedUsers(
-	membershipEvent gomatrixserverlib.Event, iDsToRemove []string, roomID string,
+	membershipEvent gomatrixserverlib.Event, eventsToRemove []gomatrixserverlib.Event, roomID string,
 ) error {
 	membership, err := membershipEvent.Membership()
 	if err != nil {
@@ -177,12 +180,14 @@ func (d *PublicRoomsServerDatabase) updateNumJoinedUsers(
 	}
 
 	if membership == "join" {
-		if len(iDsToRemove) > 0 {
-			// This is an update for an user who already joined the room, most
-			// likely triggered by a profile update. We don't increment the
-			// number of joined member in this case because we already counted
-			// this user.
-			return nil
+		for _, event := range eventsToRemove {
+			if event.Type() == "m.room.member" {
+				// This is an update for an user who already joined the room, most
+				// likely triggered by a profile update. We don't increment the
+				// number of joined member in this case because we already counted
+				// this user.
+				return nil
+			}
 		}
 		return d.statements.incrementJoinedMembersInRoom(roomID)
 	} else if membership == "leave" || membership == "ban" {

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/storage/storage.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/storage/storage.go
@@ -1,0 +1,104 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"database/sql"
+	"encoding/json"
+
+	"github.com/matrix-org/dendrite/common"
+	"github.com/matrix-org/dendrite/publicroomsapi/types"
+
+	"github.com/matrix-org/gomatrixserverlib"
+)
+
+// PublicRoomsServerDatabase represents a public rooms server database
+type PublicRoomsServerDatabase struct {
+	db         *sql.DB
+	partitions common.PartitionOffsetStatements
+	statements publicRoomsStatements
+}
+
+type attributeValue interface{}
+
+// NewPublicRoomsServerDatabase creates a new public rooms server database
+func NewPublicRoomsServerDatabase(dataSourceName string) (*PublicRoomsServerDatabase, error) {
+	var db *sql.DB
+	var err error
+	if db, err = sql.Open("postgres", dataSourceName); err != nil {
+		return nil, err
+	}
+	partitions := common.PartitionOffsetStatements{}
+	if err = partitions.Prepare(db, "publicroomsapi"); err != nil {
+		return nil, err
+	}
+	statements := publicRoomsStatements{}
+	if err = statements.prepare(db); err != nil {
+		return nil, err
+	}
+	return &PublicRoomsServerDatabase{db, partitions, statements}, nil
+}
+
+// CountPublicRooms returns the number of room set as publicly visible on the server.
+// Returns an error if the retrieval failed.
+func (d *PublicRoomsServerDatabase) CountPublicRooms() (int64, error) {
+	return d.statements.countPublicRooms()
+}
+
+// GetPublicRooms returns an array containing the local rooms set as publicly visible, ordered by their number
+// of joined members. This array can be limited by a given number of elements, and offset by a given value.
+// If the limit is 0, doesn't limit the number of results. If the offset is 0 too, the array contains all
+// the rooms set as publicly visible on the server.
+// Returns an error if the retrieval failed.
+func (d *PublicRoomsServerDatabase) GetPublicRooms(offset int64, limit int16) ([]types.PublicRoom, error) {
+	return d.statements.selectPublicRooms(offset, limit)
+}
+
+// UpdateRoomFromEvent updates the database representation of a room from a Matrix event, by
+// checking the event's type to know which attribute to change and using the event's content
+// to define the new value of the attribute.
+// If the event doesn't match with any property used to compute the public room directory,
+// does nothing.
+// If something went wrong during the process, returns an error.
+func (d *PublicRoomsServerDatabase) UpdateRoomFromEvent(event gomatrixserverlib.Event) error {
+	var attrName string
+	var attrValue attributeValue
+
+	roomID := event.RoomID()
+	switch event.Type() {
+	case "m.room.create":
+		return d.statements.insertNewRoom(roomID)
+	case "m.room.aliases":
+		var content common.AliasesContent
+		if err := json.Unmarshal(event.Content(), &content); err != nil {
+			return err
+		}
+
+		attrName = "aliases"
+		attrValue = content.Aliases
+		break
+	case "m.room.canonical_alias":
+		var content common.CanonicalAliasContent
+		if err := json.Unmarshal(event.Content(), &content); err != nil {
+			return err
+		}
+
+		attrName = "canonical_alias"
+		attrValue = content.Alias
+		break
+	}
+
+	return d.statements.updateRoomAttribute(attrName, attrValue, roomID)
+}

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/storage/storage.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/storage/storage.go
@@ -24,7 +24,7 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
-// PublicRoomsServerDatabase represents a public rooms server database
+// PublicRoomsServerDatabase represents a public rooms server database.
 type PublicRoomsServerDatabase struct {
 	db         *sql.DB
 	partitions common.PartitionOffsetStatements
@@ -33,7 +33,7 @@ type PublicRoomsServerDatabase struct {
 
 type attributeValue interface{}
 
-// NewPublicRoomsServerDatabase creates a new public rooms server database
+// NewPublicRoomsServerDatabase creates a new public rooms server database.
 func NewPublicRoomsServerDatabase(dataSourceName string) (*PublicRoomsServerDatabase, error) {
 	var db *sql.DB
 	var err error
@@ -49,6 +49,20 @@ func NewPublicRoomsServerDatabase(dataSourceName string) (*PublicRoomsServerData
 		return nil, err
 	}
 	return &PublicRoomsServerDatabase{db, partitions, statements}, nil
+}
+
+// GetRoomVisibility returns the room visibility as a boolean: true if the room
+// is publicly visible, false if not.
+// Returns an error if the retrieval failed.
+func (d *PublicRoomsServerDatabase) GetRoomVisibility(roomID string) (bool, error) {
+	return d.statements.selectRoomVisibility(roomID)
+}
+
+// SetRoomVisibility updates the visibility attribute of a room. This attribute
+// must be set to true if the room is publicly visible, false if not.
+// Returns an error if the update failed.
+func (d *PublicRoomsServerDatabase) SetRoomVisibility(visible bool, roomID string) error {
+	return d.statements.updateRoomAttribute("visibility", visible, roomID)
 }
 
 // CountPublicRooms returns the number of room set as publicly visible on the server.

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/storage/storage.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/storage/storage.go
@@ -86,8 +86,8 @@ func (d *PublicRoomsServerDatabase) CountPublicRooms() (int64, error) {
 // If the limit is 0, doesn't limit the number of results. If the offset is 0 too, the array contains all
 // the rooms set as publicly visible on the server.
 // Returns an error if the retrieval failed.
-func (d *PublicRoomsServerDatabase) GetPublicRooms(offset int64, limit int16) ([]types.PublicRoom, error) {
-	return d.statements.selectPublicRooms(offset, limit)
+func (d *PublicRoomsServerDatabase) GetPublicRooms(offset int64, limit int16, filter string) ([]types.PublicRoom, error) {
+	return d.statements.selectPublicRooms(offset, limit, filter)
 }
 
 // UpdateRoomFromEvent updates the database representation of a room from a Matrix event, by

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/storage/storage.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/storage/storage.go
@@ -51,6 +51,16 @@ func NewPublicRoomsServerDatabase(dataSourceName string) (*PublicRoomsServerData
 	return &PublicRoomsServerDatabase{db, partitions, statements}, nil
 }
 
+// PartitionOffsets implements common.PartitionStorer
+func (d *PublicRoomsServerDatabase) PartitionOffsets(topic string) ([]common.PartitionOffset, error) {
+	return d.partitions.SelectPartitionOffsets(topic)
+}
+
+// SetPartitionOffset implements common.PartitionStorer
+func (d *PublicRoomsServerDatabase) SetPartitionOffset(topic string, partition int32, offset int64) error {
+	return d.partitions.UpsertPartitionOffset(topic, partition, offset)
+}
+
 // GetRoomVisibility returns the room visibility as a boolean: true if the room
 // is publicly visible, false if not.
 // Returns an error if the retrieval failed.

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/types/types.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/types/types.go
@@ -1,0 +1,28 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+// PublicRoom represents a local public room
+type PublicRoom struct {
+	RoomID           string   `json:"room_id"`
+	Aliases          []string `json:"aliases,omitempty"`
+	CanonicalAlias   string   `json:"canonical_alias,omitempty"`
+	Name             string   `json:"name,omitempty"`
+	Topic            string   `json:"topic,omitempty"`
+	AvatarURL        string   `json:"avatar_url,omitempty"`
+	NumJoinedMembers int64    `json:"num_joined_members"`
+	WorldReadable    bool     `json:"world_readable"`
+	GuestCanJoin     bool     `json:"guest_can_join"`
+}

--- a/src/github.com/matrix-org/dendrite/roomserver/storage/room_aliases_table.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/storage/room_aliases_table.go
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS roomserver_room_aliases (
     room_id TEXT NOT NULL
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS roomserver_room_id_idx ON roomserver_room_aliases(room_id);
+CREATE INDEX IF NOT EXISTS roomserver_room_id_idx ON roomserver_room_aliases(room_id);
 `
 
 const insertRoomAliasSQL = "" +


### PR DESCRIPTION
This PR adds a new component to Dendrite which implements:

* `PUT /_matrix/client/r0/directory/list/room/{roomID}`
* `GET /_matrix/client/r0/directory/list/room/{roomID}`
* `POST /_matrix/client/r0/publicRooms`
* `GET /_matrix/client/r0/publicRooms`

Like all other components in Dendrite, it can be run separated from the others, or as part of the monolith.

I also moved the `eventcontent.go` file from the client API server to `common` as the public rooms API server is also using it.

Sorry for the length or this PR. I should have thought about how I could have split it in smaller ones beforehand.