### PR TITLE
`vars["txnID"]` is always empty when sending state events.

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -103,14 +103,14 @@ func Setup(
 			if strings.HasSuffix(eventType, "/") {
 				eventType = eventType[:len(eventType)-1]
 			}
-			return writers.SendEvent(req, device, vars["roomID"], eventType, vars["txnID"], &emptyString, cfg, queryAPI, producer)
+			return writers.SendEvent(req, device, vars["roomID"], eventType, "", &emptyString, cfg, queryAPI, producer)
 		}),
 	)
 	r0mux.Handle("/rooms/{roomID}/state/{eventType}/{stateKey}",
 		common.MakeAuthAPI("send_message", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			stateKey := vars["stateKey"]
-			return writers.SendEvent(req, device, vars["roomID"], vars["eventType"], vars["txnID"], &stateKey, cfg, queryAPI, producer)
+			return writers.SendEvent(req, device, vars["roomID"], vars["eventType"], "", &stateKey, cfg, queryAPI, producer)
 		}),
 	)
 


### PR DESCRIPTION
The client API for sending state events doesn't take a "txnID" parameter. They are made idempotent by comparing the content of the proposed state event with the existing current state for the room.

So referring to `vars["txnID"]` in the routing for /state/ is a bit confusing. (It looks like this was just copy+pasted from the code for sending ordinary message events that does take an optional "txnID")
