### PR TITLE
Membership viewing API when user left the room

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/readers/memberships.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/readers/memberships.go
@@ -33,13 +33,14 @@ type response struct {
 
 // GetMemberships implements GET /rooms/{roomId}/members
 func GetMemberships(
-	req *http.Request, device *authtypes.Device, roomID string,
+	req *http.Request, device *authtypes.Device, roomID string, joinedOnly bool,
 	accountDB *accounts.Database, cfg config.Dendrite,
 	queryAPI api.RoomserverQueryAPI,
 ) util.JSONResponse {
 	queryReq := api.QueryMembershipsForRoomRequest{
-		RoomID: roomID,
-		Sender: device.UserID,
+		JoinedOnly: joinedOnly,
+		RoomID:     roomID,
+		Sender:     device.UserID,
 	}
 	var queryRes api.QueryMembershipsForRoomResponse
 	if err := queryAPI.QueryMembershipsForRoom(&queryReq, &queryRes); err != nil {

--- a/src/github.com/matrix-org/dendrite/clientapi/readers/memberships.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/readers/memberships.go
@@ -23,8 +23,13 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/common/config"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 )
+
+type response struct {
+	Chunk []gomatrixserverlib.ClientEvent `json:"chunk"`
+}
 
 // GetMemberships implements GET /rooms/{roomId}/members
 func GetMemberships(
@@ -50,6 +55,6 @@ func GetMemberships(
 
 	return util.JSONResponse{
 		Code: 200,
-		JSON: queryRes.JoinEvents,
+		JSON: response{queryRes.JoinEvents},
 	}
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -302,7 +302,14 @@ func Setup(
 	r0mux.Handle("/rooms/{roomID}/members",
 		common.MakeAuthAPI("rooms_members", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
-			return readers.GetMemberships(req, device, vars["roomID"], accountDB, cfg, queryAPI)
+			return readers.GetMemberships(req, device, vars["roomID"], false, accountDB, cfg, queryAPI)
+		}),
+	)
+
+	r0mux.Handle("/rooms/{roomID}/joined_members",
+		common.MakeAuthAPI("rooms_members", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+			vars := mux.Vars(req)
+			return readers.GetMemberships(req, device, vars["roomID"], true, accountDB, cfg, queryAPI)
 		}),
 	)
 

--- a/src/github.com/matrix-org/dendrite/roomserver/api/query.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/api/query.go
@@ -102,6 +102,8 @@ type QueryEventsByIDResponse struct {
 
 // QueryMembershipsForRoomRequest is a request to QueryMembershipsForRoom
 type QueryMembershipsForRoomRequest struct {
+	// If true, only returns the membership events of "join" membership
+	JoinedOnly bool `json:"joined_only"`
 	// ID of the room to fetch memberships from
 	RoomID string `json:"room_id"`
 	// ID of the user sending the request

--- a/src/github.com/matrix-org/dendrite/roomserver/query/query.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/query/query.go
@@ -271,7 +271,7 @@ func (r *RoomserverQueryAPI) getMembershipsBeforeEventNID(eventNID types.EventNI
 	var eventNIDs []types.EventNID
 	for _, entry := range stateEntries {
 		// Filter the events to retrieve to only keep the membership events
-		if entry.EventStateKeyNID == types.MRoomMemberNID {
+		if entry.EventTypeNID == types.MRoomMemberNID {
 			eventNIDs = append(eventNIDs, entry.EventNID)
 		}
 	}

--- a/src/github.com/matrix-org/dendrite/roomserver/query/query.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/query/query.go
@@ -43,18 +43,6 @@ type RoomserverQueryAPIDatabase interface {
 	// Lookup the event IDs for a batch of event numeric IDs.
 	// Returns an error if the retrieval went wrong.
 	EventIDs(eventNIDs []types.EventNID) (map[types.EventNID]string, error)
-	// Save a given room alias with the room ID it refers to.
-	// Returns an error if there was a problem talking to the database.
-	SetRoomAlias(alias string, roomID string) error
-	// Lookup the room ID a given alias refers to.
-	// Returns an error if there was a problem talking to the database.
-	GetRoomIDFromAlias(alias string) (string, error)
-	// Lookup all aliases referring to a given room ID.
-	// Returns an error if there was a problem talking to the database.
-	GetAliasesFromRoomID(roomID string) ([]string, error)
-	// Remove a given room alias.
-	// Returns an error if there was a problem talking to the database.
-	RemoveRoomAlias(alias string) error
 	// Lookup the membership of a given user in a given room.
 	// Returns the numeric ID of the latest membership event sent from this user
 	// in this room, along a boolean set to true if the user is still in this room,

--- a/src/github.com/matrix-org/dendrite/roomserver/storage/membership_table.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/storage/membership_table.go
@@ -77,7 +77,7 @@ const selectMembershipsFromRoomAndMembershipSQL = "" +
 	" WHERE room_nid = $1 AND membership_nid = $2"
 
 const selectMembershipsFromRoomSQL = "" +
-	"SELECT membership_nid, event_nid FROM roomserver_membership" +
+	"SELECT event_nid FROM roomserver_membership" +
 	" WHERE room_nid = $1"
 
 const selectMembershipForUpdateSQL = "" +
@@ -140,20 +140,18 @@ func (s *membershipStatements) selectMembershipFromRoomAndTarget(
 
 func (s *membershipStatements) selectMembershipsFromRoom(
 	roomNID types.RoomNID,
-) (eventNIDs map[types.EventNID]membershipState, err error) {
+) (eventNIDs []types.EventNID, err error) {
 	rows, err := s.selectMembershipsFromRoomStmt.Query(roomNID)
 	if err != nil {
 		return
 	}
 
-	eventNIDs = make(map[types.EventNID]membershipState)
 	for rows.Next() {
 		var eNID types.EventNID
-		var membership membershipState
-		if err = rows.Scan(&membership, &eNID); err != nil {
+		if err = rows.Scan(&eNID); err != nil {
 			return
 		}
-		eventNIDs[eNID] = membership
+		eventNIDs = append(eventNIDs, eNID)
 	}
 	return
 }

--- a/src/github.com/matrix-org/dendrite/roomserver/storage/storage.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/storage/storage.go
@@ -574,7 +574,9 @@ func (d *Database) getMembershipsBeforeEventNID(eventNID types.EventNID) ([]type
 
 	var eventNIDs []types.EventNID
 	for _, entry := range stateEntries {
-		eventNIDs = append(eventNIDs, entry.EventNID)
+		if entry.EventStateKeyNID == types.MRoomMemberNID {
+			eventNIDs = append(eventNIDs, entry.EventNID)
+		}
 	}
 
 	// Get all of the events in this state
@@ -585,15 +587,13 @@ func (d *Database) getMembershipsBeforeEventNID(eventNID types.EventNID) ([]type
 
 	// Filter the events to only keep the "join" membership events
 	for _, event := range stateEvents {
-		if event.Type() == "m.room.member" {
-			membership, err := event.Membership()
-			if err != nil {
-				return nil, err
-			}
+		membership, err := event.Membership()
+		if err != nil {
+			return nil, err
+		}
 
-			if membership == "join" {
-				events = append(events, event)
-			}
+		if membership == "join" {
+			events = append(events, event)
 		}
 	}
 

--- a/src/github.com/matrix-org/dendrite/roomserver/storage/storage.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/storage/storage.go
@@ -576,9 +576,13 @@ func (d *Database) GetMembership(roomNID types.RoomNID, requestSenderUserID stri
 	return senderMembershipEventNID, senderMembership == membershipStateJoin, nil
 }
 
-// GetJoinMembershipEventNIDsForRoom implements query.RoomserverQueryAPIDB
-func (d *Database) GetJoinMembershipEventNIDsForRoom(roomNID types.RoomNID) ([]types.EventNID, error) {
-	return d.statements.selectMembershipsFromRoomAndMembership(roomNID, membershipStateJoin)
+// GetMembershipEventNIDsForRoom implements query.RoomserverQueryAPIDB
+func (d *Database) GetMembershipEventNIDsForRoom(roomNID types.RoomNID, joinOnly bool) ([]types.EventNID, error) {
+	if joinOnly {
+		return d.statements.selectMembershipsFromRoomAndMembership(roomNID, membershipStateJoin)
+	}
+
+	return d.statements.selectMembershipsFromRoom(roomNID)
 }
 
 type transaction struct {


### PR DESCRIPTION
Following-up #174, if the user left the room, retrieves its state and filters it to keep only the `m.room.member` events of `join` membership, then send it to the user.