### PR TITLE
Fix sync not returning on room join

### DIFF
--- a/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
@@ -79,6 +79,9 @@ func (n *Notifier) OnNewEvent(ev *gomatrixserverlib.Event, userID string, pos ty
 				case "invite":
 					userIDs = append(userIDs, userID)
 				case "join":
+					// We have to manually append the new user's ID so they get
+					// notified along all members in the room
+					userIDs = append(userIDs, userID)
 					n.addJoinedUser(ev.RoomID(), userID)
 				case "leave":
 					fallthrough

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
@@ -79,8 +79,8 @@ func (n *Notifier) OnNewEvent(ev *gomatrixserverlib.Event, userID string, pos ty
 				case "invite":
 					userIDs = append(userIDs, userID)
 				case "join":
-					// We have to manually append the new user's ID so they get
-					// notified along all members in the room
+					// Manually append the new user's ID so they get notified
+					// along all members in the room
 					userIDs = append(userIDs, userID)
 					n.addJoinedUser(ev.RoomID(), userID)
 				case "leave":


### PR DESCRIPTION
Manually update the list of user to notify on a room join in the sync API so the newly joined user gets notified at the same time as all members of the room.

FTR https://github.com/matrix-org/dendrite/commit/2010332d354505d3166a890dd40533e66624eb0c is unrelated but I saw a small improvement to make so I sneaked it in.