### PR TITLE
Add publicroomsapi to the database list

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -64,7 +64,7 @@ Dendrite requires a postgres database engine, version 9.5 or later.
   ```
 * Create databases:
   ```bash
-  for i in account device mediaapi syncapi roomserver serverkey federationsender; do
+  for i in account device mediaapi syncapi roomserver serverkey federationsender publicroomsapi; do
       sudo -u postgres createdb -O dendrite dendrite_$i
   done
   ```


### PR DESCRIPTION
The publicroomsapi database is missing in the installation instructions.