### PR TITLE
Add command to generate test keys/certs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -71,21 +71,14 @@ Dendrite requires a postgres database engine, version 9.5 or later.
 
 ### Crypto key generation
 
-Generate the keys (unlike synapse, dendrite doesn't autogen yet):
+Generate the keys:
 
 ```bash
 # Generate a self-signed SSL cert for federation:
 test -f server.key || openssl req -x509 -newkey rsa:4096 -keyout server.key -out server.crt -days 3650 -nodes -subj /CN=localhost
 
 # generate ed25519 signing key
-test -f matrix_key.pem || python3 > matrix_key.pem <<EOF
-import base64;
-r = lambda n: base64.b64encode(open("/dev/urandom", "rb").read(n)).decode("utf8");
-print("-----BEGIN MATRIX PRIVATE KEY-----")
-print("Key-ID:", "ed25519:" + r(3).rstrip("="))
-print(r(32))
-print("-----END MATRIX PRIVATE KEY-----")
-EOF
+test -f matrix_key.pem || ./bin/generate-keys -private-key matrix_key.pem
 ```
 
 ### Configuration

--- a/src/github.com/matrix-org/dendrite/cmd/generate-keys/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/generate-keys/main.go
@@ -1,0 +1,65 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/matrix-org/dendrite/common/test"
+)
+
+const usage = `Usage: %s
+
+Generate key files which are required by dendrite.
+
+Arguments:
+
+`
+
+var (
+	tlsCertFile    = flag.String("tls-cert", "", "An X509 certificate file to generate for use for TLS")
+	tlsKeyFile     = flag.String("tls-key", "", "An RSA private key file to generate for use for TLS")
+	privateKeyFile = flag.String("private-key", "", "An Ed25519 private key to generate for use for object signing")
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, usage, os.Args[0])
+		flag.PrintDefaults()
+	}
+
+	flag.Parse()
+
+	if *tlsCertFile != "" || *tlsKeyFile != "" {
+		if *tlsCertFile == "" || *tlsKeyFile == "" {
+			log.Fatal("Zero or both of --tls-key and --tls-cert must be supplied")
+		}
+		if err := test.NewTLSKey(*tlsKeyFile, *tlsCertFile); err != nil {
+			panic(err)
+		}
+		fmt.Printf("Created TLS cert file:    %s\n", *tlsCertFile)
+		fmt.Printf("Created TLS key file:     %s\n", *tlsKeyFile)
+	}
+
+	if *privateKeyFile != "" {
+		if err := test.NewMatrixKey(*privateKeyFile); err != nil {
+			panic(err)
+		}
+		fmt.Printf("Created private key file: %s\n", *privateKeyFile)
+	}
+}

--- a/src/github.com/matrix-org/dendrite/common/test/config.go
+++ b/src/github.com/matrix-org/dendrite/common/test/config.go
@@ -62,11 +62,11 @@ func MakeConfig(configDir, kafkaURI, database, host string, startPort int) (*con
 	tlsKeyPath := filepath.Join(configDir, TLSCertFile)
 	mediaBasePath := filepath.Join(configDir, MediaDir)
 
-	if err := newMatrixKey(serverKeyPath); err != nil {
+	if err := NewMatrixKey(serverKeyPath); err != nil {
 		return nil, 0, err
 	}
 
-	if err := newTLSKey(tlsKeyPath, tlsCertPath); err != nil {
+	if err := NewTLSKey(tlsKeyPath, tlsCertPath); err != nil {
 		return nil, 0, err
 	}
 
@@ -119,8 +119,8 @@ func WriteConfig(cfg *config.Dendrite, configDir string) error {
 	return nil
 }
 
-// newMatrixKey generates a new ed25519 matrix server key and writes it to a file.
-func newMatrixKey(matrixKeyPath string) error {
+// NewMatrixKey generates a new ed25519 matrix server key and writes it to a file.
+func NewMatrixKey(matrixKeyPath string) error {
 	var data [35]byte
 	if _, err := rand.Read(data[:]); err != nil {
 		return err
@@ -145,8 +145,8 @@ func newMatrixKey(matrixKeyPath string) error {
 
 const certificateDuration = time.Hour * 24 * 365 * 10
 
-// newTLSKey generates a new RSA TLS key and certificate and writes it to a file.
-func newTLSKey(tlsKeyPath, tlsCertPath string) error {
+// NewTLSKey generates a new RSA TLS key and certificate and writes it to a file.
+func NewTLSKey(tlsKeyPath, tlsCertPath string) error {
 	priv, err := rsa.GenerateKey(rand.Reader, 4096)
 	if err != nil {
 		return err


### PR DESCRIPTION
Add `generate-keys` command, which can be used to generate TLS keys/certs, and,
more usefully, matrix signing keys.