### PR TITLE
Implement client API routes for 3PID handling

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/auth/authtypes/threepid.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/authtypes/threepid.go
@@ -1,0 +1,21 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authtypes
+
+// ThreePID represents a third-party identifier
+type ThreePID struct {
+	Address string `json:"address"`
+	Medium  string `json:"medium"`
+}

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
@@ -248,9 +248,9 @@ var Err3PIDInUse = errors.New("This third-party identifier is already in use")
 // and a local Matrix user (identified by the user's ID's local part).
 // If the third-party identifier is already part of an association, returns Err3PIDInUse.
 // Returns an error if there was a problem talking to the database.
-func (d *Database) SaveThreePIDAssociation(threepid string, localpart string) (err error) {
+func (d *Database) SaveThreePIDAssociation(threepid string, localpart string, medium string) (err error) {
 	return common.WithTransaction(d.db, func(txn *sql.Tx) error {
-		user, err := d.threepids.selectLocalpartForThreePID(txn, threepid)
+		user, err := d.threepids.selectLocalpartForThreePID(txn, threepid, medium)
 		if err != nil {
 			return err
 		}
@@ -259,7 +259,7 @@ func (d *Database) SaveThreePIDAssociation(threepid string, localpart string) (e
 			return Err3PIDInUse
 		}
 
-		return d.threepids.insertThreePID(txn, threepid, localpart)
+		return d.threepids.insertThreePID(txn, threepid, medium, localpart)
 	})
 }
 
@@ -267,8 +267,8 @@ func (d *Database) SaveThreePIDAssociation(threepid string, localpart string) (e
 // identifier.
 // If no association exists involving this third-party identifier, returns nothing.
 // If there was a problem talking to the database, returns an error.
-func (d *Database) RemoveThreePIDAssociation(threepid string) (err error) {
-	return d.threepids.deleteThreePID(threepid)
+func (d *Database) RemoveThreePIDAssociation(threepid string, medium string) (err error) {
+	return d.threepids.deleteThreePID(threepid, medium)
 }
 
 // GetLocalpartForThreePID looks up the localpart associated with a given third-party
@@ -276,8 +276,8 @@ func (d *Database) RemoveThreePIDAssociation(threepid string) (err error) {
 // If no association involves the given third-party idenfitier, returns an empty
 // string.
 // Returns an error if there was a problem talking to the database.
-func (d *Database) GetLocalpartForThreePID(threepid string) (localpart string, err error) {
-	return d.threepids.selectLocalpartForThreePID(nil, threepid)
+func (d *Database) GetLocalpartForThreePID(threepid string, medium string) (localpart string, err error) {
+	return d.threepids.selectLocalpartForThreePID(nil, threepid, medium)
 }
 
 // GetThreePIDsForLocalpart looks up the third-party identifiers associated with

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
@@ -284,6 +284,6 @@ func (d *Database) GetLocalpartForThreePID(threepid string, medium string) (loca
 // a given local user.
 // If no association is known for this user, returns an empty slice.
 // Returns an error if there was an issue talking to the database.
-func (d *Database) GetThreePIDsForLocalpart(localpart string) (threepids map[string]string, err error) {
+func (d *Database) GetThreePIDsForLocalpart(localpart string) (threepids []authtypes.ThreePID, err error) {
 	return d.threepids.selectThreePIDsForLocalpart(localpart)
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/threepid_table.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/threepid_table.go
@@ -16,6 +16,8 @@ package accounts
 
 import (
 	"database/sql"
+
+	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 )
 
 const threepidSchema = `
@@ -88,20 +90,20 @@ func (s *threepidStatements) selectLocalpartForThreePID(txn *sql.Tx, threepid st
 	return
 }
 
-func (s *threepidStatements) selectThreePIDsForLocalpart(localpart string) (threepids map[string]string, err error) {
+func (s *threepidStatements) selectThreePIDsForLocalpart(localpart string) (threepids []authtypes.ThreePID, err error) {
 	rows, err := s.selectThreePIDsForLocalpartStmt.Query(localpart)
 	if err != nil {
 		return
 	}
 
-	threepids = make(map[string]string)
+	threepids = []authtypes.ThreePID{}
 	for rows.Next() {
 		var threepid string
 		var medium string
 		if err = rows.Scan(&threepid, &medium); err != nil {
 			return
 		}
-		threepids[threepid] = medium
+		threepids = append(threepids, authtypes.ThreePID{threepid, medium})
 	}
 
 	return

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/threepid_table.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/threepid_table.go
@@ -1,0 +1,118 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package accounts
+
+import (
+	"database/sql"
+)
+
+const threepidSchema = `
+-- Stores data about third party identifiers
+CREATE TABLE IF NOT EXISTS account_threepid (
+	-- The third party identifier
+	threepid TEXT NOT NULL,
+	-- The 3PID medium
+	medium TEXT NOT NULL DEFAULT 'email',
+	-- The localpart of the Matrix user ID associated to this 3PID
+	localpart TEXT NOT NULL,
+
+	PRIMARY KEY(threepid, medium)
+);
+
+CREATE INDEX IF NOT EXISTS account_threepid_localpart ON account_threepid(localpart);
+`
+
+const selectLocalpartForThreePIDSQL = "" +
+	"SELECT localpart FROM account_threepid WHERE threepid = $1"
+
+const selectThreePIDsForLocalpartSQL = "" +
+	"SELECT threepid, medium FROM account_threepid WHERE localpart = $1"
+
+const insertThreePIDSQL = "" +
+	"INSERT INTO account_threepid (threepid, localpart) VALUES ($1, $2)"
+
+const deleteThreePIDSQL = "" +
+	"DELETE FROM account_threepid WHERE threepid = $1"
+
+type threepidStatements struct {
+	selectLocalpartForThreePIDStmt  *sql.Stmt
+	selectThreePIDsForLocalpartStmt *sql.Stmt
+	insertThreePIDStmt              *sql.Stmt
+	deleteThreePIDStmt              *sql.Stmt
+}
+
+func (s *threepidStatements) prepare(db *sql.DB) (err error) {
+	_, err = db.Exec(threepidSchema)
+	if err != nil {
+		return
+	}
+	if s.selectLocalpartForThreePIDStmt, err = db.Prepare(selectLocalpartForThreePIDSQL); err != nil {
+		return
+	}
+	if s.selectThreePIDsForLocalpartStmt, err = db.Prepare(selectThreePIDsForLocalpartSQL); err != nil {
+		return
+	}
+	if s.insertThreePIDStmt, err = db.Prepare(insertThreePIDSQL); err != nil {
+		return
+	}
+	if s.deleteThreePIDStmt, err = db.Prepare(deleteThreePIDSQL); err != nil {
+		return
+	}
+
+	return
+}
+
+func (s *threepidStatements) selectLocalpartForThreePID(txn *sql.Tx, threepid string) (localpart string, err error) {
+	var stmt *sql.Stmt
+	if txn != nil {
+		stmt = txn.Stmt(s.selectLocalpartForThreePIDStmt)
+	} else {
+		stmt = s.selectLocalpartForThreePIDStmt
+	}
+	err = stmt.QueryRow(threepid).Scan(&localpart)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return
+}
+
+func (s *threepidStatements) selectThreePIDsForLocalpart(localpart string) (threepids map[string]string, err error) {
+	rows, err := s.selectThreePIDsForLocalpartStmt.Query(localpart)
+	if err != nil {
+		return
+	}
+
+	threepids = make(map[string]string)
+	for rows.Next() {
+		var threepid string
+		var medium string
+		if err = rows.Scan(&threepid, &medium); err != nil {
+			return
+		}
+		threepids[threepid] = medium
+	}
+
+	return
+}
+
+func (s *threepidStatements) insertThreePID(txn *sql.Tx, threepid string, localpart string) (err error) {
+	_, err = txn.Stmt(s.insertThreePIDStmt).Exec(threepid, localpart)
+	return
+}
+
+func (s *threepidStatements) deleteThreePID(threepid string) (err error) {
+	_, err = s.deleteThreePIDStmt.Exec(threepid)
+	return
+}

--- a/src/github.com/matrix-org/dendrite/clientapi/readers/threepid.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/readers/threepid.go
@@ -1,0 +1,162 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package readers
+
+import (
+	"net/http"
+
+	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
+	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
+	"github.com/matrix-org/dendrite/clientapi/httputil"
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"github.com/matrix-org/dendrite/clientapi/threepid"
+
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/util"
+)
+
+type reqTokenResponse struct {
+	SID string `json:"sid"`
+}
+
+type threePIDsResponse struct {
+	ThreePIDs []threePID `json:"threepids"`
+}
+
+type threePID struct {
+	Medium  string `json:"medium"`
+	Address string `json:"address"`
+}
+
+// Request3PIDToken implements:
+//     POST /account/3pid/email/requestToken
+//     POST /register/email/requestToken
+func Request3PIDToken(req *http.Request, accountDB *accounts.Database) util.JSONResponse {
+	var body threepid.EmailAssociationRequest
+	if reqErr := httputil.UnmarshalJSONRequest(req, &body); reqErr != nil {
+		return *reqErr
+	}
+
+	var resp reqTokenResponse
+	var err error
+
+	// Check if the 3PID is already in use locally
+	localpart, err := accountDB.GetLocalpartForThreePID(body.Email)
+	if err != nil {
+		return httputil.LogThenError(req, err)
+	}
+
+	if len(localpart) > 0 {
+		return util.JSONResponse{
+			Code: 400,
+			JSON: jsonerror.MatrixError{
+				ErrCode: "M_THREEPID_IN_USE",
+				Err:     accounts.Err3PIDInUse.Error(),
+			},
+		}
+	}
+
+	resp.SID, err = threepid.CreateSession(body)
+	if err != nil {
+		return httputil.LogThenError(req, err)
+	}
+
+	return util.JSONResponse{
+		Code: 200,
+		JSON: resp,
+	}
+}
+
+// CheckAndSave3PIDAssociation implements POST /account/3pid
+func CheckAndSave3PIDAssociation(
+	req *http.Request, accountDB *accounts.Database, device *authtypes.Device,
+) util.JSONResponse {
+	var body threepid.EmailAssociationCheckRequest
+	if reqErr := httputil.UnmarshalJSONRequest(req, &body); reqErr != nil {
+		return *reqErr
+	}
+
+	verified, address, err := threepid.CheckAssociation(body.Creds)
+	if err != nil {
+		return httputil.LogThenError(req, err)
+	}
+
+	if !verified {
+		return util.JSONResponse{
+			Code: 400,
+			JSON: jsonerror.MatrixError{
+				ErrCode: "M_THREEPID_AUTH_FAILED",
+				Err:     "Failed to auth 3pid",
+			},
+		}
+	}
+
+	localpart, _, err := gomatrixserverlib.SplitID('@', device.UserID)
+	if err != nil {
+		return httputil.LogThenError(req, err)
+	}
+
+	if err = accountDB.SaveThreePIDAssociation(address, localpart); err != nil {
+		return httputil.LogThenError(req, err)
+	}
+
+	return util.JSONResponse{
+		Code: 200,
+		JSON: struct{}{},
+	}
+}
+
+// GetAssociated3PIDs implements GET /account/3pid
+func GetAssociated3PIDs(
+	req *http.Request, accountDB *accounts.Database, device *authtypes.Device,
+) util.JSONResponse {
+	localpart, _, err := gomatrixserverlib.SplitID('@', device.UserID)
+	if err != nil {
+		return httputil.LogThenError(req, err)
+	}
+
+	threepids, err := accountDB.GetThreePIDsForLocalpart(localpart)
+	if err != nil {
+		return httputil.LogThenError(req, err)
+	}
+
+	var resp threePIDsResponse
+	for address, medium := range threepids {
+		tpid := threePID{Medium: medium, Address: address}
+		resp.ThreePIDs = append(resp.ThreePIDs, tpid)
+	}
+
+	return util.JSONResponse{
+		Code: 200,
+		JSON: resp,
+	}
+}
+
+// Forget3PID implements POST /account/3pid/delete
+func Forget3PID(req *http.Request, accountDB *accounts.Database) util.JSONResponse {
+	var body threePID
+	if reqErr := httputil.UnmarshalJSONRequest(req, &body); reqErr != nil {
+		return *reqErr
+	}
+
+	if err := accountDB.RemoveThreePIDAssociation(body.Address); err != nil {
+		return httputil.LogThenError(req, err)
+	}
+
+	return util.JSONResponse{
+		Code: 200,
+		JSON: struct{}{},
+	}
+}

--- a/src/github.com/matrix-org/dendrite/clientapi/readers/threepid.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/readers/threepid.go
@@ -32,12 +32,7 @@ type reqTokenResponse struct {
 }
 
 type threePIDsResponse struct {
-	ThreePIDs []threePID `json:"threepids"`
-}
-
-type threePID struct {
-	Medium  string `json:"medium"`
-	Address string `json:"address"`
+	ThreePIDs []authtypes.ThreePID `json:"threepids"`
 }
 
 // RequestEmailToken implements:
@@ -141,22 +136,15 @@ func GetAssociated3PIDs(
 		return httputil.LogThenError(req, err)
 	}
 
-	var resp threePIDsResponse
-	resp.ThreePIDs = []threePID{}
-	for address, medium := range threepids {
-		tpid := threePID{Medium: medium, Address: address}
-		resp.ThreePIDs = append(resp.ThreePIDs, tpid)
-	}
-
 	return util.JSONResponse{
 		Code: 200,
-		JSON: resp,
+		JSON: threePIDsResponse{threepids},
 	}
 }
 
 // Forget3PID implements POST /account/3pid/delete
 func Forget3PID(req *http.Request, accountDB *accounts.Database) util.JSONResponse {
-	var body threePID
+	var body authtypes.ThreePID
 	if reqErr := httputil.UnmarshalJSONRequest(req, &body); reqErr != nil {
 		return *reqErr
 	}

--- a/src/github.com/matrix-org/dendrite/clientapi/readers/threepid.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/readers/threepid.go
@@ -88,6 +88,7 @@ func CheckAndSave3PIDAssociation(
 		return *reqErr
 	}
 
+	// Check if the association has been validated
 	verified, address, medium, err := threepid.CheckAssociation(body.Creds)
 	if err != nil {
 		return httputil.LogThenError(req, err)
@@ -103,6 +104,14 @@ func CheckAndSave3PIDAssociation(
 		}
 	}
 
+	if body.Bind {
+		// Publish the association on the identity server if requested
+		if err = threepid.PublishAssociation(body.Creds, device.UserID); err != nil {
+			return httputil.LogThenError(req, err)
+		}
+	}
+
+	// Save the association in the database
 	localpart, _, err := gomatrixserverlib.SplitID('@', device.UserID)
 	if err != nil {
 		return httputil.LogThenError(req, err)

--- a/src/github.com/matrix-org/dendrite/clientapi/readers/threepid.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/readers/threepid.go
@@ -133,6 +133,7 @@ func GetAssociated3PIDs(
 	}
 
 	var resp threePIDsResponse
+	resp.ThreePIDs = []threePID{}
 	for address, medium := range threepids {
 		tpid := threePID{Medium: medium, Address: address}
 		resp.ThreePIDs = append(resp.ThreePIDs, tpid)

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -253,7 +253,7 @@ func Setup(
 
 	r0mux.Handle("/{path:(?:account/3pid|register)}/email/requestToken",
 		common.MakeAPI("account_3pid_request_token", func(req *http.Request) util.JSONResponse {
-			return readers.Request3PIDToken(req, accountDB)
+			return readers.RequestEmailToken(req, accountDB)
 		}),
 	).Methods("POST", "OPTIONS")
 

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -234,15 +234,28 @@ func Setup(
 	// PUT requests, so we need to allow this method
 
 	r0mux.Handle("/account/3pid",
-		common.MakeAPI("account_3pid", func(req *http.Request) util.JSONResponse {
-			// TODO: Get 3pid data for user ID
-			res := json.RawMessage(`{"threepids":[]}`)
-			return util.JSONResponse{
-				Code: 200,
-				JSON: &res,
-			}
+		common.MakeAuthAPI("account_3pid", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+			return readers.GetAssociated3PIDs(req, accountDB, device)
 		}),
-	)
+	).Methods("GET")
+
+	r0mux.Handle("/account/3pid",
+		common.MakeAuthAPI("account_3pid", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+			return readers.CheckAndSave3PIDAssociation(req, accountDB, device)
+		}),
+	).Methods("POST", "OPTIONS")
+
+	unstableMux.Handle("/account/3pid/delete",
+		common.MakeAuthAPI("account_3pid", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+			return readers.Forget3PID(req, accountDB)
+		}),
+	).Methods("POST", "OPTIONS")
+
+	r0mux.Handle("/{path:(?:account/3pid|register)}/email/requestToken",
+		common.MakeAPI("account_3pid_request_token", func(req *http.Request) util.JSONResponse {
+			return readers.Request3PIDToken(req, accountDB)
+		}),
+	).Methods("POST", "OPTIONS")
 
 	// Riot logs get flooded unless this is handled
 	r0mux.Handle("/presence/{userID}/status",

--- a/src/github.com/matrix-org/dendrite/clientapi/threepid/invites.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/threepid/invites.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package thirdpartyinvites
+package threepid
 
 import (
 	"encoding/json"
@@ -66,7 +66,7 @@ type idServerStoreInviteResponse struct {
 	PublicKeys  []common.PublicKey `json:"public_keys"`
 }
 
-// CheckAndProcess analyses the body of an incoming membership request.
+// CheckAndProcessInvite analyses the body of an incoming membership request.
 // If the fields relative to a third-party-invite are all supplied, lookups the
 // matching Matrix ID from the given identity server. If no Matrix ID is
 // associated to the given 3PID, asks the identity server to store the invite
@@ -79,7 +79,7 @@ type idServerStoreInviteResponse struct {
 // must be processed as a non-3PID membership request. In the latter case,
 // fills the Matrix ID in the request body so a normal invite membership event
 // can be emitted.
-func CheckAndProcess(
+func CheckAndProcessInvite(
 	req *http.Request, device *authtypes.Device, body *MembershipRequest,
 	cfg config.Dendrite, queryAPI api.RoomserverQueryAPI, db *accounts.Database,
 	producer *producers.RoomserverProducer, membership string, roomID string,

--- a/src/github.com/matrix-org/dendrite/clientapi/threepid/threepid.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/threepid/threepid.go
@@ -1,0 +1,120 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package threepid
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// EmailAssociationRequest represents the request defined at https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-register-email-requesttoken
+type EmailAssociationRequest struct {
+	IDServer    string `json:"id_server"`
+	Secret      string `json:"client_secret"`
+	Email       string `json:"email"`
+	SendAttempt int    `json:"send_attempt"`
+}
+
+// EmailAssociationCheckRequest represents the request defined at https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-account-3pid
+type EmailAssociationCheckRequest struct {
+	Creds Credentials `json:"threePidCreds"`
+	Bind  bool        `json:"bind"`
+}
+
+// Credentials represents the "ThreePidCredentials" structure defined at https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-account-3pid
+type Credentials struct {
+	SID      string `json:"sid"`
+	IDServer string `json:"id_server"`
+	Secret   string `json:"client_secret"`
+}
+
+// CreateSession creates a session on an identity server.
+// Returns the session's ID.
+// Returns an error if there was a problem sending the request or decoding the
+// response, or if the identity server responded with a non-OK status.
+func CreateSession(req EmailAssociationRequest) (string, error) {
+	// Create a session on the ID server
+	postURL := fmt.Sprintf("https://%s/_matrix/identity/api/v1/validate/email/requestToken", req.IDServer)
+
+	data := url.Values{}
+	data.Add("client_secret", req.Secret)
+	data.Add("email", req.Email)
+	data.Add("send_attempt", strconv.Itoa(req.SendAttempt))
+
+	request, err := http.NewRequest("POST", postURL, strings.NewReader(data.Encode()))
+	if err != nil {
+		return "", err
+	}
+	request.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	client := http.Client{}
+	resp, err := client.Do(request)
+	if err != nil {
+		return "", err
+	}
+
+	// Error if the status isn't OK
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Could not create a session on the server %s", req.IDServer)
+	}
+
+	// Extract the SID from the response and return it
+	var sid struct {
+		SID string `json:"sid"`
+	}
+	err = json.NewDecoder(resp.Body).Decode(&sid)
+
+	return sid.SID, err
+}
+
+// CheckAssociation checks the status of an ongoing association validation on an
+// identity server.
+// Returns a boolean set to true if the association has been validated, false if not.
+// If the association has been validated, also returns the related third-party
+// identifier.
+// Returns an error if there was a problem sending the request or decoding the
+// response, or if the identity server responded with a non-OK status.
+func CheckAssociation(creds Credentials) (bool, string, error) {
+	url := fmt.Sprintf("https://%s/_matrix/identity/api/v1/3pid/getValidated3pid?sid=%s&client_secret=%s", creds.IDServer, creds.SID, creds.Secret)
+	resp, err := http.Get(url)
+	if err != nil {
+		return false, "", err
+	}
+
+	var respBody struct {
+		Medium      string `json:"medium"`
+		ValidatedAt int64  `json:"validated_at"`
+		Address     string `json:"address"`
+		ErrCode     string `json:"errcode"`
+		Error       string `json:"error"`
+	}
+
+	if err = json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+		return false, "", err
+	}
+
+	if respBody.ErrCode == "M_SESSION_NOT_VALIDATED" {
+		return false, "", nil
+	} else if len(respBody.ErrCode) > 0 {
+		return false, "", errors.New(respBody.Error)
+	}
+
+	return true, respBody.Address, nil
+}

--- a/src/github.com/matrix-org/dendrite/clientapi/threepid/threepid.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/threepid/threepid.go
@@ -50,6 +50,8 @@ type Credentials struct {
 // Returns an error if there was a problem sending the request or decoding the
 // response, or if the identity server responded with a non-OK status.
 func CreateSession(req EmailAssociationRequest) (string, error) {
+	// TODO: Check if the ID server is trusted
+
 	// Create a session on the ID server
 	postURL := fmt.Sprintf("https://%s/_matrix/identity/api/v1/validate/email/requestToken", req.IDServer)
 
@@ -92,6 +94,7 @@ func CreateSession(req EmailAssociationRequest) (string, error) {
 // Returns an error if there was a problem sending the request or decoding the
 // response, or if the identity server responded with a non-OK status.
 func CheckAssociation(creds Credentials) (bool, string, string, error) {
+	// TODO: Check if the ID server is trusted
 	url := fmt.Sprintf("https://%s/_matrix/identity/api/v1/3pid/getValidated3pid?sid=%s&client_secret=%s", creds.IDServer, creds.SID, creds.Secret)
 	resp, err := http.Get(url)
 	if err != nil {
@@ -124,6 +127,7 @@ func CheckAssociation(creds Credentials) (bool, string, string, error) {
 // Returns an error if there was a problem sending the request or decoding the
 // response, or if the identity server responded with a non-OK status.
 func PublishAssociation(creds Credentials, userID string) error {
+	// TODO: Check if the ID server is trusted
 	postURL := fmt.Sprintf("https://%s/_matrix/identity/api/v1/3pid/bind", creds.IDServer)
 
 	data := url.Values{}

--- a/src/github.com/matrix-org/dendrite/clientapi/writers/membership.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/writers/membership.go
@@ -23,7 +23,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/clientapi/producers"
-	"github.com/matrix-org/dendrite/clientapi/thirdpartyinvites"
+	"github.com/matrix-org/dendrite/clientapi/threepid"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/config"
 	"github.com/matrix-org/dendrite/roomserver/api"
@@ -39,12 +39,12 @@ func SendMembership(
 	roomID string, membership string, cfg config.Dendrite,
 	queryAPI api.RoomserverQueryAPI, producer *producers.RoomserverProducer,
 ) util.JSONResponse {
-	var body thirdpartyinvites.MembershipRequest
+	var body threepid.MembershipRequest
 	if reqErr := httputil.UnmarshalJSONRequest(req, &body); reqErr != nil {
 		return *reqErr
 	}
 
-	if res := thirdpartyinvites.CheckAndProcess(
+	if res := threepid.CheckAndProcessInvite(
 		req, device, &body, cfg, queryAPI, accountDB, producer, membership, roomID,
 	); res != nil {
 		return *res
@@ -129,7 +129,7 @@ func loadProfile(userID string, cfg config.Dendrite, accountDB *accounts.Databas
 // In the latter case, if there was an issue retrieving the user ID from the request body,
 // returns a JSONResponse with a corresponding error code and message.
 func getMembershipStateKey(
-	body thirdpartyinvites.MembershipRequest, device *authtypes.Device, membership string,
+	body threepid.MembershipRequest, device *authtypes.Device, membership string,
 ) (stateKey string, reason string, response *util.JSONResponse) {
 	if membership == "ban" || membership == "unban" || membership == "kick" || membership == "invite" {
 		// If we're in this case, the state key is contained in the request body,


### PR DESCRIPTION
Implements:

* `POST /_matrix/client/r0/register/email/requestToken`
* `POST /_matrix/client/r0/account/3pid/email/requestToken`
* `POST /_matrix/client/r0/account/3pid`
* `GET /_matrix/client/r0/account/3pid`
* `POST /_matrix/client/unstable/account/3pid/delete`