### PR TITLE
Use gometalinter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ services:
 
 install:
  - go get github.com/constabulary/gb/...
- - go get github.com/client9/misspell/...
 
 # Generate a self-signed X.509 certificate for TLS.
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ services:
 install:
  - go get github.com/constabulary/gb/...
  - go get github.com/client9/misspell/...
- - go get github.com/alecthomas/gometalinter
 
 # Generate a self-signed X.509 certificate for TLS.
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,8 @@ services:
 
 install:
  - go get github.com/constabulary/gb/...
- - go get github.com/golang/lint/golint
- - go get github.com/fzipp/gocyclo
  - go get github.com/client9/misspell/...
- - go get github.com/gordonklaus/ineffassign
+ - go get github.com/alecthomas/gometalinter
 
 # Generate a self-signed X.509 certificate for TLS.
 before_script:

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -7,6 +7,7 @@ export PATH="$PATH:$(pwd)/vendor/bin:$(pwd)/bin"
 
 echo "Installing lint search engine..."
 go install github.com/alecthomas/gometalinter/
+gometalinter --config=linter.json ./... --install
 
 echo "Looking for lint..."
 gometalinter --config=linter.json ./...

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -2,8 +2,14 @@
 
 set -eu
 
+export GOPATH="$(pwd):$(pwd)/vendor"
+export PATH="$PATH:$(pwd)/vendor/bin:$(pwd)/bin"
+
+echo "Installing lint search engine..."
+go install github.com/alecthomas/gometalinter/
+
 echo "Looking for lint..."
-GOPATH="$(pwd):$(pwd)/vendor" gometalinter --config=linter.json ./...
+gometalinter --config=linter.json ./...
 
 echo "Double checking spelling..."
 misspell -error src *.md
@@ -16,6 +22,6 @@ gb test
 # checks that everything builds. This seems to do a better job of handling
 # missing imports than `gb build` does.
 echo "Double checking it builds..."
-GOPATH=$(pwd):$(pwd)/vendor go build github.com/matrix-org/dendrite/cmd/...
+go build github.com/matrix-org/dendrite/cmd/...
 
 echo "Done!"

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -2,29 +2,20 @@
 
 set -eu
 
-golint src/...
+echo "Looking for lint..."
+GOPATH="$(pwd):$(pwd)/vendor" gometalinter --config=linter.json ./...
+
+echo "Double checking spelling..."
 misspell -error src *.md
 
-# gofmt doesn't exit with an error code if the files don't match the expected
-# format. So we have to run it and see if it outputs anything.
-if gofmt -l -s ./src/ 2>&1 | read
-then
-    echo "Error: not all code had been formatted with gofmt."
-    echo "Fixing the following files"
-    gofmt -s -w -l ./src/
-    echo
-    echo "Please add them to the commit"
-    git status --short
-    exit 1
-fi
-
-ineffassign ./src/
-go tool vet --all --shadow ./src
-gocyclo -over 12 src/
+echo "Testing..."
 gb test
 
 # Check that all the packages can build.
 # When `go build` is given multiple packages it won't output anything, and just
 # checks that everything builds. This seems to do a better job of handling
 # missing imports than `gb build` does.
+echo "Double checking it builds..."
 GOPATH=$(pwd):$(pwd)/vendor go build github.com/matrix-org/dendrite/cmd/...
+
+echo "Done!"

--- a/linter.json
+++ b/linter.json
@@ -1,0 +1,17 @@
+{
+    "Vendor": true,
+    "Cyclo": 12,
+    "Enable": [
+        "vetshadow",
+        "gotype",
+        "deadcode",
+        "gocyclo",
+        "golint",
+        "varcheck",
+        "structcheck",
+        "aligncheck",
+        "ineffassign",
+        "gas",
+        "misspell"
+    ]
+}

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/account_data_table.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/account_data_table.go
@@ -47,9 +47,6 @@ const selectAccountDataSQL = "" +
 const selectAccountDataByTypeSQL = "" +
 	"SELECT content FROM account_data WHERE localpart = $1 AND room_id = $2 AND type = $3"
 
-const deleteAccountDataSQL = "" +
-	"DELETE FROM account_data WHERE localpart = $1 AND room_id = $2 AND type = $3"
-
 type accountDataStatements struct {
 	insertAccountDataStmt       *sql.Stmt
 	selectAccountDataStmt       *sql.Stmt

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/membership_table.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/membership_table.go
@@ -56,7 +56,6 @@ const updateMembershipByEventIDSQL = "" +
 type membershipStatements struct {
 	deleteMembershipsByEventIDsStmt  *sql.Stmt
 	insertMembershipStmt             *sql.Stmt
-	selectMembershipByEventIDStmt    *sql.Stmt
 	selectMembershipsByLocalpartStmt *sql.Stmt
 	updateMembershipByEventIDStmt    *sql.Stmt
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/readers/login.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/readers/login.go
@@ -15,7 +15,6 @@
 package readers
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/matrix-org/dendrite/clientapi/auth"
@@ -120,8 +119,4 @@ func Login(
 		Code: 405,
 		JSON: jsonerror.NotFound("Bad method"),
 	}
-}
-
-func makeUserID(localpart string, domain gomatrixserverlib.ServerName) string {
-	return fmt.Sprintf("@%s:%s", localpart, domain)
 }

--- a/src/github.com/matrix-org/dendrite/cmd/create-room-events/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/create-room-events/main.go
@@ -49,13 +49,6 @@ var (
 	format           = flag.String("Format", "InputRoomEvent", "The output format to use for the messages: InputRoomEvent or Event")
 )
 
-func defaulting(value, defaultValue string) string {
-	if value == "" {
-		return defaultValue
-	}
-	return value
-}
-
 // By default we use a private key of 0.
 const defaultKey = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
@@ -197,7 +197,6 @@ func (m *monolith) setupFederation() {
 }
 
 func (m *monolith) setupKafka() {
-	var err error
 	if m.cfg.Kafka.UseNaffka {
 		naff, err := naffka.New(&naffka.MemoryDatabase{})
 		if err != nil {
@@ -208,6 +207,7 @@ func (m *monolith) setupKafka() {
 		m.naffka = naff
 		m.kafkaProducer = naff
 	} else {
+		var err error
 		m.kafkaProducer, err = sarama.NewSyncProducer(m.cfg.Kafka.Addresses, nil)
 		if err != nil {
 			log.WithFields(log.Fields{

--- a/src/github.com/matrix-org/dendrite/cmd/roomserver-integration-tests/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/roomserver-integration-tests/main.go
@@ -221,14 +221,14 @@ func testRoomserver(input []string, wantOutput []string, checkQueries func(api.R
 	if err != nil {
 		panic(err)
 	}
-	if err := test.WriteConfig(cfg, dir); err != nil {
+	if err = test.WriteConfig(cfg, dir); err != nil {
 		panic(err)
 	}
 
 	outputTopic := string(cfg.Kafka.Topics.OutputRoomEvent)
 
 	exe.DeleteTopic(outputTopic)
-	if err := exe.CreateTopic(outputTopic); err != nil {
+	if err = exe.CreateTopic(outputTopic); err != nil {
 		panic(err)
 	}
 

--- a/src/github.com/matrix-org/dendrite/cmd/roomserver-integration-tests/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/roomserver-integration-tests/main.go
@@ -271,17 +271,6 @@ func testRoomserver(input []string, wantOutput []string, checkQueries func(api.R
 	}
 }
 
-func canonicalJSONInput(jsonData []string) []string {
-	for i := range jsonData {
-		jsonBytes, err := gomatrixserverlib.CanonicalJSON([]byte(jsonData[i]))
-		if err != nil {
-			panic(err)
-		}
-		jsonData[i] = string(jsonBytes)
-	}
-	return jsonData
-}
-
 func equalJSON(a, b string) bool {
 	canonicalA, err := gomatrixserverlib.CanonicalJSON([]byte(a))
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/cmd/syncserver-integration-tests/testdata.go
+++ b/src/github.com/matrix-org/dendrite/cmd/syncserver-integration-tests/testdata.go
@@ -14,6 +14,7 @@
 
 package main
 
+// nolint: varcheck, deadcode
 const (
 	i0StateRoomCreate = iota
 	i1StateAliceJoin

--- a/src/github.com/matrix-org/dendrite/roomserver/input/latest_events.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/input/latest_events.go
@@ -99,14 +99,14 @@ type latestEventsUpdater struct {
 }
 
 func (u *latestEventsUpdater) doUpdateLatestEvents() error {
-	var err error
 	var prevEvents []gomatrixserverlib.EventReference
 	prevEvents = u.event.PrevEvents()
 	oldLatest := u.updater.LatestEvents()
 	u.lastEventIDSent = u.updater.LastEventIDSent()
 	u.oldStateNID = u.updater.CurrentStateSnapshotNID()
 
-	if hasBeenSent, err := u.updater.HasEventBeenSent(u.stateAtEvent.EventNID); err != nil {
+	hasBeenSent, err := u.updater.HasEventBeenSent(u.stateAtEvent.EventNID)
+	if err != nil {
 		return err
 	} else if hasBeenSent {
 		// Already sent this event so we can stop processing
@@ -119,8 +119,8 @@ func (u *latestEventsUpdater) doUpdateLatestEvents() error {
 
 	eventReference := u.event.EventReference()
 	// Check if this event is already referenced by another event in the room.
-	var alreadyReferenced bool
-	if alreadyReferenced, err = u.updater.IsReferenced(eventReference); err != nil {
+	alreadyReferenced, err := u.updater.IsReferenced(eventReference)
+	if err != nil {
 		return err
 	}
 

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
@@ -67,7 +67,7 @@ func (n *Notifier) OnNewEvent(ev *gomatrixserverlib.Event, userID string, pos ty
 		userIDs := n.joinedUsers(ev.RoomID())
 		// If this is an invite, also add in the invitee to this list.
 		if ev.Type() == "m.room.member" && ev.StateKey() != nil {
-			userID := *ev.StateKey()
+			targetUserID := *ev.StateKey()
 			membership, err := ev.Membership()
 			if err != nil {
 				log.WithError(err).WithField("event_id", ev.EventID()).Errorf(
@@ -77,22 +77,22 @@ func (n *Notifier) OnNewEvent(ev *gomatrixserverlib.Event, userID string, pos ty
 				// Keep the joined user map up-to-date
 				switch membership {
 				case "invite":
-					userIDs = append(userIDs, userID)
+					userIDs = append(userIDs, targetUserID)
 				case "join":
 					// Manually append the new user's ID so they get notified
 					// along all members in the room
-					userIDs = append(userIDs, userID)
-					n.addJoinedUser(ev.RoomID(), userID)
+					userIDs = append(userIDs, targetUserID)
+					n.addJoinedUser(ev.RoomID(), targetUserID)
 				case "leave":
 					fallthrough
 				case "ban":
-					n.removeJoinedUser(ev.RoomID(), userID)
+					n.removeJoinedUser(ev.RoomID(), targetUserID)
 				}
 			}
 		}
 
-		for _, userID := range userIDs {
-			n.wakeupUser(userID, pos)
+		for _, toNotifyUserID := range userIDs {
+			n.wakeupUser(toNotifyUserID, pos)
 		}
 	} else if len(userID) > 0 {
 		n.wakeupUser(userID, pos)


### PR DESCRIPTION
I've basically enabled every lint that doesn't fail. We should look at enabling some of the lints currently disabled, e.g.:

- `errcheck` check that we are checking error return values
- `vet` this checks a bunch of stuff, but currently fails as we don't always create we don't always create composite struct literals with keys syntax.
- `dupl`/`goconst` check that we're not duplicating code or constants
- `gosimple` checks if code could be simpler (part of `megacheck`)
- `staticheck` checks things like checking error on `file.Close`, if we're using deprecated APIs, etc (part of `megacheck`)
- `unused` if there are any unused "stuff" (part of `megacheck`)
- `megacheck` does the previous three tests in one pass, so more efficient than enabling them independently
- `unparam` are there any unused params?
- `safesql` check that our sql statements are statically "safe"

Things left disabled:
- `goimports` ermh, no idea why this is failing
- `interfacer` seems to be fairly unhelpful thing
- `unconvert` checks for unnecessary conversions, this picks up when we e.g. explicitly cast from an int to a a typedef when passing it to a param expecting the typedef. I'm not sure we want to get rid of such explicit conversions
- `test*` no idea what these do, but they're not enabled by default
- `lll` checks for line length

We also should look at lowering gocyclo back to the default of 10 and add `// nolint: gocyclo` exceptions to specific functions. Maybe.

We should also look at hooking this up to CI/jenkins stuff using checkstyle XML output to get pretty graphs.
