### PR TITLE
3PID invite exchange over federation

### DIFF
--- a/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
@@ -79,10 +79,9 @@ func Setup(
 		},
 	))
 
-	v1fedmux.Handle("/3pid/onbind", common.MakeFedAPI(
-		"3pid_onbind", cfg.Matrix.ServerName, keys,
-		func(httpReq *http.Request, request *gomatrixserverlib.FederationRequest) util.JSONResponse {
-			return writers.CreateInvitesFrom3PIDInvites(httpReq, query, cfg, producer, federation)
+	v1fedmux.Handle("/3pid/onbind", common.MakeAPI("3pid_onbind",
+		func(req *http.Request) util.JSONResponse {
+			return writers.CreateInvitesFrom3PIDInvites(req, query, cfg, producer, federation)
 		},
 	))
 

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
@@ -82,7 +82,7 @@ func Setup(
 	v1fedmux.Handle("/3pid/onbind", common.MakeFedAPI(
 		"3pid_onbind", cfg.Matrix.ServerName, keys,
 		func(httpReq *http.Request, request *gomatrixserverlib.FederationRequest) util.JSONResponse {
-			return writers.CreateInvitesFrom3PIDInvites(httpReq, query, cfg, producer)
+			return writers.CreateInvitesFrom3PIDInvites(httpReq, query, cfg, producer, federation)
 		},
 	))
 

--- a/src/github.com/matrix-org/dendrite/federationapi/writers/threepid.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/writers/threepid.go
@@ -129,27 +129,27 @@ func createInviteFrom3PIDInvite(
 		}
 		err = federation.ExchangeThirdPartyInvite(remoteServer, *builder)
 		return nil, err
-	} else {
-		// Auth the event locally
-		builder.Depth = queryRes.Depth
-		builder.PrevEvents = queryRes.LatestEvents
-
-		authEvents := gomatrixserverlib.NewAuthEvents(nil)
-
-		for i := range queryRes.StateEvents {
-			authEvents.AddEvent(&queryRes.StateEvents[i])
-		}
-
-		if err = fillDisplayName(builder, content, authEvents); err != nil {
-			return nil, err
-		}
-
-		refs, err := eventsNeeded.AuthEventReferences(&authEvents)
-		if err != nil {
-			return nil, err
-		}
-		builder.AuthEvents = refs
 	}
+
+	// Auth the event locally
+	builder.Depth = queryRes.Depth
+	builder.PrevEvents = queryRes.LatestEvents
+
+	authEvents := gomatrixserverlib.NewAuthEvents(nil)
+
+	for i := range queryRes.StateEvents {
+		authEvents.AddEvent(&queryRes.StateEvents[i])
+	}
+
+	if err = fillDisplayName(builder, content, authEvents); err != nil {
+		return nil, err
+	}
+
+	refs, err := eventsNeeded.AuthEventReferences(&authEvents)
+	if err != nil {
+		return nil, err
+	}
+	builder.AuthEvents = refs
 
 	eventID := fmt.Sprintf("$%s:%s", util.RandomString(16), cfg.Matrix.ServerName)
 	now := time.Now()

--- a/src/github.com/matrix-org/dendrite/federationapi/writers/threepid.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/writers/threepid.go
@@ -122,7 +122,11 @@ func createInviteFrom3PIDInvite(
 
 	if !queryRes.RoomExists {
 		// Use federation to auth the event
-		_, remoteServer, err := gomatrixserverlib.SplitID('!', inv.RoomID)
+		var remoteServer gomatrixserverlib.ServerName
+		_, remoteServer, err = gomatrixserverlib.SplitID('!', inv.RoomID)
+		if err != nil {
+			return nil, err
+		}
 		*builder, err = federation.ExchangeThirdPartyInvite(remoteServer, *builder)
 		if err != nil {
 			return nil, err

--- a/src/github.com/matrix-org/dendrite/federationapi/writers/threepid.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/writers/threepid.go
@@ -127,10 +127,8 @@ func createInviteFrom3PIDInvite(
 		if err != nil {
 			return nil, err
 		}
-		*builder, err = federation.ExchangeThirdPartyInvite(remoteServer, *builder)
-		if err != nil {
-			return nil, err
-		}
+		err = federation.ExchangeThirdPartyInvite(remoteServer, *builder)
+		return nil, err
 	} else {
 		// Auth the event locally
 		builder.Depth = queryRes.Depth

--- a/src/github.com/matrix-org/dendrite/federationapi/writers/threepid.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/writers/threepid.go
@@ -30,7 +30,7 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 
-	"github.com/sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 )
 
 type invite struct {

--- a/src/github.com/matrix-org/dendrite/federationapi/writers/threepid.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/writers/threepid.go
@@ -165,23 +165,23 @@ func createInviteFrom3PIDInvite(
 // them responded with an error.
 func sendToRemoteServer(
 	inv invite, federation *gomatrixserverlib.FederationClient, cfg config.Dendrite,
-) error {
+) (err error) {
 	remoteServers := make([]gomatrixserverlib.ServerName, 2)
 	_, remoteServers[0], err = gomatrixserverlib.SplitID('@', inv.Sender)
 	if err != nil {
-		return err
+		return
 	}
 	// Fallback to the room's server if the sender's domain is the same as
 	// the current server's
 	_, remoteServers[1], err = gomatrixserverlib.SplitID('!', inv.RoomID)
 	if err != nil {
-		return err
+		return
 	}
 
 	for _, server := range remoteServers {
 		err = federation.ExchangeThirdPartyInvite(server, *builder)
 		if err == nil {
-			return nil
+			return
 		}
 		logrus.WithError(err).Warn("Failed to send 3PID invite via %s.", server)
 	}

--- a/src/github.com/matrix-org/dendrite/federationapi/writers/threepid.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/writers/threepid.go
@@ -122,7 +122,7 @@ func createInviteFrom3PIDInvite(
 
 	if !queryRes.RoomExists {
 		// Use federation to auth the event
-		var remoteServers []gomatrixserverlib.ServerName
+		remoteServers := make([]gomatrixserverlib.ServerName, 2)
 		_, remoteServers[0], err = gomatrixserverlib.SplitID('@', inv.Sender)
 		if err != nil {
 			return nil, err
@@ -135,12 +135,10 @@ func createInviteFrom3PIDInvite(
 		}
 
 		for _, server := range remoteServers {
-			if server == cfg.Matrix.ServerName {
-				continue
+			if server != cfg.Matrix.ServerName {
+				err = federation.ExchangeThirdPartyInvite(server, *builder)
+				return nil, err
 			}
-
-			err = federation.ExchangeThirdPartyInvite(server, *builder)
-			return nil, err
 		}
 	}
 

--- a/src/github.com/matrix-org/dendrite/federationapi/writers/threepid.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/writers/threepid.go
@@ -125,7 +125,7 @@ func createInviteFrom3PIDInvite(
 
 	if !queryRes.RoomExists {
 		// Use federation to auth the event
-		return sendToRemoteServer(inv, federation, cfg)
+		return nil, sendToRemoteServer(inv, federation, cfg, *builder)
 	}
 
 	// Auth the event locally
@@ -165,6 +165,7 @@ func createInviteFrom3PIDInvite(
 // them responded with an error.
 func sendToRemoteServer(
 	inv invite, federation *gomatrixserverlib.FederationClient, cfg config.Dendrite,
+	builder gomatrixserverlib.EventBuilder,
 ) (err error) {
 	remoteServers := make([]gomatrixserverlib.ServerName, 2)
 	_, remoteServers[0], err = gomatrixserverlib.SplitID('@', inv.Sender)
@@ -179,14 +180,14 @@ func sendToRemoteServer(
 	}
 
 	for _, server := range remoteServers {
-		err = federation.ExchangeThirdPartyInvite(server, *builder)
+		err = federation.ExchangeThirdPartyInvite(server, builder)
 		if err == nil {
 			return
 		}
-		logrus.WithError(err).Warn("Failed to send 3PID invite via %s.", server)
+		logrus.WithError(err).Warn("failed to send 3PID invite via %s", server)
 	}
 
-	return errors.New("Failed to send 3PID invite via any server.")
+	return errors.New("failed to send 3PID invite via any server")
 }
 
 // fillDisplayName looks in a list of auth events for a m.room.third_party_invite

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -13,7 +13,7 @@ gb build github.com/matrix-org/dendrite/cmd/mediaapi-integration-tests
 gb build github.com/matrix-org/dendrite/cmd/client-api-proxy
 
 # Run the pre commit hooks
-./hooks/pre-commit
+# ./hooks/pre-commit
 
 # Run the integration tests
 bin/roomserver-integration-tests

--- a/travis-test.sh
+++ b/travis-test.sh
@@ -13,7 +13,7 @@ gb build github.com/matrix-org/dendrite/cmd/mediaapi-integration-tests
 gb build github.com/matrix-org/dendrite/cmd/client-api-proxy
 
 # Run the pre commit hooks
-# ./hooks/pre-commit
+./hooks/pre-commit
 
 # Run the integration tests
 bin/roomserver-integration-tests

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -116,7 +116,7 @@
 		{
 			"importpath": "github.com/matrix-org/gomatrixserverlib",
 			"repository": "https://github.com/matrix-org/gomatrixserverlib",
-			"revision": "2e9caead882bcdeb999cf4677cfff47e39d3271e",
+			"revision": "c8e825a7db0067101858975a8b689b3797cb31e9",
 			"branch": "master"
 		},
 		{

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -116,7 +116,7 @@
 		{
 			"importpath": "github.com/matrix-org/gomatrixserverlib",
 			"repository": "https://github.com/matrix-org/gomatrixserverlib",
-			"revision": "c8e825a7db0067101858975a8b689b3797cb31e9",
+			"revision": "fe45d482f2280c9f92f09eb6650e7aa3cca051c5",
 			"branch": "master"
 		},
 		{

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/client.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/client.go
@@ -114,7 +114,7 @@ func (fc *Client) LookupUserInfo(matrixServer ServerName, token string) (u UserI
 	var response *http.Response
 	response, err = fc.client.Get(url.String())
 	if response != nil {
-		defer response.Body.Close()
+		defer response.Body.Close() // nolint: errcheck
 	}
 	if err != nil {
 		return
@@ -152,7 +152,7 @@ func (fc *Client) LookupUserInfo(matrixServer ServerName, token string) (u UserI
 // return a cached copy of the keys or whether they will need to retrieve a fresh
 // copy of the keys.
 // Returns the keys or an error if there was a problem talking to the server.
-func (fc *Client) LookupServerKeys(
+func (fc *Client) LookupServerKeys( // nolint: gocyclo
 	matrixServer ServerName, keyRequests map[PublicKeyRequest]Timestamp,
 ) (map[PublicKeyRequest]ServerKeys, error) {
 	url := url.URL{
@@ -185,7 +185,7 @@ func (fc *Client) LookupServerKeys(
 
 	response, err := fc.client.Post(url.String(), "application/json", bytes.NewBuffer(requestBytes))
 	if response != nil {
-		defer response.Body.Close()
+		defer response.Body.Close() // nolint: errcheck
 	}
 	if err != nil {
 		return nil, err

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/clientevent_test.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/clientevent_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-func TestToClientEvent(t *testing.T) {
+func TestToClientEvent(t *testing.T) { // nolint: gocyclo
 	ev, err := NewEventFromTrustedJSON([]byte(`{
 		"type": "m.room.name",
 		"state_key": "",

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/event.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/event.go
@@ -315,6 +315,7 @@ func (e Event) Sign(signingName string, keyID KeyID, privateKey ed25519.PrivateK
 	return Event{
 		redacted:  e.redacted,
 		eventJSON: eventJSON,
+		fields:    e.fields,
 	}
 }
 
@@ -361,7 +362,7 @@ const (
 // Returns an error if the total length of the event JSON is too long.
 // Returns an error if the event ID doesn't match the origin of the event.
 // https://matrix.org/docs/spec/client_server/r0.2.0.html#size-limits
-func (e Event) CheckFields() error {
+func (e Event) CheckFields() error { // nolint: gocyclo
 	if len(e.eventJSON) > maxEventLength {
 		return fmt.Errorf(
 			"gomatrixserverlib: event is too long, length %d > maximum %d",

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/eventauth.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/eventauth.go
@@ -86,7 +86,7 @@ func (s StateNeeded) Tuples() (res []StateKeyTuple) {
 // AuthEventReferences returns the auth_events references for the StateNeeded. Returns an error if the
 // provider returns an error. If an event is missing from the provider but is required in StateNeeded, it
 // is skipped over: no error is returned.
-func (s StateNeeded) AuthEventReferences(provider AuthEventProvider) (refs []EventReference, err error) {
+func (s StateNeeded) AuthEventReferences(provider AuthEventProvider) (refs []EventReference, err error) { // nolint: gocyclo
 	var e *Event
 	if s.Create {
 		if e, err = provider.Create(); err != nil {
@@ -294,7 +294,7 @@ func (a *AuthEvents) ThirdPartyInvite(stateKey string) (*Event, error) {
 func NewAuthEvents(events []*Event) AuthEvents {
 	a := AuthEvents{make(map[StateKeyTuple]*Event)}
 	for _, e := range events {
-		a.AddEvent(e)
+		a.AddEvent(e) // nolint: errcheck
 	}
 	return a
 }
@@ -775,7 +775,7 @@ type membershipAllower struct {
 
 // newMembershipAllower loads the information needed to authenticate the m.room.member event
 // from the auth events.
-func newMembershipAllower(authEvents AuthEventProvider, event Event) (m membershipAllower, err error) {
+func newMembershipAllower(authEvents AuthEventProvider, event Event) (m membershipAllower, err error) { // nolint: gocyclo
 	stateKey := event.StateKey()
 	if stateKey == nil {
 		err = errorf("m.room.member must be a state event")
@@ -816,7 +816,7 @@ func newMembershipAllower(authEvents AuthEventProvider, event Event) (m membersh
 }
 
 // membershipAllowed checks whether the membership event is allowed
-func (m *membershipAllower) membershipAllowed(event Event) error {
+func (m *membershipAllower) membershipAllowed(event Event) error { // nolint: gocyclo
 	if m.create.roomID != event.RoomID() {
 		return errorf("create event has different roomID: %q != %q", event.RoomID(), m.create.roomID)
 	}
@@ -896,7 +896,7 @@ func (m *membershipAllower) membershipAllowedFromThirdPartyInvite() error {
 }
 
 // membershipAllowedSelf determines if the change made by the user to their own membership is allowed.
-func (m *membershipAllower) membershipAllowedSelf() error {
+func (m *membershipAllower) membershipAllowedSelf() error { // nolint: gocyclo
 	if m.newMember.Membership == join {
 		// A user that is not in the room is allowed to join if the room
 		// join rules are "public".
@@ -930,7 +930,7 @@ func (m *membershipAllower) membershipAllowedSelf() error {
 }
 
 // membershipAllowedOther determines if the user is allowed to change the membership of another user.
-func (m *membershipAllower) membershipAllowedOther() error {
+func (m *membershipAllower) membershipAllowedOther() error { // nolint: gocyclo
 	senderLevel := m.powerLevels.userLevel(m.senderID)
 	targetLevel := m.powerLevels.userLevel(m.targetID)
 

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/eventauth_test.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/eventauth_test.go
@@ -128,7 +128,9 @@ func TestStateNeededForJoin(t *testing.T) {
 		StateKey: &skey,
 		Sender:   "@u1:a",
 	}
-	b.SetContent(memberContent{"join", nil})
+	if err := b.SetContent(memberContent{"join", nil}); err != nil {
+		t.Fatal(err)
+	}
 	testStateNeededForAuth(t, `[{
 		"type": "m.room.member",
 		"state_key": "@u1:a",
@@ -149,7 +151,9 @@ func TestStateNeededForInvite(t *testing.T) {
 		StateKey: &skey,
 		Sender:   "@u1:a",
 	}
-	b.SetContent(memberContent{"invite", nil})
+	if err := b.SetContent(memberContent{"invite", nil}); err != nil {
+		t.Fatal(err)
+	}
 	testStateNeededForAuth(t, `[{
 		"type": "m.room.member",
 		"state_key": "@u2:b",
@@ -170,11 +174,13 @@ func TestStateNeededForInvite3PID(t *testing.T) {
 		Sender:   "@u1:a",
 	}
 
-	b.SetContent(memberContent{"invite", &memberThirdPartyInvite{
+	if err := b.SetContent(memberContent{"invite", &memberThirdPartyInvite{
 		Signed: memberThirdPartyInviteSigned{
 			Token: "my_token",
 		},
-	}})
+	}}); err != nil {
+		t.Fatal(err)
+	}
 	testStateNeededForAuth(t, `[{
 		"type": "m.room.member",
 		"state_key": "@u2:b",

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/eventcrypto.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/eventcrypto.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+
 	"golang.org/x/crypto/ed25519"
 )
 
@@ -98,7 +99,7 @@ func checkEventContentHash(eventJSON []byte) error {
 
 	sha256Hash := sha256.Sum256(hashableEventJSON)
 
-	if bytes.Compare(sha256Hash[:], []byte(hashes.Sha256)) != 0 {
+	if !bytes.Equal(sha256Hash[:], []byte(hashes.Sha256)) {
 		return fmt.Errorf("Invalid Sha256 content hash: %v != %v", sha256Hash[:], []byte(hashes.Sha256))
 	}
 
@@ -187,7 +188,7 @@ func verifyEventSignature(signingName string, keyID KeyID, publicKey ed25519.Pub
 
 // VerifyEventSignatures checks that each event in a list of events has valid
 // signatures from the server that sent it.
-func VerifyEventSignatures(events []Event, keyRing KeyRing) error {
+func VerifyEventSignatures(events []Event, keyRing KeyRing) error { // nolint: gocyclo
 	var toVerify []VerifyJSONRequest
 	for _, event := range events {
 		redactedJSON, err := redactEvent(event.eventJSON)

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/eventcrypto_test.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/eventcrypto_test.go
@@ -18,8 +18,9 @@ package gomatrixserverlib
 import (
 	"bytes"
 	"encoding/base64"
-	"golang.org/x/crypto/ed25519"
 	"testing"
+
+	"golang.org/x/crypto/ed25519"
 )
 
 func TestVerifyEventSignatureTestVectors(t *testing.T) {

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/hooks/pre-commit
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/hooks/pre-commit
@@ -4,7 +4,7 @@ set -eu
 
 echo "Installing lint search engine..."
 go get github.com/alecthomas/gometalinter/
-gometalinter --config=linter.json --install
+gometalinter --config=linter.json --install --update
 
 echo "Looking for lint..."
 gometalinter --config=linter.json

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/hooks/pre-commit
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/hooks/pre-commit
@@ -2,23 +2,17 @@
 
 set -eu
 
-golint ./...
-misspell -error .
+echo "Installing lint search engine..."
+go get github.com/alecthomas/gometalinter/
+gometalinter --config=linter.json --install
 
-# gofmt doesn't exit with an error code if the files don't match the expected
-# format. So we have to run it and see if it outputs anything.
-if gofmt -l -s . 2>&1 | read
-then
-    echo "Error: not all code had been formatted with gofmt."
-    echo "Fixing the following files"
-    gofmt -s -w -l .
-    echo
-    echo "Please add them to the commit"
-    git status --short
-    exit 1
-fi
+echo "Looking for lint..."
+gometalinter --config=linter.json
 
-ineffassign .
-go tool vet --all --shadow .
-gocyclo -over 16 .
-go test -timeout 5s . ./...
+echo "Double checking spelling..."
+misspell -error src *.md
+
+echo "Testing..."
+go test
+
+echo "Done!"

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/keyring.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/keyring.go
@@ -2,9 +2,10 @@ package gomatrixserverlib
 
 import (
 	"fmt"
-	"golang.org/x/crypto/ed25519"
 	"strings"
 	"time"
+
+	"golang.org/x/crypto/ed25519"
 )
 
 // A PublicKeyRequest is a request for a public key with a particular key ID.
@@ -72,7 +73,7 @@ type VerifyJSONResult struct {
 // The caller should check the Result field for each entry to see if it was valid.
 // Returns an error if there was a problem talking to the database or one of the other methods
 // of fetching the public keys.
-func (k *KeyRing) VerifyJSONs(requests []VerifyJSONRequest) ([]VerifyJSONResult, error) {
+func (k *KeyRing) VerifyJSONs(requests []VerifyJSONRequest) ([]VerifyJSONResult, error) { // nolint: gocyclo
 	results := make([]VerifyJSONResult, len(requests))
 	keyIDs := make([][]KeyID, len(requests))
 

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/keyring_test.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/keyring_test.go
@@ -6,7 +6,6 @@ import (
 )
 
 var privateKeySeed1 = `QJvXAPj0D9MUb1exkD8pIWmCvT1xajlsB8jRYz/G5HE`
-var privateKeySeed2 = `AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA`
 
 // testKeys taken from a copy of synapse.
 var testKeys = `{

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/linter.json
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/linter.json
@@ -1,0 +1,25 @@
+{
+    "Enable": [
+        "vet",
+        "vetshadow",
+        "gotype",
+        "deadcode",
+        "gocyclo",
+        "golint",
+        "varcheck",
+        "structcheck",
+        "aligncheck",
+        "ineffassign",
+        "gas",
+        "misspell",
+        "gosimple",
+        "megacheck",
+        "unparam",
+        "goimports",
+        "goconst",
+        "unconvert",
+        "errcheck",
+        "interfacer",
+        "testify"
+    ]
+}

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/request.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/request.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/matrix-org/util"
-	"golang.org/x/crypto/ed25519"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/matrix-org/util"
+	"golang.org/x/crypto/ed25519"
 )
 
 // A FederationRequest is a request to send to a remote server or a request
@@ -156,7 +157,7 @@ func (r *FederationRequest) HTTPRequest() (*http.Request, error) {
 //
 //    qdtext         = HTAB / SP / %x21 / %x23-5B / %x5D-7E / %x80-FF
 //
-func isSafeInHTTPQuotedString(text string) bool {
+func isSafeInHTTPQuotedString(text string) bool { // nolint: gocyclo
 	for i := 0; i < len(text); i++ {
 		c := text[i]
 		switch {
@@ -234,7 +235,7 @@ func VerifyHTTPRequest(
 }
 
 // Returns an error if there was a problem reading the content of the request
-func readHTTPRequest(req *http.Request) (*FederationRequest, error) {
+func readHTTPRequest(req *http.Request) (*FederationRequest, error) { // nolint: gocyclo
 	var result FederationRequest
 
 	result.fields.Method = req.Method

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/request_test.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/request_test.go
@@ -4,10 +4,11 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/base64"
-	"golang.org/x/crypto/ed25519"
 	"net/http"
 	"testing"
 	"time"
+
+	"golang.org/x/crypto/ed25519"
 )
 
 // This GET request is taken from a request made by a synapse run by sytest.
@@ -62,7 +63,7 @@ func TestSignGetRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := string(buf.Bytes())
+	got := buf.String()
 	want := exampleGetRequest
 	if want != got {
 		t.Errorf("Wanted %q got %q", want, got)
@@ -121,7 +122,7 @@ func TestSignPutRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := string(buf.Bytes())
+	got := buf.String()
 	want := examplePutRequest
 	if want != got {
 		t.Errorf("Wanted %q got %q", want, got)
@@ -159,7 +160,6 @@ func TestVerifyPutRequest(t *testing.T) {
 }
 
 var privateKey1 = mustLoadPrivateKey(privateKeySeed1)
-var privateKey2 = mustLoadPrivateKey(privateKeySeed2)
 
 func mustLoadPrivateKey(seed string) ed25519.PrivateKey {
 	seedBytes, err := base64.RawStdEncoding.DecodeString(seed)

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/resolve.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/resolve.go
@@ -43,7 +43,7 @@ func LookupServer(serverName ServerName) (*DNSResult, error) { // nolint: gocycl
 	result.Hosts = map[string]HostResult{}
 
 	hosts := map[string][]net.SRV{}
-	if strings.Contains(string(serverName), ":") {
+	if !strings.Contains(string(serverName), ":") {
 		// If there isn't an explicit port set then try to look up the SRV record.
 		var err error
 		result.SRVCName, result.SRVRecords, err = net.LookupSRV("matrix", "tcp", string(serverName))

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/resolve.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/resolve.go
@@ -38,12 +38,12 @@ type DNSResult struct {
 }
 
 // LookupServer looks up a matrix server in DNS.
-func LookupServer(serverName ServerName) (*DNSResult, error) {
+func LookupServer(serverName ServerName) (*DNSResult, error) { // nolint: gocyclo
 	var result DNSResult
 	result.Hosts = map[string]HostResult{}
 
 	hosts := map[string][]net.SRV{}
-	if strings.Index(string(serverName), ":") == -1 {
+	if strings.Contains(string(serverName), ":") {
 		// If there isn't an explicit port set then try to look up the SRV record.
 		var err error
 		result.SRVCName, result.SRVRecords, err = net.LookupSRV("matrix", "tcp", string(serverName))

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/signing.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/signing.go
@@ -18,6 +18,7 @@ package gomatrixserverlib
 import (
 	"encoding/json"
 	"fmt"
+
 	"golang.org/x/crypto/ed25519"
 )
 

--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/stateresolution.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/stateresolution.go
@@ -99,7 +99,7 @@ func (r *stateResolver) Member(key string) (*Event, error) {
 	return r.resolvedMembers[key], nil
 }
 
-func (r *stateResolver) addConflicted(events []Event) {
+func (r *stateResolver) addConflicted(events []Event) { // nolint: gocyclo
 	type conflictKey struct {
 		eventType string
 		stateKey  string


### PR DESCRIPTION
Follows https://github.com/matrix-org/gomatrixserverlib/pull/61

This PR address the case where the server receives a 3PID invite from an identity server for a room it's not in. It will then send to the room's server all the necessary data for building a `m.room.member` event so the room's server can authenticate it.