### PR TITLE
Implement federation route PUT /exchange_third_party_invite

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/threepid/invites.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/threepid/invites.go
@@ -254,6 +254,7 @@ func queryIDServerStoreInvite(
 
 // queryIDServerPubKey requests a public key identified with a given ID to the
 // a given identity server and returns the matching base64-decoded public key.
+// We assume that the ID server is trusted at this point.
 // Returns an error if the request couldn't be sent, if its body couldn't be parsed
 // or if the key couldn't be decoded from base64.
 func queryIDServerPubKey(idServerName string, keyID string) ([]byte, error) {
@@ -280,6 +281,7 @@ func queryIDServerPubKey(idServerName string, keyID string) ([]byte, error) {
 // If no signature can be found for the ID server's domain, returns an error, else
 // iterates over the signature for the said domain, retrieves the matching public
 // key, and verify it.
+// We assume that the ID server is trusted at this point.
 // Returns nil if all the verifications succeeded.
 // Returns an error if something failed in the process.
 func checkIDServerSignatures(body *MembershipRequest, res *idServerLookupResponse) error {

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
@@ -85,6 +85,16 @@ func Setup(
 		},
 	))
 
+	v1fedmux.Handle("/exchange_third_party_invite/{roomID}", common.MakeFedAPI(
+		"exchange_third_party_invite", cfg.Matrix.ServerName, keys,
+		func(httpReq *http.Request, request *gomatrixserverlib.FederationRequest) util.JSONResponse {
+			vars := mux.Vars(httpReq)
+			return writers.ExchangeThirdPartyInvite(
+				httpReq, request, vars["roomID"], query, cfg, federation, producer,
+			)
+		},
+	))
+
 	v1fedmux.Handle("/event/{eventID}", common.MakeFedAPI(
 		"federation_get_event", cfg.Matrix.ServerName, keys,
 		func(httpReq *http.Request, request *gomatrixserverlib.FederationRequest) util.JSONResponse {

--- a/src/github.com/matrix-org/dendrite/federationapi/writers/threepid.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/writers/threepid.go
@@ -126,7 +126,7 @@ func ExchangeThirdPartyInvite(
 	}
 
 	// Send the event to the roomserver
-	if err = producer.SendInvite(signedEvent.Event); err != nil {
+	if err = producer.SendEvents([]gomatrixserverlib.Event{signedEvent.Event}, cfg.Matrix.ServerName); err != nil {
 		return httputil.LogThenError(httpReq, err)
 	}
 

--- a/src/github.com/matrix-org/dendrite/federationapi/writers/threepid.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/writers/threepid.go
@@ -116,6 +116,8 @@ func ExchangeThirdPartyInvite(
 			Code: 404,
 			JSON: jsonerror.NotFound("Unknown room " + roomID),
 		}
+	} else if err != nil {
+		return httputil.LogThenError(httpReq, err)
 	}
 
 	// Ask the requesting server to sign the newly created event so we know it

--- a/src/github.com/matrix-org/dendrite/federationapi/writers/threepid.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/writers/threepid.go
@@ -109,6 +109,23 @@ func ExchangeThirdPartyInvite(
 		}
 	}
 
+	// Check that the state key is correct.
+	_, targetDomain, err := gomatrixserverlib.SplitID('@', *builder.StateKey)
+	if err != nil {
+		return util.JSONResponse{
+			Code: 400,
+			JSON: jsonerror.BadJSON("The event's state key isn't a Matrix user ID"),
+		}
+	}
+
+	// Check that the target user is from the requesting homeserver.
+	if targetDomain != request.Origin() {
+		return util.JSONResponse{
+			Code: 400,
+			JSON: jsonerror.BadJSON("The event's state key doesn't have the same domain as the request's origin"),
+		}
+	}
+
 	// Auth and build the event from what the remote server sent us
 	event, err := buildMembershipEvent(&builder, queryAPI, cfg)
 	if err == errNotInRoom {

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -116,7 +116,7 @@
 		{
 			"importpath": "github.com/matrix-org/gomatrixserverlib",
 			"repository": "https://github.com/matrix-org/gomatrixserverlib",
-			"revision": "fe45d482f2280c9f92f09eb6650e7aa3cca051c5",
+			"revision": "790f02e8f465552dab4317ffe7ca047ccb594cbf",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
Also rearranged a bit the `threepid.go` writer in the federation API.