### PR TITLE
Use a shared PostgreSQL sequence to generate ids.

### DIFF
--- a/src/github.com/matrix-org/dendrite/syncapi/storage/account_data_table.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/storage/account_data_table.go
@@ -27,7 +27,8 @@ const accountDataSchema = `
 -- This sequence is shared between all the tables generated from kafka logs.
 CREATE SEQUENCE IF NOT EXISTS syncapi_stream_id;
 
--- Stores the users account data
+-- Stores the types of account data that a user set has globally and in each room
+-- and the stream ID when that type was last updated.
 CREATE TABLE IF NOT EXISTS syncapi_account_data_type (
     -- An incrementing ID which denotes the position in the log that this event resides at.
     id BIGINT PRIMARY KEY DEFAULT nextval('syncapi_stream_id'),

--- a/src/github.com/matrix-org/dendrite/syncapi/storage/account_data_table.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/storage/account_data_table.go
@@ -46,7 +46,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS syncapi_account_data_id_idx ON syncapi_account
 `
 
 const insertAccountDataSQL = "" +
-	"INSERT INTO syncapi_account_data_type (user_id, room_id, type) VALUES ($2, $3, $4)" +
+	"INSERT INTO syncapi_account_data_type (user_id, room_id, type) VALUES ($1, $2, $3)" +
 	" ON CONFLICT ON CONSTRAINT syncapi_account_data_unique" +
 	" DO UPDATE SET id = EXCLUDED.id" +
 	" RETURNING id"

--- a/src/github.com/matrix-org/dendrite/syncapi/storage/account_data_table.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/storage/account_data_table.go
@@ -38,8 +38,6 @@ CREATE TABLE IF NOT EXISTS syncapi_account_data_type (
     -- Type of the data
     type TEXT NOT NULL,
 
-    PRIMARY KEY(user_id, room_id, type),
-
     -- We don't want two entries of the same type for the same user
     CONSTRAINT syncapi_account_data_unique UNIQUE (user_id, room_id, type)
 );


### PR DESCRIPTION
Share an auto-incrementing sequence between the account data and the room event table.
This means that account data updates can be received independently of room events updates.

This should give some basic support for fixing #212