### PR TITLE
Add staticcheck lint

### DIFF
--- a/linter.json
+++ b/linter.json
@@ -17,6 +17,7 @@
         "unparam",
         "errcheck",
         "vet",
-        "gosimple"
+        "gosimple",
+        "staticcheck"
     ]
 }

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-room-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-room-server/main.go
@@ -80,7 +80,9 @@ func main() {
 
 	aliasAPI.SetupHTTP(http.DefaultServeMux)
 
-	http.DefaultServeMux.Handle("/metrics", prometheus.Handler())
+	// This is deprecated, but prometheus are still arguing on what to replace
+	// it with. Alternatively we could set it up manually.
+	http.DefaultServeMux.Handle("/metrics", prometheus.Handler()) // nolint: staticcheck, megacheck
 
 	log.Info("Started room server on ", cfg.Listen.RoomServer)
 

--- a/src/github.com/matrix-org/dendrite/cmd/mediaapi-integration-tests/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/mediaapi-integration-tests/main.go
@@ -190,7 +190,7 @@ func getMediaURI(host, endpoint, query string, components []string) string {
 func testUpload(host, filePath string) {
 	fmt.Printf("==TESTING== upload %v to %v\n", filePath, host)
 	file, err := os.Open(filePath)
-	defer file.Close() // nolint: errcheck
+	defer file.Close() // nolint: errcheck, staticcheck, megacheck
 	if err != nil {
 		panic(err)
 	}

--- a/src/github.com/matrix-org/dendrite/common/httpapi.go
+++ b/src/github.com/matrix-org/dendrite/common/httpapi.go
@@ -52,6 +52,7 @@ func MakeFedAPI(
 // SetupHTTPAPI registers an HTTP API mux under /api and sets up a metrics
 // listener.
 func SetupHTTPAPI(servMux *http.ServeMux, apiMux *mux.Router) {
-	servMux.Handle("/metrics", prometheus.Handler())
+	// This is deprecated.
+	servMux.Handle("/metrics", prometheus.Handler()) // nolint: megacheck, staticcheck
 	servMux.Handle("/api/", http.StripPrefix("/api", apiMux))
 }

--- a/src/github.com/matrix-org/dendrite/mediaapi/writers/download.go
+++ b/src/github.com/matrix-org/dendrite/mediaapi/writers/download.go
@@ -236,7 +236,7 @@ func (r *downloadRequest) respondFromLocalFile(
 		return nil, errors.Wrap(err, "failed to get file path from metadata")
 	}
 	file, err := os.Open(filePath)
-	defer file.Close() // nolint: errcheck
+	defer file.Close() // nolint: errcheck, staticcheck, megacheck
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open file")
 	}


### PR DESCRIPTION
We actually enable megacheck, as that is a faster version of "unused", "staticcheck" and "gosimple"