### PR TITLE
Add context to the partition offset table

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
@@ -29,8 +29,8 @@ import (
 
 // Database represents an account database
 type Database struct {
-	db           *sql.DB
-	partitions   common.PartitionOffsetStatements
+	db *sql.DB
+	common.PartitionOffsetStatements
 	accounts     accountsStatements
 	profiles     profilesStatements
 	memberships  membershipStatements
@@ -125,16 +125,6 @@ func (d *Database) CreateAccount(
 		return nil, err
 	}
 	return d.accounts.insertAccount(ctx, localpart, hash)
-}
-
-// PartitionOffsets implements common.PartitionStorer
-func (d *Database) PartitionOffsets(topic string) ([]common.PartitionOffset, error) {
-	return d.partitions.SelectPartitionOffsets(topic)
-}
-
-// SetPartitionOffset implements common.PartitionStorer
-func (d *Database) SetPartitionOffset(topic string, partition int32, offset int64) error {
-	return d.partitions.UpsertPartitionOffset(topic, partition, offset)
 }
 
 // SaveMembership saves the user matching a given localpart as a member of a given

--- a/src/github.com/matrix-org/dendrite/federationsender/storage/storage.go
+++ b/src/github.com/matrix-org/dendrite/federationsender/storage/storage.go
@@ -61,16 +61,6 @@ func (d *Database) prepare() error {
 	return nil
 }
 
-// PartitionOffsets implements common.PartitionStorer
-func (d *Database) PartitionOffsets(topic string) ([]common.PartitionOffset, error) {
-	return d.SelectPartitionOffsets(topic)
-}
-
-// SetPartitionOffset implements common.PartitionStorer
-func (d *Database) SetPartitionOffset(topic string, partition int32, offset int64) error {
-	return d.UpsertPartitionOffset(topic, partition, offset)
-}
-
 // UpdateRoom updates the joined hosts for a room and returns what the joined
 // hosts were before the update.
 func (d *Database) UpdateRoom(

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/storage/storage.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/storage/storage.go
@@ -27,8 +27,8 @@ import (
 
 // PublicRoomsServerDatabase represents a public rooms server database.
 type PublicRoomsServerDatabase struct {
-	db         *sql.DB
-	partitions common.PartitionOffsetStatements
+	db *sql.DB
+	common.PartitionOffsetStatements
 	statements publicRoomsStatements
 }
 
@@ -50,16 +50,6 @@ func NewPublicRoomsServerDatabase(dataSourceName string) (*PublicRoomsServerData
 		return nil, err
 	}
 	return &PublicRoomsServerDatabase{db, partitions, statements}, nil
-}
-
-// PartitionOffsets implements common.PartitionStorer
-func (d *PublicRoomsServerDatabase) PartitionOffsets(topic string) ([]common.PartitionOffset, error) {
-	return d.partitions.SelectPartitionOffsets(topic)
-}
-
-// SetPartitionOffset implements common.PartitionStorer
-func (d *PublicRoomsServerDatabase) SetPartitionOffset(topic string, partition int32, offset int64) error {
-	return d.partitions.UpsertPartitionOffset(topic, partition, offset)
 }
 
 // GetRoomVisibility returns the room visibility as a boolean: true if the room

--- a/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
@@ -42,8 +42,8 @@ type streamEvent struct {
 
 // SyncServerDatabase represents a sync server database
 type SyncServerDatabase struct {
-	db          *sql.DB
-	partitions  common.PartitionOffsetStatements
+	db *sql.DB
+	common.PartitionOffsetStatements
 	accountData accountDataStatements
 	events      outputRoomEventsStatements
 	roomstate   currentRoomStateStatements
@@ -57,7 +57,7 @@ func NewSyncServerDatabase(dataSourceName string) (*SyncServerDatabase, error) {
 	if d.db, err = sql.Open("postgres", dataSourceName); err != nil {
 		return nil, err
 	}
-	if err = d.partitions.Prepare(d.db, "syncapi"); err != nil {
+	if err = d.PartitionOffsetStatements.Prepare(d.db, "syncapi"); err != nil {
 		return nil, err
 	}
 	if err = d.accountData.prepare(d.db); err != nil {
@@ -160,16 +160,6 @@ func (d *SyncServerDatabase) GetStateEvent(
 	ctx context.Context, evType, roomID, stateKey string,
 ) (*gomatrixserverlib.Event, error) {
 	return d.roomstate.selectStateEvent(ctx, evType, roomID, stateKey)
-}
-
-// PartitionOffsets implements common.PartitionStorer
-func (d *SyncServerDatabase) PartitionOffsets(topic string) ([]common.PartitionOffset, error) {
-	return d.partitions.SelectPartitionOffsets(topic)
-}
-
-// SetPartitionOffset implements common.PartitionStorer
-func (d *SyncServerDatabase) SetPartitionOffset(topic string, partition int32, offset int64) error {
-	return d.partitions.UpsertPartitionOffset(topic, partition, offset)
 }
 
 // SyncStreamPosition returns the latest position in the sync stream. Returns 0 if there are no events yet.


### PR DESCRIPTION
As well as adding context I've made the ```PartitionOffsetStatements``` type directly implement the interface required by the ```Consumer``` type. This means that we can simply inherit the ```PartitionOffsets``` and ```SetPartitionOffset``` methods in the various storage types.