### PR TITLE
Implement room state retrieval endpoint

### DIFF
--- a/src/github.com/matrix-org/dendrite/syncapi/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/consumers/roomserver.go
@@ -262,9 +262,9 @@ func (s *OutputRoomEvent) updateStateEvent(event gomatrixserverlib.Event) (gomat
 	}
 
 	prev := types.PrevEventRef{
-		PrevContent: prevEvent.Content(),
-		PrevID:      prevEvent.EventID(),
-		PrevSender:  prevEvent.Sender(),
+		PrevContent:   prevEvent.Content(),
+		ReplacesState: prevEvent.EventID(),
+		PrevSender:    prevEvent.Sender(),
 	}
 
 	return event.SetUnsigned(prev)

--- a/src/github.com/matrix-org/dendrite/syncapi/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/consumers/roomserver.go
@@ -38,12 +38,6 @@ type OutputRoomEvent struct {
 	query              api.RoomserverQueryAPI
 }
 
-type prevEventRef struct {
-	PrevContent json.RawMessage `json:"prev_content"`
-	PrevID      string          `json:"replaces_state"`
-	UserID      string          `json:"prev_sender"`
-}
-
 // NewOutputRoomEvent creates a new OutputRoomEvent consumer. Call Start() to begin consuming from room servers.
 func NewOutputRoomEvent(
 	cfg *config.Dendrite,
@@ -267,10 +261,10 @@ func (s *OutputRoomEvent) updateStateEvent(event gomatrixserverlib.Event) (gomat
 		return event, nil
 	}
 
-	prev := prevEventRef{
+	prev := types.PrevEventRef{
 		PrevContent: prevEvent.Content(),
 		PrevID:      prevEvent.EventID(),
-		UserID:      prevEvent.Sender(),
+		PrevSender:  prevEvent.Sender(),
 	}
 
 	return event.SetUnsigned(prev)

--- a/src/github.com/matrix-org/dendrite/syncapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/routing/routing.go
@@ -33,4 +33,9 @@ func Setup(apiMux *mux.Router, srp *sync.RequestPool, deviceDB *devices.Database
 	r0mux.Handle("/sync", common.MakeAuthAPI("sync", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 		return srp.OnIncomingSyncRequest(req, device)
 	})).Methods("GET")
+
+	r0mux.Handle("/rooms/{roomID}/state", common.MakeAuthAPI("room_state", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		vars := mux.Vars(req)
+		return srp.OnIncomingStateRequest(req, vars["roomID"])
+	}))
 }

--- a/src/github.com/matrix-org/dendrite/syncapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/routing/routing.go
@@ -30,6 +30,7 @@ const pathPrefixR0 = "/_matrix/client/r0"
 // Setup configures the given mux with sync-server listeners
 func Setup(apiMux *mux.Router, srp *sync.RequestPool, deviceDB *devices.Database) {
 	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
+
 	r0mux.Handle("/sync", common.MakeAuthAPI("sync", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 		return srp.OnIncomingSyncRequest(req, device)
 	})).Methods("GET")
@@ -37,5 +38,5 @@ func Setup(apiMux *mux.Router, srp *sync.RequestPool, deviceDB *devices.Database
 	r0mux.Handle("/rooms/{roomID}/state", common.MakeAuthAPI("room_state", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 		vars := mux.Vars(req)
 		return srp.OnIncomingStateRequest(req, vars["roomID"])
-	}))
+	})).Methods("GET")
 }

--- a/src/github.com/matrix-org/dendrite/syncapi/storage/current_room_state_table.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/storage/current_room_state_table.go
@@ -216,7 +216,7 @@ func (s *currentRoomStateStatements) selectEventsWithEventIDs(
 }
 
 func rowsToEvents(rows *sql.Rows) ([]gomatrixserverlib.Event, error) {
-	var result []gomatrixserverlib.Event
+	result := []gomatrixserverlib.Event{}
 	for rows.Next() {
 		var eventBytes []byte
 		if err := rows.Scan(&eventBytes); err != nil {

--- a/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
@@ -162,6 +162,16 @@ func (d *SyncServerDatabase) GetStateEvent(
 	return d.roomstate.selectStateEvent(ctx, evType, roomID, stateKey)
 }
 
+func (d *SyncServerDatabase) GetStateEventsForRoom(
+	ctx context.Context, roomID string,
+) (stateEvents []gomatrixserverlib.Event, err error) {
+	err = common.WithTransaction(d.db, func(txn *sql.Tx) error {
+		stateEvents, err = d.roomstate.selectCurrentState(ctx, txn, roomID)
+		return err
+	})
+	return
+}
+
 // SyncStreamPosition returns the latest position in the sync stream. Returns 0 if there are no events yet.
 func (d *SyncServerDatabase) SyncStreamPosition(ctx context.Context) (types.StreamPosition, error) {
 	return d.syncStreamPositionTx(ctx, nil)

--- a/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
@@ -162,6 +162,9 @@ func (d *SyncServerDatabase) GetStateEvent(
 	return d.roomstate.selectStateEvent(ctx, evType, roomID, stateKey)
 }
 
+// GetStateEventsForRoom fetches the state events for a given room.
+// Returns an empty slice if no state events could be found for this room.
+// Returns an error if there was an issue with the retrieval.
 func (d *SyncServerDatabase) GetStateEventsForRoom(
 	ctx context.Context, roomID string,
 ) (stateEvents []gomatrixserverlib.Event, err error) {

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
@@ -16,7 +16,6 @@ package sync
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -133,7 +132,6 @@ func (rp *RequestPool) OnIncomingStateRequest(req *http.Request, roomID string) 
 			ClientEvent: gomatrixserverlib.ToClientEvent(event, gomatrixserverlib.FormatAll),
 		}
 		var prevEventRef types.PrevEventRef
-		fmt.Println(len(event.Unsigned()))
 		if len(event.Unsigned()) > 0 {
 			if err := json.Unmarshal(event.Unsigned(), &prevEventRef); err != nil {
 				return httputil.LogThenError(req, err)

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
@@ -169,8 +169,11 @@ func (rp *RequestPool) currentSyncForUser(req syncRequest, currentPos types.Stre
 func (rp *RequestPool) appendAccountData(
 	data *types.Response, userID string, req syncRequest, currentPos types.StreamPosition,
 ) (*types.Response, error) {
-	// TODO: We currently send all account data on every sync response, we should instead send data
-	// that has changed on incremental sync responses
+	// TODO: Account data doesn't have a sync position of its own, meaning that
+	// account data might be sent multiple time to the client if multiple account
+	// data keys were set between two message. This isn't a huge issue since the
+	// duplicate data doesn't represent a huge quantity of data, but an optimisation
+	// here would be making sure each data is sent only once to the client.
 	localpart, _, err := gomatrixserverlib.SplitID('@', userID)
 	if err != nil {
 		return nil, err

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
@@ -130,7 +130,7 @@ func (rp *RequestPool) OnIncomingStateRequest(req *http.Request, roomID string) 
 	// Fill the prev_content and replaces_state keys if necessary
 	for _, event := range stateEvents {
 		stateEvent := stateEventInStateResp{
-			ClientEvent: gomatrixserverlib.ToClientEvent(event, gomatrixserverlib.FormatAll)
+			ClientEvent: gomatrixserverlib.ToClientEvent(event, gomatrixserverlib.FormatAll),
 		}
 		var prevEventRef types.PrevEventRef
 		fmt.Println(len(event.Unsigned()))

--- a/src/github.com/matrix-org/dendrite/syncapi/types/types.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/types/types.go
@@ -31,9 +31,9 @@ func (sp StreamPosition) String() string {
 
 // PrevEventRef represents a reference to a previous event in a state event upgrade
 type PrevEventRef struct {
-	PrevContent json.RawMessage `json:"prev_content"`
-	PrevID      string          `json:"replaces_state"`
-	PrevSender  string          `json:"prev_sender"`
+	PrevContent   json.RawMessage `json:"prev_content"`
+	ReplacesState string          `json:"replaces_state"`
+	PrevSender    string          `json:"prev_sender"`
 }
 
 // Response represents a /sync API response. See https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-sync

--- a/src/github.com/matrix-org/dendrite/syncapi/types/types.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/types/types.go
@@ -15,6 +15,7 @@
 package types
 
 import (
+	"encoding/json"
 	"strconv"
 
 	"github.com/matrix-org/gomatrixserverlib"
@@ -26,6 +27,13 @@ type StreamPosition int64
 // String implements the Stringer interface.
 func (sp StreamPosition) String() string {
 	return strconv.FormatInt(int64(sp), 10)
+}
+
+// PrevEventRef represents a reference to a previous event in a state event upgrade
+type PrevEventRef struct {
+	PrevContent json.RawMessage `json:"prev_content"`
+	PrevID      string          `json:"replaces_state"`
+	PrevSender  string          `json:"prev_sender"`
 }
 
 // Response represents a /sync API response. See https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-sync


### PR DESCRIPTION
This PR implements `GET /_matrix/client/r0/rooms/{roomID}/state`, allowing a client to retrieves the full state of a room.