### PR TITLE
Stub /events and /initialSync APIs for sytest

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -345,4 +345,23 @@ func Setup(
 			return util.JSONResponse{Code: 200, JSON: struct{}{}}
 		}),
 	).Methods("PUT", "OPTIONS")
+
+	// Stub implementations for sytest
+	r0mux.Handle("/events",
+		common.MakeAPI("events", func(req *http.Request) util.JSONResponse {
+			return util.JSONResponse{Code: 200, JSON: map[string]interface{}{
+				"chunk": []interface{}{},
+				"start": "",
+				"end":   "",
+			}}
+		}),
+	).Methods("GET")
+
+	r0mux.Handle("/initialSync",
+		common.MakeAPI("initial_sync", func(req *http.Request) util.JSONResponse {
+			return util.JSONResponse{Code: 200, JSON: map[string]interface{}{
+				"end": "",
+			}}
+		}),
+	).Methods("GET")
 }


### PR DESCRIPTION
This is just enough for sytest to think that the APIs exist so that it moves on to more interesting tests.