### PR TITLE
Fix initial / fullSync request

### DIFF
--- a/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
@@ -77,9 +77,7 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request, device *authtype
 		// We stop the timer BEFORE calculating the response so the cpu work
 		// done to calculate the response is not timed. This stops us from
 		// doing lots of work then timing out and sending back an empty response.
-		if syncReq.timeout != 0 && syncReq.since != types.StreamPosition(0) && !syncReq.wantFullState {
-			timer.Stop()
-		}
+		timer.Stop()
 		syncData, err := rp.currentSyncForUser(*syncReq, currentPos)
 		var res util.JSONResponse
 		if err != nil {


### PR DESCRIPTION
The initial/fullSync request sometimes crashed as the timeout triggered before it finished.

Compare Synpase which got the same if: https://github.com/matrix-org/synapse/blob/b23cb8fba8c783bf7a267bfbe33b50e010f17787/synapse/handlers/sync.py#L192

Signed-Off-By: Marcel Radzio <mtrnord1@gmail.com>