### PR TITLE
Handle duplicate kafka messages

### DIFF
--- a/src/github.com/matrix-org/dendrite/federationsender/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/federationsender/consumers/roomserver.go
@@ -146,7 +146,7 @@ func (s *OutputRoomEvent) processMessage(ore api.OutputNewRoomEvent) error {
 	}
 
 	// Work out which hosts were joined at the event itself.
-	joinedHostsAtEvent, err := s.joinedHostsAtEvent(ore, *oldJoinedHosts)
+	joinedHostsAtEvent, err := s.joinedHostsAtEvent(ore, oldJoinedHosts)
 	if err != nil {
 		return err
 	}

--- a/src/github.com/matrix-org/dendrite/federationsender/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/federationsender/consumers/roomserver.go
@@ -137,6 +137,8 @@ func (s *OutputRoomEvent) processMessage(ore api.OutputNewRoomEvent) error {
 	if oldJoinedHosts == nil {
 		// This means that there is nothing to update as this is a duplicate
 		// message.
+		// This can happen if dendrite crashed between reading the message and
+		// persisting the stream position.
 		return nil
 	}
 

--- a/src/github.com/matrix-org/dendrite/federationsender/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/federationsender/consumers/roomserver.go
@@ -134,25 +134,27 @@ func (s *OutputRoomEvent) processMessage(ore api.OutputNewRoomEvent) error {
 		return err
 	}
 
+	if oldJoinedHosts == nil {
+		// This means that there is nothing to update as this is a duplicate
+		// message.
+		return nil
+	}
+
 	if ore.SendAsServer == api.DoNotSendToOtherServers {
 		// Ignore event that we don't need to send anywhere.
 		return nil
 	}
 
 	// Work out which hosts were joined at the event itself.
-	joinedHostsAtEvent, err := s.joinedHostsAtEvent(ore, oldJoinedHosts)
+	joinedHostsAtEvent, err := s.joinedHostsAtEvent(ore, *oldJoinedHosts)
 	if err != nil {
 		return err
 	}
 
 	// Send the event.
-	if err = s.queues.SendEvent(
+	return s.queues.SendEvent(
 		&ore.Event, gomatrixserverlib.ServerName(ore.SendAsServer), joinedHostsAtEvent,
-	); err != nil {
-		return err
-	}
-
-	return nil
+	)
 }
 
 // joinedHostsAtEvent works out a list of matrix servers that were joined to

--- a/src/github.com/matrix-org/dendrite/federationsender/storage/storage.go
+++ b/src/github.com/matrix-org/dendrite/federationsender/storage/storage.go
@@ -71,11 +71,9 @@ func (d *Database) UpdateRoom(
 	roomID, oldEventID, newEventID string,
 	addHosts []types.JoinedHost,
 	removeHosts []string,
-) (*[]types.JoinedHost, error) {
-	var joinedHostsPtr *[]types.JoinedHost
-
-	err := common.WithTransaction(d.db, func(txn *sql.Tx) error {
-		err := d.insertRoom(ctx, txn, roomID)
+) (joinedHosts []types.JoinedHost, err error) {
+	err = common.WithTransaction(d.db, func(txn *sql.Tx) error {
+		err = d.insertRoom(ctx, txn, roomID)
 		if err != nil {
 			return err
 		}
@@ -96,12 +94,10 @@ func (d *Database) UpdateRoom(
 			}
 		}
 
-		joinedHosts, err := d.selectJoinedHosts(ctx, txn, roomID)
+		joinedHosts, err = d.selectJoinedHosts(ctx, txn, roomID)
 		if err != nil {
 			return err
 		}
-
-		joinedHostsPtr = &joinedHosts
 
 		for _, add := range addHosts {
 			err = d.insertJoinedHosts(ctx, txn, roomID, add.MemberEventID, add.ServerName)
@@ -114,5 +110,5 @@ func (d *Database) UpdateRoom(
 		}
 		return d.updateRoom(ctx, txn, roomID, newEventID)
 	})
-	return joinedHostsPtr, err
+	return
 }

--- a/src/github.com/matrix-org/dendrite/federationsender/storage/storage.go
+++ b/src/github.com/matrix-org/dendrite/federationsender/storage/storage.go
@@ -84,7 +84,9 @@ func (d *Database) UpdateRoom(
 		}
 
 		if lastSentEventID == newEventID {
-			// We've handled this messages before, so lets just ignore it
+			// We've handled this message before, so let's just ignore it.
+			// We can only get a duplicate for the last message we processed,
+			// so its enough just to compare the newEventID with lastSentEventID
 			return nil
 		}
 


### PR DESCRIPTION
The way we store the partition offsets for kafka streams means that when we start after a crash we may get the last message we processed again. This means that we have to be careful to ensure that the processing handles consecutive duplicates correctly.

This may or may not be a temporary fix depending on how we more generally address #300