### PR TITLE
Fix some edge cases with /sync

### DIFF
--- a/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
@@ -100,7 +100,9 @@ func (n *Notifier) OnNewEvent(ev *gomatrixserverlib.Event, userID string, pos ty
 	}
 }
 
-// WaitForEvents blocks until there are new events for this request.
+// WaitForEvents blocks until there are events for this request after sincePos.
+// In particular, it will return immediately if there are already events after
+// sincePos for the request, but otherwise blocks waiting for new events.
 func (n *Notifier) WaitForEvents(req syncRequest, sincePos types.StreamPosition) types.StreamPosition {
 	// Do what synapse does: https://github.com/matrix-org/synapse/blob/v0.20.0/synapse/notifier.py#L298
 	// - Bucket request into a lookup map keyed off a list of joined room IDs and separately a user ID

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/notifier_test.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/notifier_test.go
@@ -258,7 +258,7 @@ func TestNewEventAndWasPreviouslyJoinedToRoom(t *testing.T) {
 func waitForEvents(n *Notifier, req syncRequest) (types.StreamPosition, error) {
 	done := make(chan types.StreamPosition, 1)
 	go func() {
-		newPos := n.WaitForEvents(req)
+		newPos := n.WaitForEvents(req, req.since)
 		done <- newPos
 		close(done)
 	}()

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
@@ -122,6 +122,9 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request, device *authtype
 func (rp *RequestPool) makeNotifyChannel(syncReq syncRequest, sincePos types.StreamPosition) chan types.StreamPosition {
 	notified := make(chan types.StreamPosition)
 
+	// TODO(#303): We need to ensure that WaitForEvents gets properly cancelled
+	// when the request is finished, or use some other mechanism to ensure we
+	// don't leak goroutines here
 	go (func() {
 		currentPos := rp.notifier.WaitForEvents(syncReq, sincePos)
 		notified <- currentPos

--- a/src/github.com/matrix-org/dendrite/syncapi/types/types.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/types/types.go
@@ -74,6 +74,16 @@ func NewResponse(pos StreamPosition) *Response {
 	return &res
 }
 
+// IsEmpty returns true if the response is empty, i.e. used to decided whether
+// to return the response immediately to the client or to wait for more data.
+func (r *Response) IsEmpty() bool {
+	return len(r.Rooms.Join) > 0 ||
+		len(r.Rooms.Invite) > 0 ||
+		len(r.Rooms.Leave) > 0 ||
+		len(r.AccountData.Events) > 0 ||
+		len(r.Presence.Events) > 0
+}
+
 // JoinResponse represents a /sync response for a room which is under the 'join' key.
 type JoinResponse struct {
 	State struct {

--- a/src/github.com/matrix-org/dendrite/syncapi/types/types.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/types/types.go
@@ -77,11 +77,11 @@ func NewResponse(pos StreamPosition) *Response {
 // IsEmpty returns true if the response is empty, i.e. used to decided whether
 // to return the response immediately to the client or to wait for more data.
 func (r *Response) IsEmpty() bool {
-	return len(r.Rooms.Join) > 0 ||
-		len(r.Rooms.Invite) > 0 ||
-		len(r.Rooms.Leave) > 0 ||
-		len(r.AccountData.Events) > 0 ||
-		len(r.Presence.Events) > 0
+	return len(r.Rooms.Join) == 0 &&
+		len(r.Rooms.Invite) == 0 &&
+		len(r.Rooms.Leave) == 0 &&
+		len(r.AccountData.Events) == 0 &&
+		len(r.Presence.Events) == 0
 }
 
 // JoinResponse represents a /sync response for a room which is under the 'join' key.


### PR DESCRIPTION
Including:
- Handle timeout=0 correctly
- Always return immediately on initial sync
- Handle spurious wake ups from the notifier

Fixes #293