### PR TITLE
Refactor Notifier to return channel

### DIFF
--- a/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
@@ -121,7 +121,6 @@ func (n *Notifier) GetNotifyChannel(
 	// TODO: v1 /events 'peeking' has an 'explicit room ID' which is also tracked,
 	//       but given we don't do /events, let's pretend it doesn't exist.
 
-	// In a guard, check if the /sync request should block, and block it until we get woken up
 	n.streamLock.Lock()
 	defer n.streamLock.Unlock()
 

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
@@ -106,9 +106,13 @@ func (n *Notifier) OnNewEvent(ev *gomatrixserverlib.Event, userID string, pos ty
 	}
 }
 
-// WaitForEvents returns a channel that produces a single stream position when
+// GetNotifyChannel returns a channel that produces a single stream position when
 // a new event *may* be available to return to the client.
-func (n *Notifier) WaitForEvents(req syncRequest, sincePos types.StreamPosition) <-chan types.StreamPosition {
+// sincePos specifies from which point we want to be notified about, i.e. don't
+// notify for anything before sincePos
+func (n *Notifier) GetNotifyChannel(
+	req syncRequest, sincePos types.StreamPosition,
+) <-chan types.StreamPosition {
 	// Do what synapse does: https://github.com/matrix-org/synapse/blob/v0.20.0/synapse/notifier.py#L298
 	// - Bucket request into a lookup map keyed off a list of joined room IDs and separately a user ID
 	// - Incoming events wake requests for a matching room ID
@@ -123,7 +127,7 @@ func (n *Notifier) WaitForEvents(req syncRequest, sincePos types.StreamPosition)
 
 	n.removeEmptyUserStreams()
 
-	return n.fetchUserStream(req.userID, true).Wait(req.ctx, sincePos)
+	return n.fetchUserStream(req.userID, true).GetNotifyChannel(req.ctx, sincePos)
 }
 
 // Load the membership states required to notify users correctly.

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
@@ -106,9 +106,8 @@ func (n *Notifier) OnNewEvent(ev *gomatrixserverlib.Event, userID string, pos ty
 	}
 }
 
-// WaitForEvents blocks until there are events for this request after sincePos.
-// In particular, it will return immediately if there are already events after
-// sincePos for the request, but otherwise blocks waiting for new events.
+// WaitForEvents returns a channel that produces a single stream position when
+// a new event *may* be available to return to the client.
 func (n *Notifier) WaitForEvents(req syncRequest, sincePos types.StreamPosition) <-chan types.StreamPosition {
 	// Do what synapse does: https://github.com/matrix-org/synapse/blob/v0.20.0/synapse/notifier.py#L298
 	// - Bucket request into a lookup map keyed off a list of joined room IDs and separately a user ID

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
@@ -108,11 +108,8 @@ func (n *Notifier) OnNewEvent(ev *gomatrixserverlib.Event, userID string, pos ty
 
 // GetListener returns a UserStreamListener that can be used to wait for
 // updates for a user. Must be closed.
-// sincePos specifies from which point we want to be notified about, i.e. don't
 // notify for anything before sincePos
-func (n *Notifier) GetListener(
-	req syncRequest, sincePos types.StreamPosition,
-) UserStreamListener {
+func (n *Notifier) GetListener(req syncRequest) UserStreamListener {
 	// Do what synapse does: https://github.com/matrix-org/synapse/blob/v0.20.0/synapse/notifier.py#L298
 	// - Bucket request into a lookup map keyed off a list of joined room IDs and separately a user ID
 	// - Incoming events wake requests for a matching room ID
@@ -126,7 +123,7 @@ func (n *Notifier) GetListener(
 
 	n.removeEmptyUserStreams()
 
-	return n.fetchUserStream(req.userID, true).GetListener(sincePos)
+	return n.fetchUserStream(req.userID, true).GetListener(req.ctx)
 }
 
 // Load the membership states required to notify users correctly.

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/notifier.go
@@ -106,13 +106,13 @@ func (n *Notifier) OnNewEvent(ev *gomatrixserverlib.Event, userID string, pos ty
 	}
 }
 
-// GetNotifyChannel returns a channel that produces a single stream position when
-// a new event *may* be available to return to the client.
+// GetListener returns a UserStreamListener that can be used to wait for
+// updates for a user. Must be closed.
 // sincePos specifies from which point we want to be notified about, i.e. don't
 // notify for anything before sincePos
-func (n *Notifier) GetNotifyChannel(
+func (n *Notifier) GetListener(
 	req syncRequest, sincePos types.StreamPosition,
-) <-chan types.StreamPosition {
+) UserStreamListener {
 	// Do what synapse does: https://github.com/matrix-org/synapse/blob/v0.20.0/synapse/notifier.py#L298
 	// - Bucket request into a lookup map keyed off a list of joined room IDs and separately a user ID
 	// - Incoming events wake requests for a matching room ID
@@ -126,7 +126,7 @@ func (n *Notifier) GetNotifyChannel(
 
 	n.removeEmptyUserStreams()
 
-	return n.fetchUserStream(req.userID, true).GetNotifyChannel(req.ctx, sincePos)
+	return n.fetchUserStream(req.userID, true).GetListener(sincePos)
 }
 
 // Load the membership states required to notify users correctly.

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/notifier_test.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/notifier_test.go
@@ -256,18 +256,12 @@ func TestNewEventAndWasPreviouslyJoinedToRoom(t *testing.T) {
 
 // same as Notifier.WaitForEvents but with a timeout.
 func waitForEvents(n *Notifier, req syncRequest) (types.StreamPosition, error) {
-	done := make(chan types.StreamPosition, 1)
-	go func() {
-		newPos := n.WaitForEvents(req, req.since)
-		done <- newPos
-		close(done)
-	}()
 	select {
 	case <-time.After(5 * time.Second):
 		return types.StreamPosition(0), fmt.Errorf(
 			"waitForEvents timed out waiting for %s (pos=%d)", req.userID, req.since,
 		)
-	case p := <-done:
+	case p := <-n.WaitForEvents(req, req.since):
 		return p, nil
 	}
 }
@@ -288,5 +282,6 @@ func newTestSyncRequest(userID string, since types.StreamPosition) syncRequest {
 		wantFullState: false,
 		limit:         defaultTimelineLimit,
 		log:           util.GetLogger(context.TODO()),
+		ctx:           context.TODO(),
 	}
 }

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/notifier_test.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/notifier_test.go
@@ -261,7 +261,7 @@ func waitForEvents(n *Notifier, req syncRequest) (types.StreamPosition, error) {
 		return types.StreamPosition(0), fmt.Errorf(
 			"waitForEvents timed out waiting for %s (pos=%d)", req.userID, req.since,
 		)
-	case p := <-n.WaitForEvents(req, req.since):
+	case p := <-n.GetNotifyChannel(req, req.since):
 		return p, nil
 	}
 }

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/notifier_test.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/notifier_test.go
@@ -256,7 +256,7 @@ func TestNewEventAndWasPreviouslyJoinedToRoom(t *testing.T) {
 
 // same as Notifier.WaitForEvents but with a timeout.
 func waitForEvents(n *Notifier, req syncRequest) (types.StreamPosition, error) {
-	listener := n.GetListener(req, req.since)
+	listener := n.GetListener(req)
 	defer listener.Close()
 
 	select {
@@ -264,7 +264,7 @@ func waitForEvents(n *Notifier, req syncRequest) (types.StreamPosition, error) {
 		return types.StreamPosition(0), fmt.Errorf(
 			"waitForEvents timed out waiting for %s (pos=%d)", req.userID, req.since,
 		)
-	case <-listener.GetNotifyChannel():
+	case <-listener.GetNotifyChannel(req.since):
 		p := listener.GetStreamPosition()
 		return p, nil
 	}

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
@@ -85,7 +85,7 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request, device *authtype
 	for {
 		select {
 		// Wait for notifier to wake us up
-		case currPos = <-rp.notifier.WaitForEvents(*syncReq, currPos):
+		case currPos = <-rp.notifier.GetNotifyChannel(*syncReq, currPos):
 		// Or for timeout to expire
 		case <-timer.C:
 			return util.JSONResponse{

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
@@ -82,14 +82,14 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request, device *authtype
 	timer := time.NewTimer(syncReq.timeout) // case of timeout=0 is handled above
 	defer timer.Stop()
 
-	userStream := rp.notifier.GetListener(*syncReq)
-	defer userStream.Close()
+	userStreamListener := rp.notifier.GetListener(*syncReq)
+	defer userStreamListener.Close()
 
 	for {
 		select {
 		// Wait for notifier to wake us up
-		case <-userStream.GetNotifyChannel(currPos):
-			currPos = userStream.GetStreamPosition()
+		case <-userStreamListener.GetNotifyChannel(currPos):
+			currPos = userStreamListener.GetStreamPosition()
 		// Or for timeout to expire
 		case <-timer.C:
 			return util.JSONResponse{

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/requestpool.go
@@ -82,13 +82,13 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request, device *authtype
 	timer := time.NewTimer(syncReq.timeout) // case of timeout=0 is handled above
 	defer timer.Stop()
 
-	userStream := rp.notifier.GetListener(*syncReq, currPos)
+	userStream := rp.notifier.GetListener(*syncReq)
 	defer userStream.Close()
 
 	for {
 		select {
 		// Wait for notifier to wake us up
-		case <-userStream.GetNotifyChannel():
+		case <-userStream.GetNotifyChannel(currPos):
 			currPos = userStream.GetStreamPosition()
 		// Or for timeout to expire
 		case <-timer.C:

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/userstream.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/userstream.go
@@ -129,7 +129,9 @@ func (s *UserStreamListener) GetStreamPosition() types.StreamPosition {
 
 // GetNotifyChannel returns a channel that is closed when there may be an
 // update for the user.
-// sincePos specifies from which point we want to be notified about
+// sincePos specifies from which point we want to be notified about. If there
+// has already been an update after sincePos we'll return a closed channel
+// immediately.
 func (s *UserStreamListener) GetNotifyChannel(sincePos types.StreamPosition) <-chan struct{} {
 	s.userStream.lock.Lock()
 	defer s.userStream.lock.Unlock()

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/userstream.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/userstream.go
@@ -77,7 +77,7 @@ func (s *UserStream) Wait(ctx context.Context, waitAtPos types.StreamPosition) <
 		// Icky but efficient way of filtering out the given channel
 		for idx, ch := range s.waitingChannels {
 			if posChannel == ch {
-				lastIdx := len(s.waitingChannels)
+				lastIdx := len(s.waitingChannels) - 1
 				s.waitingChannels[idx] = s.waitingChannels[lastIdx]
 				s.waitingChannels[lastIdx] = nil // Ensure that the channel gets GCed
 				s.waitingChannels = s.waitingChannels[:lastIdx]

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/userstream.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/userstream.go
@@ -46,8 +46,8 @@ func NewUserStream(userID string, currPos types.StreamPosition) *UserStream {
 	}
 }
 
-// Wait blocks until there is a new stream position for this user, which is then returned.
-// waitAtPos should be the position the stream thinks it should be waiting at.
+// Wait returns a channel that produces a single stream position when
+// a new event *may* be available to return to the client.
 func (s *UserStream) Wait(ctx context.Context, waitAtPos types.StreamPosition) <-chan types.StreamPosition {
 	posChannel := make(chan types.StreamPosition, 1)
 
@@ -79,7 +79,7 @@ func (s *UserStream) Wait(ctx context.Context, waitAtPos types.StreamPosition) <
 			if posChannel == ch {
 				lastIdx := len(s.waitingChannels)
 				s.waitingChannels[idx] = s.waitingChannels[lastIdx]
-				s.waitingChannels[lastIdx] = nil
+				s.waitingChannels[lastIdx] = nil // Ensure that the channel gets GCed
 				s.waitingChannels = s.waitingChannels[:lastIdx]
 
 				if len(s.waitingChannels) == 0 {

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/userstream.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/userstream.go
@@ -28,11 +28,15 @@ import (
 type UserStream struct {
 	UserID string
 	// The lock that protects changes to this struct
-	lock              sync.Mutex
-	signalChannel     chan struct{}
-	pos               types.StreamPosition
+	lock sync.Mutex
+	// Closed when there is an update.
+	signalChannel chan struct{}
+	// The last stream position that there may have been an update for the suser
+	pos types.StreamPosition
+	// The last time when we had some listeners waiting
 	timeOfLastChannel time.Time
-	numWaiting        uint
+	// The number of listeners waiting
+	numWaiting uint
 }
 
 // UserStreamListener allows a sync request to wait for updates for a user.

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/userstream.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/userstream.go
@@ -55,8 +55,8 @@ func NewUserStream(userID string, currPos types.StreamPosition) *UserStream {
 	}
 }
 
-// GetListener returns UserStreamListener a sync request can use to wait for
-// new updates.
+// GetListener returns UserStreamListener that a sync request can use to wait
+// for new updates with.
 // sincePos specifies from which point we want to be notified about
 // UserStreamListener must be closed
 func (s *UserStream) GetListener(sincePos types.StreamPosition) UserStreamListener {

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/userstream.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/userstream.go
@@ -135,9 +135,12 @@ func (s *UserStreamListener) GetNotifyChannel(sincePos types.StreamPosition) <-c
 	defer s.lock.Unlock()
 
 	if sincePos < s.pos {
-		posChannel := make(chan struct{})
-		close(posChannel)
-		return posChannel
+		// If the listener is behind, i.e. missed a potential update, then we
+		// want them to wake up immediately. We do this by returning a new
+		// closed stream, which returns immediately when selected.
+		closedChannel := make(chan struct{})
+		close(closedChannel)
+		return closedChannel
 	}
 
 	return s.signalChannel


### PR DESCRIPTION
This has two benefits:

1. Using channels makes it easier to time out while waiting
2. Allows us to clean up goroutines that were waiting if we timeout the
   request