### PR TITLE
Move federationapi.readers package into routing

### DIFF
--- a/src/github.com/matrix-org/dendrite/federationapi/routing/events.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/events.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package readers
+package routing
 
 import (
 	"context"

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/keys.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/keys.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package readers
+package routing
 
 import (
 	"encoding/json"

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
@@ -23,7 +23,6 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/producers"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/config"
-	"github.com/matrix-org/dendrite/federationapi/readers"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
@@ -48,7 +47,7 @@ func Setup(
 	v1fedmux := apiMux.PathPrefix(pathPrefixV1Federation).Subrouter()
 
 	localKeys := common.MakeExternalAPI("localkeys", func(req *http.Request) util.JSONResponse {
-		return readers.LocalKeys(cfg)
+		return LocalKeys(cfg)
 	})
 
 	// Ignore the {keyID} argument as we only have a single server key so we always
@@ -100,7 +99,7 @@ func Setup(
 		"federation_get_event", cfg.Matrix.ServerName, keys,
 		func(httpReq *http.Request, request *gomatrixserverlib.FederationRequest) util.JSONResponse {
 			vars := mux.Vars(httpReq)
-			return readers.GetEvent(
+			return GetEvent(
 				httpReq.Context(), request, cfg, query, time.Now(), keys, vars["eventID"],
 			)
 		},
@@ -109,7 +108,7 @@ func Setup(
 	v1fedmux.Handle("/version", common.MakeExternalAPI(
 		"federation_version",
 		func(httpReq *http.Request) util.JSONResponse {
-			return readers.Version()
+			return Version()
 		},
 	)).Methods("GET")
 }

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/version.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/version.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package readers
+package routing
 
 import (
 	"github.com/matrix-org/util"


### PR DESCRIPTION
This seems to have been missed when we folded all the readers and
writers packages into routing.