### PR TITLE
Implement /make_join and /send_join

### DIFF
--- a/src/github.com/matrix-org/dendrite/common/events.go
+++ b/src/github.com/matrix-org/dendrite/common/events.go
@@ -42,7 +42,7 @@ func BuildEvent(
 	builder *gomatrixserverlib.EventBuilder, cfg config.Dendrite,
 	queryAPI api.RoomserverQueryAPI, queryRes *api.QueryLatestEventsAndStateResponse,
 ) (*gomatrixserverlib.Event, error) {
-	err := AddPrevEventsToEvent(ctx, builder, cfg, queryAPI, queryRes)
+	err := AddPrevEventsToEvent(ctx, builder, queryAPI, queryRes)
 	if err != nil {
 		return nil, err
 	}
@@ -57,9 +57,10 @@ func BuildEvent(
 	return &event, nil
 }
 
+// AddPrevEventsToEvent fills out the prev_events and auth_events fields in EventBuilder
 func AddPrevEventsToEvent(
 	ctx context.Context,
-	builder *gomatrixserverlib.EventBuilder, cfg config.Dendrite,
+	builder *gomatrixserverlib.EventBuilder,
 	queryAPI api.RoomserverQueryAPI, queryRes *api.QueryLatestEventsAndStateResponse,
 ) error {
 	eventsNeeded, err := gomatrixserverlib.StateNeededForEventBuilder(builder)

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/join.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/join.go
@@ -90,7 +90,7 @@ func MakeJoin(
 
 	return util.JSONResponse{
 		Code: 200,
-		JSON: event,
+		JSON: map[string]interface{}{"event": builder},
 	}
 }
 
@@ -159,6 +159,7 @@ func SendJoin(
 	var stateAndAuthChainRepsonse api.QueryStateAndAuthChainResponse
 	err = query.QueryStateAndAuthChain(ctx, &api.QueryStateAndAuthChainRequest{
 		PrevEventIDs: event.PrevEventIDs(),
+		AuthEventIDs: event.AuthEventIDs(),
 		RoomID:       roomID,
 	}, &stateAndAuthChainRepsonse)
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/join.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/join.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
@@ -37,8 +36,6 @@ func MakeJoin(
 	request *gomatrixserverlib.FederationRequest,
 	cfg config.Dendrite,
 	query api.RoomserverQueryAPI,
-	now time.Time,
-	keys gomatrixserverlib.KeyRing,
 	roomID, userID string,
 ) util.JSONResponse {
 	_, domain, err := gomatrixserverlib.SplitID('@', userID)
@@ -105,7 +102,6 @@ func SendJoin(
 	cfg config.Dendrite,
 	query api.RoomserverQueryAPI,
 	producer *producers.RoomserverProducer,
-	now time.Time,
 	keys gomatrixserverlib.KeyRing,
 	roomID, eventID string,
 ) util.JSONResponse {
@@ -147,7 +143,7 @@ func SendJoin(
 		Message:    event.Redact().JSON(),
 		AtTS:       event.OriginServerTS(),
 	}}
-	verifyResults, err := keys.VerifyJSONs(httpReq.Context(), verifyRequests)
+	verifyResults, err := keys.VerifyJSONs(ctx, verifyRequests)
 	if err != nil {
 		return httputil.LogThenError(httpReq, err)
 	}

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/join.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/join.go
@@ -1,0 +1,93 @@
+// Copyright 2017 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/matrix-org/dendrite/clientapi/httputil"
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"github.com/matrix-org/dendrite/common"
+	"github.com/matrix-org/dendrite/common/config"
+	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/util"
+)
+
+func MakeJoin(
+	ctx context.Context,
+	httpReq *http.Request,
+	request *gomatrixserverlib.FederationRequest,
+	cfg config.Dendrite,
+	query api.RoomserverQueryAPI,
+	now time.Time,
+	keys gomatrixserverlib.KeyRing,
+	roomID, userID string,
+) util.JSONResponse {
+	builder := gomatrixserverlib.EventBuilder{
+		Sender:   userID,
+		RoomID:   roomID,
+		Type:     "m.room.member",
+		StateKey: &userID,
+	}
+	err := builder.SetContent(map[string]interface{}{"membership": "join"})
+	if err != nil {
+		return httputil.LogThenError(httpReq, err)
+	}
+
+	var queryRes api.QueryLatestEventsAndStateResponse
+	event, err := common.BuildEvent(ctx, &builder, cfg, query, &queryRes)
+	if err == common.ErrRoomNoExists {
+		return util.JSONResponse{
+			Code: 404,
+			JSON: jsonerror.NotFound("Room does not exist"),
+		}
+	} else if err != nil {
+		return httputil.LogThenError(httpReq, err)
+	}
+
+	// check to see if this user can perform this operation
+	stateEvents := make([]*gomatrixserverlib.Event, len(queryRes.StateEvents))
+	for i := range queryRes.StateEvents {
+		stateEvents[i] = &queryRes.StateEvents[i]
+	}
+	provider := gomatrixserverlib.NewAuthEvents(stateEvents)
+	if err = gomatrixserverlib.Allowed(*event, &provider); err != nil {
+		return util.JSONResponse{
+			Code: 403,
+			JSON: jsonerror.Forbidden(err.Error()), // TODO: Is this error string comprehensible to the client?
+		}
+	}
+
+	return util.JSONResponse{
+		Code: 200,
+		JSON: event,
+	}
+}
+
+func SendJoin(
+	ctx context.Context,
+	httpReq *http.Request,
+	request *gomatrixserverlib.FederationRequest,
+	cfg config.Dendrite,
+	query api.RoomserverQueryAPI,
+	now time.Time,
+	keys gomatrixserverlib.KeyRing,
+	roomID, eventID string,
+) util.JSONResponse {
+
+}

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
@@ -136,6 +136,18 @@ func Setup(
 		},
 	)).Methods("GET")
 
+	v1fedmux.Handle("/send_join/{roomID}/{userID}", common.MakeFedAPI(
+		"federation_send_join", cfg.Matrix.ServerName, keys,
+		func(httpReq *http.Request, request *gomatrixserverlib.FederationRequest) util.JSONResponse {
+			vars := mux.Vars(httpReq)
+			roomID := vars["roomID"]
+			userID := vars["userID"]
+			return MakeJoin(
+				httpReq.Context(), httpReq, request, cfg, query, time.Now(), keys, roomID, userID,
+			)
+		},
+	)).Methods("PUT")
+
 	v1fedmux.Handle("/version", common.MakeExternalAPI(
 		"federation_version",
 		func(httpReq *http.Request) util.JSONResponse {

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
@@ -124,6 +124,18 @@ func Setup(
 		},
 	)).Methods("GET")
 
+	v1fedmux.Handle("/make_join/{roomID}/{userID}", common.MakeFedAPI(
+		"federation_make_join", cfg.Matrix.ServerName, keys,
+		func(httpReq *http.Request, request *gomatrixserverlib.FederationRequest) util.JSONResponse {
+			vars := mux.Vars(httpReq)
+			roomID := vars["roomID"]
+			userID := vars["userID"]
+			return MakeJoin(
+				httpReq.Context(), httpReq, request, cfg, query, time.Now(), keys, roomID, userID,
+			)
+		},
+	)).Methods("GET")
+
 	v1fedmux.Handle("/version", common.MakeExternalAPI(
 		"federation_version",
 		func(httpReq *http.Request) util.JSONResponse {

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
@@ -142,8 +142,8 @@ func Setup(
 			vars := mux.Vars(httpReq)
 			roomID := vars["roomID"]
 			userID := vars["userID"]
-			return MakeJoin(
-				httpReq.Context(), httpReq, request, cfg, query, time.Now(), keys, roomID, userID,
+			return SendJoin(
+				httpReq.Context(), httpReq, request, cfg, query, producer, time.Now(), keys, roomID, userID,
 			)
 		},
 	)).Methods("PUT")

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
@@ -131,7 +131,7 @@ func Setup(
 			roomID := vars["roomID"]
 			userID := vars["userID"]
 			return MakeJoin(
-				httpReq.Context(), httpReq, request, cfg, query, time.Now(), keys, roomID, userID,
+				httpReq.Context(), httpReq, request, cfg, query, roomID, userID,
 			)
 		},
 	)).Methods("GET")
@@ -143,7 +143,7 @@ func Setup(
 			roomID := vars["roomID"]
 			userID := vars["userID"]
 			return SendJoin(
-				httpReq.Context(), httpReq, request, cfg, query, producer, time.Now(), keys, roomID, userID,
+				httpReq.Context(), httpReq, request, cfg, query, producer, keys, roomID, userID,
 			)
 		},
 	)).Methods("PUT")


### PR DESCRIPTION
This PR is mainly just to track whats happening on this front. It hasn't been tested as sytest doesn't like dendrite federation atm, and we don't have the alias lookup APIs to test it using Riot, so this is blocked for now.

(This will probably end up being split into separate PRs)