### PR TITLE
Check for existing filter before inserting a new one

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
@@ -321,22 +321,25 @@ func (d *Database) GetThreePIDsForLocalpart(
 }
 
 // GetFilter looks up the filter associated with a given local user and filter ID.
-// Returns an error if no such filter exists or if there was an error taling to the database.
+// Returns a filter represented as a byte slice. Otherwise returns an error if
+// no such filter exists or if there was an error talking to the database.
 func (d *Database) GetFilter(
 	ctx context.Context, localpart string, filterID string,
-) (string, error) {
+) ([]byte, error) {
 	return d.filter.selectFilter(ctx, localpart, filterID)
 }
 
 // PutFilter puts the passed filter into the database.
-// Returns an error if something goes wrong.
+// Returns the filterID as a string. Otherwise returns an error if something
+// goes wrong.
 func (d *Database) PutFilter(
-	ctx context.Context, localpart, filter string,
+	ctx context.Context, localpart string, filter []byte,
 ) (string, error) {
 	return d.filter.insertFilter(ctx, filter, localpart)
 }
 
-// CheckAccountAvailability checks if the username/localpart is already present in the database.
+// CheckAccountAvailability checks if the username/localpart is already present
+// in the database.
 // If the DB returns sql.ErrNoRows the Localpart isn't taken.
 func (d *Database) CheckAccountAvailability(ctx context.Context, localpart string) (bool, error) {
 	_, err := d.accounts.selectAccountByLocalpart(ctx, localpart)

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/filter.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/filter.go
@@ -60,7 +60,7 @@ func GetFilter(
 		}
 	}
 	filter := gomatrix.Filter{}
-	err = json.Unmarshal([]byte(res), &filter)
+	err = json.Unmarshal(res, &filter)
 	if err != nil {
 		httputil.LogThenError(req, err)
 	}
@@ -111,7 +111,7 @@ func PutFilter(
 		}
 	}
 
-	filterID, err := accountDB.PutFilter(req.Context(), localpart, string(filterArray))
+	filterID, err := accountDB.PutFilter(req.Context(), localpart, filterArray)
 	if err != nil {
 		return httputil.LogThenError(req, err)
 	}

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/matrix-org/dendrite/common/config"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/matrix-org/dendrite/clientapi/auth"
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
@@ -37,6 +36,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
+	log "github.com/sirupsen/logrus"
 )
 
 const (


### PR DESCRIPTION
Closes #298

This is my naive solution to the issue. Let me know if it should be done another way and I can switch things around.

We check whether a row with the given filter and user localpart already exists in the database, and just returns that filterID if so.