### PR TITLE
Split travis into multiple jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ install:
 
 # Generate a self-signed X.509 certificate for TLS.
 before_script:
- - if [[ "$TEST_SUITE" -eq "integ-test" ]]; then openssl req -x509 -newkey rsa:512 -keyout server.key -out server.crt -days 365 -nodes -subj /CN=localhost; fi
- - if [[ "$TEST_SUITE" -eq "integ-test" ]]; then ./scripts/install-local-kafka.sh; fi
+ - if [[ "$TEST_SUITE" == "integ-test" ]]; then openssl req -x509 -newkey rsa:512 -keyout server.key -out server.crt -days 365 -nodes -subj /CN=localhost; fi
+ - if [[ "$TEST_SUITE" == "integ-test" ]]; then ./scripts/install-local-kafka.sh; fi
 
 script:
  - ./scripts/travis-test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,6 @@ env:
 - TEST_SUITE="unit-test"
 - TEST_SUITE="integ-test"
 
-matrix:
-  include:
-    - env: TEST_SUITE="integ-test"
-      apt:
-        packages:
-          - openssl
-
 sudo: false
 
 # Use trusty for postgres 9.5 support

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ install:
 
 # Generate a self-signed X.509 certificate for TLS.
 before_script:
- - if [[ "$TEST_SUITE" == "integ-test" ]]; then openssl req -x509 -newkey rsa:512 -keyout server.key -out server.crt -days 365 -nodes -subj /CN=localhost; fi
- - if [[ "$TEST_SUITE" == "integ-test" ]]; then ./scripts/install-local-kafka.sh; fi
+ - if [[ "${TEST_SUITE:-integ-test}" == "integ-test" ]]; then ./scripts/install-local-kafka.sh; fi
 
 script:
  - ./scripts/travis-test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,6 @@ services:
 install:
  - go get github.com/constabulary/gb/...
 
-# Generate a self-signed X.509 certificate for TLS.
-before_script:
- - if [[ "${TEST_SUITE:-integ-test}" == "integ-test" ]]; then ./scripts/install-local-kafka.sh; fi
-
 script:
  - ./scripts/travis-test.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ install:
 
 # Generate a self-signed X.509 certificate for TLS.
 before_script:
- - if [ "$TEST_SUITE" -eq "integ-test" ] openssl req -x509 -newkey rsa:512 -keyout server.key -out server.crt -days 365 -nodes -subj /CN=localhost
- - if [ "$TEST_SUITE" -eq "integ-test" ] ./scripts/install-local-kafka.sh
+ - ("$TEST_SUITE" -eq "integ-test") && openssl req -x509 -newkey rsa:512 -keyout server.key -out server.crt -days 365 -nodes -subj /CN=localhost
+ - ("$TEST_SUITE" -eq "integ-test") && ./scripts/install-local-kafka.sh
 
 script:
  - ./scripts/travis-test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ install:
 
 # Generate a self-signed X.509 certificate for TLS.
 before_script:
- - ("$TEST_SUITE" -eq "integ-test") && openssl req -x509 -newkey rsa:512 -keyout server.key -out server.crt -days 365 -nodes -subj /CN=localhost
- - ("$TEST_SUITE" -eq "integ-test") && ./scripts/install-local-kafka.sh
+ - if [[ "$TEST_SUITE" -eq "integ-test" ]]; then openssl req -x509 -newkey rsa:512 -keyout server.key -out server.crt -days 365 -nodes -subj /CN=localhost; fi
+ - if [[ "$TEST_SUITE" -eq "integ-test" ]]; then ./scripts/install-local-kafka.sh; fi
 
 script:
  - ./scripts/travis-test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: go
 go:
  - 1.8
+ - 1.9
+
+env:
+- TEST_SUITE="lint"
+- TEST_SUITE="unit-test"
+- TEST_SUITE="integ-test"
 
 sudo: false
 
@@ -21,10 +27,10 @@ install:
 
 # Generate a self-signed X.509 certificate for TLS.
 before_script:
- - openssl req -x509 -newkey rsa:4096 -keyout server.key -out server.crt -days 365 -nodes -subj /CN=localhost
+ - if [ "$TEST_SUITE" -eq "integ-test" ] openssl req -x509 -newkey rsa:512 -keyout server.key -out server.crt -days 365 -nodes -subj /CN=localhost
+ - if [ "$TEST_SUITE" -eq "integ-test" ] ./scripts/install-local-kafka.sh
 
 script:
- - ./scripts/install-local-kafka.sh
  - ./scripts/travis-test.sh
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,19 @@ env:
 - TEST_SUITE="unit-test"
 - TEST_SUITE="integ-test"
 
+matrix:
+  include:
+    - env: TEST_SUITE="integ-test"
+      apt:
+        packages:
+          - openssl
+
 sudo: false
 
 # Use trusty for postgres 9.5 support
 dist: trusty
 
 addons:
-  apt:
-    packages:
-    - openssl
   postgresql: "9.5"
 
 services:

--- a/scripts/build-test-lint.sh
+++ b/scripts/build-test-lint.sh
@@ -7,23 +7,17 @@ set -eu
 export GOPATH="$(pwd):$(pwd)/vendor"
 export PATH="$PATH:$(pwd)/vendor/bin:$(pwd)/bin"
 
-if [ "${TEST_SUITE-}" != "lint" ]; then
-    echo "Checking that it builds"
-    gb build
+echo "Checking that it builds"
+gb build
 
-    # Check that all the packages can build.
-    # When `go build` is given multiple packages it won't output anything, and just
-    # checks that everything builds. This seems to do a better job of handling
-    # missing imports than `gb build` does.
-    echo "Double checking it builds..."
-    go build github.com/matrix-org/dendrite/cmd/...
-fi
+# Check that all the packages can build.
+# When `go build` is given multiple packages it won't output anything, and just
+# checks that everything builds. This seems to do a better job of handling
+# missing imports than `gb build` does.
+echo "Double checking it builds..."
+go build github.com/matrix-org/dendrite/cmd/...
 
-if [ "${TEST_SUITE-lint}" == "lint" ]; then
-    ./scripts/find-lint.sh
-fi
+./scripts/find-lint.sh
 
-if [ "${TEST_SUITE-unit-test}" == "unit-test" ]; then
-    echo "Testing..."
-    gb test
-fi
+echo "Testing..."
+gb test

--- a/scripts/build-test-lint.sh
+++ b/scripts/build-test-lint.sh
@@ -7,20 +7,26 @@ set -eu
 export GOPATH="$(pwd):$(pwd)/vendor"
 export PATH="$PATH:$(pwd)/vendor/bin:$(pwd)/bin"
 
-echo "Checking that it builds"
-gb build
+if [ "${TEST_SUITE-}" != "lint" ]; then
+    echo "Checking that it builds"
+    gb build
 
-# Check that all the packages can build.
-# When `go build` is given multiple packages it won't output anything, and just
-# checks that everything builds. This seems to do a better job of handling
-# missing imports than `gb build` does.
-echo "Double checking it builds..."
-go build github.com/matrix-org/dendrite/cmd/...
+    # Check that all the packages can build.
+    # When `go build` is given multiple packages it won't output anything, and just
+    # checks that everything builds. This seems to do a better job of handling
+    # missing imports than `gb build` does.
+    echo "Double checking it builds..."
+    go build github.com/matrix-org/dendrite/cmd/...
+fi
 
-./scripts/find-lint.sh
+if [ "${TEST_SUITE-lint}" == "lint" ]; then
+    ./scripts/find-lint.sh
+fi
 
 echo "Double checking spelling..."
 misspell -error src *.md
 
-echo "Testing..."
-gb test
+if [ "${TEST_SUITE-unit-test}" == "unit-test" ]; then
+    echo "Testing..."
+    gb test
+fi

--- a/scripts/build-test-lint.sh
+++ b/scripts/build-test-lint.sh
@@ -23,9 +23,6 @@ if [ "${TEST_SUITE-lint}" == "lint" ]; then
     ./scripts/find-lint.sh
 fi
 
-echo "Double checking spelling..."
-misspell -error src *.md
-
 if [ "${TEST_SUITE-unit-test}" == "unit-test" ]; then
     echo "Testing..."
     gb test

--- a/scripts/find-lint.sh
+++ b/scripts/find-lint.sh
@@ -31,7 +31,7 @@ then args="$args --enable-gc"
 fi
 
 echo "Installing lint search engine..."
-go install github.com/alecthomas/gometalinter/
+gb build github.com/alecthomas/gometalinter/
 gometalinter --config=linter.json ./... --install
 
 echo "Looking for lint..."

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -1,6 +1,10 @@
 #! /bin/bash
 
 # The entry point for travis tests
+#
+# TEST_SUITE env var can be set to "lint", "unit-test" or "integ-test", in
+# which case only the linting, unit tests or integration tests will be run
+# respectively. If not specified or null all tests are run.
 
 set -eu
 
@@ -8,8 +12,26 @@ set -eu
 export GOGC=400
 export DENDRITE_LINT_DISABLE_GC=1
 
-# We don't bother to build if we're only checking the linting
-if [ "${TEST_SUITE-}" != "lint" ]; then
+export GOPATH="$(pwd):$(pwd)/vendor"
+export PATH="$PATH:$(pwd)/vendor/bin:$(pwd)/bin"
+
+if [ "${TEST_SUITE:-lint}" == "lint" ]; then
+    ./scripts/find-lint.sh
+fi
+
+if [ "${TEST_SUITE:-unit-test}" == "unit-test" ]; then
+    gb test
+fi
+
+if [ "${TEST_SUITE:-integ-test}" == "integ-test" ]; then
+    gb build
+
+    # Check that all the packages can build.
+    # When `go build` is given multiple packages it won't output anything, and just
+    # checks that everything builds. This seems to do a better job of handling
+    # missing imports than `gb build` does.
+    go build github.com/matrix-org/dendrite/cmd/...
+
     # Check that the servers build (this is done explicitly because `gb build` can silently fail (exit 0) and then we'd test a stale binary)
     gb build github.com/matrix-org/dendrite/cmd/dendrite-room-server
     gb build github.com/matrix-org/dendrite/cmd/roomserver-integration-tests
@@ -19,12 +41,7 @@ if [ "${TEST_SUITE-}" != "lint" ]; then
     gb build github.com/matrix-org/dendrite/cmd/dendrite-media-api-server
     gb build github.com/matrix-org/dendrite/cmd/mediaapi-integration-tests
     gb build github.com/matrix-org/dendrite/cmd/client-api-proxy
-fi
 
-# Run unit tests and linters
-./scripts/build-test-lint.sh
-
-if [ "${TEST_SUITE-integ-test}" == "integ-test" ]; then
     # Run the integration tests
     bin/roomserver-integration-tests
     bin/syncserver-integration-tests

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -24,7 +24,7 @@ fi
 # Run unit tests and linters
 ./scripts/build-test-lint.sh
 
-if [ "${TEST_SUITE-unit-test}" == "integ-test" ]; then
+if [ "${TEST_SUITE-integ-test}" == "integ-test" ]; then
     # Run the integration tests
     bin/roomserver-integration-tests
     bin/syncserver-integration-tests

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -43,7 +43,8 @@ if [ "${TEST_SUITE:-integ-test}" == "integ-test" ]; then
     gb build github.com/matrix-org/dendrite/cmd/client-api-proxy
 
     # Create necessary certificates and keys to run dendrite
-    openssl req -x509 -newkey rsa:512 -keyout server.key -out server.crt -days 365 -nodes -subj /CN=localhost
+    time openssl req -x509 -newkey rsa:512 -keyout server.key -out server.crt -days 365 -nodes -subj /CN=localhost
+    time ./scripts/install-local-kafka.sh
 
     # Run the integration tests
     bin/roomserver-integration-tests

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -8,20 +8,25 @@ set -eu
 export GOGC=400
 export DENDRITE_LINT_DISABLE_GC=1
 
-# Check that the servers build (this is done explicitly because `gb build` can silently fail (exit 0) and then we'd test a stale binary)
-gb build github.com/matrix-org/dendrite/cmd/dendrite-room-server
-gb build github.com/matrix-org/dendrite/cmd/roomserver-integration-tests
-gb build github.com/matrix-org/dendrite/cmd/dendrite-sync-api-server
-gb build github.com/matrix-org/dendrite/cmd/syncserver-integration-tests
-gb build github.com/matrix-org/dendrite/cmd/create-account
-gb build github.com/matrix-org/dendrite/cmd/dendrite-media-api-server
-gb build github.com/matrix-org/dendrite/cmd/mediaapi-integration-tests
-gb build github.com/matrix-org/dendrite/cmd/client-api-proxy
+# We don't bother to build if we're only checking the linting
+if [ "${TEST_SUITE-}" != "lint" ]; then
+    # Check that the servers build (this is done explicitly because `gb build` can silently fail (exit 0) and then we'd test a stale binary)
+    gb build github.com/matrix-org/dendrite/cmd/dendrite-room-server
+    gb build github.com/matrix-org/dendrite/cmd/roomserver-integration-tests
+    gb build github.com/matrix-org/dendrite/cmd/dendrite-sync-api-server
+    gb build github.com/matrix-org/dendrite/cmd/syncserver-integration-tests
+    gb build github.com/matrix-org/dendrite/cmd/create-account
+    gb build github.com/matrix-org/dendrite/cmd/dendrite-media-api-server
+    gb build github.com/matrix-org/dendrite/cmd/mediaapi-integration-tests
+    gb build github.com/matrix-org/dendrite/cmd/client-api-proxy
+fi
 
 # Run unit tests and linters
 ./scripts/build-test-lint.sh
 
-# Run the integration tests
-bin/roomserver-integration-tests
-bin/syncserver-integration-tests
-bin/mediaapi-integration-tests
+if [ "${TEST_SUITE-unit-test}" == "integ-test" ]; then
+    # Run the integration tests
+    bin/roomserver-integration-tests
+    bin/syncserver-integration-tests
+    bin/mediaapi-integration-tests
+fi

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -42,6 +42,9 @@ if [ "${TEST_SUITE:-integ-test}" == "integ-test" ]; then
     gb build github.com/matrix-org/dendrite/cmd/mediaapi-integration-tests
     gb build github.com/matrix-org/dendrite/cmd/client-api-proxy
 
+    # Create necessary certificates and keys to run dendrite
+    openssl req -x509 -newkey rsa:512 -keyout server.key -out server.crt -days 365 -nodes -subj /CN=localhost
+
     # Run the integration tests
     bin/roomserver-integration-tests
     bin/syncserver-integration-tests

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -43,7 +43,9 @@ if [ "${TEST_SUITE:-integ-test}" == "integ-test" ]; then
     gb build github.com/matrix-org/dendrite/cmd/client-api-proxy
 
     # Create necessary certificates and keys to run dendrite
+    echo "Generating certs..."
     time openssl req -x509 -newkey rsa:512 -keyout server.key -out server.crt -days 365 -nodes -subj /CN=localhost
+    echo "Installing kafka..."
     time ./scripts/install-local-kafka.sh
 
     # Run the integration tests


### PR DESCRIPTION
The motivation for this is to make it easier to see whether a travis failure is due to linting, unit tests or integration test failures, without having to look in the logs.

It also means that each job is independent, so if e.g. the linting fails then the unit tests will still be run.