### PR TITLE
Just run the linter in the commit hook

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -2,4 +2,4 @@
 
 set -eu
 
-./scripts/build-test-lint.sh
+./scripts/find-lint.sh fast


### PR DESCRIPTION
The pre-commit hook took 45 seconds to run on my machine, which was more than
enough time for me to get distracted by a swordfight in the corridor.

Let's just run the linters (which still take 6 seconds). It's not the place of
a commit hook to run every test we can think of - that is what CI is for.