### PR TITLE
Remove vendor/bin from PATH in script

### DIFF
--- a/scripts/build-test-lint.sh
+++ b/scripts/build-test-lint.sh
@@ -5,7 +5,7 @@
 set -eu
 
 export GOPATH="$(pwd):$(pwd)/vendor"
-export PATH="$PATH:$(pwd)/vendor/bin:$(pwd)/bin"
+export PATH="$PATH:$(pwd)/bin"
 
 echo "Checking that it builds"
 gb build

--- a/scripts/find-lint.sh
+++ b/scripts/find-lint.sh
@@ -14,7 +14,7 @@
 set -eu
 
 export GOPATH="$(pwd):$(pwd)/vendor"
-export PATH="$PATH:$(pwd)/vendor/bin:$(pwd)/bin"
+export PATH="$PATH:$(pwd)/bin"
 
 args=""
 if [ ${1:-""} = "fast" ]

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -13,7 +13,7 @@ export GOGC=400
 export DENDRITE_LINT_DISABLE_GC=1
 
 export GOPATH="$(pwd):$(pwd)/vendor"
-export PATH="$PATH:$(pwd)/vendor/bin:$(pwd)/bin"
+export PATH="$PATH:$(pwd)/bin"
 
 if [ "${TEST_SUITE:-lint}" == "lint" ]; then
     ./scripts/find-lint.sh


### PR DESCRIPTION
We should no longer be building anything into vendor/bin in the scripts,
so adding it to the path can lead to all sorts of confusion if old
binaries are there.