### PR TITLE
 Fix linting errors in go1.9.1

### DIFF
--- a/scripts/build-test-lint.sh
+++ b/scripts/build-test-lint.sh
@@ -5,7 +5,7 @@
 set -eu
 
 export GOPATH="$(pwd):$(pwd)/vendor"
-export PATH="$PATH:$(pwd)/vendor/bin:$(pwd)/bin"
+export PATH="$PATH:$(pwd)/bin"
 
 echo "Checking that it builds"
 gb build

--- a/scripts/find-lint.sh
+++ b/scripts/find-lint.sh
@@ -14,7 +14,7 @@
 set -eu
 
 export GOPATH="$(pwd):$(pwd)/vendor"
-export PATH="$PATH:$(pwd)/vendor/bin:$(pwd)/bin"
+export PATH="$PATH:$(pwd)/bin"
 
 args=""
 if [ ${1:-""} = "fast" ]

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -13,7 +13,7 @@ export GOGC=400
 export DENDRITE_LINT_DISABLE_GC=1
 
 export GOPATH="$(pwd):$(pwd)/vendor"
-export PATH="$PATH:$(pwd)/vendor/bin:$(pwd)/bin"
+export PATH="$PATH:$(pwd)/bin"
 
 if [ "${TEST_SUITE:-lint}" == "lint" ]; then
     ./scripts/find-lint.sh

--- a/src/github.com/matrix-org/dendrite/clientapi/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/consumers/roomserver.go
@@ -96,11 +96,7 @@ func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 		return err
 	}
 
-	if err := s.db.UpdateMemberships(context.TODO(), events, output.NewRoomEvent.RemovesStateEventIDs); err != nil {
-		return err
-	}
-
-	return nil
+	return s.db.UpdateMemberships(context.TODO(), events, output.NewRoomEvent.RemovesStateEventIDs)
 }
 
 // lookupStateEvents looks up the state events that are added by a new event.

--- a/src/github.com/matrix-org/dendrite/clientapi/threepid/invites.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/threepid/invites.go
@@ -355,9 +355,5 @@ func emit3PIDInviteEvent(
 		return err
 	}
 
-	if err := producer.SendEvents(ctx, []gomatrixserverlib.Event{*event}, cfg.Matrix.ServerName); err != nil {
-		return err
-	}
-
-	return nil
+	return producer.SendEvents(ctx, []gomatrixserverlib.Event{*event}, cfg.Matrix.ServerName)
 }

--- a/src/github.com/matrix-org/dendrite/common/test/config.go
+++ b/src/github.com/matrix-org/dendrite/common/test/config.go
@@ -113,10 +113,7 @@ func WriteConfig(cfg *config.Dendrite, configDir string) error {
 	if err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile(filepath.Join(configDir, ConfigFile), data, 0666); err != nil {
-		return err
-	}
-	return nil
+	return ioutil.WriteFile(filepath.Join(configDir, ConfigFile), data, 0666)
 }
 
 // NewMatrixKey generates a new ed25519 matrix server key and writes it to a file.

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/profile.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/profile.go
@@ -63,11 +63,11 @@ func GetProfile(
 		switch field {
 		case "displayname":
 			res = common.DisplayName{
-				profile.DisplayName,
+				DisplayName: profile.DisplayName,
 			}
 		case "avatar_url":
 			res = common.AvatarURL{
-				profile.AvatarURL,
+				AvatarURL: profile.AvatarURL,
 			}
 		default:
 			code = 400
@@ -75,8 +75,8 @@ func GetProfile(
 		}
 	} else {
 		res = common.ProfileResponse{
-			profile.AvatarURL,
-			profile.DisplayName,
+			AvatarURL:   profile.AvatarURL,
+			DisplayName: profile.DisplayName,
 		}
 	}
 

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/send.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/send.go
@@ -170,11 +170,7 @@ func (t *txnReq) processEvent(e gomatrixserverlib.Event) error {
 	// TODO: Check that the event is allowed by its auth_events.
 
 	// pass the event to the roomserver
-	if err := t.producer.SendEvents(t.context, []gomatrixserverlib.Event{e}, api.DoNotSendToOtherServers); err != nil {
-		return err
-	}
-
-	return nil
+	return t.producer.SendEvents(t.context, []gomatrixserverlib.Event{e}, api.DoNotSendToOtherServers)
 }
 
 func checkAllowedByState(e gomatrixserverlib.Event, stateEvents []gomatrixserverlib.Event) error {
@@ -218,8 +214,5 @@ func (t *txnReq) processEventWithMissingState(e gomatrixserverlib.Event) error {
 		return err
 	}
 	// pass the event along with the state to the roomserver
-	if err := t.producer.SendEventWithState(t.context, state, e); err != nil {
-		return err
-	}
-	return nil
+	return t.producer.SendEventWithState(t.context, state, e)
 }

--- a/src/github.com/matrix-org/dendrite/federationsender/storage/storage.go
+++ b/src/github.com/matrix-org/dendrite/federationsender/storage/storage.go
@@ -54,11 +54,7 @@ func (d *Database) prepare() error {
 		return err
 	}
 
-	if err = d.PartitionOffsetStatements.Prepare(d.db, "federationsender"); err != nil {
-		return err
-	}
-
-	return nil
+	return d.PartitionOffsetStatements.Prepare(d.db, "federationsender")
 }
 
 // UpdateRoom updates the joined hosts for a room and returns what the joined

--- a/src/github.com/matrix-org/dendrite/mediaapi/routing/upload.go
+++ b/src/github.com/matrix-org/dendrite/mediaapi/routing/upload.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"path"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/common/config"
 	"github.com/matrix-org/dendrite/mediaapi/fileutils"
@@ -31,6 +30,7 @@ import (
 	"github.com/matrix-org/dendrite/mediaapi/types"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
+	log "github.com/sirupsen/logrus"
 )
 
 // uploadRequest metadata included in or derivable from an upload request
@@ -161,14 +161,10 @@ func (r *uploadRequest) doUpload(
 		}
 	}
 
-	if resErr := r.storeFileAndMetadata(
+	return r.storeFileAndMetadata(
 		ctx, tmpDir, cfg.Media.AbsBasePath, db, cfg.Media.ThumbnailSizes,
 		activeThumbnailGeneration, cfg.Media.MaxThumbnailGenerators,
-	); resErr != nil {
-		return resErr
-	}
-
-	return nil
+	)
 }
 
 // Validate validates the uploadRequest fields

--- a/src/github.com/matrix-org/dendrite/mediaapi/storage/sql.go
+++ b/src/github.com/matrix-org/dendrite/mediaapi/storage/sql.go
@@ -23,15 +23,13 @@ type statements struct {
 	thumbnail thumbnailStatements
 }
 
-func (s *statements) prepare(db *sql.DB) error {
-	var err error
-
+func (s *statements) prepare(db *sql.DB) (err error) {
 	if err = s.media.prepare(db); err != nil {
-		return err
+		return
 	}
 	if err = s.thumbnail.prepare(db); err != nil {
-		return err
+		return
 	}
 
-	return nil
+	return
 }

--- a/src/github.com/matrix-org/dendrite/roomserver/alias/alias.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/alias/alias.go
@@ -79,11 +79,7 @@ func (r *RoomserverAliasAPI) SetRoomAlias(
 	// At this point we've already committed the alias to the database so we
 	// shouldn't cancel this request.
 	// TODO: Ensure that we send unsent events when if server restarts.
-	if err := r.sendUpdatedAliasesEvent(context.TODO(), request.UserID, request.RoomID); err != nil {
-		return err
-	}
-
-	return nil
+	return r.sendUpdatedAliasesEvent(context.TODO(), request.UserID, request.RoomID)
 }
 
 // GetAliasRoomID implements api.RoomserverAliasAPI
@@ -123,11 +119,7 @@ func (r *RoomserverAliasAPI) RemoveRoomAlias(
 	// At this point we've already committed the alias to the database so we
 	// shouldn't cancel this request.
 	// TODO: Ensure that we send unsent events when if server restarts.
-	if err := r.sendUpdatedAliasesEvent(context.TODO(), request.UserID, roomID); err != nil {
-		return err
-	}
-
-	return nil
+	return r.sendUpdatedAliasesEvent(context.TODO(), request.UserID, roomID)
 }
 
 type roomAliasesContent struct {

--- a/src/github.com/matrix-org/dendrite/roomserver/input/events.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/input/events.go
@@ -129,11 +129,7 @@ func processRoomEvent(
 	}
 
 	// Update the extremities of the event graph for the room
-	if err := updateLatestEvents(ctx, db, ow, roomNID, stateAtEvent, event, input.SendAsServer); err != nil {
-		return err
-	}
-
-	return nil
+	return updateLatestEvents(ctx, db, ow, roomNID, stateAtEvent, event, input.SendAsServer)
 }
 
 func processInviteEvent(

--- a/src/github.com/matrix-org/dendrite/roomserver/input/latest_events.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/input/latest_events.go
@@ -162,11 +162,7 @@ func (u *latestEventsUpdater) doUpdateLatestEvents() error {
 		return err
 	}
 
-	if err = u.updater.MarkEventAsSent(u.stateAtEvent.EventNID); err != nil {
-		return err
-	}
-
-	return nil
+	return u.updater.MarkEventAsSent(u.stateAtEvent.EventNID)
 }
 
 func (u *latestEventsUpdater) latestState() error {


### PR DESCRIPTION
It seems this is mostly being better at detecting redundant `if ...; err != nil` checks at the end of functions

(Include #335)