### PR TITLE
Fix /sync when we have no events

### DIFF
--- a/src/github.com/matrix-org/dendrite/syncapi/sync/notifier_test.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/notifier_test.go
@@ -264,7 +264,7 @@ func waitForEvents(n *Notifier, req syncRequest) (types.StreamPosition, error) {
 		return types.StreamPosition(0), fmt.Errorf(
 			"waitForEvents timed out waiting for %s (pos=%d)", req.userID, req.since,
 		)
-	case <-listener.GetNotifyChannel(req.since):
+	case <-listener.GetNotifyChannel(*req.since):
 		p := listener.GetStreamPosition()
 		return p, nil
 	}
@@ -282,7 +282,7 @@ func newTestSyncRequest(userID string, since types.StreamPosition) syncRequest {
 	return syncRequest{
 		userID:        userID,
 		timeout:       1 * time.Minute,
-		since:         since,
+		since:         &since,
 		wantFullState: false,
 		limit:         defaultTimelineLimit,
 		log:           util.GetLogger(context.TODO()),

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/request.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/request.go
@@ -34,7 +34,7 @@ type syncRequest struct {
 	userID        string
 	limit         int
 	timeout       time.Duration
-	since         types.StreamPosition
+	since         *types.StreamPosition
 	wantFullState bool
 	log           *log.Entry
 }
@@ -70,13 +70,14 @@ func getTimeout(timeoutMS string) time.Duration {
 	return time.Duration(i) * time.Millisecond
 }
 
-func getSyncStreamPosition(since string) (types.StreamPosition, error) {
+func getSyncStreamPosition(since string) (*types.StreamPosition, error) {
 	if since == "" {
-		return types.StreamPosition(0), nil
+		return nil, nil
 	}
 	i, err := strconv.Atoi(since)
 	if err != nil {
-		return types.StreamPosition(0), err
+		return nil, err
 	}
-	return types.StreamPosition(i), nil
+	token := types.StreamPosition(i)
+	return &token, nil
 }

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/request.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/request.go
@@ -70,6 +70,8 @@ func getTimeout(timeoutMS string) time.Duration {
 	return time.Duration(i) * time.Millisecond
 }
 
+// getSyncStreamPosition tries to pass a string taken from the API to a stream
+// position. If the string is empty then (nil, nil) is returned.
 func getSyncStreamPosition(since string) (*types.StreamPosition, error) {
 	if since == "" {
 		return nil, nil

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/request.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/request.go
@@ -34,7 +34,7 @@ type syncRequest struct {
 	userID        string
 	limit         int
 	timeout       time.Duration
-	since         *types.StreamPosition
+	since         *types.StreamPosition // nil means that no since token was supplied
 	wantFullState bool
 	log           *log.Entry
 }
@@ -70,8 +70,8 @@ func getTimeout(timeoutMS string) time.Duration {
 	return time.Duration(i) * time.Millisecond
 }
 
-// getSyncStreamPosition tries to pass a string taken from the API to a stream
-// position. If the string is empty then (nil, nil) is returned.
+// getSyncStreamPosition tries to pass a 'since' token taken from the API to a
+// stream position. If the string is empty then (nil, nil) is returned.
 func getSyncStreamPosition(since string) (*types.StreamPosition, error) {
 	if since == "" {
 		return nil, nil

--- a/src/github.com/matrix-org/dendrite/syncapi/sync/request.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/request.go
@@ -70,7 +70,7 @@ func getTimeout(timeoutMS string) time.Duration {
 	return time.Duration(i) * time.Millisecond
 }
 
-// getSyncStreamPosition tries to pass a 'since' token taken from the API to a
+// getSyncStreamPosition tries to parse a 'since' token taken from the API to a
 // stream position. If the string is empty then (nil, nil) is returned.
 func getSyncStreamPosition(since string) (*types.StreamPosition, error) {
 	if since == "" {


### PR DESCRIPTION
We used a since token of 0 to mean that no token was given. However, naffka
streams start at 0. This causes clients to get stuck spinning forever until an
event is sent.

This changes it so that we pass around pointers instead, with nil meaning a
since token wasn't given.