### PR TITLE
Pass opentracing span contexts through kafka streams

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/consumers/roomserver.go
@@ -77,6 +77,9 @@ func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 		return nil
 	}
 
+	ctx, span := output.StartSpanAndReplaceContext(context.Background())
+	defer span.Finish()
+
 	if output.Type != api.OutputTypeNewRoomEvent {
 		log.WithField("type", output.Type).Debug(
 			"roomserver output log: ignoring unknown output type",
@@ -96,7 +99,7 @@ func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 		return err
 	}
 
-	return s.db.UpdateMemberships(context.TODO(), events, output.NewRoomEvent.RemovesStateEventIDs)
+	return s.db.UpdateMemberships(ctx, events, output.NewRoomEvent.RemovesStateEventIDs)
 }
 
 // lookupStateEvents looks up the state events that are added by a new event.

--- a/src/github.com/matrix-org/dendrite/federationsender/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/federationsender/consumers/roomserver.go
@@ -85,6 +85,10 @@ func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 		)
 		return nil
 	}
+
+	ctx, span := output.StartSpanAndReplaceContext(context.Background())
+	defer span.Finish()
+
 	ev := &output.NewRoomEvent.Event
 	log.WithFields(log.Fields{
 		"event_id":       ev.EventID(),
@@ -92,7 +96,7 @@ func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 		"send_as_server": output.NewRoomEvent.SendAsServer,
 	}).Info("received event from roomserver")
 
-	if err := s.processMessage(*output.NewRoomEvent); err != nil {
+	if err := s.processMessage(ctx, *output.NewRoomEvent); err != nil {
 		// panic rather than continue with an inconsistent database
 		log.WithFields(log.Fields{
 			"event":      string(ev.JSON()),
@@ -108,8 +112,10 @@ func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 
 // processMessage updates the list of currently joined hosts in the room
 // and then sends the event to the hosts that were joined before the event.
-func (s *OutputRoomEventConsumer) processMessage(ore api.OutputNewRoomEvent) error {
-	addsStateEvents, err := s.lookupStateEvents(ore.AddsStateEventIDs, ore.Event)
+func (s *OutputRoomEventConsumer) processMessage(
+	ctx context.Context, ore api.OutputNewRoomEvent,
+) error {
+	addsStateEvents, err := s.lookupStateEvents(ctx, ore.AddsStateEventIDs, ore.Event)
 	if err != nil {
 		return err
 	}
@@ -123,7 +129,7 @@ func (s *OutputRoomEventConsumer) processMessage(ore api.OutputNewRoomEvent) err
 	// TODO(#290): handle EventIDMismatchError and recover the current state by
 	// talking to the roomserver
 	oldJoinedHosts, err := s.db.UpdateRoom(
-		context.TODO(),
+		ctx,
 		ore.Event.RoomID(),
 		ore.LastSentEventID,
 		ore.Event.EventID(),
@@ -148,7 +154,7 @@ func (s *OutputRoomEventConsumer) processMessage(ore api.OutputNewRoomEvent) err
 	}
 
 	// Work out which hosts were joined at the event itself.
-	joinedHostsAtEvent, err := s.joinedHostsAtEvent(ore, oldJoinedHosts)
+	joinedHostsAtEvent, err := s.joinedHostsAtEvent(ctx, ore, oldJoinedHosts)
 	if err != nil {
 		return err
 	}
@@ -169,7 +175,7 @@ func (s *OutputRoomEventConsumer) processMessage(ore api.OutputNewRoomEvent) err
 // events from the room server.
 // Returns an error if there was a problem talking to the room server.
 func (s *OutputRoomEventConsumer) joinedHostsAtEvent(
-	ore api.OutputNewRoomEvent, oldJoinedHosts []types.JoinedHost,
+	ctx context.Context, ore api.OutputNewRoomEvent, oldJoinedHosts []types.JoinedHost,
 ) ([]gomatrixserverlib.ServerName, error) {
 	// Combine the delta into a single delta so that the adds and removes can
 	// cancel each other out. This should reduce the number of times we need
@@ -178,7 +184,7 @@ func (s *OutputRoomEventConsumer) joinedHostsAtEvent(
 		ore.AddsStateEventIDs, ore.RemovesStateEventIDs,
 		ore.StateBeforeAddsEventIDs, ore.StateBeforeRemovesEventIDs,
 	)
-	combinedAddsEvents, err := s.lookupStateEvents(combinedAdds, ore.Event)
+	combinedAddsEvents, err := s.lookupStateEvents(ctx, combinedAdds, ore.Event)
 	if err != nil {
 		return nil, err
 	}
@@ -288,7 +294,7 @@ func combineDeltas(adds1, removes1, adds2, removes2 []string) (adds, removes []s
 
 // lookupStateEvents looks up the state events that are added by a new event.
 func (s *OutputRoomEventConsumer) lookupStateEvents(
-	addsStateEventIDs []string, event gomatrixserverlib.Event,
+	ctx context.Context, addsStateEventIDs []string, event gomatrixserverlib.Event,
 ) ([]gomatrixserverlib.Event, error) {
 	// Fast path if there aren't any new state events.
 	if len(addsStateEventIDs) == 0 {
@@ -321,7 +327,7 @@ func (s *OutputRoomEventConsumer) lookupStateEvents(
 	// from the roomserver using the query API.
 	eventReq := api.QueryEventsByIDRequest{EventIDs: missing}
 	var eventResp api.QueryEventsByIDResponse
-	if err := s.query.QueryEventsByID(context.TODO(), &eventReq, &eventResp); err != nil {
+	if err := s.query.QueryEventsByID(ctx, &eventReq, &eventResp); err != nil {
 		return nil, err
 	}
 

--- a/src/github.com/matrix-org/dendrite/roomserver/api/output.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/api/output.go
@@ -53,7 +53,7 @@ type OutputEvent struct {
 func (o *OutputEvent) AddSpanFromContext(ctx context.Context) error {
 	span := opentracing.SpanFromContext(ctx)
 	ext.SpanKindProducer.Set(span)
-	var carrier opentracing.TextMapCarrier
+	carrier := make(opentracing.TextMapCarrier)
 	tracer := opentracing.GlobalTracer()
 
 	err := tracer.Inject(span.Context(), opentracing.TextMap, carrier)
@@ -73,12 +73,12 @@ func (o *OutputEvent) StartSpanAndReplaceContext(
 	producerContext, err := tracer.Extract(opentracing.TextMap, o.OpentracingCarrier)
 
 	var span opentracing.Span
-	if err == nil {
+	if err != nil {
 		// Default to a span without reference to producer context.
-		span = tracer.StartSpan("room_event_consumer")
+		span = tracer.StartSpan("output_event_consumer")
 	} else {
 		// Set the producer context.
-		span = tracer.StartSpan("room_event_consumer", opentracing.FollowsFrom(producerContext))
+		span = tracer.StartSpan("output_event_consumer", opentracing.FollowsFrom(producerContext))
 	}
 
 	return opentracing.ContextWithSpan(ctx, span), span

--- a/src/github.com/matrix-org/dendrite/roomserver/api/output.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/api/output.go
@@ -66,6 +66,8 @@ func (o *OutputEvent) AddSpanFromContext(ctx context.Context) error {
 	return nil
 }
 
+// StartSpanAndReplaceContext produces a context and opentracing span from the
+// info embedded in OutputEvent
 func (o *OutputEvent) StartSpanAndReplaceContext(
 	ctx context.Context,
 ) (context.Context, opentracing.Span) {

--- a/src/github.com/matrix-org/dendrite/roomserver/input/events.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/input/events.go
@@ -183,7 +183,7 @@ func processInviteEvent(
 		return nil
 	}
 
-	outputUpdates, err := updateToInviteMembership(updater, &input.Event, nil)
+	outputUpdates, err := updateToInviteMembership(ctx, updater, &input.Event, nil)
 	if err != nil {
 		return err
 	}

--- a/src/github.com/matrix-org/dendrite/roomserver/input/latest_events.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/input/latest_events.go
@@ -275,10 +275,17 @@ func (u *latestEventsUpdater) makeOutputNewRoomEvent() (*api.OutputEvent, error)
 	}
 	ore.SendAsServer = u.sendAsServer
 
-	return &api.OutputEvent{
+	oe := api.OutputEvent{
 		Type:         api.OutputTypeNewRoomEvent,
 		NewRoomEvent: &ore,
-	}, nil
+	}
+
+	err = oe.AddSpanFromContext(u.ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &oe, nil
 }
 
 type eventNIDSorter []types.EventNID

--- a/src/github.com/matrix-org/dendrite/syncapi/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/consumers/roomserver.go
@@ -80,13 +80,16 @@ func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 		return nil
 	}
 
+	ctx, span := output.StartSpanAndReplaceContext(context.Background())
+	defer span.Finish()
+
 	switch output.Type {
 	case api.OutputTypeNewRoomEvent:
-		return s.onNewRoomEvent(context.TODO(), *output.NewRoomEvent)
+		return s.onNewRoomEvent(ctx, *output.NewRoomEvent)
 	case api.OutputTypeNewInviteEvent:
-		return s.onNewInviteEvent(context.TODO(), *output.NewInviteEvent)
+		return s.onNewInviteEvent(ctx, *output.NewInviteEvent)
 	case api.OutputTypeRetireInviteEvent:
-		return s.onRetireInviteEvent(context.TODO(), *output.RetireInviteEvent)
+		return s.onRetireInviteEvent(ctx, *output.RetireInviteEvent)
 	default:
 		log.WithField("type", output.Type).Debug(
 			"roomserver output log: ignoring unknown output type",


### PR DESCRIPTION
This will allow us to see how what downstream effects the request has.

This change produces the following (on a monolith):

![screenshot from 2017-11-30 16-45-21](https://user-images.githubusercontent.com/8428120/33442782-e588332a-d5ed-11e7-907b-34c7563afd06.png)

We'll probably want to figure out how to differentiate the different components better, but we need to do that for the logging anyway.

The integration test is failing because we do a bytewise comparison of the output of the roomserver, but the `opentracing_carrier` is non-deterministic. Not sure how best to fix that, thoughts? Maybe try and do a JSON subset comparison or something? 