### PR TITLE
Disable the maligned lint

### DIFF
--- a/linter.json
+++ b/linter.json
@@ -9,7 +9,6 @@
         "golint",
         "varcheck",
         "structcheck",
-        "maligned",
         "ineffassign",
         "gas",
         "misspell",


### PR DESCRIPTION
We don't really care about ensuring our structs are small, and sometimes
its clearer to group struct fields together.