### PR TITLE
User registration return M_USER_IN_USE when username is already taken

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
@@ -24,7 +24,7 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 	"golang.org/x/crypto/bcrypt"
 	// Import the postgres database driver.
-	"github.com/lib/pq"
+	_ "github.com/lib/pq"
 )
 
 // Database represents an account database
@@ -128,11 +128,8 @@ func (d *Database) CreateAccount(
 		return nil, err
 	}
 	if err := d.profiles.insertProfile(ctx, localpart); err != nil {
-		if err, ok := err.(*pq.Error); ok {
-			if err.Code.Class() == "23" {
-				// 23 => unique_violation => Account already exists
-				return nil, nil
-			}
+		if common.IsUniqueConstraintViolationErr(err) {
+			return nil, nil
 		}
 		return nil, err
 	}

--- a/src/github.com/matrix-org/dendrite/clientapi/jsonerror/jsonerror.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/jsonerror/jsonerror.go
@@ -103,7 +103,7 @@ func InvalidUsername(msg string) *MatrixError {
 	return &MatrixError{"M_INVALID_USERNAME", msg}
 }
 
-// InvalidUsername is an error returned when the client tries to register an
+// UserInUse is an error returned when the client tries to register an
 // username that already exists
 func UserInUse(msg string) *MatrixError {
 	return &MatrixError{"M_USER_IN_USE", msg}

--- a/src/github.com/matrix-org/dendrite/clientapi/jsonerror/jsonerror.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/jsonerror/jsonerror.go
@@ -103,6 +103,12 @@ func InvalidUsername(msg string) *MatrixError {
 	return &MatrixError{"M_INVALID_USERNAME", msg}
 }
 
+// InvalidUsername is an error returned when the client tries to register an
+// username that already exists
+func UserInUse(msg string) *MatrixError {
+	return &MatrixError{"M_USER_IN_USE", msg}
+}
+
 // GuestAccessForbidden is an error which is returned when the client is
 // forbidden from accessing a resource as a guest.
 func GuestAccessForbidden(msg string) *MatrixError {

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
@@ -457,6 +457,19 @@ func completeRegistration(
 		}
 	}
 
+	avail, err := accountDB.CheckAccountAvailability(ctx, username)
+	if err == nil && avail == false {
+		return util.JSONResponse{
+			Code: 400,
+			JSON: jsonerror.UserInUse("Desired user ID is already taken."),
+		}
+	} else if err != nil {
+		return util.JSONResponse{
+			Code: 500,
+			JSON: jsonerror.Unknown("Failed to check account availability: " + err.Error()),
+		}
+	}
+
 	acc, err := accountDB.CreateAccount(ctx, username, password)
 	if err != nil {
 		return util.JSONResponse{

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
@@ -458,7 +458,7 @@ func completeRegistration(
 	}
 
 	avail, err := accountDB.CheckAccountAvailability(ctx, username)
-	if err == nil && avail == false {
+	if err == nil && !avail {
 		return util.JSONResponse{
 			Code: 400,
 			JSON: jsonerror.UserInUse("Desired user ID is already taken."),

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
@@ -457,24 +457,16 @@ func completeRegistration(
 		}
 	}
 
-	avail, err := accountDB.CheckAccountAvailability(ctx, username)
-	if err == nil && !avail {
-		return util.JSONResponse{
-			Code: 400,
-			JSON: jsonerror.UserInUse("Desired user ID is already taken."),
-		}
-	} else if err != nil {
-		return util.JSONResponse{
-			Code: 500,
-			JSON: jsonerror.Unknown("Failed to check account availability: " + err.Error()),
-		}
-	}
-
 	acc, err := accountDB.CreateAccount(ctx, username, password)
 	if err != nil {
 		return util.JSONResponse{
 			Code: 500,
 			JSON: jsonerror.Unknown("failed to create account: " + err.Error()),
+		}
+	} else if acc == nil {
+		return util.JSONResponse{
+			Code: 400,
+			JSON: jsonerror.UserInUse("Desired user ID is already taken."),
 		}
 	}
 

--- a/src/github.com/matrix-org/dendrite/cmd/create-account/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/create-account/main.go
@@ -69,9 +69,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	_, err = accountDB.CreateAccount(context.Background(), *username, *password)
+	account, err := accountDB.CreateAccount(context.Background(), *username, *password)
 	if err != nil {
 		fmt.Println(err.Error())
+		os.Exit(1)
+	} else if account == nil {
+		fmt.Println("Username already exists")
 		os.Exit(1)
 	}
 

--- a/src/github.com/matrix-org/dendrite/common/sql.go
+++ b/src/github.com/matrix-org/dendrite/common/sql.go
@@ -16,6 +16,8 @@ package common
 
 import (
 	"database/sql"
+
+	"github.com/lib/pq"
 )
 
 // A Transaction is something that can be committed or rolledback.
@@ -65,4 +67,10 @@ func TxStmt(transaction *sql.Tx, statement *sql.Stmt) *sql.Stmt {
 		statement = transaction.Stmt(statement)
 	}
 	return statement
+}
+
+// IsUniqueConstraintViolationErr returns true if the error is a postgresql unique_violation error
+func IsUniqueConstraintViolationErr(err error) bool {
+	pqErr, ok := err.(*pq.Error)
+	return ok && pqErr.Code == "23505"
 }


### PR DESCRIPTION
When registering a new user using POST `/_matrix/client/r0/register`, the server was returning a 500 error when user name was already taken.

I added a check in `completeRegistration` to verify if the username is available before inserting it, and return a 400 `M_USER_IN_USE` error if there is a conflict, as [defined in matrix-doc](https://matrix.org/speculator/spec/HEAD/client_server/unstable.html#post-matrix-client-r0-register)

Signed-off-by: Thibaut CHARLES cromfr@gmail.com