### PR TITLE
Implement some createRoom parameters

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/routing/createroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/createroom.go
@@ -55,13 +55,11 @@ const (
 
 const (
 	joinRulePublic = "public"
-	// joinRuleCanJoin = "can_join"
 	joinRuleInvite = "invite"
-	// joinRuleKnock   = "knock"
-	// joinRulePrivate = "private"
 )
 const (
 	historyVisibilityShared = "shared"
+	// TODO: These should be implemented once history visibility is implemented
 	// historyVisibilityWorldReadable = "world_readable"
 	// historyVisibilityInvited       = "invited"
 )
@@ -222,11 +220,9 @@ func createRoom(req *http.Request, device *authtypes.Device,
 	if r.Topic != "" {
 		eventsToMake = append(eventsToMake, fledglingEvent{"m.room.topic", "", common.TopicContent{Topic: r.Topic}})
 	}
-	// eventsToMake = append(eventsToMake,
-	// 	// TODO: invite events
-	// 	// TODO: 3pid invite events
-	// 	// TODO: m.room.aliases
-	// )
+	// TODO: invite events
+	// TODO: 3pid invite events
+	// TODO: m.room.aliases
 
 	authEvents := gomatrixserverlib.NewAuthEvents(nil)
 	for i, e := range eventsToMake {


### PR DESCRIPTION
I'm sure there is plenty to discuss about this PR, since I'm still learning how Dendrite is put together :)

#### createRoom implementation changes:
- Set room join rules & history visibility according to `Preset` parameter (+ request preset value validation)
- Added `GuestCanJoin` parameter (see matrix-doc PR #1093)
- Process state events defined in the `InitialState` parameter
- Do not set room name if empty/not provided
- Do not set room topic if empty/not provided

#### Thoughts
- In Synapse implementation, initial events are overridden by those in the `InitialState` parameter (if they have the same event type), to reduce the number of sent events. It may be good to do the same here.
- Made `fledglingEvent` convertible from json. It may be good to rename it to something more generic like `stateEvent`
- I'm appending events to be sent to the room server in a slice. There may be a nicer/cleaner/more efficient way? (ie pre-allocate the slice)


Signed-off-by: Thibaut CHARLES cromfr@gmail.com