### PR TITLE
Ensure we only process one event at a time

### DIFF
--- a/src/github.com/matrix-org/dendrite/roomserver/input/events.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/input/events.go
@@ -69,6 +69,11 @@ type OutputRoomEventWriter interface {
 	WriteOutputEvents(roomID string, updates []api.OutputEvent) error
 }
 
+// processRoomEvent can only be called once at a time
+//
+// TODO(#375): This should be rewritten to allow concurrent calls. The
+// difficulty is in ensuring that we correctly annotate events with the correct
+// state deltas when sending to kafka streams
 func processRoomEvent(
 	ctx context.Context,
 	db RoomEventDatabase,

--- a/src/github.com/matrix-org/dendrite/roomserver/input/latest_events.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/input/latest_events.go
@@ -42,6 +42,7 @@ import (
 //      |
 //      7 <----- latest
 //
+// Can only be called once at a time
 func updateLatestEvents(
 	ctx context.Context,
 	db RoomEventDatabase,


### PR DESCRIPTION
c.f. #375 

This is just a quick fix for now, and we should definitely revisit this to remove the need for the mutex