### PR TITLE
Load Application Service Configuration Files

### DIFF
--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -120,3 +120,7 @@ tracing:
     # for documtation.
     jaeger:
         disabled: true
+
+# A list of application service config files to use
+applicationservice:
+    app_service_config_files:

--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -123,4 +123,4 @@ tracing:
 
 # A list of application service config files to use
 applicationservice:
-    app_service_config_files:
+    app_service_config_files: []

--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -122,5 +122,5 @@ tracing:
         disabled: true
 
 # A list of application service config files to use
-applicationservice:
-    app_service_config_files: []
+application_services:
+    config_files: []

--- a/src/github.com/matrix-org/dendrite/common/config/appservice.go
+++ b/src/github.com/matrix-org/dendrite/common/config/appservice.go
@@ -1,0 +1,79 @@
+// Copyright 2017 Andrew Morgan <andrew@amorgan.xyz>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"gopkg.in/yaml.v2"
+)
+
+// ApplicationServiceNamespace is the namespace that a specific application
+// service has management over.
+type ApplicationServiceNamespace struct {
+	// Whether or not the namespace is managed solely by this application service
+	Exclusive bool `yaml:"exclusive"`
+	// A regex pattern that represents the namespace
+	Regex string `yaml:"regex"`
+}
+
+// ApplicationService represents a Matrix application service.
+// https://matrix.org/docs/spec/application_service/unstable.html
+type ApplicationService struct {
+	// User-defined, unique, persistent ID of the application service
+	ID string `yaml:"id"`
+	// Base URL of the application service
+	URL string `yaml:"url"`
+	// Application service token provided in requests to a homeserver
+	ASToken string `yaml:"as_token"`
+	// Homeserver token provided in requests to an application service
+	HSToken string `yaml:"hs_token"`
+	// Localpart of application service user
+	SenderLocalpart string `yaml:"sender_localpart"`
+	// Information about an application service's namespaces
+	Namespaces map[string][]interface{} `yaml:"namespaces"`
+}
+
+func loadAppservices(config *Dendrite) error {
+	// Iterate through and return all the Application Services
+	for _, configPath := range config.ApplicationService.ConfigFiles {
+		// Create a new application service
+		var appservice ApplicationService
+
+		// Create an absolute path from a potentially relative path
+		absPath, err := filepath.Abs(configPath)
+		if err != nil {
+			return err
+		}
+
+		// Read the application service's config file
+		configData, err := ioutil.ReadFile(absPath)
+		if err != nil {
+			return err
+		}
+
+		// Load the config data into our struct
+		if err = yaml.UnmarshalStrict(configData, &appservice); err != nil {
+			return err
+		}
+
+		// Append the parsed application service to the global config
+		config.Derived.ApplicationServices = append(
+			config.Derived.ApplicationServices, appservice)
+	}
+
+	return nil
+}

--- a/src/github.com/matrix-org/dendrite/common/config/appservice.go
+++ b/src/github.com/matrix-org/dendrite/common/config/appservice.go
@@ -44,7 +44,7 @@ type ApplicationService struct {
 	// Localpart of application service user
 	SenderLocalpart string `yaml:"sender_localpart"`
 	// Information about an application service's namespaces
-	Namespaces map[string][]interface{} `yaml:"namespaces"`
+	Namespaces map[string][]ApplicationServiceNamespace `yaml:"namespaces"`
 }
 
 func loadAppservices(config *Dendrite) error {

--- a/src/github.com/matrix-org/dendrite/common/config/appservice.go
+++ b/src/github.com/matrix-org/dendrite/common/config/appservice.go
@@ -49,7 +49,7 @@ type ApplicationService struct {
 
 func loadAppservices(config *Dendrite) error {
 	// Iterate through and return all the Application Services
-	for _, configPath := range config.ApplicationService.ConfigFiles {
+	for _, configPath := range config.ApplicationServices.ConfigFiles {
 		// Create a new application service
 		var appservice ApplicationService
 

--- a/src/github.com/matrix-org/dendrite/common/config/config.go
+++ b/src/github.com/matrix-org/dendrite/common/config/config.go
@@ -334,7 +334,8 @@ func loadConfig(
 
 	for _, certPath := range config.Matrix.FederationCertificatePaths {
 		absCertPath := absPath(basePath, certPath)
-		pemData, err := readFile(absCertPath)
+		var pemData []byte
+		pemData, err = readFile(absCertPath)
 		if err != nil {
 			return nil, err
 		}
@@ -348,14 +349,17 @@ func loadConfig(
 	config.Media.AbsBasePath = Path(absPath(basePath, config.Media.BasePath))
 
 	// Generate data from config options
-	config.derive()
+	err = config.derive()
+	if err != nil {
+		return nil, err
+	}
 
 	return &config, nil
 }
 
 // derive generates data that is derived from various values provided in
 // the config file.
-func (config *Dendrite) derive() {
+func (config *Dendrite) derive() error {
 	// Determine registrations flows based off config values
 
 	config.Derived.Registration.Params = make(map[string]interface{})
@@ -373,12 +377,13 @@ func (config *Dendrite) derive() {
 	}
 
 	// Load application service configuration files
-	fmt.Println(config.ApplicationService.ConfigFiles)
 	if len(config.ApplicationService.ConfigFiles) > 0 {
 		if err := loadAppservices(config); err != nil {
-			fmt.Println("Error loading AS config: ", err)
+			return err
 		}
 	}
+
+	return nil
 }
 
 // setDefaults sets default config values if they are not explicitly set.

--- a/src/github.com/matrix-org/dendrite/common/config/config.go
+++ b/src/github.com/matrix-org/dendrite/common/config/config.go
@@ -186,7 +186,7 @@ type Dendrite struct {
 		// Hardcoded Username and Password
 		Username string `yaml:"turn_username"`
 		Password string `yaml:"turn_password"`
-	}
+	} `yaml:"turn"`
 
 	// The internal addresses the components will listen on.
 	// These should not be exposed externally as they expose metrics and debugging APIs.
@@ -204,14 +204,14 @@ type Dendrite struct {
 	Tracing struct {
 		// The config for the jaeger opentracing reporter.
 		Jaeger jaegerconfig.Configuration `yaml:"jaeger"`
-	}
+	} `yaml:"tracing"`
 
 	// Application Services
 	// https://matrix.org/docs/spec/application_service/unstable.html
 	ApplicationService struct {
 		// Configuration files for various application services
 		ConfigFiles []string `yaml:"app_service_config_files"`
-	}
+	} `yaml:"applicationservice"`
 
 	// Any information derived from the configuration options for later use.
 	Derived struct {
@@ -230,7 +230,7 @@ type Dendrite struct {
 		// Application Services parsed from their config files
 		// The paths of which were given above in the main config file
 		ApplicationServices []ApplicationService
-	}
+	} `yaml:"-"`
 }
 
 // A Path on the filesystem.
@@ -377,10 +377,8 @@ func (config *Dendrite) derive() error {
 	}
 
 	// Load application service configuration files
-	if len(config.ApplicationService.ConfigFiles) > 0 {
-		if err := loadAppservices(config); err != nil {
-			return err
-		}
+	if err := loadAppservices(config); err != nil {
+		return err
 	}
 
 	return nil

--- a/src/github.com/matrix-org/dendrite/common/config/config.go
+++ b/src/github.com/matrix-org/dendrite/common/config/config.go
@@ -206,6 +206,13 @@ type Dendrite struct {
 		Jaeger jaegerconfig.Configuration `yaml:"jaeger"`
 	}
 
+	// Application Services
+	// https://matrix.org/docs/spec/application_service/unstable.html
+	ApplicationService struct {
+		// Configuration files for various application services
+		ConfigFiles []string `yaml:"app_service_config_files"`
+	}
+
 	// Any information derived from the configuration options for later use.
 	Derived struct {
 		Registration struct {
@@ -219,6 +226,10 @@ type Dendrite struct {
 			// registration in order to complete registration stages.
 			Params map[string]interface{} `json:"params"`
 		}
+
+		// Application Services parsed from their config files
+		// The paths of which were given above in the main config file
+		ApplicationServices []ApplicationService
 	}
 }
 
@@ -359,6 +370,14 @@ func (config *Dendrite) derive() {
 	} else {
 		config.Derived.Registration.Flows = append(config.Derived.Registration.Flows,
 			authtypes.Flow{Stages: []authtypes.LoginType{authtypes.LoginTypeDummy}})
+	}
+
+	// Load application service configuration files
+	fmt.Println(config.ApplicationService.ConfigFiles)
+	if len(config.ApplicationService.ConfigFiles) > 0 {
+		if err := loadAppservices(config); err != nil {
+			fmt.Println("Error loading AS config: ", err)
+		}
 	}
 }
 

--- a/src/github.com/matrix-org/dendrite/common/config/config.go
+++ b/src/github.com/matrix-org/dendrite/common/config/config.go
@@ -208,10 +208,10 @@ type Dendrite struct {
 
 	// Application Services
 	// https://matrix.org/docs/spec/application_service/unstable.html
-	ApplicationService struct {
+	ApplicationServices struct {
 		// Configuration files for various application services
-		ConfigFiles []string `yaml:"app_service_config_files"`
-	} `yaml:"applicationservice"`
+		ConfigFiles []string `yaml:"config_files"`
+	} `yaml:"application_services"`
 
 	// Any information derived from the configuration options for later use.
 	Derived struct {

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -458,7 +458,7 @@
 		{
 			"importpath": "gopkg.in/yaml.v2",
 			"repository": "https://gopkg.in/yaml.v2",
-			"revision": "a3f3340b5840cee44f372bddb5880fcbc419b46a",
+			"revision": "287cf08546ab5e7e37d55a84f7ed3fd1db036de5",
 			"branch": "v2"
 		}
 	]

--- a/vendor/src/gopkg.in/yaml.v2/LICENSE
+++ b/vendor/src/gopkg.in/yaml.v2/LICENSE
@@ -1,13 +1,201 @@
-Copyright 2011-2016 Canonical Ltd.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-    http://www.apache.org/licenses/LICENSE-2.0
+   1. Definitions.
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/src/gopkg.in/yaml.v2/README.md
+++ b/vendor/src/gopkg.in/yaml.v2/README.md
@@ -48,6 +48,8 @@ The yaml package is licensed under the Apache License 2.0. Please see the LICENS
 Example
 -------
 
+Some more examples can be found in the "examples" folder.
+
 ```Go
 package main
 

--- a/vendor/src/gopkg.in/yaml.v2/decode.go
+++ b/vendor/src/gopkg.in/yaml.v2/decode.go
@@ -120,7 +120,6 @@ func (p *parser) parse() *node {
 	default:
 		panic("attempted to parse unknown event: " + strconv.Itoa(int(p.event.typ)))
 	}
-	panic("unreachable")
 }
 
 func (p *parser) node(kind int) *node {
@@ -191,6 +190,7 @@ type decoder struct {
 	aliases map[string]bool
 	mapType reflect.Type
 	terrors []string
+	strict  bool
 }
 
 var (
@@ -200,8 +200,8 @@ var (
 	ifaceType      = defaultMapType.Elem()
 )
 
-func newDecoder() *decoder {
-	d := &decoder{mapType: defaultMapType}
+func newDecoder(strict bool) *decoder {
+	d := &decoder{mapType: defaultMapType, strict: strict}
 	d.aliases = make(map[string]bool)
 	return d
 }
@@ -251,7 +251,7 @@ func (d *decoder) callUnmarshaler(n *node, u Unmarshaler) (good bool) {
 //
 // If n holds a null value, prepare returns before doing anything.
 func (d *decoder) prepare(n *node, out reflect.Value) (newout reflect.Value, unmarshaled, good bool) {
-	if n.tag == yaml_NULL_TAG || n.kind == scalarNode && n.tag == "" && (n.value == "null" || n.value == "" && n.implicit) {
+	if n.tag == yaml_NULL_TAG || n.kind == scalarNode && n.tag == "" && (n.value == "null" || n.value == "~" || n.value == "" && n.implicit) {
 		return out, false, false
 	}
 	again := true
@@ -640,6 +640,8 @@ func (d *decoder) mappingStruct(n *node, out reflect.Value) (good bool) {
 			value := reflect.New(elemType).Elem()
 			d.unmarshal(n.children[i+1], value)
 			inlineMap.SetMapIndex(name, value)
+		} else if d.strict {
+			d.terrors = append(d.terrors, fmt.Sprintf("line %d: field %s not found in struct %s", n.line+1, name.String(), out.Type()))
 		}
 	}
 	return true

--- a/vendor/src/gopkg.in/yaml.v2/decode_test.go
+++ b/vendor/src/gopkg.in/yaml.v2/decode_test.go
@@ -405,6 +405,12 @@ var unmarshalTests = []struct {
 		map[string]interface{}{"v": 1},
 	},
 
+	// Non-specific tag (Issue #75)
+	{
+		"v: ! test",
+		map[string]interface{}{"v": "test"},
+	},
+
 	// Anchors and aliases.
 	{
 		"a: &x 1\nb: &y 2\nc: *x\nd: *y\n",
@@ -434,9 +440,24 @@ var unmarshalTests = []struct {
 		map[string]*string{"foo": new(string)},
 	}, {
 		"foo: null",
+		map[string]*string{"foo": nil},
+	}, {
+		"foo: null",
 		map[string]string{"foo": ""},
 	}, {
 		"foo: null",
+		map[string]interface{}{"foo": nil},
+	},
+
+	// Support for ~
+	{
+		"foo: ~",
+		map[string]*string{"foo": nil},
+	}, {
+		"foo: ~",
+		map[string]string{"foo": ""},
+	}, {
+		"foo: ~",
 		map[string]interface{}{"foo": nil},
 	},
 
@@ -604,7 +625,8 @@ type inlineC struct {
 }
 
 func (s *S) TestUnmarshal(c *C) {
-	for _, item := range unmarshalTests {
+	for i, item := range unmarshalTests {
+		c.Logf("test %d: %q", i, item.data)
 		t := reflect.ValueOf(item.value).Type()
 		var value interface{}
 		switch t.Kind() {
@@ -648,6 +670,7 @@ var unmarshalErrorTests = []struct {
 	{"a: !!binary ==", "yaml: !!binary value contains invalid base64 data"},
 	{"{[.]}", `yaml: invalid map key: \[\]interface \{\}\{"\."\}`},
 	{"{{.}}", `yaml: invalid map key: map\[interface\ \{\}\]interface \{\}\{".":interface \{\}\(nil\)\}`},
+	{"%TAG !%79! tag:yaml.org,2002:\n---\nv: !%79!int '1'", "yaml: did not find expected whitespace"},
 }
 
 func (s *S) TestUnmarshalErrors(c *C) {
@@ -966,6 +989,17 @@ func (s *S) TestUnmarshalSliceOnPreset(c *C) {
 	v := struct{ A []int }{[]int{1}}
 	yaml.Unmarshal([]byte("a: [2]"), &v)
 	c.Assert(v.A, DeepEquals, []int{2})
+}
+
+func (s *S) TestUnmarshalStrict(c *C) {
+	v := struct{ A, B int }{}
+
+	err := yaml.UnmarshalStrict([]byte("a: 1\nb: 2"), &v)
+	c.Check(err, IsNil)
+	err = yaml.Unmarshal([]byte("a: 1\nb: 2\nc: 3"), &v)
+	c.Check(err, IsNil)
+	err = yaml.UnmarshalStrict([]byte("a: 1\nb: 2\nc: 3"), &v)
+	c.Check(err, ErrorMatches, "yaml: unmarshal errors:\n  line 1: field c not found in struct struct { A int; B int }")
 }
 
 //var data []byte

--- a/vendor/src/gopkg.in/yaml.v2/emitterc.go
+++ b/vendor/src/gopkg.in/yaml.v2/emitterc.go
@@ -666,7 +666,6 @@ func yaml_emitter_emit_node(emitter *yaml_emitter_t, event *yaml_event_t,
 		return yaml_emitter_set_emitter_error(emitter,
 			"expected SCALAR, SEQUENCE-START, MAPPING-START, or ALIAS")
 	}
-	return false
 }
 
 // Expect ALIAS.
@@ -995,7 +994,7 @@ func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
 		break_space    = false
 		space_break    = false
 
-		preceeded_by_whitespace = false
+		preceded_by_whitespace = false
 		followed_by_whitespace  = false
 		previous_space          = false
 		previous_break          = false
@@ -1017,7 +1016,7 @@ func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
 		flow_indicators = true
 	}
 
-	preceeded_by_whitespace = true
+	preceded_by_whitespace = true
 	for i, w := 0, 0; i < len(value); i += w {
 		w = width(value[i])
 		followed_by_whitespace = i+w >= len(value) || is_blank(value, i+w)
@@ -1048,7 +1047,7 @@ func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
 					block_indicators = true
 				}
 			case '#':
-				if preceeded_by_whitespace {
+				if preceded_by_whitespace {
 					flow_indicators = true
 					block_indicators = true
 				}
@@ -1089,7 +1088,7 @@ func yaml_emitter_analyze_scalar(emitter *yaml_emitter_t, value []byte) bool {
 		}
 
 		// [Go]: Why 'z'? Couldn't be the end of the string as that's the loop condition.
-		preceeded_by_whitespace = is_blankz(value, i)
+		preceded_by_whitespace = is_blankz(value, i)
 	}
 
 	emitter.scalar_data.multiline = line_breaks

--- a/vendor/src/gopkg.in/yaml.v2/example_embedded_test.go
+++ b/vendor/src/gopkg.in/yaml.v2/example_embedded_test.go
@@ -1,0 +1,41 @@
+package yaml_test
+
+import (
+	"fmt"
+	"log"
+
+        "gopkg.in/yaml.v2"
+)
+
+// An example showing how to unmarshal embedded
+// structs from YAML.
+
+type StructA struct {
+	A string `yaml:"a"`
+}
+
+type StructB struct {
+	// Embedded structs are not treated as embedded in YAML by default. To do that,
+	// add the ",inline" annotation below
+	StructA   `yaml:",inline"`
+	B string `yaml:"b"`
+}
+
+var data = `
+a: a string from struct A
+b: a string from struct B
+`
+
+func ExampleUnmarshal_embedded() {
+	var b StructB
+
+	err := yaml.Unmarshal([]byte(data), &b)
+	if err != nil {
+		log.Fatal("cannot unmarshal data: %v", err)
+	}
+        fmt.Println(b.A)
+        fmt.Println(b.B)
+        // Output:
+        // a string from struct A
+        // a string from struct B
+}

--- a/vendor/src/gopkg.in/yaml.v2/parserc.go
+++ b/vendor/src/gopkg.in/yaml.v2/parserc.go
@@ -166,7 +166,6 @@ func yaml_parser_state_machine(parser *yaml_parser_t, event *yaml_event_t) bool 
 	default:
 		panic("invalid parser state")
 	}
-	return false
 }
 
 // Parse the production:

--- a/vendor/src/gopkg.in/yaml.v2/scannerc.go
+++ b/vendor/src/gopkg.in/yaml.v2/scannerc.go
@@ -611,7 +611,7 @@ func yaml_parser_set_scanner_tag_error(parser *yaml_parser_t, directive bool, co
 	if directive {
 		context = "while parsing a %TAG directive"
 	}
-	return yaml_parser_set_scanner_error(parser, context, context_mark, "did not find URI escaped octet")
+	return yaml_parser_set_scanner_error(parser, context, context_mark, problem)
 }
 
 func trace(args ...interface{}) func() {
@@ -1944,7 +1944,7 @@ func yaml_parser_scan_tag_handle(parser *yaml_parser_t, directive bool, start_ma
 	} else {
 		// It's either the '!' tag or not really a tag handle.  If it's a %TAG
 		// directive, it's an error.  If it's a tag token, it must be a part of URI.
-		if directive && !(s[0] == '!' && s[1] == 0) {
+		if directive && string(s) != "!" {
 			yaml_parser_set_scanner_tag_error(parser, directive,
 				start_mark, "did not find expected '!'")
 			return false
@@ -1959,6 +1959,7 @@ func yaml_parser_scan_tag_handle(parser *yaml_parser_t, directive bool, start_ma
 func yaml_parser_scan_tag_uri(parser *yaml_parser_t, directive bool, head []byte, start_mark yaml_mark_t, uri *[]byte) bool {
 	//size_t length = head ? strlen((char *)head) : 0
 	var s []byte
+	hasTag := len(head) > 0
 
 	// Copy the head if needed.
 	//
@@ -2000,10 +2001,10 @@ func yaml_parser_scan_tag_uri(parser *yaml_parser_t, directive bool, head []byte
 		if parser.unread < 1 && !yaml_parser_update_buffer(parser, 1) {
 			return false
 		}
+		hasTag = true
 	}
 
-	// Check if the tag is non-empty.
-	if len(s) == 0 {
+	if !hasTag {
 		yaml_parser_set_scanner_tag_error(parser, directive,
 			start_mark, "did not find expected tag URI")
 		return false

--- a/vendor/src/gopkg.in/yaml.v2/yaml.go
+++ b/vendor/src/gopkg.in/yaml.v2/yaml.go
@@ -77,8 +77,19 @@ type Marshaler interface {
 // supported tag options.
 //
 func Unmarshal(in []byte, out interface{}) (err error) {
+	return unmarshal(in, out, false)
+}
+
+// UnmarshalStrict is like Unmarshal except that any fields that are found
+// in the data that do not have corresponding struct members will result in
+// an error.
+func UnmarshalStrict(in []byte, out interface{}) (err error) {
+	return unmarshal(in, out, true)
+}
+
+func unmarshal(in []byte, out interface{}, strict bool) (err error) {
 	defer handleErr(&err)
-	d := newDecoder()
+	d := newDecoder(strict)
 	p := newParser(in)
 	defer p.destroy()
 	node := p.parse()
@@ -129,7 +140,7 @@ func Unmarshal(in []byte, out interface{}) (err error) {
 // For example:
 //
 //     type T struct {
-//         F int "a,omitempty"
+//         F int `yaml:"a,omitempty"`
 //         B int
 //     }
 //     yaml.Marshal(&T{B: 2}) // Returns "b: 2\n"

--- a/vendor/src/gopkg.in/yaml.v2/yamlh.go
+++ b/vendor/src/gopkg.in/yaml.v2/yamlh.go
@@ -508,7 +508,7 @@ type yaml_parser_t struct {
 
 	problem string // Error description.
 
-	// The byte about which the problem occured.
+	// The byte about which the problem occurred.
 	problem_offset int
 	problem_value  int
 	problem_mark   yaml_mark_t


### PR DESCRIPTION
WIP for all of application services. This'll load the config of each AS specified in `dendrite.yaml` and unmarshal the values out into `config.Dendrite.Derived.ApplicationServices`, which is a slice of type `ApplicationService`.

`yaml.v2` was updated for its new `UnmarshalStrict()` method, which will error out if any types don't match from the YAML to a struct.