### PR TITLE
Enable debug logs using a configuration parameter and put all logs in a single file

### DIFF
--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -117,6 +117,13 @@ listen:
 tracing:
     # Config for the jaeger opentracing reporter.
     # See https://godoc.org/github.com/uber/jaeger-client-go/config#Configuration
-    # for documtation.
+    # for documentation.
     jaeger:
         disabled: true
+
+# The configuration for logs of dendrite
+logging:
+    # The logging level, must be one of debug, info, warn, error, fatal, panic.
+    level: "info"
+    # The file on which save logs. If commented, logs won't be saved by dendrite and only printed to stdout
+    # path: /var/log/dendrite.log

--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -121,9 +121,19 @@ tracing:
     jaeger:
         disabled: true
 
-# The configuration for logs of dendrite
+# The configuration for dendrite logs
 logging:
-    # The logging level, must be one of debug, info, warn, error, fatal, panic.
-    level: "info"
-    # The file on which save logs. If commented, logs won't be saved by dendrite and only printed to stdout
-    # path: /var/log/dendrite.log
+    # The logging type, only "file" is supported at the moment
+    - type: "file"
+      # The logging level, must be one of debug, info, warn, error, fatal, panic.
+      level: "info"
+      # Parameters for this type of log
+      params:
+        # File logging must be given a path to a directory. Each component will write to a different file. Logs are rotated each day and gzipped
+        path: "/var/log/dendrite"
+    # It is possible to have multiple logging hooks at the same time.
+    # To save only errors in a different directory, uncomment the following.
+    # - type: "file"
+    #   level: "error"
+    #   params:
+    #     path: "/var/log/dendrite/errors"

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-client-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-client-api-server/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"flag"
 	"net/http"
-	"os"
 
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
@@ -37,12 +36,11 @@ import (
 )
 
 var (
-	logDir     = os.Getenv("LOG_DIR")
 	configPath = flag.String("config", "dendrite.yaml", "The path to the config file, For more information see the config file in this repository")
 )
 
 func main() {
-	common.SetupLogging(logDir)
+	common.SetupStdLogging()
 
 	flag.Parse()
 
@@ -50,6 +48,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("Invalid config file: %s", err)
 	}
+
+	common.SetupFileLogging(string(cfg.Logging.FPath), cfg.Derived.LogLevel)
 
 	closer, err := cfg.SetupTracing("DendriteClientAPI")
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-client-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-client-api-server/main.go
@@ -35,6 +35,8 @@ import (
 	sarama "gopkg.in/Shopify/sarama.v1"
 )
 
+const componentName = "clientapi"
+
 var (
 	configPath = flag.String("config", "dendrite.yaml", "The path to the config file, For more information see the config file in this repository")
 )
@@ -49,7 +51,7 @@ func main() {
 		log.Fatalf("Invalid config file: %s", err)
 	}
 
-	common.SetupFileLogging(string(cfg.Logging.FPath), cfg.Derived.LogLevel)
+	common.SetupHookLogging(cfg.Logging, componentName)
 
 	closer, err := cfg.SetupTracing("DendriteClientAPI")
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-federation-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-federation-api-server/main.go
@@ -31,6 +31,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const componentName = "federationapi"
+
 var (
 	configPath = flag.String("config", "dendrite.yaml", "The path to the config file. For more information, see the config file in this repository.")
 )
@@ -48,7 +50,7 @@ func main() {
 		log.Fatalf("Invalid config file: %s", err)
 	}
 
-	common.SetupFileLogging(string(cfg.Logging.FPath), cfg.Derived.LogLevel)
+	common.SetupHookLogging(cfg.Logging, componentName)
 
 	closer, err := cfg.SetupTracing("DendriteFederationAPI")
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-federation-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-federation-api-server/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"flag"
 	"net/http"
-	"os"
 
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
@@ -33,12 +32,11 @@ import (
 )
 
 var (
-	logDir     = os.Getenv("LOG_DIR")
 	configPath = flag.String("config", "dendrite.yaml", "The path to the config file. For more information, see the config file in this repository.")
 )
 
 func main() {
-	common.SetupLogging(logDir)
+	common.SetupStdLogging()
 
 	flag.Parse()
 
@@ -49,6 +47,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("Invalid config file: %s", err)
 	}
+
+	common.SetupFileLogging(string(cfg.Logging.FPath), cfg.Derived.LogLevel)
 
 	closer, err := cfg.SetupTracing("DendriteFederationAPI")
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-federation-sender-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-federation-sender-server/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"flag"
 	"net/http"
-	"os"
 
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/common"
@@ -35,7 +34,7 @@ import (
 var configPath = flag.String("config", "dendrite.yaml", "The path to the config file. For more information, see the config file in this repository.")
 
 func main() {
-	common.SetupLogging(os.Getenv("LOG_DIR"))
+	common.SetupStdLogging()
 
 	flag.Parse()
 
@@ -46,6 +45,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("Invalid config file: %s", err)
 	}
+
+	common.SetupFileLogging(string(cfg.Logging.FPath), cfg.Derived.LogLevel)
 
 	closer, err := cfg.SetupTracing("DendriteFederationSender")
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-federation-sender-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-federation-sender-server/main.go
@@ -31,6 +31,8 @@ import (
 	sarama "gopkg.in/Shopify/sarama.v1"
 )
 
+const componentName = "federationsender"
+
 var configPath = flag.String("config", "dendrite.yaml", "The path to the config file. For more information, see the config file in this repository.")
 
 func main() {
@@ -46,7 +48,7 @@ func main() {
 		log.Fatalf("Invalid config file: %s", err)
 	}
 
-	common.SetupFileLogging(string(cfg.Logging.FPath), cfg.Derived.LogLevel)
+	common.SetupHookLogging(cfg.Logging, componentName)
 
 	closer, err := cfg.SetupTracing("DendriteFederationSender")
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-media-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-media-api-server/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"flag"
 	"net/http"
-	"os"
 
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
@@ -31,12 +30,11 @@ import (
 )
 
 var (
-	logDir     = os.Getenv("LOG_DIR")
 	configPath = flag.String("config", "dendrite.yaml", "The path to the config file. For more information, see the config file in this repository.")
 )
 
 func main() {
-	common.SetupLogging(logDir)
+	common.SetupStdLogging()
 
 	flag.Parse()
 
@@ -47,6 +45,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("Invalid config file: %s", err)
 	}
+
+	common.SetupFileLogging(string(cfg.Logging.FPath), cfg.Derived.LogLevel)
 
 	closer, err := cfg.SetupTracing("DendriteMediaAPI")
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-media-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-media-api-server/main.go
@@ -29,6 +29,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const componentName = "mediaapi"
+
 var (
 	configPath = flag.String("config", "dendrite.yaml", "The path to the config file. For more information, see the config file in this repository.")
 )
@@ -46,7 +48,7 @@ func main() {
 		log.Fatalf("Invalid config file: %s", err)
 	}
 
-	common.SetupFileLogging(string(cfg.Logging.FPath), cfg.Derived.LogLevel)
+	common.SetupHookLogging(cfg.Logging, componentName)
 
 	closer, err := cfg.SetupTracing("DendriteMediaAPI")
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
@@ -61,6 +61,8 @@ import (
 	sarama "gopkg.in/Shopify/sarama.v1"
 )
 
+const componentName = "monolith"
+
 var (
 	configPath    = flag.String("config", "dendrite.yaml", "The path to the config file. For more information, see the config file in this repository.")
 	httpBindAddr  = flag.String("http-bind-address", ":8008", "The HTTP listening port for the server")
@@ -82,7 +84,7 @@ func main() {
 		log.Fatalf("Invalid config file: %s", err)
 	}
 
-	common.SetupFileLogging(string(cfg.Logging.FPath), cfg.Derived.LogLevel)
+	common.SetupHookLogging(cfg.Logging, componentName)
 
 	closer, err := cfg.SetupTracing("DendriteMonolith")
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
@@ -19,7 +19,6 @@ import (
 	"database/sql"
 	"flag"
 	"net/http"
-	"os"
 
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
@@ -63,7 +62,6 @@ import (
 )
 
 var (
-	logDir        = os.Getenv("LOG_DIR")
 	configPath    = flag.String("config", "dendrite.yaml", "The path to the config file. For more information, see the config file in this repository.")
 	httpBindAddr  = flag.String("http-bind-address", ":8008", "The HTTP listening port for the server")
 	httpsBindAddr = flag.String("https-bind-address", ":8448", "The HTTPS listening port for the server")
@@ -72,7 +70,7 @@ var (
 )
 
 func main() {
-	common.SetupLogging(logDir)
+	common.SetupStdLogging()
 
 	flag.Parse()
 
@@ -83,6 +81,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("Invalid config file: %s", err)
 	}
+
+	common.SetupFileLogging(string(cfg.Logging.FPath), cfg.Derived.LogLevel)
 
 	closer, err := cfg.SetupTracing("DendriteMonolith")
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-public-rooms-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-public-rooms-api-server/main.go
@@ -31,6 +31,8 @@ import (
 	sarama "gopkg.in/Shopify/sarama.v1"
 )
 
+const componentName = "publicroomsapi"
+
 var configPath = flag.String("config", "dendrite.yaml", "The path to the config file. For more information, see the config file in this repository.")
 
 func main() {
@@ -46,7 +48,7 @@ func main() {
 		log.Fatalf("Invalid config file: %s", err)
 	}
 
-	common.SetupFileLogging(string(cfg.Logging.FPath), cfg.Derived.LogLevel)
+	common.SetupHookLogging(cfg.Logging, componentName)
 
 	closer, err := cfg.SetupTracing("DendritePublicRoomsAPI")
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-public-rooms-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-public-rooms-api-server/main.go
@@ -17,7 +17,6 @@ package main
 import (
 	"flag"
 	"net/http"
-	"os"
 
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
@@ -35,7 +34,7 @@ import (
 var configPath = flag.String("config", "dendrite.yaml", "The path to the config file. For more information, see the config file in this repository.")
 
 func main() {
-	common.SetupLogging(os.Getenv("LOG_DIR"))
+	common.SetupStdLogging()
 
 	flag.Parse()
 
@@ -46,6 +45,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("Invalid config file: %s", err)
 	}
+
+	common.SetupFileLogging(string(cfg.Logging.FPath), cfg.Derived.LogLevel)
 
 	closer, err := cfg.SetupTracing("DendritePublicRoomsAPI")
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-room-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-room-server/main.go
@@ -30,6 +30,8 @@ import (
 	sarama "gopkg.in/Shopify/sarama.v1"
 )
 
+const componentName = "roomserver"
+
 var (
 	configPath = flag.String("config", "dendrite.yaml", "The path to the config file. For more information, see the config file in this repository.")
 )
@@ -47,7 +49,7 @@ func main() {
 		log.Fatalf("Invalid config file: %s", err)
 	}
 
-	common.SetupFileLogging(string(cfg.Logging.FPath), cfg.Derived.LogLevel)
+	common.SetupHookLogging(cfg.Logging, componentName)
 
 	closer, err := cfg.SetupTracing("DendriteRoomServer")
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-room-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-room-server/main.go
@@ -18,7 +18,6 @@ import (
 	"flag"
 	"net/http"
 	_ "net/http/pprof"
-	"os"
 
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/config"
@@ -32,12 +31,11 @@ import (
 )
 
 var (
-	logDir     = os.Getenv("LOG_DIR")
 	configPath = flag.String("config", "dendrite.yaml", "The path to the config file. For more information, see the config file in this repository.")
 )
 
 func main() {
-	common.SetupLogging(logDir)
+	common.SetupStdLogging()
 
 	flag.Parse()
 
@@ -48,6 +46,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("Invalid config file: %s", err)
 	}
+
+	common.SetupFileLogging(string(cfg.Logging.FPath), cfg.Derived.LogLevel)
 
 	closer, err := cfg.SetupTracing("DendriteRoomServer")
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-sync-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-sync-api-server/main.go
@@ -35,6 +35,8 @@ import (
 	sarama "gopkg.in/Shopify/sarama.v1"
 )
 
+const componentName = "syncapi"
+
 var configPath = flag.String("config", "dendrite.yaml", "The path to the config file. For more information, see the config file in this repository.")
 
 func main() {
@@ -50,7 +52,7 @@ func main() {
 		log.Fatalf("Invalid config file: %s", err)
 	}
 
-	common.SetupFileLogging(string(cfg.Logging.FPath), cfg.Derived.LogLevel)
+	common.SetupHookLogging(cfg.Logging, componentName)
 
 	closer, err := cfg.SetupTracing("DendriteSyncAPI")
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-sync-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-sync-api-server/main.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"flag"
 	"net/http"
-	"os"
 
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
@@ -39,7 +38,7 @@ import (
 var configPath = flag.String("config", "dendrite.yaml", "The path to the config file. For more information, see the config file in this repository.")
 
 func main() {
-	common.SetupLogging(os.Getenv("LOG_DIR"))
+	common.SetupStdLogging()
 
 	flag.Parse()
 
@@ -50,6 +49,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("Invalid config file: %s", err)
 	}
+
+	common.SetupFileLogging(string(cfg.Logging.FPath), cfg.Derived.LogLevel)
 
 	closer, err := cfg.SetupTracing("DendriteSyncAPI")
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/common/config/config.go
+++ b/src/github.com/matrix-org/dendrite/common/config/config.go
@@ -206,6 +206,15 @@ type Dendrite struct {
 		Jaeger jaegerconfig.Configuration `yaml:"jaeger"`
 	}
 
+	// The config for logging informations
+	Logging struct {
+		// The path to the log file
+		FPath Path `yaml:"path"`
+
+		// The logging level
+		Level string `yaml:"level"`
+	} `yaml:"logging"`
+
 	// Any information derived from the configuration options for later use.
 	Derived struct {
 		Registration struct {
@@ -219,6 +228,9 @@ type Dendrite struct {
 			// registration in order to complete registration stages.
 			Params map[string]interface{} `json:"params"`
 		}
+
+		// The logrus level used for logging configuration
+		LogLevel logrus.Level
 	}
 }
 
@@ -470,6 +482,12 @@ func (config *Dendrite) check(monolithic bool) error {
 		checkNotEmpty("listen.federation_api", string(config.Listen.FederationAPI))
 		checkNotEmpty("listen.sync_api", string(config.Listen.SyncAPI))
 		checkNotEmpty("listen.room_server", string(config.Listen.RoomServer))
+	}
+
+	if level, err := logrus.ParseLevel(config.Logging.Level); err != nil {
+		problems = append(problems, fmt.Sprintf("Invalid value for key logging.level: %s", config.Logging.Level))
+	} else {
+		config.Derived.LogLevel = level
 	}
 
 	if problems != nil {

--- a/src/github.com/matrix-org/dendrite/common/config/config_test.go
+++ b/src/github.com/matrix-org/dendrite/common/config/config_test.go
@@ -59,6 +59,9 @@ listen:
   federation_api: "localhost:7772"
   sync_api: "localhost:7773"
   media_api: "localhost:7774"
+logging:
+  level: "debug"
+  path: "/my/log/dir/dendrite.log"
 `
 
 type mockReadFile map[string]string

--- a/src/github.com/matrix-org/dendrite/common/config/config_test.go
+++ b/src/github.com/matrix-org/dendrite/common/config/config_test.go
@@ -60,8 +60,10 @@ listen:
   sync_api: "localhost:7773"
   media_api: "localhost:7774"
 logging:
-  level: "debug"
-  path: "/my/log/dir/dendrite.log"
+  - type: "file"
+    level: "info"
+    params:
+      path: "/my/log/dir"
 `
 
 type mockReadFile map[string]string

--- a/src/github.com/matrix-org/dendrite/common/log.go
+++ b/src/github.com/matrix-org/dendrite/common/log.go
@@ -16,7 +16,7 @@ package common
 
 import (
 	"os"
-	"path/filepath"
+	"path"
 
 	"github.com/matrix-org/dugong"
 	"github.com/sirupsen/logrus"
@@ -31,8 +31,8 @@ func (f utcFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	return f.Formatter.Format(entry)
 }
 
-// SetupLogging configures the logging format and destination(s).
-func SetupLogging(logDir string) {
+// SetupStdLogging configures the logging format to standard output. Typically, it is called when the config is not yet loaded.
+func SetupStdLogging() {
 	logrus.SetFormatter(&utcFormatter{
 		&logrus.TextFormatter{
 			TimestampFormat:  "2006-01-02T15:04:05.000000000Z07:00",
@@ -42,12 +42,15 @@ func SetupLogging(logDir string) {
 			DisableSorting:   false,
 		},
 	})
-	if logDir != "" {
-		_ = os.Mkdir(logDir, os.ModePerm)
+}
+
+// SetupFileLogging configures the logging format to a file.
+func SetupFileLogging(logFile string, logLevel logrus.Level) {
+	logrus.SetLevel(logLevel)
+	if logFile != "" {
+		_ = os.MkdirAll(path.Dir(logFile), os.ModePerm)
 		logrus.AddHook(dugong.NewFSHook(
-			filepath.Join(logDir, "info.log"),
-			filepath.Join(logDir, "warn.log"),
-			filepath.Join(logDir, "error.log"),
+			logFile,
 			&utcFormatter{
 				&logrus.TextFormatter{
 					TimestampFormat:  "2006-01-02T15:04:05.000000000Z07:00",


### PR DESCRIPTION
Enable debug logs using a configuration parameter and put all logs in a single file as per #346 .
Linked to the PR on [dugong](https://github.com/matrix-org/dugong/pull/6) so vendors have not yet been updated.