### PR TITLE
Fix roomserver deadlock

### DIFF
--- a/src/github.com/matrix-org/dendrite/roomserver/input/input.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/input/input.go
@@ -61,11 +61,10 @@ func (r *RoomserverInputAPI) InputRoomEvents(
 	request *api.InputRoomEventsRequest,
 	response *api.InputRoomEventsResponse,
 ) error {
+	// We lock as processRoomEvent can only be called once at a time
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	for i := range request.InputRoomEvents {
-		// We lock as processRoomEvent can ony be called once at a time
-		r.mutex.Lock()
-		defer r.mutex.Unlock()
-
 		if err := processRoomEvent(ctx, r.DB, r, request.InputRoomEvents[i]); err != nil {
 			return err
 		}


### PR DESCRIPTION
Move the mutex lock outside the loop so that we don't lock up if there is more
than one event