### PR TITLE
Application Service Registration

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/auth/authtypes/account.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/authtypes/account.go
@@ -20,10 +20,11 @@ import (
 
 // Account represents a Matrix account on this home server.
 type Account struct {
-	UserID     string
-	Localpart  string
-	ServerName gomatrixserverlib.ServerName
-	Profile    *Profile
+	UserID       string
+	Localpart    string
+	ServerName   gomatrixserverlib.ServerName
+	Profile      *Profile
+	AppServiceID string
 	// TODO: Other flags like IsAdmin, IsGuest
 	// TODO: Devices
 	// TODO: Associations (e.g. with application services)

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/authtypes/logintypes.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/authtypes/logintypes.go
@@ -5,7 +5,8 @@ type LoginType string
 
 // The relevant login types implemented in Dendrite
 const (
-	LoginTypeDummy        = "m.login.dummy"
-	LoginTypeSharedSecret = "org.matrix.login.shared_secret"
-	LoginTypeRecaptcha    = "m.login.recaptcha"
+	LoginTypeDummy              = "m.login.dummy"
+	LoginTypeSharedSecret       = "org.matrix.login.shared_secret"
+	LoginTypeRecaptcha          = "m.login.recaptcha"
+	LoginTypeApplicationService = "m.login.application_service"
 )

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/accounts_table.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/accounts_table.go
@@ -33,7 +33,7 @@ CREATE TABLE IF NOT EXISTS account_accounts (
     created_ts BIGINT NOT NULL,
     -- The password hash for this account. Can be NULL if this is a passwordless account.
     password_hash TEXT,
-    -- Identifies which Application Service this account belongs to.
+    -- Identifies which Application Service this account belongs to, if any.
     appservice_id TEXT
     -- TODO:
     -- is_guest, is_admin, upgraded_ts, devices, any email reset stuff?
@@ -84,7 +84,7 @@ func (s *accountsStatements) insertAccount(
 ) (*authtypes.Account, error) {
 	createdTimeMS := time.Now().UnixNano() / 1000000
 	stmt := s.insertAccountStmt
-	if _, err := stmt.ExecContext(ctx, localpart, createdTimeMS, hash, appserviceID); err != nil {
+    if _, err := stmt.ExecContext(ctx, localpart, createdTimeMS, hash, appserviceID ? appserviceID : nil); err != nil {
 		return nil, err
 	}
 	return &authtypes.Account{

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/accounts_table.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/accounts_table.go
@@ -34,7 +34,7 @@ CREATE TABLE IF NOT EXISTS account_accounts (
     -- The password hash for this account. Can be NULL if this is a passwordless account.
     password_hash TEXT,
     -- Identifies which Application Service this account belongs to.
-    appservice_id TEXT,
+    appservice_id TEXT
     -- TODO:
     -- is_guest, is_admin, upgraded_ts, devices, any email reset stuff?
 );
@@ -84,7 +84,7 @@ func (s *accountsStatements) insertAccount(
 ) (*authtypes.Account, error) {
 	createdTimeMS := time.Now().UnixNano() / 1000000
 	stmt := s.insertAccountStmt
-	if _, err := stmt.ExecContext(ctx, localpart, createdTimeMS, hash); err != nil {
+	if _, err := stmt.ExecContext(ctx, localpart, createdTimeMS, hash, appserviceID); err != nil {
 		return nil, err
 	}
 	return &authtypes.Account{

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/accounts_table.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/accounts_table.go
@@ -84,9 +84,17 @@ func (s *accountsStatements) insertAccount(
 ) (*authtypes.Account, error) {
 	createdTimeMS := time.Now().UnixNano() / 1000000
 	stmt := s.insertAccountStmt
-    if _, err := stmt.ExecContext(ctx, localpart, createdTimeMS, hash, appserviceID ? appserviceID : nil); err != nil {
+
+	var err error
+	if appserviceID == "" {
+		_, err = stmt.ExecContext(ctx, localpart, createdTimeMS, hash, nil)
+	} else {
+		_, err = stmt.ExecContext(ctx, localpart, createdTimeMS, hash, appserviceID)
+	}
+	if err != nil {
 		return nil, err
 	}
+
 	return &authtypes.Account{
 		Localpart:    localpart,
 		UserID:       makeUserID(localpart, s.serverName),

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
@@ -121,11 +121,17 @@ func (d *Database) SetDisplayName(
 // for this account. If no password is supplied, the account will be a passwordless account. If the
 // account already exists, it will return nil, nil.
 func (d *Database) CreateAccount(
-	ctx context.Context, localpart, plaintextPassword string,
+	ctx context.Context, localpart, plaintextPassword, appserviceID string,
 ) (*authtypes.Account, error) {
-	hash, err := hashPassword(plaintextPassword)
-	if err != nil {
-		return nil, err
+	var err error
+
+	// Generate a password hash if this is not a password-less user
+	hash := ""
+	if appserviceID == "" && plaintextPassword != "" {
+		hash, err = hashPassword(plaintextPassword)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if err := d.profiles.insertProfile(ctx, localpart); err != nil {
 		if common.IsUniqueConstraintViolationErr(err) {
@@ -133,7 +139,7 @@ func (d *Database) CreateAccount(
 		}
 		return nil, err
 	}
-	return d.accounts.insertAccount(ctx, localpart, hash)
+	return d.accounts.insertAccount(ctx, localpart, hash, appserviceID)
 }
 
 // SaveMembership saves the user matching a given localpart as a member of a given

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
@@ -127,7 +127,7 @@ func (d *Database) CreateAccount(
 
 	// Generate a password hash if this is not a password-less user
 	hash := ""
-	if appserviceID == "" && plaintextPassword != "" {
+	if plaintextPassword != "" {
 		hash, err = hashPassword(plaintextPassword)
 		if err != nil {
 			return nil, err

--- a/src/github.com/matrix-org/dendrite/clientapi/jsonerror/jsonerror.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/jsonerror/jsonerror.go
@@ -86,7 +86,7 @@ func MissingToken(msg string) *MatrixError {
 }
 
 // UnknownToken is an error when the client tries to access a resource which
-// requires authentication and supplies a valid, but out-of-date token.
+// requires authentication and supplies an unrecognized token
 func UnknownToken(msg string) *MatrixError {
 	return &MatrixError{"M_UNKNOWN_TOKEN", msg}
 }
@@ -109,9 +109,10 @@ func UserInUse(msg string) *MatrixError {
 	return &MatrixError{"M_USER_IN_USE", msg}
 }
 
-// Exclusive is an error returned when an application service tries to register
-// an username that is outside of its registered namespace
-func Exclusive(msg string) *MatrixError {
+// ASExclusive is an error returned when an application service tries to
+// register an username that is outside of its registered namespace, or if a
+// user attempts to register a username within an exclusive namespace
+func ASExclusive(msg string) *MatrixError {
 	return &MatrixError{"M_EXCLUSIVE", msg}
 }
 

--- a/src/github.com/matrix-org/dendrite/clientapi/jsonerror/jsonerror.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/jsonerror/jsonerror.go
@@ -109,6 +109,12 @@ func UserInUse(msg string) *MatrixError {
 	return &MatrixError{"M_USER_IN_USE", msg}
 }
 
+// Exclusive is an error returned when an application service tries to register
+// an username that is outside of its registered namespace
+func Exclusive(msg string) *MatrixError {
+	return &MatrixError{"M_EXCLUSIVE", msg}
+}
+
 // GuestAccessForbidden is an error which is returned when the client is
 // forbidden from accessing a resource as a guest.
 func GuestAccessForbidden(msg string) *MatrixError {

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
@@ -312,7 +312,7 @@ func validateApplicationService(
 	if matchedApplicationService != nil {
 		return "", &util.JSONResponse{
 			Code: 401,
-			JSON: jsonerror.BadJSON("Supplied access_token does not match any known application service"),
+			JSON: jsonerror.UnknownToken("Supplied access_token does not match any known application service"),
 		}
 	}
 
@@ -321,8 +321,8 @@ func validateApplicationService(
 		// If we didn't find any matches, return M_EXCLUSIVE
 		return "", &util.JSONResponse{
 			Code: 401,
-			JSON: jsonerror.Exclusive("Supplied username " + username +
-				" did not match any namespaces for application service ID: " + matchedApplicationService.ID),
+			JSON: jsonerror.ASExclusive(fmt.Sprintf(
+				"Supplied username %s did not match any namespaces for application service ID: %s", username, matchedApplicationService.ID)),
 		}
 	}
 
@@ -330,8 +330,8 @@ func validateApplicationService(
 	if UsernameMatchesMultipleExclusiveNamespaces(cfg, username) {
 		return "", &util.JSONResponse{
 			Code: 401,
-			JSON: jsonerror.Exclusive("Supplied username " + username +
-				" matches multiple exclusive application service namespaces. Only 1 match allowed"),
+			JSON: jsonerror.ASExclusive(fmt.Sprintf(
+				"Supplied username %s matches multiple exclusive application service namespaces. Only 1 match allowed", username)),
 		}
 	}
 
@@ -386,7 +386,7 @@ func Register(
 		cfg.Derived.ExclusiveApplicationServicesUsernameRegexp.MatchString(r.Username) {
 		return util.JSONResponse{
 			Code: 400,
-			JSON: jsonerror.Exclusive("This username is registered by an application service."),
+			JSON: jsonerror.ASExclusive("This username is reserved by an application service."),
 		}
 	}
 

--- a/src/github.com/matrix-org/dendrite/cmd/create-account/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/create-account/main.go
@@ -69,7 +69,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	account, err := accountDB.CreateAccount(context.Background(), *username, *password)
+	account, err := accountDB.CreateAccount(context.Background(), *username, *password, "")
 	if err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)

--- a/src/github.com/matrix-org/dendrite/common/config/appservice.go
+++ b/src/github.com/matrix-org/dendrite/common/config/appservice.go
@@ -47,8 +47,9 @@ type ApplicationService struct {
 	Namespaces map[string][]ApplicationServiceNamespace `yaml:"namespaces"`
 }
 
+// loadAppservices iterates through all application service config files
+// and loads their data into the config object for later access.
 func loadAppservices(config *Dendrite) error {
-	// Iterate through and return all the Application Services
 	for _, configPath := range config.ApplicationServices.ConfigFiles {
 		// Create a new application service
 		var appservice ApplicationService
@@ -74,6 +75,19 @@ func loadAppservices(config *Dendrite) error {
 		config.Derived.ApplicationServices = append(
 			config.Derived.ApplicationServices, appservice)
 	}
+
+	// Check for any errors in the loaded application services
+	return checkErrors(config)
+}
+
+// checkErrors checks for any configuration errors amongst the loaded
+// application services according to the application service spec.
+func checkErrors(config *Dendrite) error {
+	// TODO: Check that no two app services have the same as_token or id
+
+	// TODO: Check that namespace(s) are valid regex
+
+	// TODO: Check that exclusive namespaces are actually exclusive
 
 	return nil
 }

--- a/src/github.com/matrix-org/dendrite/common/config/appservice.go
+++ b/src/github.com/matrix-org/dendrite/common/config/appservice.go
@@ -15,8 +15,11 @@
 package config
 
 import (
+	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 )
@@ -28,6 +31,8 @@ type ApplicationServiceNamespace struct {
 	Exclusive bool `yaml:"exclusive"`
 	// A regex pattern that represents the namespace
 	Regex string `yaml:"regex"`
+	// Regex object representing our pattern. Saves having to recompile every time
+	RegexpObject *regexp.Regexp
 }
 
 // ApplicationService represents a Matrix application service.
@@ -44,7 +49,7 @@ type ApplicationService struct {
 	// Localpart of application service user
 	SenderLocalpart string `yaml:"sender_localpart"`
 	// Information about an application service's namespaces
-	Namespaces map[string][]ApplicationServiceNamespace `yaml:"namespaces"`
+	NamespaceMap map[string][]ApplicationServiceNamespace `yaml:"namespaces"`
 }
 
 // loadAppservices iterates through all application service config files
@@ -80,14 +85,106 @@ func loadAppservices(config *Dendrite) error {
 	return checkErrors(config)
 }
 
+// setupRegexps will create regex objects for exclusive and non-exclusive
+// usernames, aliases and rooms of all application services, so that other
+// methods can quickly check if a particular string matches any of them.
+func setupRegexps(cfg *Dendrite) {
+	// Combine all exclusive namespaces for later string checking
+	var exclusiveUsernameStrings, exclusiveAliasStrings, exclusiveRoomStrings []string
+
+	// If an application service's regex is marked as exclusive, add
+	// it's contents to the overall exlusive regex string
+	for _, appservice := range cfg.Derived.ApplicationServices {
+		for key, namespaceSlice := range appservice.NamespaceMap {
+			switch key {
+			case "users":
+				appendExclusiveNamespaceRegexs(&exclusiveUsernameStrings, namespaceSlice)
+			case "aliases":
+				appendExclusiveNamespaceRegexs(&exclusiveAliasStrings, namespaceSlice)
+			case "rooms":
+				appendExclusiveNamespaceRegexs(&exclusiveRoomStrings, namespaceSlice)
+			}
+		}
+	}
+
+	// Join the regexes together into one big regex.
+	// i.e. "app1.*", "app2.*" -> "(app1.*)|(app2.*)"
+	// Later we can check if a username or some other string matches any exclusive
+	// regex and deny access if it isn't from an application service
+	exclusiveUsernames := strings.Join(exclusiveUsernameStrings, "|")
+
+	// TODO: Aliases and rooms. Needed?
+	//exclusiveAliases := strings.Join(exclusiveAliasStrings, "|")
+	//exclusiveRooms := strings.Join(exclusiveRoomStrings, "|")
+
+	cfg.Derived.ExclusiveApplicationServicesUsernameRegexp, _ = regexp.Compile(exclusiveUsernames)
+}
+
+// concatenateExclusiveNamespaces takes a slice of strings and a slice of
+// namespaces and will append the regexes of only the exclusive namespaces
+// into the string slice
+func appendExclusiveNamespaceRegexs(
+	exclusiveStrings *[]string, namespaces []ApplicationServiceNamespace,
+) {
+	for _, namespace := range namespaces {
+		if namespace.Exclusive {
+			// We append parenthesis to later separate each regex when we compile
+			// i.e. "app1.*", "app2.*" -> "(app1.*)|(app2.*)"
+			*exclusiveStrings = append(*exclusiveStrings, "("+namespace.Regex+")")
+		}
+
+		// Compile this regex into a Regexp object for later use
+		namespace.RegexpObject, _ = regexp.Compile(namespace.Regex)
+	}
+}
+
 // checkErrors checks for any configuration errors amongst the loaded
 // application services according to the application service spec.
 func checkErrors(config *Dendrite) error {
-	// TODO: Check that no two app services have the same as_token or id
+	var idMap = make(map[string]bool)
+	var tokenMap = make(map[string]bool)
 
-	// TODO: Check that namespace(s) are valid regex
+	// Check that no two application services have the same as_token or id
+	for _, appservice := range config.Derived.ApplicationServices {
+		// Check if we've already seen this ID
+		if idMap[appservice.ID] {
+			return Error{[]string{fmt.Sprintf(
+				"Application Service ID %s must be unique", appservice.ID,
+			)}}
+		}
+		if tokenMap[appservice.ASToken] {
+			return Error{[]string{fmt.Sprintf(
+				"Application Service Token %s must be unique", appservice.ASToken,
+			)}}
+		}
 
-	// TODO: Check that exclusive namespaces are actually exclusive
+		// Add the id/token to their respective maps if we haven't already
+		// seen them.
+		idMap[appservice.ID] = true
+		tokenMap[appservice.ID] = true
+	}
+
+	// Check that namespace(s) are valid regex
+	for _, appservice := range config.Derived.ApplicationServices {
+		for _, namespaceSlice := range appservice.NamespaceMap {
+			for _, namespace := range namespaceSlice {
+				if !IsValidRegex(namespace.Regex) {
+					return Error{[]string{fmt.Sprintf(
+						"Invalid regex string for Application Service %s", appservice.ID,
+					)}}
+				}
+			}
+		}
+	}
+	setupRegexps(config)
 
 	return nil
+}
+
+// IsValidRegex returns true or false based on whether the
+// given string is valid regex or not
+func IsValidRegex(regexString string) bool {
+	_, err := regexp.Compile(regexString)
+
+	return err == nil
 }

--- a/src/github.com/matrix-org/dendrite/common/config/config.go
+++ b/src/github.com/matrix-org/dendrite/common/config/config.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"io/ioutil"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -230,6 +231,13 @@ type Dendrite struct {
 		// Application Services parsed from their config files
 		// The paths of which were given above in the main config file
 		ApplicationServices []ApplicationService
+
+		// A meta-regex compiled from all exclusive Application Service
+		// Regexes. When a user registers, we check that their username
+		// does not match any exclusive Application Service namespaces
+		ExclusiveApplicationServicesUsernameRegexp *regexp.Regexp
+
+		// TODO: Exclusive alias, room regexp's
 	} `yaml:"-"`
 }
 


### PR DESCRIPTION
We now verify and validate loaded application services as well as have the registration flow required for them to register password-less users.

Had to change the database schema to allow for an `appservice_id` for each user. Not sure what this will mean in terms of adapting old databases.

Ready for review, I'm sure there's lots to be said about things :)