### PR TITLE
Add MacOS kafka setup instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -60,13 +60,6 @@ brew services start zookeeper
 brew services start kafka
 ```
 
-You can stop Kafka service by running
-
-```bash
-brew services stop zookeeper
-brew services stop kafka
-```
-
 ## Configuration
 
 ### Postgres database setup

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -52,6 +52,21 @@ kafka/bin/zookeeper-server-start.sh -daemon kafka/config/zookeeper.properties
 kafka/bin/kafka-server-start.sh -daemon kafka/config/server.properties
 ```
 
+On MacOS, you can use [homebrew](https://brew.sh/) for easier setup of kafka
+
+```bash
+brew install kafka
+brew services start zookeeper
+brew services start kafka
+```
+
+You can stop Kafka service by running
+
+```bash
+brew services stop zookeeper
+brew services stop kafka
+```
+
 ## Configuration
 
 ### Postgres database setup


### PR DESCRIPTION
Setting up Kafka using the provided script wasn't working for me, daemon would start and close instead of staying alive.
Using `brew` for installation is cleaner and easier.
So adding it to the INSTALL.md doc. Would help Mac users in future! :)