### PR TITLE
Update install instructions for mac

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -62,10 +62,23 @@ Dendrite requires a postgres database engine, version 9.5 or later.
   ```bash
   sudo -u postgres createuser -P dendrite     # prompts for password
   ```
+
+On macOS you need to run:
+```bash
+createuser -P dendrite
+```
+
 * Create databases:
   ```bash
   for i in account device mediaapi syncapi roomserver serverkey federationsender publicroomsapi naffka; do
       sudo -u postgres createdb -O dendrite dendrite_$i
+  done
+  ```
+
+On macOS you need to run:
+  ```bash
+  for i in account device mediaapi syncapi roomserver serverkey federationsender publicroomsapi naffka; do
+     createdb -O dendrite dendrite_$i
   done
   ```
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,10 +63,7 @@ Dendrite requires a postgres database engine, version 9.5 or later.
   sudo -u postgres createuser -P dendrite     # prompts for password
   ```
 
-On macOS you need to run:
-```bash
-createuser -P dendrite
-```
+On macOS, omit `sudo -u postgres`.
 
 * Create databases:
   ```bash
@@ -75,12 +72,7 @@ createuser -P dendrite
   done
   ```
 
-On macOS you need to run:
-  ```bash
-  for i in account device mediaapi syncapi roomserver serverkey federationsender publicroomsapi naffka; do
-     createdb -O dendrite dendrite_$i
-  done
-  ```
+On macOS, omit `sudo -u postgres`.
 
 ### Crypto key generation
 


### PR DESCRIPTION
I tried to run the setup as described in INSTALL.md file in [configuration](https://github.com/matrix-org/dendrite/blob/master/INSTALL.md#configuration). But the instructions for setting up Postgres failed on macOS. You don't need to use `sudo -u postgres` there.

I updated the instructions to include the equivalent mac commands. I checked and the commands do indeed create a user and the databases.