### PR TITLE
Support user_id query param (and implement whoami endpoint)

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/auth/auth.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/auth.go
@@ -63,7 +63,7 @@ func VerifyUserFromRequest(
 		return dev.UserID, nil
 	}
 
-	// Try to find Application Service user
+	// Try to find the Application Service user
 	token, err := extractAccessToken(req)
 
 	if err != nil {
@@ -96,14 +96,8 @@ func VerifyUserFromRequest(
 		// Verify that the user is registered
 		account, accountErr := accountDB.GetAccountByLocalpart(req.Context(), localpart)
 
-		if accountErr != nil {
-			return "", &util.JSONResponse{
-				Code: http.StatusForbidden,
-				JSON: jsonerror.Forbidden("Application service has not registered this user"),
-			}
-		}
-
-		if account.AppServiceID == appService.ID {
+		// Verify that account exists & appServiceID matches
+		if accountErr == nil && account.AppServiceID == appService.ID {
 			return userID, nil
 		}
 

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
@@ -358,3 +358,11 @@ func (d *Database) CheckAccountAvailability(ctx context.Context, localpart strin
 	}
 	return false, err
 }
+
+// GetAccountByLocalpart returns the account associated with the given localpart.
+// This function assumes the request is authenticated or the account data is used only internally.
+// Returns sql.ErrNoRows if no account exists which matches the given localpart.
+func (d *Database) GetAccountByLocalpart(ctx context.Context, localpart string,
+) (*authtypes.Account, error) {
+	return d.accounts.selectAccountByLocalpart(ctx, localpart)
+}

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/devices/storage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/devices/storage.go
@@ -25,6 +25,9 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
+// The length of generated device IDs
+var deviceIDByteLength = 6
+
 // Database represents a device database.
 type Database struct {
 	db      *sql.DB
@@ -94,7 +97,7 @@ func (d *Database) CreateDevice(
 		// We cap this at going round 5 times to ensure we don't spin forever
 		var newDeviceID string
 		for i := 1; i <= 5; i++ {
-			newDeviceID, returnErr = GenerateDeviceID()
+			newDeviceID, returnErr = generateDeviceID()
 			if returnErr != nil {
 				return
 			}

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/devices/storage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/devices/storage.go
@@ -16,9 +16,10 @@ package devices
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/base64"
 
-	"github.com/matrix-org/dendrite/clientapi/auth"
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -93,7 +94,7 @@ func (d *Database) CreateDevice(
 		// We cap this at going round 5 times to ensure we don't spin forever
 		var newDeviceID string
 		for i := 1; i <= 5; i++ {
-			newDeviceID, returnErr = auth.GenerateDeviceID()
+			newDeviceID, returnErr = GenerateDeviceID()
 			if returnErr != nil {
 				return
 			}
@@ -109,6 +110,18 @@ func (d *Database) CreateDevice(
 		}
 	}
 	return
+}
+
+// generateDeviceID creates a new device id. Returns an error if failed to generate
+// random bytes.
+func generateDeviceID() (string, error) {
+	b := make([]byte, deviceIDByteLength)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", err
+	}
+	// url-safe no padding
+	return base64.RawURLEncoding.EncodeToString(b), nil
 }
 
 // UpdateDevice updates the given device with the display name.

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/login.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/login.go
@@ -16,13 +16,13 @@ package routing
 
 import (
 	"net/http"
-	"strings"
 
 	"github.com/matrix-org/dendrite/clientapi/auth"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/config"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
@@ -82,24 +82,11 @@ func Login(
 
 		util.GetLogger(req.Context()).WithField("user", r.User).Info("Processing login request")
 
-		// r.User can either be a user ID or just the localpart... or other things maybe.
-		localpart := r.User
-		if strings.HasPrefix(r.User, "@") {
-			var domain gomatrixserverlib.ServerName
-			var err error
-			localpart, domain, err = gomatrixserverlib.SplitID('@', r.User)
-			if err != nil {
-				return util.JSONResponse{
-					Code: http.StatusBadRequest,
-					JSON: jsonerror.InvalidUsername("Invalid username"),
-				}
-			}
-
-			if domain != cfg.Matrix.ServerName {
-				return util.JSONResponse{
-					Code: http.StatusBadRequest,
-					JSON: jsonerror.InvalidUsername("User ID not ours"),
-				}
+		localpart, err = common.GetLocalpartFromUsername(r.User)
+		if err != nil {
+			return &util.JSONResponse{
+				Code: http.StatusBadRequest,
+				JSON: jsonerror.InvalidUsername(err.Error()),
 			}
 		}
 

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -389,4 +389,10 @@ func Setup(
 			}}
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
+
+	r0mux.Handle("/account/whoami",
+		common.MakeExternalAPI("whoami", func(req *http.Request) util.JSONResponse {
+			return Whoami(req, accountDB, deviceDB, &cfg)
+		}),
+	).Methods(http.MethodGet, http.MethodOptions)
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/whoami.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/whoami.go
@@ -1,0 +1,60 @@
+// Copyright 2018 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"net/http"
+
+	"github.com/matrix-org/dendrite/clientapi/auth"
+	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
+	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"github.com/matrix-org/dendrite/common/config"
+	"github.com/matrix-org/util"
+)
+
+// whoamiResponse represents an response for a `whoami` request
+type whoamiResponse struct {
+	UserID string `json:"user_id"`
+}
+
+// Whoami implements `/account/whoami` which enables client to query owner of the HTTP request.
+// https://matrix.org/docs/spec/client_server/r0.3.0.html#get-matrix-client-r0-account-whoami
+func Whoami(
+	req *http.Request, accountDB *accounts.Database, deviceDB *devices.Database,
+	cfg *config.Dendrite,
+) util.JSONResponse {
+
+	if req.Method == http.MethodGet {
+		user, err := auth.VerifyUserFromRequest(req, accountDB, deviceDB, cfg.Derived.ApplicationServices)
+
+		if err != nil {
+			return *err
+		}
+		util.GetLogger(req.Context()).WithField("user", user).Info("Processing whoami request")
+
+		return util.JSONResponse{
+			Code: http.StatusOK,
+			JSON: whoamiResponse{
+				UserID: user,
+			},
+		}
+	}
+
+	return util.JSONResponse{
+		Code: http.StatusMethodNotAllowed,
+		JSON: jsonerror.NotFound("Bad method"),
+	}
+}

--- a/src/github.com/matrix-org/dendrite/clientapi/userutil/userutil.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/userutil/userutil.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package common
+package userutil
 
 import (
 	"errors"
@@ -21,36 +21,28 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
-// GetLocalpartDomainFromUserID extracts localpart & domain of server from userID.
-// Returns error in case of invalid username.
-func GetLocalpartDomainFromUserID(userID string,
-) (string, gomatrixserverlib.ServerName, error) {
-	localpart, domain, err := gomatrixserverlib.SplitID('@', userID)
+// GetDomainFromUserID extracts the domain of server from userID.
+// Returns error in case of invalid userID.
+func GetDomainFromUserID(userID string,
+) (gomatrixserverlib.ServerName, error) {
+	_, domain, err := gomatrixserverlib.SplitID('@', userID)
 
-	if err != nil {
-		return localpart, domain, err
-	}
-
-	return localpart, domain, nil
+	return domain, err
 }
 
-// GetLocalpartFromUsername extracts localpart from userID
-// userID can either be a user ID or just the localpart.
+// GetLocalpartFromUsername extracts localpart from username.
+// username can either be a user ID or just the localpart.
 // Returns error in case of invalid username.
-func GetLocalpartFromUsername(userID string,
-) (string, error) {
+func GetLocalpartFromUsername(userID string) (string, error) {
 	localpart := userID
 
 	if strings.HasPrefix(userID, "@") {
-		lp, domain, err := GetLocalpartDomainFromUserid(userID)
+		lp, _, err := gomatrixserverlib.SplitID('@', userID)
 
 		if err != nil {
 			return "", errors.New("Invalid username")
 		}
 
-		if domain != cfg.Matrix.ServerName {
-			return "", errors.New("User ID not ours")
-		}
 		localpart = lp
 	}
 	return localpart, nil

--- a/src/github.com/matrix-org/dendrite/common/username_utils.go
+++ b/src/github.com/matrix-org/dendrite/common/username_utils.go
@@ -1,0 +1,57 @@
+// Copyright 2018 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/matrix-org/gomatrixserverlib"
+)
+
+// GetLocalpartDomainFromUserID extracts localpart & domain of server from userID.
+// Returns error in case of invalid username.
+func GetLocalpartDomainFromUserID(userID string,
+) (string, gomatrixserverlib.ServerName, error) {
+	localpart, domain, err := gomatrixserverlib.SplitID('@', userID)
+
+	if err != nil {
+		return localpart, domain, err
+	}
+
+	return localpart, domain, nil
+}
+
+// GetLocalpartFromUsername extracts localpart from userID
+// userID can either be a user ID or just the localpart.
+// Returns error in case of invalid username.
+func GetLocalpartFromUsername(userID string,
+) (string, error) {
+	localpart := userID
+
+	if strings.HasPrefix(userID, "@") {
+		lp, domain, err := GetLocalpartDomainFromUserid(userID)
+
+		if err != nil {
+			return "", errors.New("Invalid username")
+		}
+
+		if domain != cfg.Matrix.ServerName {
+			return "", errors.New("User ID not ours")
+		}
+		localpart = lp
+	}
+	return localpart, nil
+}


### PR DESCRIPTION
* Implement `VerifyUserFromRequest` which verifies an user is authenticated.
Handles AS users as well.
* Move `GenerateDeviceID` from `auth.go` to `auth/storage/devices/storage.go` to avoid cyclic import of package auth. This move includes `deviceIDByteLength` .
* Factor out `GetLocalpartFromUsername` & `GetDomainFromUserID` from `routing.login` into `userutil` package since they are useful pretty much everywhere.
* Add `/account/whoami` endpoint. fixes #404 
