### PR TITLE
Correct Application Service Logic

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
@@ -309,7 +309,7 @@ func validateApplicationService(
 			break
 		}
 	}
-	if matchedApplicationService != nil {
+	if matchedApplicationService == nil {
 		return "", &util.JSONResponse{
 			Code: 401,
 			JSON: jsonerror.UnknownToken("Supplied access_token does not match any known application service"),


### PR DESCRIPTION
Should return error if we didn't find an Application Service, not the other way around.

Reported by @APWhitehat