### PR TITLE
Implement transactions cache to ensure idempotency of sendEvents

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/clientapi.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/clientapi.go
@@ -20,6 +20,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/consumers"
 	"github.com/matrix-org/dendrite/clientapi/producers"
 	"github.com/matrix-org/dendrite/clientapi/routing"
+	"github.com/matrix-org/dendrite/clientapi/transactions"
 	"github.com/matrix-org/dendrite/common/basecomponent"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -37,6 +38,7 @@ func SetupClientAPIComponent(
 	aliasAPI api.RoomserverAliasAPI,
 	inputAPI api.RoomserverInputAPI,
 	queryAPI api.RoomserverQueryAPI,
+	transactionsCache *transactions.Cache,
 ) {
 	roomserverProducer := producers.NewRoomserverProducer(inputAPI)
 
@@ -62,5 +64,6 @@ func SetupClientAPIComponent(
 		queryAPI, aliasAPI, accountsDB, deviceDB,
 		federation, *keyRing,
 		userUpdateProducer, syncProducer,
+		transactionsCache,
 	)
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/transactions/transactions.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/transactions/transactions.go
@@ -1,0 +1,91 @@
+// Copyright 2018 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transactions
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/matrix-org/util"
+)
+
+// CleanupPeriod represents time in nanoseconds after which cacheCleanService runs.
+const CleanupPeriod time.Duration = 30 * time.Minute
+
+type response struct {
+	cache     *util.JSONResponse
+	cacheTime time.Time
+}
+
+// Cache represents a temporary store for responses.
+// This is used to ensure idempotency of requests.
+type Cache struct {
+	sync.RWMutex
+	txns map[string]response
+}
+
+// CreateCache creates and returns a initialized Cache object.
+// This cache is automatically cleaned every `CleanupPeriod`.
+func CreateCache() *Cache {
+	t := Cache{txns: make(map[string]response)}
+
+	// Start cleanup service as the Cache is created
+	go cacheCleanService(&t)
+
+	return &t
+}
+
+// FetchTransaction looks up response for txnID in Cache.
+// Returns a JSON response if txnID is found, which can be sent to client,
+// else returns error.
+func (t *Cache) FetchTransaction(txnID string) (*util.JSONResponse, error) {
+	t.RLock()
+	res, ok := t.txns[txnID]
+	t.RUnlock()
+
+	if ok {
+		return res.cache, nil
+	}
+
+	return nil, errors.New("TxnID not present")
+}
+
+// AddTransaction adds a response for txnID in Cache for later access.
+func (t *Cache) AddTransaction(txnID string, res *util.JSONResponse) {
+	t.Lock()
+	defer t.Unlock()
+	t.txns[txnID] = response{cache: res, cacheTime: time.Now()}
+}
+
+// cacheCleanService is responsible for cleaning up transactions older than 30 min.
+// It guarantees that a transaction will be present in cache for at least 30 min & at most 60 min.
+func cacheCleanService(t *Cache) {
+	for {
+		time.Sleep(CleanupPeriod)
+		go clean(t)
+	}
+}
+
+func clean(t *Cache) {
+	expire := time.Now().Add(-CleanupPeriod)
+	for key := range t.txns {
+		t.Lock()
+		if t.txns[key].cacheTime.Before(expire) {
+			delete(t.txns, key)
+		}
+		t.Unlock()
+	}
+}

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-client-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-client-api-server/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"github.com/matrix-org/dendrite/clientapi"
+	"github.com/matrix-org/dendrite/clientapi/transactions"
 	"github.com/matrix-org/dendrite/common/basecomponent"
 	"github.com/matrix-org/dendrite/common/keydb"
 )
@@ -33,10 +34,11 @@ func main() {
 	keyRing := keydb.CreateKeyRing(federation.Client, keyDB)
 
 	alias, input, query := base.CreateHTTPRoomserverAPIs()
+	txnCache := transactions.CreateCache()
 
 	clientapi.SetupClientAPIComponent(
 		base, deviceDB, accountDB, federation, &keyRing,
-		alias, input, query,
+		alias, input, query, txnCache,
 	)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Listen.ClientAPI))

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/matrix-org/dendrite/common/keydb"
 
 	"github.com/matrix-org/dendrite/clientapi"
+	"github.com/matrix-org/dendrite/clientapi/transactions"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/basecomponent"
 	"github.com/matrix-org/dendrite/federationapi"
@@ -51,8 +52,9 @@ func main() {
 	keyRing := keydb.CreateKeyRing(federation.Client, keyDB)
 
 	alias, input, query := roomserver.SetupRoomServerComponent(base)
+	txnCache := transactions.CreateCache()
 
-	clientapi.SetupClientAPIComponent(base, deviceDB, accountDB, federation, &keyRing, alias, input, query)
+	clientapi.SetupClientAPIComponent(base, deviceDB, accountDB, federation, &keyRing, alias, input, query, txnCache)
 	federationapi.SetupFederationAPIComponent(base, accountDB, federation, &keyRing, alias, input, query)
 	federationsender.SetupFederationSenderComponent(base, federation, query)
 	mediaapi.SetupMediaAPIComponent(base, deviceDB)


### PR DESCRIPTION
Fixes #327 .
This implements transactions cache, which is used to ensure idempotency of clientapi:`/rooms/{roomID}/send/{eventType}/{txnID}` .
This can be extended as required to other events with txnID.

@erikjohnston: How to proceed further ?