### PR TITLE
Explain gb test output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,10 @@ instance of dendrite, and [CODE_STYLE.md](CODE_STYLE.md) for the code style
 guide.
 
 We use `gb` for managing our dependencies, so `gb build` and `gb test` is how
-to build dendrite and run the unit tests respectively. There are [scripts](scripts)
-for [linting](scripts/find-lint.sh) and doing a [build/test/lint run](scripts/build-test-lint.sh).
+to build dendrite and run the unit tests respectively. Be aware that a list of
+all dendrite packages is the expected output for all tests succeeding with `gb
+test`. There are also [scripts](scripts) for [linting](scripts/find-lint.sh)
+and doing a [build/test/lint run](scripts/build-test-lint.sh).
 
 
 ## Picking Things To Do


### PR DESCRIPTION
`gb test`s output is confusing as it is similar to that of `gb build`.
Rather than building, it's actually running all the tests. If no output
past this shows, then all tests have succeeded.

Updates CONTRIBUTING.md to include a note about this.