### PR TITLE
Add login tests and a structure for /profile tests

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/routing/account_data.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/account_data.go
@@ -15,22 +15,26 @@
 package routing
 
 import (
+	"context"
 	"io/ioutil"
 	"net/http"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
-	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/clientapi/producers"
 	"github.com/matrix-org/gomatrixserverlib"
-
 	"github.com/matrix-org/util"
 )
 
+// interface for database layer
+type accountsData interface {
+	SaveAccountData(context.Context, string, string, string, string) error
+}
+
 // SaveAccountData implements PUT /user/{userId}/[rooms/{roomId}/]account_data/{type}
 func SaveAccountData(
-	req *http.Request, accountDB *accounts.Database, device *authtypes.Device,
+	req *http.Request, accountDB accountsData, device *authtypes.Device,
 	userID string, roomID string, dataType string, syncProducer *producers.SyncAPIProducer,
 ) util.JSONResponse {
 	if req.Method != "PUT" {

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/filter.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/filter.go
@@ -15,12 +15,11 @@
 package routing
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 
-	"encoding/json"
-
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
-	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/gomatrix"
@@ -28,9 +27,15 @@ import (
 	"github.com/matrix-org/util"
 )
 
+// interface to database layer
+type filterData interface {
+	GetFilter(context.Context, string, string) ([]byte, error)
+	PutFilter(context.Context, string, []byte) (string, error)
+}
+
 // GetFilter implements GET /_matrix/client/r0/user/{userId}/filter/{filterId}
 func GetFilter(
-	req *http.Request, device *authtypes.Device, accountDB *accounts.Database, userID string, filterID string,
+	req *http.Request, device *authtypes.Device, accountDB filterData, userID string, filterID string,
 ) util.JSONResponse {
 	if req.Method != http.MethodGet {
 		return util.JSONResponse{
@@ -77,7 +82,7 @@ type filterResponse struct {
 
 //PutFilter implements POST /_matrix/client/r0/user/{userId}/filter
 func PutFilter(
-	req *http.Request, device *authtypes.Device, accountDB *accounts.Database, userID string,
+	req *http.Request, device *authtypes.Device, accountDB filterData, userID string,
 ) util.JSONResponse {
 	if req.Method != http.MethodPost {
 		return util.JSONResponse{

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/joinroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/joinroom.go
@@ -15,13 +15,13 @@
 package routing
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
-	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/clientapi/producers"
@@ -32,6 +32,11 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 )
+
+// interface to Database
+type joinRoomData interface {
+	GetProfileByLocalpart(context.Context, string) (*authtypes.Profile, error)
+}
 
 // JoinRoomByIDOrAlias implements the "/join/{roomIDOrAlias}" API.
 // https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-join-roomidoralias
@@ -45,7 +50,7 @@ func JoinRoomByIDOrAlias(
 	queryAPI api.RoomserverQueryAPI,
 	aliasAPI api.RoomserverAliasAPI,
 	keyRing gomatrixserverlib.KeyRing,
-	accountDB *accounts.Database,
+	accountDB joinRoomData,
 ) util.JSONResponse {
 	var content map[string]interface{} // must be a JSON object
 	if resErr := httputil.UnmarshalJSONRequest(req, &content); resErr != nil {

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/login_test.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/login_test.go
@@ -1,0 +1,169 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"bytes"
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"encoding/json"
+	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"github.com/matrix-org/dendrite/common/config"
+)
+
+type MockAccountsDB struct{}
+type MockDevicesDB struct{}
+
+func (MockAccountsDB) GetAccountByPassword(context.Context, string, string) (*authtypes.Account, error) {
+	var fakeAccount = authtypes.Account{
+		"reguser:matrix.org",
+		"reguser",
+		"matrix.org",
+		&authtypes.Profile{},
+		"",
+	}
+	return &fakeAccount, nil
+}
+
+func (MockDevicesDB) CreateDevice(context.Context, string, *string, string, *string) (*authtypes.Device, error) {
+	var fakeDevice = authtypes.Device{
+		"fakedevices",
+		"requser:matrix.org",
+		"asikdhfkhdsafkjsdjkfasdf",
+	}
+	return &fakeDevice, nil
+}
+
+type InvalidAccountDB struct{}
+type InvalidDeviceDB struct{}
+type fakeErr struct{}
+
+func (fakeErr) Error() string { return "forced error" }
+
+func (InvalidAccountDB) GetAccountByPassword(context.Context, string, string) (*authtypes.Account, error) {
+	var err fakeErr
+	return nil, err
+}
+
+func (InvalidDeviceDB) CreateDevice(context.Context, string, *string, string, *string) (*authtypes.Device, error) {
+	var err fakeErr
+	return nil, err
+}
+
+var (
+	accountDB    = MockAccountsDB{}
+	deviceDB     = MockDevicesDB{}
+	BadAccountDB = InvalidAccountDB{}
+	BadDeviceDB  = InvalidDeviceDB{}
+	cfg          = config.Dendrite{}
+)
+
+type loginRequest struct {
+	User     string
+	Password string
+}
+
+// not sending the user at all
+func TestNoUserLogin(t *testing.T) {
+	u := loginRequest{"", "blahblah"}
+	b := new(bytes.Buffer)
+	json.NewEncoder(b).Encode(u)
+	req := httptest.NewRequest("POST", "https://api.com", b)
+	err := Login(req, accountDB, deviceDB, cfg).JSON.(*jsonerror.MatrixError).ErrCode
+	if err != "M_BAD_JSON" {
+		t.Error("No usern verification expected error_code 'M_BAD_JSON' got: ", err)
+	}
+}
+
+// sending invalid username
+func TestInvalidUsername(t *testing.T) {
+	cfg.Matrix.ServerName = "matrix.org"
+	u := loginRequest{"@minions", "blahblah"}
+	b := new(bytes.Buffer)
+	json.NewEncoder(b).Encode(u)
+	req := httptest.NewRequest("POST", "https://api.com", b)
+	err := Login(req, accountDB, deviceDB, cfg).JSON.(*jsonerror.MatrixError).ErrCode
+	if err != "M_INVALID_USERNAME" {
+		t.Error("invalid username verification, expected error_code 'M_INVALID_USERNAME' got: ", err)
+	}
+}
+
+// sending wrong servername in ID
+func TestInvalidServerName(t *testing.T) {
+	cfg.Matrix.ServerName = "matrix.org"
+	u := loginRequest{"@minions:notmatrix.org", "blahblah"}
+	b := new(bytes.Buffer)
+	json.NewEncoder(b).Encode(u)
+	req := httptest.NewRequest("POST", "https://api.com", b)
+	err := Login(req, accountDB, deviceDB, cfg).JSON.(*jsonerror.MatrixError).ErrCode
+	if err != "M_INVALID_USERNAME" {
+		t.Error("invalid servername verification, expected error_code 'M_INVALID_USERNAME' got: ", err)
+	}
+}
+
+// wrong username password
+func TestWrongUsernamePassword(t *testing.T) {
+	cfg.Matrix.ServerName = "matrix.org"
+	u := loginRequest{"@minions:matrix.org", "blahblah"}
+	b := new(bytes.Buffer)
+	json.NewEncoder(b).Encode(u)
+	req := httptest.NewRequest("POST", "https://api.com", b)
+	err := Login(req, BadAccountDB, deviceDB, cfg).JSON.(*jsonerror.MatrixError).ErrCode
+	if err != "M_FORBIDDEN" {
+		t.Error("wrong username password verification, expected error_code 'M_FORBIDDEN' got: ", err)
+	}
+}
+
+// devices database failure
+func TestDeviceNotCreated(t *testing.T) {
+	cfg.Matrix.ServerName = "matrix.org"
+	u := loginRequest{"minions", "blahblah"}
+	b := new(bytes.Buffer)
+	json.NewEncoder(b).Encode(u)
+	req := httptest.NewRequest("POST", "https://api.com", b)
+	err := Login(req, accountDB, BadDeviceDB, cfg).JSON.(*jsonerror.MatrixError).ErrCode
+	if err != "M_UNKNOWN" {
+		t.Error("device database failure verification, expected error_code 'M_UNKNOWN' got: ", err)
+	}
+}
+
+// login with userID
+func TestValidLoginviaUserID(t *testing.T) {
+	cfg.Matrix.ServerName = "matrix.org"
+	u := loginRequest{"@minions:matrix.org", "blahblah"}
+	b := new(bytes.Buffer)
+	json.NewEncoder(b).Encode(u)
+	req := httptest.NewRequest("POST", "https://api.com", b)
+	err := Login(req, accountDB, deviceDB, cfg).Code
+	if err != 200 {
+		t.Error("valid login via userID verification, expected http response code '200' got: ", err)
+	}
+}
+
+// login with username
+func TestValidLoginViaUsername(t *testing.T) {
+	cfg.Matrix.ServerName = "matrix.org"
+	u := loginRequest{"minions", "blahblah"}
+	b := new(bytes.Buffer)
+	json.NewEncoder(b).Encode(u)
+	req := httptest.NewRequest("POST", "https://api.com", b)
+	err := Login(req, accountDB, deviceDB, cfg).Code
+	if err != 200 {
+		t.Error("valid login verification via username, expected http response code '200' got: ", err)
+	}
+}

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/logout.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/logout.go
@@ -15,19 +15,25 @@
 package routing
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
-	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 )
 
+//interface to devices database layer
+type logoutDevicesData interface {
+	RemoveDevice(context.Context, string, string) error
+	RemoveAllDevices(context.Context, string) error
+}
+
 // Logout handles POST /logout
 func Logout(
-	req *http.Request, deviceDB *devices.Database, device *authtypes.Device,
+	req *http.Request, deviceDB logoutDevicesData, device *authtypes.Device,
 ) util.JSONResponse {
 	if req.Method != "POST" {
 		return util.JSONResponse{
@@ -53,7 +59,7 @@ func Logout(
 
 // LogoutAll handles POST /logout/all
 func LogoutAll(
-	req *http.Request, deviceDB *devices.Database, device *authtypes.Device,
+	req *http.Request, deviceDB logoutDevicesData, device *authtypes.Device,
 ) util.JSONResponse {
 	localpart, _, err := gomatrixserverlib.SplitID('@', device.UserID)
 	if err != nil {

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/profile_test.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/profile_test.go
@@ -1,0 +1,102 @@
+package routing
+
+import (
+	"context"
+	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"net/http/httptest"
+	"testing"
+)
+
+func (MockAccountsDB) GetProfileByLocalpart(context.Context, string) (*authtypes.Profile, error) {
+	return &authtypes.Profile{
+		"minions",
+		"minions",
+		"http://minion.org",
+	}, nil
+}
+
+func (MockAccountsDB) SetAvatarURL(context.Context, string, string) error {
+	return nil
+}
+
+func (MockAccountsDB) GetMembershipsByLocalpart(context.Context, string) ([]authtypes.Membership, error) {
+	return []authtypes.Membership{
+		{
+			"minions",
+			"despicable_me",
+			"mission_1",
+		},
+		{
+			"minions",
+			"despicable_me_2",
+			"mission_2",
+		},
+	}, nil
+}
+
+func (MockAccountsDB) SetDisplayName(context.Context, string, string) error {
+	return nil
+}
+
+func (InvalidAccountDB) GetProfileByLocalpart(context.Context, string) (*authtypes.Profile, error) {
+	var err fakeErr
+	return nil, err
+}
+
+func (InvalidAccountDB) SetAvatarURL(context.Context, string, string) error {
+	var err fakeErr
+	return err
+}
+
+func (InvalidAccountDB) GetMembershipsByLocalpart(context.Context, string) ([]authtypes.Membership, error) {
+	var err fakeErr
+	return nil, err
+}
+
+func (InvalidAccountDB) SetDisplayName(context.Context, string, string) error {
+	var err fakeErr
+	return err
+}
+
+// Post method
+func TestPostMethodProfile(t *testing.T) {
+	const userID = "@minions:matrix.org"
+	req := httptest.NewRequest("POST", "https://api.com", nil)
+	err := GetProfile(req, accountDB, userID).JSON.(*jsonerror.MatrixError).ErrCode
+	if err != "M_NOT_FOUND" {
+		t.Error("POST method verification expected error_code 'M_NOT_FOUND' got: ", err)
+	}
+}
+
+// invalid userID
+func TestInvalidUserID(t *testing.T) {
+	const userID = "@minimatrix"
+	req := httptest.NewRequest("GET", "https://api.com", nil)
+	err := GetProfile(req, accountDB, userID).Code
+	if err != 500 {
+		t.Error("invalid userID verification expected error_code '500' got: ", err)
+	}
+}
+
+// Database Error
+func TestDatabaseError(t *testing.T) {
+	const userID = "@minions:matrix.org"
+	req := httptest.NewRequest("GET", "https://api.com", nil)
+	err := GetProfile(req, BadAccountDB, userID).Code
+	if err != 500 {
+		t.Error("Database Error verification expected error_code '500' got: ", err)
+	}
+}
+
+// Valid Request
+func TestValidGetProfileRequest(t *testing.T) {
+	const userID = "@minions:matrix.org"
+	req := httptest.NewRequest("GET", "https://api.com", nil)
+	err := GetProfile(req, accountDB, userID).Code
+	if err != 200 {
+		t.Error("Valid GetProfile verification expected code '200' got: ", err)
+	}
+}
+
+// Todo write similar tests for other get and put functions

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/voip.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/voip.go
@@ -15,12 +15,11 @@
 package routing
 
 import (
-	"net/http"
-
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/base64"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"


### PR DESCRIPTION
added login unit tests. #410 
Added some of the /profile endpoint tests to give an idea of unit_tests :)
This PR is based on #423 which is the 1st commit listed below. (It can be reviewed separately in that PR)