### PR TITLE
Add AS support to common.MakeAuthAPI

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/auth/auth.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/auth.go
@@ -57,7 +57,7 @@ type Data struct {
 }
 
 // VerifyUserFromRequest authenticates the HTTP request,
-// on success returns UserID, Device of the requester.
+// on success returns Device of the requester.
 // Finds local user or an application service user.
 // Note: For an AS user, AS dummy device is returned.
 // On failure returns an JSON error response which can be sent to the client.

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/auth.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/auth.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/matrix-org/dendrite/appservice/types"
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
@@ -106,7 +107,7 @@ func VerifyUserFromRequest(
 			// Create a dummy device for AS user
 			dev := authtypes.Device{
 				// Use AS dummy device ID
-				ID: "AS_Device",
+				ID: types.AppServiceDeviceID,
 				// User the AS is masquerading as.
 				UserID: userID,
 				// AS dummy device has AS's token.

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -73,12 +73,12 @@ func Setup(
 	unstableMux := apiMux.PathPrefix(pathPrefixUnstable).Subrouter()
 
 	r0mux.Handle("/createRoom",
-		common.MakeAuthAPI("createRoom", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("createRoom", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			return CreateRoom(req, device, cfg, producer, accountDB, aliasAPI)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 	r0mux.Handle("/join/{roomIDOrAlias}",
-		common.MakeAuthAPI("join", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("join", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return JoinRoomByIDOrAlias(
 				req, device, vars["roomIDOrAlias"], cfg, federation, producer, queryAPI, aliasAPI, keyRing, accountDB,
@@ -86,19 +86,19 @@ func Setup(
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 	r0mux.Handle("/rooms/{roomID}/{membership:(?:join|kick|ban|unban|leave|invite)}",
-		common.MakeAuthAPI("membership", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("membership", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SendMembership(req, accountDB, device, vars["roomID"], vars["membership"], cfg, queryAPI, producer)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 	r0mux.Handle("/rooms/{roomID}/send/{eventType}",
-		common.MakeAuthAPI("send_message", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("send_message", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SendEvent(req, device, vars["roomID"], vars["eventType"], nil, nil, cfg, queryAPI, producer, nil)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 	r0mux.Handle("/rooms/{roomID}/send/{eventType}/{txnID}",
-		common.MakeAuthAPI("send_message", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("send_message", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			txnID := vars["txnID"]
 			return SendEvent(req, device, vars["roomID"], vars["eventType"], &txnID,
@@ -106,7 +106,7 @@ func Setup(
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 	r0mux.Handle("/rooms/{roomID}/state/{eventType:[^/]+/?}",
-		common.MakeAuthAPI("send_message", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("send_message", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			emptyString := ""
 			eventType := vars["eventType"]
@@ -118,7 +118,7 @@ func Setup(
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 	r0mux.Handle("/rooms/{roomID}/state/{eventType}/{stateKey}",
-		common.MakeAuthAPI("send_message", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("send_message", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			stateKey := vars["stateKey"]
 			return SendEvent(req, device, vars["roomID"], vars["eventType"], nil, &stateKey, cfg, queryAPI, producer, nil)
@@ -138,34 +138,34 @@ func Setup(
 	})).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/directory/room/{roomAlias}",
-		common.MakeAuthAPI("directory_room", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("directory_room", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return DirectoryRoom(req, vars["roomAlias"], federation, &cfg, aliasAPI)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/directory/room/{roomAlias}",
-		common.MakeAuthAPI("directory_room", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("directory_room", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SetLocalAlias(req, device, vars["roomAlias"], &cfg, aliasAPI)
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 
 	r0mux.Handle("/directory/room/{roomAlias}",
-		common.MakeAuthAPI("directory_room", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("directory_room", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return RemoveLocalAlias(req, device, vars["roomAlias"], aliasAPI)
 		}),
 	).Methods(http.MethodDelete, http.MethodOptions)
 
 	r0mux.Handle("/logout",
-		common.MakeAuthAPI("logout", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("logout", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			return Logout(req, deviceDB, device)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 
 	r0mux.Handle("/logout/all",
-		common.MakeAuthAPI("logout", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("logout", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			return LogoutAll(req, deviceDB, device)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
@@ -198,14 +198,14 @@ func Setup(
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/user/{userId}/filter",
-		common.MakeAuthAPI("put_filter", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("put_filter", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return PutFilter(req, device, accountDB, vars["userId"])
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 
 	r0mux.Handle("/user/{userId}/filter/{filterId}",
-		common.MakeAuthAPI("get_filter", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("get_filter", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return GetFilter(req, device, accountDB, vars["userId"], vars["filterId"])
 		}),
@@ -228,7 +228,7 @@ func Setup(
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/profile/{userID}/avatar_url",
-		common.MakeAuthAPI("profile_avatar_url", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("profile_avatar_url", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SetAvatarURL(req, accountDB, device, vars["userID"], userUpdateProducer, &cfg, producer, queryAPI)
 		}),
@@ -244,7 +244,7 @@ func Setup(
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/profile/{userID}/displayname",
-		common.MakeAuthAPI("profile_displayname", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("profile_displayname", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SetDisplayName(req, accountDB, device, vars["userID"], userUpdateProducer, &cfg, producer, queryAPI)
 		}),
@@ -253,19 +253,19 @@ func Setup(
 	// PUT requests, so we need to allow this method
 
 	r0mux.Handle("/account/3pid",
-		common.MakeAuthAPI("account_3pid", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("account_3pid", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			return GetAssociated3PIDs(req, accountDB, device)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/account/3pid",
-		common.MakeAuthAPI("account_3pid", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("account_3pid", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			return CheckAndSave3PIDAssociation(req, accountDB, device, cfg)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 
 	unstableMux.Handle("/account/3pid/delete",
-		common.MakeAuthAPI("account_3pid", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("account_3pid", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			return Forget3PID(req, accountDB)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
@@ -288,7 +288,7 @@ func Setup(
 	).Methods(http.MethodPut, http.MethodOptions)
 
 	r0mux.Handle("/voip/turnServer",
-		common.MakeAuthAPI("turn_server", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("turn_server", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			return RequestTurnServer(req, device, cfg)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
@@ -314,28 +314,28 @@ func Setup(
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/user/{userID}/account_data/{type}",
-		common.MakeAuthAPI("user_account_data", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("user_account_data", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SaveAccountData(req, accountDB, device, vars["userID"], "", vars["type"], syncProducer)
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 
 	r0mux.Handle("/user/{userID}/rooms/{roomID}/account_data/{type}",
-		common.MakeAuthAPI("user_account_data", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("user_account_data", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SaveAccountData(req, accountDB, device, vars["userID"], vars["roomID"], vars["type"], syncProducer)
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 
 	r0mux.Handle("/rooms/{roomID}/members",
-		common.MakeAuthAPI("rooms_members", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("rooms_members", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return GetMemberships(req, device, vars["roomID"], false, cfg, queryAPI)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/rooms/{roomID}/joined_members",
-		common.MakeAuthAPI("rooms_members", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("rooms_members", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return GetMemberships(req, device, vars["roomID"], true, cfg, queryAPI)
 		}),
@@ -356,20 +356,20 @@ func Setup(
 	).Methods(http.MethodPut, http.MethodOptions)
 
 	r0mux.Handle("/devices",
-		common.MakeAuthAPI("get_devices", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("get_devices", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			return GetDevicesByLocalpart(req, deviceDB, device)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/devices/{deviceID}",
-		common.MakeAuthAPI("get_device", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("get_device", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return GetDeviceByID(req, deviceDB, device, vars["deviceID"])
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/devices/{deviceID}",
-		common.MakeAuthAPI("device_data", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("device_data", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return UpdateDeviceByID(req, deviceDB, device, vars["deviceID"])
 		}),

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/matrix-org/dendrite/clientapi/auth"
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
@@ -72,13 +73,15 @@ func Setup(
 	v1mux := apiMux.PathPrefix(pathPrefixV1).Subrouter()
 	unstableMux := apiMux.PathPrefix(pathPrefixUnstable).Subrouter()
 
+	authData := auth.Data{accountDB, deviceDB, cfg.Derived.ApplicationServices}
+
 	r0mux.Handle("/createRoom",
-		common.MakeAuthAPI("createRoom", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("createRoom", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			return CreateRoom(req, device, cfg, producer, accountDB, aliasAPI)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 	r0mux.Handle("/join/{roomIDOrAlias}",
-		common.MakeAuthAPI("join", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("join", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return JoinRoomByIDOrAlias(
 				req, device, vars["roomIDOrAlias"], cfg, federation, producer, queryAPI, aliasAPI, keyRing, accountDB,
@@ -86,19 +89,19 @@ func Setup(
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 	r0mux.Handle("/rooms/{roomID}/{membership:(?:join|kick|ban|unban|leave|invite)}",
-		common.MakeAuthAPI("membership", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("membership", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SendMembership(req, accountDB, device, vars["roomID"], vars["membership"], cfg, queryAPI, producer)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 	r0mux.Handle("/rooms/{roomID}/send/{eventType}",
-		common.MakeAuthAPI("send_message", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("send_message", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SendEvent(req, device, vars["roomID"], vars["eventType"], nil, nil, cfg, queryAPI, producer, nil)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 	r0mux.Handle("/rooms/{roomID}/send/{eventType}/{txnID}",
-		common.MakeAuthAPI("send_message", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("send_message", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			txnID := vars["txnID"]
 			return SendEvent(req, device, vars["roomID"], vars["eventType"], &txnID,
@@ -106,7 +109,7 @@ func Setup(
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 	r0mux.Handle("/rooms/{roomID}/state/{eventType:[^/]+/?}",
-		common.MakeAuthAPI("send_message", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("send_message", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			emptyString := ""
 			eventType := vars["eventType"]
@@ -118,7 +121,7 @@ func Setup(
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 	r0mux.Handle("/rooms/{roomID}/state/{eventType}/{stateKey}",
-		common.MakeAuthAPI("send_message", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("send_message", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			stateKey := vars["stateKey"]
 			return SendEvent(req, device, vars["roomID"], vars["eventType"], nil, &stateKey, cfg, queryAPI, producer, nil)
@@ -138,34 +141,34 @@ func Setup(
 	})).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/directory/room/{roomAlias}",
-		common.MakeAuthAPI("directory_room", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("directory_room", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return DirectoryRoom(req, vars["roomAlias"], federation, &cfg, aliasAPI)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/directory/room/{roomAlias}",
-		common.MakeAuthAPI("directory_room", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("directory_room", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SetLocalAlias(req, device, vars["roomAlias"], &cfg, aliasAPI)
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 
 	r0mux.Handle("/directory/room/{roomAlias}",
-		common.MakeAuthAPI("directory_room", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("directory_room", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return RemoveLocalAlias(req, device, vars["roomAlias"], aliasAPI)
 		}),
 	).Methods(http.MethodDelete, http.MethodOptions)
 
 	r0mux.Handle("/logout",
-		common.MakeAuthAPI("logout", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("logout", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			return Logout(req, deviceDB, device)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 
 	r0mux.Handle("/logout/all",
-		common.MakeAuthAPI("logout", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("logout", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			return LogoutAll(req, deviceDB, device)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
@@ -198,14 +201,14 @@ func Setup(
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/user/{userId}/filter",
-		common.MakeAuthAPI("put_filter", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("put_filter", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return PutFilter(req, device, accountDB, vars["userId"])
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 
 	r0mux.Handle("/user/{userId}/filter/{filterId}",
-		common.MakeAuthAPI("get_filter", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("get_filter", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return GetFilter(req, device, accountDB, vars["userId"], vars["filterId"])
 		}),
@@ -228,7 +231,7 @@ func Setup(
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/profile/{userID}/avatar_url",
-		common.MakeAuthAPI("profile_avatar_url", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("profile_avatar_url", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SetAvatarURL(req, accountDB, device, vars["userID"], userUpdateProducer, &cfg, producer, queryAPI)
 		}),
@@ -244,7 +247,7 @@ func Setup(
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/profile/{userID}/displayname",
-		common.MakeAuthAPI("profile_displayname", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("profile_displayname", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SetDisplayName(req, accountDB, device, vars["userID"], userUpdateProducer, &cfg, producer, queryAPI)
 		}),
@@ -253,19 +256,19 @@ func Setup(
 	// PUT requests, so we need to allow this method
 
 	r0mux.Handle("/account/3pid",
-		common.MakeAuthAPI("account_3pid", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("account_3pid", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			return GetAssociated3PIDs(req, accountDB, device)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/account/3pid",
-		common.MakeAuthAPI("account_3pid", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("account_3pid", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			return CheckAndSave3PIDAssociation(req, accountDB, device, cfg)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 
 	unstableMux.Handle("/account/3pid/delete",
-		common.MakeAuthAPI("account_3pid", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("account_3pid", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			return Forget3PID(req, accountDB)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
@@ -288,7 +291,7 @@ func Setup(
 	).Methods(http.MethodPut, http.MethodOptions)
 
 	r0mux.Handle("/voip/turnServer",
-		common.MakeAuthAPI("turn_server", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("turn_server", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			return RequestTurnServer(req, device, cfg)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
@@ -314,28 +317,28 @@ func Setup(
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/user/{userID}/account_data/{type}",
-		common.MakeAuthAPI("user_account_data", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("user_account_data", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SaveAccountData(req, accountDB, device, vars["userID"], "", vars["type"], syncProducer)
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 
 	r0mux.Handle("/user/{userID}/rooms/{roomID}/account_data/{type}",
-		common.MakeAuthAPI("user_account_data", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("user_account_data", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SaveAccountData(req, accountDB, device, vars["userID"], vars["roomID"], vars["type"], syncProducer)
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 
 	r0mux.Handle("/rooms/{roomID}/members",
-		common.MakeAuthAPI("rooms_members", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("rooms_members", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return GetMemberships(req, device, vars["roomID"], false, cfg, queryAPI)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/rooms/{roomID}/joined_members",
-		common.MakeAuthAPI("rooms_members", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("rooms_members", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return GetMemberships(req, device, vars["roomID"], true, cfg, queryAPI)
 		}),
@@ -356,20 +359,20 @@ func Setup(
 	).Methods(http.MethodPut, http.MethodOptions)
 
 	r0mux.Handle("/devices",
-		common.MakeAuthAPI("get_devices", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("get_devices", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			return GetDevicesByLocalpart(req, deviceDB, device)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/devices/{deviceID}",
-		common.MakeAuthAPI("get_device", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("get_device", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return GetDeviceByID(req, deviceDB, device, vars["deviceID"])
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/devices/{deviceID}",
-		common.MakeAuthAPI("device_data", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("device_data", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return UpdateDeviceByID(req, deviceDB, device, vars["deviceID"])
 		}),

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -73,12 +73,12 @@ func Setup(
 	unstableMux := apiMux.PathPrefix(pathPrefixUnstable).Subrouter()
 
 	r0mux.Handle("/createRoom",
-		common.MakeAuthAPI("createRoom", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("createRoom", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			return CreateRoom(req, device, cfg, producer, accountDB, aliasAPI)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 	r0mux.Handle("/join/{roomIDOrAlias}",
-		common.MakeAuthAPI("join", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("join", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return JoinRoomByIDOrAlias(
 				req, device, vars["roomIDOrAlias"], cfg, federation, producer, queryAPI, aliasAPI, keyRing, accountDB,
@@ -86,19 +86,19 @@ func Setup(
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 	r0mux.Handle("/rooms/{roomID}/{membership:(?:join|kick|ban|unban|leave|invite)}",
-		common.MakeAuthAPI("membership", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("membership", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SendMembership(req, accountDB, device, vars["roomID"], vars["membership"], cfg, queryAPI, producer)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 	r0mux.Handle("/rooms/{roomID}/send/{eventType}",
-		common.MakeAuthAPI("send_message", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("send_message", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SendEvent(req, device, vars["roomID"], vars["eventType"], nil, nil, cfg, queryAPI, producer, nil)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 	r0mux.Handle("/rooms/{roomID}/send/{eventType}/{txnID}",
-		common.MakeAuthAPI("send_message", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("send_message", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			txnID := vars["txnID"]
 			return SendEvent(req, device, vars["roomID"], vars["eventType"], &txnID,
@@ -106,7 +106,7 @@ func Setup(
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 	r0mux.Handle("/rooms/{roomID}/state/{eventType:[^/]+/?}",
-		common.MakeAuthAPI("send_message", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("send_message", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			emptyString := ""
 			eventType := vars["eventType"]
@@ -118,7 +118,7 @@ func Setup(
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 	r0mux.Handle("/rooms/{roomID}/state/{eventType}/{stateKey}",
-		common.MakeAuthAPI("send_message", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("send_message", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			stateKey := vars["stateKey"]
 			return SendEvent(req, device, vars["roomID"], vars["eventType"], nil, &stateKey, cfg, queryAPI, producer, nil)
@@ -138,34 +138,34 @@ func Setup(
 	})).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/directory/room/{roomAlias}",
-		common.MakeAuthAPI("directory_room", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("directory_room", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return DirectoryRoom(req, vars["roomAlias"], federation, &cfg, aliasAPI)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/directory/room/{roomAlias}",
-		common.MakeAuthAPI("directory_room", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("directory_room", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SetLocalAlias(req, device, vars["roomAlias"], &cfg, aliasAPI)
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 
 	r0mux.Handle("/directory/room/{roomAlias}",
-		common.MakeAuthAPI("directory_room", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("directory_room", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return RemoveLocalAlias(req, device, vars["roomAlias"], aliasAPI)
 		}),
 	).Methods(http.MethodDelete, http.MethodOptions)
 
 	r0mux.Handle("/logout",
-		common.MakeAuthAPI("logout", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("logout", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			return Logout(req, deviceDB, device)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 
 	r0mux.Handle("/logout/all",
-		common.MakeAuthAPI("logout", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("logout", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			return LogoutAll(req, deviceDB, device)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
@@ -198,14 +198,14 @@ func Setup(
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/user/{userId}/filter",
-		common.MakeAuthAPI("put_filter", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("put_filter", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return PutFilter(req, device, accountDB, vars["userId"])
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 
 	r0mux.Handle("/user/{userId}/filter/{filterId}",
-		common.MakeAuthAPI("get_filter", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("get_filter", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return GetFilter(req, device, accountDB, vars["userId"], vars["filterId"])
 		}),
@@ -228,7 +228,7 @@ func Setup(
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/profile/{userID}/avatar_url",
-		common.MakeAuthAPI("profile_avatar_url", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("profile_avatar_url", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SetAvatarURL(req, accountDB, device, vars["userID"], userUpdateProducer, &cfg, producer, queryAPI)
 		}),
@@ -244,7 +244,7 @@ func Setup(
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/profile/{userID}/displayname",
-		common.MakeAuthAPI("profile_displayname", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("profile_displayname", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SetDisplayName(req, accountDB, device, vars["userID"], userUpdateProducer, &cfg, producer, queryAPI)
 		}),
@@ -253,19 +253,19 @@ func Setup(
 	// PUT requests, so we need to allow this method
 
 	r0mux.Handle("/account/3pid",
-		common.MakeAuthAPI("account_3pid", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("account_3pid", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			return GetAssociated3PIDs(req, accountDB, device)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/account/3pid",
-		common.MakeAuthAPI("account_3pid", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("account_3pid", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			return CheckAndSave3PIDAssociation(req, accountDB, device, cfg)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 
 	unstableMux.Handle("/account/3pid/delete",
-		common.MakeAuthAPI("account_3pid", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("account_3pid", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			return Forget3PID(req, accountDB)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
@@ -288,7 +288,7 @@ func Setup(
 	).Methods(http.MethodPut, http.MethodOptions)
 
 	r0mux.Handle("/voip/turnServer",
-		common.MakeAuthAPI("turn_server", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("turn_server", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			return RequestTurnServer(req, device, cfg)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
@@ -314,28 +314,28 @@ func Setup(
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/user/{userID}/account_data/{type}",
-		common.MakeAuthAPI("user_account_data", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("user_account_data", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SaveAccountData(req, accountDB, device, vars["userID"], "", vars["type"], syncProducer)
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 
 	r0mux.Handle("/user/{userID}/rooms/{roomID}/account_data/{type}",
-		common.MakeAuthAPI("user_account_data", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("user_account_data", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return SaveAccountData(req, accountDB, device, vars["userID"], vars["roomID"], vars["type"], syncProducer)
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 
 	r0mux.Handle("/rooms/{roomID}/members",
-		common.MakeAuthAPI("rooms_members", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("rooms_members", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return GetMemberships(req, device, vars["roomID"], false, cfg, queryAPI)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/rooms/{roomID}/joined_members",
-		common.MakeAuthAPI("rooms_members", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("rooms_members", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return GetMemberships(req, device, vars["roomID"], true, cfg, queryAPI)
 		}),
@@ -356,20 +356,20 @@ func Setup(
 	).Methods(http.MethodPut, http.MethodOptions)
 
 	r0mux.Handle("/devices",
-		common.MakeAuthAPI("get_devices", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("get_devices", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			return GetDevicesByLocalpart(req, deviceDB, device)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/devices/{deviceID}",
-		common.MakeAuthAPI("get_device", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("get_device", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return GetDeviceByID(req, deviceDB, device, vars["deviceID"])
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/devices/{deviceID}",
-		common.MakeAuthAPI("device_data", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("device_data", accountDB, deviceDB, cfg.Derived.ApplicationServices, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return UpdateDeviceByID(req, deviceDB, device, vars["deviceID"])
 		}),

--- a/src/github.com/matrix-org/dendrite/common/httpapi.go
+++ b/src/github.com/matrix-org/dendrite/common/httpapi.go
@@ -17,20 +17,20 @@ import (
 // MakeAuthAPI turns a util.JSONRequestHandler function into an http.Handler which checks the access token in the request.
 func MakeAuthAPI(
 	metricsName string, accountDB auth.AccountDatabase, deviceDB auth.DeviceDatabase,
-	appServices []config.ApplicationService, f func(*http.Request, *authtypes.Device) util.JSONResponse) http.Handler {
+	appServices []config.ApplicationService, f func(*http.Request, string, *authtypes.Device) util.JSONResponse) http.Handler {
 	h := func(req *http.Request) util.JSONResponse {
-		_, userErr := auth.VerifyUserFromRequest(req, accountDB, deviceDB, appServices)
+		user, userErr := auth.VerifyUserFromRequest(req, accountDB, deviceDB, appServices)
 
 		if userErr != nil {
 			return *userErr
 		}
 		device, resErr := auth.VerifyAccessToken(req, deviceDB)
 
-		// AS virtual user do not have a device in database
+		// AS virtual users do not have a device in database
 		if resErr != nil {
-			return f(req, nil)
+			return f(req, user, nil)
 		}
-		return f(req, device)
+		return f(req, user, device)
 	}
 	return MakeExternalAPI(metricsName, h)
 }

--- a/src/github.com/matrix-org/dendrite/common/httpapi.go
+++ b/src/github.com/matrix-org/dendrite/common/httpapi.go
@@ -19,17 +19,12 @@ func MakeAuthAPI(
 	metricsName string, accountDB auth.AccountDatabase, deviceDB auth.DeviceDatabase,
 	appServices []config.ApplicationService, f func(*http.Request, string, *authtypes.Device) util.JSONResponse) http.Handler {
 	h := func(req *http.Request) util.JSONResponse {
-		user, userErr := auth.VerifyUserFromRequest(req, accountDB, deviceDB, appServices)
+		user, device, err := auth.VerifyUserFromRequest(req, accountDB, deviceDB, appServices)
 
-		if userErr != nil {
-			return *userErr
+		if err != nil {
+			return *err
 		}
-		device, resErr := auth.VerifyAccessToken(req, deviceDB)
-
-		// AS virtual users do not have a device in database
-		if resErr != nil {
-			return f(req, user, nil)
-		}
+		// device is nil for AS virtual users, as they do not have a device in database
 		return f(req, user, device)
 	}
 	return MakeExternalAPI(metricsName, h)

--- a/src/github.com/matrix-org/dendrite/mediaapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/mediaapi/routing/routing.go
@@ -49,7 +49,7 @@ func Setup(
 	// TODO: Add AS support
 	r0mux.Handle("/upload", common.MakeAuthAPI(
 		"upload", nil, deviceDB, nil,
-		func(req *http.Request, _ *authtypes.Device) util.JSONResponse {
+		func(req *http.Request, _ string, _ *authtypes.Device) util.JSONResponse {
 			return Upload(req, cfg, db, activeThumbnailGeneration)
 		},
 	)).Methods(http.MethodPost, http.MethodOptions)

--- a/src/github.com/matrix-org/dendrite/mediaapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/mediaapi/routing/routing.go
@@ -46,9 +46,9 @@ func Setup(
 		PathToResult: map[string]*types.ThumbnailGenerationResult{},
 	}
 
+	// TODO: Add AS support
 	r0mux.Handle("/upload", common.MakeAuthAPI(
-		"upload",
-		deviceDB,
+		"upload", nil, deviceDB, nil,
 		func(req *http.Request, _ *authtypes.Device) util.JSONResponse {
 			return Upload(req, cfg, db, activeThumbnailGeneration)
 		},

--- a/src/github.com/matrix-org/dendrite/mediaapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/mediaapi/routing/routing.go
@@ -17,6 +17,7 @@ package routing
 import (
 	"net/http"
 
+	"github.com/matrix-org/dendrite/clientapi/auth"
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 
 	"github.com/gorilla/mux"
@@ -45,11 +46,12 @@ func Setup(
 	activeThumbnailGeneration := &types.ActiveThumbnailGeneration{
 		PathToResult: map[string]*types.ThumbnailGenerationResult{},
 	}
+	authData := auth.Data{nil, deviceDB, nil}
 
 	// TODO: Add AS support
 	r0mux.Handle("/upload", common.MakeAuthAPI(
-		"upload", nil, deviceDB, nil,
-		func(req *http.Request, _ string, _ *authtypes.Device) util.JSONResponse {
+		"upload", authData,
+		func(req *http.Request, _ *authtypes.Device) util.JSONResponse {
 			return Upload(req, cfg, db, activeThumbnailGeneration)
 		},
 	)).Methods(http.MethodPost, http.MethodOptions)

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/routing/routing.go
@@ -39,7 +39,7 @@ func Setup(apiMux *mux.Router, deviceDB *devices.Database, publicRoomsDB *storag
 	).Methods(http.MethodGet, http.MethodOptions)
 	// TODO: Add AS support
 	r0mux.Handle("/directory/list/room/{roomID}",
-		common.MakeAuthAPI("directory_list", nil, deviceDB, nil, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("directory_list", nil, deviceDB, nil, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return directory.SetVisibility(req, publicRoomsDB, vars["roomID"])
 		}),

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/routing/routing.go
@@ -37,8 +37,9 @@ func Setup(apiMux *mux.Router, deviceDB *devices.Database, publicRoomsDB *storag
 			return directory.GetVisibility(req, publicRoomsDB, vars["roomID"])
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
+	// TODO: Add AS support
 	r0mux.Handle("/directory/list/room/{roomID}",
-		common.MakeAuthAPI("directory_list", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("directory_list", nil, deviceDB, nil, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return directory.SetVisibility(req, publicRoomsDB, vars["roomID"])
 		}),

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/routing/routing.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/matrix-org/dendrite/clientapi/auth"
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
 	"github.com/matrix-org/dendrite/common"
@@ -31,6 +32,9 @@ const pathPrefixR0 = "/_matrix/client/r0"
 // Setup configures the given mux with publicroomsapi server listeners
 func Setup(apiMux *mux.Router, deviceDB *devices.Database, publicRoomsDB *storage.PublicRoomsServerDatabase) {
 	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
+
+	authData := auth.Data{nil, deviceDB, nil}
+
 	r0mux.Handle("/directory/list/room/{roomID}",
 		common.MakeExternalAPI("directory_list", func(req *http.Request) util.JSONResponse {
 			vars := mux.Vars(req)
@@ -39,7 +43,7 @@ func Setup(apiMux *mux.Router, deviceDB *devices.Database, publicRoomsDB *storag
 	).Methods(http.MethodGet, http.MethodOptions)
 	// TODO: Add AS support
 	r0mux.Handle("/directory/list/room/{roomID}",
-		common.MakeAuthAPI("directory_list", nil, deviceDB, nil, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+		common.MakeAuthAPI("directory_list", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return directory.SetVisibility(req, publicRoomsDB, vars["roomID"])
 		}),

--- a/src/github.com/matrix-org/dendrite/syncapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/routing/routing.go
@@ -33,21 +33,21 @@ func Setup(apiMux *mux.Router, srp *sync.RequestPool, syncDB *storage.SyncServer
 	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
 
 	// TODO: Add AS support for all handlers below.
-	r0mux.Handle("/sync", common.MakeAuthAPI("sync", nil, deviceDB, nil, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+	r0mux.Handle("/sync", common.MakeAuthAPI("sync", nil, deviceDB, nil, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 		return srp.OnIncomingSyncRequest(req, device)
 	})).Methods(http.MethodGet, http.MethodOptions)
 
-	r0mux.Handle("/rooms/{roomID}/state", common.MakeAuthAPI("room_state", nil, deviceDB, nil, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+	r0mux.Handle("/rooms/{roomID}/state", common.MakeAuthAPI("room_state", nil, deviceDB, nil, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 		vars := mux.Vars(req)
 		return OnIncomingStateRequest(req, syncDB, vars["roomID"])
 	})).Methods(http.MethodGet, http.MethodOptions)
 
-	r0mux.Handle("/rooms/{roomID}/state/{type}", common.MakeAuthAPI("room_state", nil, deviceDB, nil, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+	r0mux.Handle("/rooms/{roomID}/state/{type}", common.MakeAuthAPI("room_state", nil, deviceDB, nil, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 		vars := mux.Vars(req)
 		return OnIncomingStateTypeRequest(req, syncDB, vars["roomID"], vars["type"], "")
 	})).Methods(http.MethodGet, http.MethodOptions)
 
-	r0mux.Handle("/rooms/{roomID}/state/{type}/{stateKey}", common.MakeAuthAPI("room_state", nil, deviceDB, nil, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+	r0mux.Handle("/rooms/{roomID}/state/{type}/{stateKey}", common.MakeAuthAPI("room_state", nil, deviceDB, nil, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
 		vars := mux.Vars(req)
 		return OnIncomingStateTypeRequest(req, syncDB, vars["roomID"], vars["type"], vars["stateKey"])
 	})).Methods(http.MethodGet, http.MethodOptions)

--- a/src/github.com/matrix-org/dendrite/syncapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/routing/routing.go
@@ -32,21 +32,22 @@ const pathPrefixR0 = "/_matrix/client/r0"
 func Setup(apiMux *mux.Router, srp *sync.RequestPool, syncDB *storage.SyncServerDatabase, deviceDB *devices.Database) {
 	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
 
-	r0mux.Handle("/sync", common.MakeAuthAPI("sync", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+	// TODO: Add AS support for all handlers below.
+	r0mux.Handle("/sync", common.MakeAuthAPI("sync", nil, deviceDB, nil, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 		return srp.OnIncomingSyncRequest(req, device)
 	})).Methods(http.MethodGet, http.MethodOptions)
 
-	r0mux.Handle("/rooms/{roomID}/state", common.MakeAuthAPI("room_state", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+	r0mux.Handle("/rooms/{roomID}/state", common.MakeAuthAPI("room_state", nil, deviceDB, nil, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 		vars := mux.Vars(req)
 		return OnIncomingStateRequest(req, syncDB, vars["roomID"])
 	})).Methods(http.MethodGet, http.MethodOptions)
 
-	r0mux.Handle("/rooms/{roomID}/state/{type}", common.MakeAuthAPI("room_state", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+	r0mux.Handle("/rooms/{roomID}/state/{type}", common.MakeAuthAPI("room_state", nil, deviceDB, nil, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 		vars := mux.Vars(req)
 		return OnIncomingStateTypeRequest(req, syncDB, vars["roomID"], vars["type"], "")
 	})).Methods(http.MethodGet, http.MethodOptions)
 
-	r0mux.Handle("/rooms/{roomID}/state/{type}/{stateKey}", common.MakeAuthAPI("room_state", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+	r0mux.Handle("/rooms/{roomID}/state/{type}/{stateKey}", common.MakeAuthAPI("room_state", nil, deviceDB, nil, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 		vars := mux.Vars(req)
 		return OnIncomingStateTypeRequest(req, syncDB, vars["roomID"], vars["type"], vars["stateKey"])
 	})).Methods(http.MethodGet, http.MethodOptions)

--- a/src/github.com/matrix-org/dendrite/syncapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/routing/routing.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/matrix-org/dendrite/clientapi/auth"
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
 	"github.com/matrix-org/dendrite/common"
@@ -32,22 +33,24 @@ const pathPrefixR0 = "/_matrix/client/r0"
 func Setup(apiMux *mux.Router, srp *sync.RequestPool, syncDB *storage.SyncServerDatabase, deviceDB *devices.Database) {
 	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
 
+	authData := auth.Data{nil, deviceDB, nil}
+
 	// TODO: Add AS support for all handlers below.
-	r0mux.Handle("/sync", common.MakeAuthAPI("sync", nil, deviceDB, nil, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+	r0mux.Handle("/sync", common.MakeAuthAPI("sync", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 		return srp.OnIncomingSyncRequest(req, device)
 	})).Methods(http.MethodGet, http.MethodOptions)
 
-	r0mux.Handle("/rooms/{roomID}/state", common.MakeAuthAPI("room_state", nil, deviceDB, nil, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+	r0mux.Handle("/rooms/{roomID}/state", common.MakeAuthAPI("room_state", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 		vars := mux.Vars(req)
 		return OnIncomingStateRequest(req, syncDB, vars["roomID"])
 	})).Methods(http.MethodGet, http.MethodOptions)
 
-	r0mux.Handle("/rooms/{roomID}/state/{type}", common.MakeAuthAPI("room_state", nil, deviceDB, nil, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+	r0mux.Handle("/rooms/{roomID}/state/{type}", common.MakeAuthAPI("room_state", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 		vars := mux.Vars(req)
 		return OnIncomingStateTypeRequest(req, syncDB, vars["roomID"], vars["type"], "")
 	})).Methods(http.MethodGet, http.MethodOptions)
 
-	r0mux.Handle("/rooms/{roomID}/state/{type}/{stateKey}", common.MakeAuthAPI("room_state", nil, deviceDB, nil, func(req *http.Request, user string, device *authtypes.Device) util.JSONResponse {
+	r0mux.Handle("/rooms/{roomID}/state/{type}/{stateKey}", common.MakeAuthAPI("room_state", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 		vars := mux.Vars(req)
 		return OnIncomingStateTypeRequest(req, syncDB, vars["roomID"], vars["type"], vars["stateKey"])
 	})).Methods(http.MethodGet, http.MethodOptions)


### PR DESCRIPTION
 * Integrate #433 into `common.MakeAuthAPI`
* Update `clientapi.routing` to utilize the AS support.
* Make other Components work ok with the new `common.MakeAuthAPI`, Add "TODO" to help their migration.