### PR TITLE
Add app service authentication functions

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/auth/auth.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/auth.go
@@ -42,7 +42,7 @@ type DeviceDatabase interface {
 	GetDeviceByAccessToken(ctx context.Context, token string) (*authtypes.Device, error)
 }
 
-// AccountDatabase represents a account database.
+// AccountDatabase represents an account database.
 type AccountDatabase interface {
 	// Look up the account matching the given localpart.
 	GetAccountByLocalpart(ctx context.Context, localpart string) (*authtypes.Account, error)

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/auth.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/auth.go
@@ -27,6 +27,8 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"github.com/matrix-org/dendrite/clientapi/userutil"
+	"github.com/matrix-org/dendrite/common/config"
 	"github.com/matrix-org/util"
 )
 
@@ -34,13 +36,81 @@ import (
 // 32 bytes => 256 bits
 var tokenByteLength = 32
 
-// The length of generated device IDs
-var deviceIDByteLength = 6
-
 // DeviceDatabase represents a device database.
 type DeviceDatabase interface {
 	// Look up the device matching the given access token.
 	GetDeviceByAccessToken(ctx context.Context, token string) (*authtypes.Device, error)
+}
+
+// AccountDatabase represents a account database.
+type AccountDatabase interface {
+	// Look up the account matching the given localpart.
+	GetAccountByLocalpart(ctx context.Context, localpart string) (*authtypes.Account, error)
+}
+
+// VerifyUserFromRequest authenticates the HTTP request,
+// on success returns UserID of the requester.
+// Finds local user or an application service user.
+// On failure returns an JSON error response which can be sent to the client.
+func VerifyUserFromRequest(
+	req *http.Request, accountDB AccountDatabase, deviceDB DeviceDatabase,
+	applicationServices []config.ApplicationService,
+) (string, *util.JSONResponse) {
+	// Try to find local user from device database
+	dev, devErr := VerifyAccessToken(req, deviceDB)
+
+	if devErr == nil {
+		return dev.UserID, nil
+	}
+
+	// Try to find the Application Service user
+	token, err := extractAccessToken(req)
+
+	if err != nil {
+		return "", &util.JSONResponse{
+			Code: http.StatusUnauthorized,
+			JSON: jsonerror.MissingToken(err.Error()),
+		}
+	}
+
+	// Search for app service with given access_token
+	var appService *config.ApplicationService
+	for _, as := range applicationServices {
+		if as.ASToken == token {
+			appService = &as
+			break
+		}
+	}
+
+	if appService != nil {
+		userID := req.URL.Query().Get("user_id")
+		localpart, err := userutil.ParseUsernameParam(userID, nil)
+
+		if err != nil {
+			return "", &util.JSONResponse{
+				Code: http.StatusBadRequest,
+				JSON: jsonerror.InvalidUsername(err.Error()),
+			}
+		}
+
+		// Verify that the user is registered
+		account, accountErr := accountDB.GetAccountByLocalpart(req.Context(), localpart)
+
+		// Verify that account exists & appServiceID matches
+		if accountErr == nil && account.AppServiceID == appService.ID {
+			return userID, nil
+		}
+
+		return "", &util.JSONResponse{
+			Code: http.StatusForbidden,
+			JSON: jsonerror.Forbidden("Application service has not registered this user"),
+		}
+	}
+
+	return "", &util.JSONResponse{
+		Code: http.StatusUnauthorized,
+		JSON: jsonerror.UnknownToken("Unrecognized access token"),
+	}
 }
 
 // VerifyAccessToken verifies that an access token was supplied in the given HTTP request
@@ -75,18 +145,6 @@ func VerifyAccessToken(req *http.Request, deviceDB DeviceDatabase) (device *auth
 func GenerateAccessToken() (string, error) {
 	b := make([]byte, tokenByteLength)
 	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
-	// url-safe no padding
-	return base64.RawURLEncoding.EncodeToString(b), nil
-}
-
-// GenerateDeviceID creates a new device id. Returns an error if failed to generate
-// random bytes.
-func GenerateDeviceID() (string, error) {
-	b := make([]byte, deviceIDByteLength)
-	_, err := rand.Read(b)
-	if err != nil {
 		return "", err
 	}
 	// url-safe no padding

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/storage.go
@@ -358,3 +358,11 @@ func (d *Database) CheckAccountAvailability(ctx context.Context, localpart strin
 	}
 	return false, err
 }
+
+// GetAccountByLocalpart returns the account associated with the given localpart.
+// This function assumes the request is authenticated or the account data is used only internally.
+// Returns sql.ErrNoRows if no account exists which matches the given localpart.
+func (d *Database) GetAccountByLocalpart(ctx context.Context, localpart string,
+) (*authtypes.Account, error) {
+	return d.accounts.selectAccountByLocalpart(ctx, localpart)
+}


### PR DESCRIPTION
Add support for AS ?user= parameter in auth.
This is to be integrated with MakeAuthAPI in #427.

This includes changes made in #432.
Note: This was earlier part of #411.