### PR TITLE
Fix typo

### DIFF
--- a/src/github.com/matrix-org/dendrite/roomserver/input/membership.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/input/membership.go
@@ -81,7 +81,7 @@ func updateMemberships(
 			return nil, err
 		}
 	}
-	return nil, nil
+	return updates, nil
 }
 
 func updateMembership(


### PR DESCRIPTION
```
// Returns a list of output events to write to the kafka log to inform the
// consumers about the invites added or retired by the change in current state.
```
So we probably shouldn't return `nil` on success.