### PR TITLE
Fix typo and bug in /devices/{deviceID}

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/devices/devices_table.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/devices/devices_table.go
@@ -173,7 +173,7 @@ func (s *devicesStatements) selectDeviceByID(
 	ctx context.Context, localpart, deviceID string,
 ) (*authtypes.Device, error) {
 	var dev authtypes.Device
-	var created int64
+	var created sql.NullInt64
 	stmt := s.selectDeviceByIDStmt
 	err := stmt.QueryRowContext(ctx, localpart, deviceID).Scan(&created)
 	if err == nil {

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/device.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/device.go
@@ -40,7 +40,7 @@ type deviceUpdateJSON struct {
 	DisplayName *string `json:"display_name"`
 }
 
-// GetDeviceByID handles /device/{deviceID}
+// GetDeviceByID handles /devices/{deviceID}
 func GetDeviceByID(
 	req *http.Request, deviceDB *devices.Database, device *authtypes.Device,
 	deviceID string,

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -361,7 +361,7 @@ func Setup(
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
-	r0mux.Handle("/device/{deviceID}",
+	r0mux.Handle("/devices/{deviceID}",
 		common.MakeAuthAPI("get_device", deviceDB, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
 			return GetDeviceByID(req, deviceDB, device, vars["deviceID"])


### PR DESCRIPTION
"device" -> "devices"

Spec link: https://matrix.org/docs/spec/client_server/unstable.html#get-matrix-client-r0-devices-deviceid

Also use a sql.NullInt64 instead of an Int64 as that allows for values to
sometimes be null when pulling from a postgres table. Can result in
error otherwise.

Fixes #416 