### PR TITLE
Filter Roomserver Events Based on Application Service

### DIFF
--- a/src/github.com/matrix-org/dendrite/appservice/appservice.go
+++ b/src/github.com/matrix-org/dendrite/appservice/appservice.go
@@ -36,10 +36,10 @@ func SetupAppServiceAPIComponent(
 	transactionsCache *transactions.Cache,
 ) {
 	consumer := consumers.NewOutputRoomEventConsumer(
-		base.Cfg, base.KafkaConsumer, accountsDB, queryAPI,
+		base.Cfg, base.KafkaConsumer, accountsDB, queryAPI, aliasAPI,
 	)
 	if err := consumer.Start(); err != nil {
-		logrus.WithError(err).Panicf("failed to start app service's room server consumer")
+		logrus.WithError(err).Panicf("failed to start app service roomserver consumer")
 	}
 
 	// Set up HTTP Endpoints

--- a/src/github.com/matrix-org/dendrite/appservice/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/appservice/consumers/roomserver.go
@@ -17,6 +17,7 @@ package consumers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
 	"github.com/matrix-org/dendrite/common"
@@ -85,6 +86,7 @@ func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	}
 
 	ev := output.NewRoomEvent.Event
+	fmt.Println("got event", ev)
 	log.WithFields(log.Fields{
 		"event_id": ev.EventID(),
 		"room_id":  ev.RoomID(),

--- a/src/github.com/matrix-org/dendrite/appservice/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/appservice/consumers/roomserver.go
@@ -29,11 +29,16 @@ import (
 	sarama "gopkg.in/Shopify/sarama.v1"
 )
 
+var (
+	appServices []config.ApplicationService
+)
+
 // OutputRoomEventConsumer consumes events that originated in the room server.
 type OutputRoomEventConsumer struct {
 	roomServerConsumer *common.ContinualConsumer
 	db                 *accounts.Database
 	query              api.RoomserverQueryAPI
+	alias              api.RoomserverAliasAPI
 	serverName         string
 }
 
@@ -43,7 +48,9 @@ func NewOutputRoomEventConsumer(
 	kafkaConsumer sarama.Consumer,
 	store *accounts.Database,
 	queryAPI api.RoomserverQueryAPI,
+	aliasAPI api.RoomserverAliasAPI,
 ) *OutputRoomEventConsumer {
+	appServices = cfg.Derived.ApplicationServices
 
 	consumer := common.ContinualConsumer{
 		Topic:          string(cfg.Kafka.Topics.OutputRoomEvent),
@@ -54,6 +61,7 @@ func NewOutputRoomEventConsumer(
 		roomServerConsumer: &consumer,
 		db:                 store,
 		query:              queryAPI,
+		alias:              aliasAPI,
 		serverName:         string(cfg.Matrix.ServerName),
 	}
 	consumer.ProcessMessage = s.onMessage
@@ -86,7 +94,6 @@ func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	}
 
 	ev := output.NewRoomEvent.Event
-	fmt.Println("got event", ev)
 	log.WithFields(log.Fields{
 		"event_id": ev.EventID(),
 		"room_id":  ev.RoomID(),
@@ -98,7 +105,12 @@ func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 		return err
 	}
 
-	return s.db.UpdateMemberships(context.TODO(), events, output.NewRoomEvent.RemovesStateEventIDs)
+	if err = s.db.UpdateMemberships(context.TODO(), events, output.NewRoomEvent.RemovesStateEventIDs); err != nil {
+		return err
+	}
+
+	// Check if any events need to passed on to external application services
+	return s.filterRoomserverEvents(events)
 }
 
 // lookupStateEvents looks up the state events that are added by a new event.
@@ -143,4 +155,56 @@ func (s *OutputRoomEventConsumer) lookupStateEvents(
 	result = append(result, eventResp.Events...)
 
 	return result, nil
+}
+
+// filterRoomserverEvents takes in events and decides whether any of them need
+// to be passed on to an external application service. It does this by checking
+// each namespace of each registered application service, and if there is a
+// match, adds the event to the queue for events to be sent to a particular
+// application service.
+func (s *OutputRoomEventConsumer) filterRoomserverEvents(events []gomatrixserverlib.Event) error {
+	for _, event := range events {
+		for _, appservice := range appServices {
+			// Check if this event is interesting to this application service
+			if s.appserviceIsInterestedInEvent(event, appservice) {
+				// TODO: Queue this event to be sent off to the application service
+				fmt.Println(appservice.ID, "was interested in", event.Sender(), event.Type(), event.RoomID())
+			}
+		}
+	}
+
+	return nil
+}
+
+// appserviceIsInterestedInEvent returns a boolean depending on whether a given
+// event falls within one of a given application service's namespaces.
+func (s *OutputRoomEventConsumer) appserviceIsInterestedInEvent(event gomatrixserverlib.Event, appservice config.ApplicationService) bool {
+	// Check sender of the event
+	for _, userNamespace := range appservice.NamespaceMap["users"] {
+		if userNamespace.RegexpObject.MatchString(event.Sender()) {
+			return true
+		}
+	}
+
+	// Check room id of the event
+	for _, roomNamespace := range appservice.NamespaceMap["rooms"] {
+		if roomNamespace.RegexpObject.MatchString(event.RoomID()) {
+			return true
+		}
+	}
+
+	// Check all known room aliases of the room the event came from
+	queryReq := api.GetAliasesForRoomIDRequest{RoomID: event.RoomID()}
+	var queryRes api.GetAliasesForRoomIDResponse
+	if err := s.alias.GetAliasesForRoomID(context.TODO(), &queryReq, &queryRes); err == nil {
+		for _, alias := range queryRes.Aliases {
+			for _, aliasNamespace := range appservice.NamespaceMap["aliases"] {
+				if aliasNamespace.RegexpObject.MatchString(alias) {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
 }

--- a/src/github.com/matrix-org/dendrite/appservice/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/appservice/consumers/roomserver.go
@@ -110,7 +110,7 @@ func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	}
 
 	// Check if any events need to passed on to external application services
-	return s.filterRoomserverEvents(events)
+	return s.filterRoomserverEvents(append(events, ev))
 }
 
 // lookupStateEvents looks up the state events that are added by a new event.
@@ -204,6 +204,8 @@ func (s *OutputRoomEventConsumer) appserviceIsInterestedInEvent(event gomatrixse
 				}
 			}
 		}
+	} else {
+		log.WithError(err).Errorf("Unable to get aliases for Room with ID: %s", event.RoomID())
 	}
 
 	return false

--- a/src/github.com/matrix-org/dendrite/clientapi/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/consumers/roomserver.go
@@ -17,6 +17,7 @@ package consumers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
 	"github.com/matrix-org/dendrite/common"
@@ -85,6 +86,7 @@ func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	}
 
 	ev := output.NewRoomEvent.Event
+	fmt.Println("ClientAPI got an event:", ev)
 	log.WithFields(log.Fields{
 		"event_id": ev.EventID(),
 		"room_id":  ev.RoomID(),

--- a/src/github.com/matrix-org/dendrite/clientapi/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/consumers/roomserver.go
@@ -17,7 +17,6 @@ package consumers
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
 	"github.com/matrix-org/dendrite/common"
@@ -86,7 +85,6 @@ func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	}
 
 	ev := output.NewRoomEvent.Event
-	fmt.Println("ClientAPI got an event:", ev)
 	log.WithFields(log.Fields{
 		"event_id": ev.EventID(),
 		"room_id":  ev.RoomID(),

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/directory.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/directory.go
@@ -46,9 +46,9 @@ func DirectoryRoom(
 	var resp gomatrixserverlib.RespDirectory
 
 	if domain == cfg.Matrix.ServerName {
-		queryReq := api.GetAliasRoomIDRequest{Alias: roomAlias}
-		var queryRes api.GetAliasRoomIDResponse
-		if err = aliasAPI.GetAliasRoomID(req.Context(), &queryReq, &queryRes); err != nil {
+		queryReq := api.GetRoomIDForAliasRequest{Alias: roomAlias}
+		var queryRes api.GetRoomIDForAliasResponse
+		if err = aliasAPI.GetRoomIDForAlias(req.Context(), &queryReq, &queryRes); err != nil {
 			return httputil.LogThenError(req, err)
 		}
 

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/joinroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/joinroom.go
@@ -145,9 +145,9 @@ func (r joinRoomReq) joinRoomByAlias(roomAlias string) util.JSONResponse {
 		}
 	}
 	if domain == r.cfg.Matrix.ServerName {
-		queryReq := api.GetAliasRoomIDRequest{Alias: roomAlias}
-		var queryRes api.GetAliasRoomIDResponse
-		if err = r.aliasAPI.GetAliasRoomID(r.req.Context(), &queryReq, &queryRes); err != nil {
+		queryReq := api.GetRoomIDForAliasRequest{Alias: roomAlias}
+		var queryRes api.GetRoomIDForAliasResponse
+		if err = r.aliasAPI.GetRoomIDForAlias(r.req.Context(), &queryReq, &queryRes); err != nil {
 			return httputil.LogThenError(r.req, err)
 		}
 

--- a/src/github.com/matrix-org/dendrite/common/config/appservice.go
+++ b/src/github.com/matrix-org/dendrite/common/config/appservice.go
@@ -48,7 +48,8 @@ type ApplicationService struct {
 	HSToken string `yaml:"hs_token"`
 	// Localpart of application service user
 	SenderLocalpart string `yaml:"sender_localpart"`
-	// Information about an application service's namespaces
+	// Information about an application service's namespaces. Key is either
+	// "users", "aliases" or "rooms"
 	NamespaceMap map[string][]ApplicationServiceNamespace `yaml:"namespaces"`
 }
 
@@ -112,21 +113,28 @@ func setupRegexps(cfg *Dendrite) {
 	// Later we can check if a username or some other string matches any exclusive
 	// regex and deny access if it isn't from an application service
 	exclusiveUsernames := strings.Join(exclusiveUsernameStrings, "|")
+	exclusiveAliases := strings.Join(exclusiveAliasStrings, "|")
+	exclusiveRooms := strings.Join(exclusiveRoomStrings, "|")
 
-	// If there are no exclusive username regexes, compile string so that it
-	// will not match any valid usernames
+	// If there are no exclusive regexes, compile string so that it will not match
+	// any valid usernames/aliases/roomIDs
 	if exclusiveUsernames == "" {
 		exclusiveUsernames = "^$"
 	}
+	if exclusiveAliases == "" {
+		exclusiveAliases = "^$"
+	}
+	if exclusiveRooms == "" {
+		exclusiveRooms = "^$"
+	}
 
-	// TODO: Aliases and rooms. Needed?
-	//exclusiveAliases := strings.Join(exclusiveAliasStrings, "|")
-	//exclusiveRooms := strings.Join(exclusiveRoomStrings, "|")
-
+	// Store compiled Regex
 	cfg.Derived.ExclusiveApplicationServicesUsernameRegexp, _ = regexp.Compile(exclusiveUsernames)
+	cfg.Derived.ExclusiveApplicationServicesUsernameRegexp, _ = regexp.Compile(exclusiveAliases)
+	cfg.Derived.ExclusiveApplicationServicesUsernameRegexp, _ = regexp.Compile(exclusiveRooms)
 }
 
-// concatenateExclusiveNamespaces takes a slice of strings and a slice of
+// appendExclusiveNamespaceRegexs takes a slice of strings and a slice of
 // namespaces and will append the regexes of only the exclusive namespaces
 // into the string slice
 func appendExclusiveNamespaceRegexs(

--- a/src/github.com/matrix-org/dendrite/common/config/config.go
+++ b/src/github.com/matrix-org/dendrite/common/config/config.go
@@ -244,10 +244,8 @@ type Dendrite struct {
 		// When a user creates a room alias, we check that it isn't already
 		// reserved by an application service
 		ExclusiveApplicationServicesAliasRegexp *regexp.Regexp
-		// TODO: Huh? When a room ID is created, we block the client from
-		// creating it if it falls under an application service's exclusive
-		// roomID regex? But why tho
-		ExclusiveApplicationServicesRoomRegexp *regexp.Regexp
+		// Note: An Exclusive Regex for room ID isn't necessary as we aren't blocking
+		// servers from creating RoomIDs in exclusive application service namespaces
 	} `yaml:"-"`
 }
 

--- a/src/github.com/matrix-org/dendrite/common/config/config.go
+++ b/src/github.com/matrix-org/dendrite/common/config/config.go
@@ -30,7 +30,7 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ed25519"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 
 	jaegerconfig "github.com/uber/jaeger-client-go/config"
 	jaegermetrics "github.com/uber/jaeger-lib/metrics"
@@ -235,12 +235,19 @@ type Dendrite struct {
 		// The paths of which were given above in the main config file
 		ApplicationServices []ApplicationService
 
-		// A meta-regex compiled from all exclusive Application Service
-		// Regexes. When a user registers, we check that their username
-		// does not match any exclusive Application Service namespaces
+		// Meta-regexes compiled from all exclusive Application Service
+		// Regexes.
+		//
+		// When a user registers, we check that their username does not match any
+		// exclusive Application Service namespaces
 		ExclusiveApplicationServicesUsernameRegexp *regexp.Regexp
-
-		// TODO: Exclusive alias, room regexp's
+		// When a user creates a room alias, we check that it isn't already
+		// reserved by an application service
+		ExclusiveApplicationServicesAliasRegexp *regexp.Regexp
+		// TODO: Huh? When a room ID is created, we block the client from
+		// creating it if it falls under an application service's exclusive
+		// roomID regex? But why tho
+		ExclusiveApplicationServicesRoomRegexp *regexp.Regexp
 	} `yaml:"-"`
 }
 

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/query.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/query.go
@@ -52,9 +52,9 @@ func RoomAliasToID(
 	var resp gomatrixserverlib.RespDirectory
 
 	if domain == cfg.Matrix.ServerName {
-		queryReq := api.GetAliasRoomIDRequest{Alias: roomAlias}
-		var queryRes api.GetAliasRoomIDResponse
-		if err = aliasAPI.GetAliasRoomID(httpReq.Context(), &queryReq, &queryRes); err != nil {
+		queryReq := api.GetRoomIDForAliasRequest{Alias: roomAlias}
+		var queryRes api.GetRoomIDForAliasResponse
+		if err = aliasAPI.GetRoomIDForAlias(httpReq.Context(), &queryReq, &queryRes); err != nil {
 			return httputil.LogThenError(httpReq, err)
 		}
 

--- a/src/github.com/matrix-org/dendrite/roomserver/api/alias.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/api/alias.go
@@ -37,16 +37,28 @@ type SetRoomAliasResponse struct {
 	AliasExists bool `json:"alias_exists"`
 }
 
-// GetAliasRoomIDRequest is a request to GetAliasRoomID
-type GetAliasRoomIDRequest struct {
+// GetRoomIDForAliasRequest is a request to GetRoomIDForAlias
+type GetRoomIDForAliasRequest struct {
 	// Alias we want to lookup
 	Alias string `json:"alias"`
 }
 
-// GetAliasRoomIDResponse is a response to GetAliasRoomID
-type GetAliasRoomIDResponse struct {
+// GetRoomIDForAliasResponse is a response to GetRoomIDForAlias
+type GetRoomIDForAliasResponse struct {
 	// The room ID the alias refers to
 	RoomID string `json:"room_id"`
+}
+
+// GetAliasesForRoomIDRequest is a request to GetAliasesForRoomID
+type GetAliasesForRoomIDRequest struct {
+	// The room ID we want to find aliases for
+	RoomID string `json:"room_id"`
+}
+
+// GetAliasesForRoomIDResponse is a response to GetAliasesForRoomID
+type GetAliasesForRoomIDResponse struct {
+	// The aliases the alias refers to
+	Aliases []string `json:"aliases"`
 }
 
 // RemoveRoomAliasRequest is a request to RemoveRoomAlias
@@ -70,10 +82,17 @@ type RoomserverAliasAPI interface {
 	) error
 
 	// Get the room ID for an alias
-	GetAliasRoomID(
+	GetRoomIDForAlias(
 		ctx context.Context,
-		req *GetAliasRoomIDRequest,
-		response *GetAliasRoomIDResponse,
+		req *GetRoomIDForAliasRequest,
+		response *GetRoomIDForAliasResponse,
+	) error
+
+	// Get all known aliases for a room ID
+	GetAliasesForRoomID(
+		ctx context.Context,
+		req *GetAliasesForRoomIDRequest,
+		response *GetAliasesForRoomIDResponse,
 	) error
 
 	// Remove a room alias
@@ -87,8 +106,11 @@ type RoomserverAliasAPI interface {
 // RoomserverSetRoomAliasPath is the HTTP path for the SetRoomAlias API.
 const RoomserverSetRoomAliasPath = "/api/roomserver/setRoomAlias"
 
-// RoomserverGetAliasRoomIDPath is the HTTP path for the GetAliasRoomID API.
-const RoomserverGetAliasRoomIDPath = "/api/roomserver/getAliasRoomID"
+// RoomserverGetRoomIDForAliasPath is the HTTP path for the GetRoomIDForAlias API.
+const RoomserverGetRoomIDForAliasPath = "/api/roomserver/GetRoomIDForAlias"
+
+// RoomserverGetAliasesForRoomIDPath is the HTTP path for the GetAliasesForRoomID API.
+const RoomserverGetAliasesForRoomIDPath = "/api/roomserver/GetAliasesForRoomID"
 
 // RoomserverRemoveRoomAliasPath is the HTTP path for the RemoveRoomAlias API.
 const RoomserverRemoveRoomAliasPath = "/api/roomserver/removeRoomAlias"
@@ -120,16 +142,29 @@ func (h *httpRoomserverAliasAPI) SetRoomAlias(
 	return postJSON(ctx, span, h.httpClient, apiURL, request, response)
 }
 
-// GetAliasRoomID implements RoomserverAliasAPI
-func (h *httpRoomserverAliasAPI) GetAliasRoomID(
+// GetRoomIDForAlias implements RoomserverAliasAPI
+func (h *httpRoomserverAliasAPI) GetRoomIDForAlias(
 	ctx context.Context,
-	request *GetAliasRoomIDRequest,
-	response *GetAliasRoomIDResponse,
+	request *GetRoomIDForAliasRequest,
+	response *GetRoomIDForAliasResponse,
 ) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "GetAliasRoomID")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "GetRoomIDForAlias")
 	defer span.Finish()
 
-	apiURL := h.roomserverURL + RoomserverGetAliasRoomIDPath
+	apiURL := h.roomserverURL + RoomserverGetRoomIDForAliasPath
+	return postJSON(ctx, span, h.httpClient, apiURL, request, response)
+}
+
+// GetAliasesForRoomID implements RoomserverAliasAPI
+func (h *httpRoomserverAliasAPI) GetAliasesForRoomID(
+	ctx context.Context,
+	request *GetAliasesForRoomIDRequest,
+	response *GetAliasesForRoomIDResponse,
+) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "GetAliasesForRoomID")
+	defer span.Finish()
+
+	apiURL := h.roomserverURL + RoomserverGetAliasesForRoomIDPath
 	return postJSON(ctx, span, h.httpClient, apiURL, request, response)
 }
 

--- a/src/github.com/matrix-org/dendrite/roomserver/storage/storage.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/storage/storage.go
@@ -422,13 +422,13 @@ func (d *Database) SetRoomAlias(ctx context.Context, alias string, roomID string
 	return d.statements.insertRoomAlias(ctx, alias, roomID)
 }
 
-// GetRoomIDFromAlias implements alias.RoomserverAliasAPIDB
-func (d *Database) GetRoomIDFromAlias(ctx context.Context, alias string) (string, error) {
+// GetRoomIDForAlias implements alias.RoomserverAliasAPIDB
+func (d *Database) GetRoomIDForAlias(ctx context.Context, alias string) (string, error) {
 	return d.statements.selectRoomIDFromAlias(ctx, alias)
 }
 
-// GetAliasesFromRoomID implements alias.RoomserverAliasAPIDB
-func (d *Database) GetAliasesFromRoomID(ctx context.Context, roomID string) ([]string, error) {
+// GetAliasesForRoomID implements alias.RoomserverAliasAPIDB
+func (d *Database) GetAliasesForRoomID(ctx context.Context, roomID string) ([]string, error) {
 	return d.statements.selectAliasesFromRoomID(ctx, roomID)
 }
 


### PR DESCRIPTION
When Application Services are registered, they specify a number of namespaces (regexes based on userID, RoomID and Room Alias) for events that they want to know about. We pull these namespaces in at startup and compile their regex into Regexp objects, which we later use to quickly check if several properties of an incoming event match what a given application service wants.

Checking sender names and room IDs were quite simple as they are part of the event, however to get all the aliases of a room, a new aliasAPI was necessary. `GetAliasesForRoomID` was added for this, right alongside `GetRoomIDForAlias` which was renamed from its earlier quite vague name of `GetAliasRoomID`.

I believe this new alias API is the correct way to get aliases for a given RoomID, though a database query for Aliases from RoomID was already available, so let me know if this was already possible somehow and the new call isn't necessary.

At the moment it just prints out whether an app service was interested in an event or not, but the next step is to queue up that event and have a module batch and send them off to the appservice.