### PR TITLE
Prevent sql scanning into nil value in accounts_table

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/accounts_table.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/accounts_table.go
@@ -124,11 +124,11 @@ func (s *accountsStatements) selectPasswordHash(
 func (s *accountsStatements) selectAccountByLocalpart(
 	ctx context.Context, localpart string,
 ) (*authtypes.Account, error) {
-	var localpartPtr, appserviceIDPtr sql.NullString
+	var appserviceIDPtr sql.NullString
 	var acc authtypes.Account
 
 	stmt := s.selectAccountByLocalpartStmt
-	err := stmt.QueryRowContext(ctx, localpart).Scan(&localpartPtr, &appserviceIDPtr)
+	err := stmt.QueryRowContext(ctx, localpart).Scan(&acc.Localpart, &appserviceIDPtr)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/accounts_table.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/accounts_table.go
@@ -130,14 +130,15 @@ func (s *accountsStatements) selectAccountByLocalpart(
 	stmt := s.selectAccountByLocalpartStmt
 	err := stmt.QueryRowContext(ctx, localpart).Scan(&localpartPtr, &appserviceIDPtr)
 	if err != nil {
-		log.WithError(err).Error("Unable to retrieve user from the db")
+		switch err {
+		case sql.ErrNoRows:
+		default:
+			log.WithError(err).Error("Unable to retrieve user from the db")
+		}
 		return nil, err
 	}
 	if appserviceIDPtr.Valid {
 		acc.AppServiceID = appserviceIDPtr.String
-	}
-	if localpartPtr.Valid {
-		acc.Localpart = localpartPtr.String
 	}
 
 	acc.UserID = userutil.MakeUserID(localpart, s.serverName)

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/accounts_table.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/storage/accounts/accounts_table.go
@@ -130,9 +130,7 @@ func (s *accountsStatements) selectAccountByLocalpart(
 	stmt := s.selectAccountByLocalpartStmt
 	err := stmt.QueryRowContext(ctx, localpart).Scan(&acc.Localpart, &appserviceIDPtr)
 	if err != nil {
-		switch err {
-		case sql.ErrNoRows:
-		default:
+		if err != sql.ErrNoRows {
 			log.WithError(err).Error("Unable to retrieve user from the db")
 		}
 		return nil, err


### PR DESCRIPTION
acc was a null pointer. Dereferencing this causes problems, but not any that the compiler picked up.

This fixes login again. Also adds in some logging so that this doesn't just return an error to the client and nothing in the log.

Oh SyTest, where are you :)