### PR TITLE
 Prevent alias registration in AS exclusive namespace 

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/jsonerror/jsonerror.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/jsonerror/jsonerror.go
@@ -112,7 +112,8 @@ func UserInUse(msg string) *MatrixError {
 
 // ASExclusive is an error returned when an application service tries to
 // register an username that is outside of its registered namespace, or if a
-// user attempts to register a username within an exclusive namespace
+// user attempts to register a username or room alias within an exclusive
+// namespace.
 func ASExclusive(msg string) *MatrixError {
 	return &MatrixError{"M_EXCLUSIVE", msg}
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/createroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/createroom.go
@@ -146,6 +146,7 @@ func createRoom(req *http.Request, device *authtypes.Device,
 	// TODO: visibility/presets/raw initial state/creation content
 
 	// TODO: Create room alias association
+	// Make sure this doesn't fall into an application service's namespace though!
 
 	logger.WithFields(log.Fields{
 		"userID": userID,

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/directory.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/directory.go
@@ -113,6 +113,23 @@ func SetLocalAlias(
 		}
 	}
 
+	// Check that the alias does not fall within an exclusive namespace of an
+	// application service
+	for _, appservice := range cfg.Derived.ApplicationServices {
+		for key, namespaceMaps := range appservice.NamespaceMap {
+			if key == "aliases" {
+				for _, namespace := range namespaceMaps {
+					if namespace.Exclusive && namespace.RegexpObject.MatchString(alias) {
+						return util.JSONResponse{
+							Code: http.StatusBadRequest,
+							JSON: jsonerror.ASExclusive("Alias is reserved by an application service"),
+						}
+					}
+				}
+			}
+		}
+	}
+
 	var r struct {
 		RoomID string `json:"room_id"`
 	}

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/directory.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/directory.go
@@ -116,14 +116,12 @@ func SetLocalAlias(
 	// Check that the alias does not fall within an exclusive namespace of an
 	// application service
 	for _, appservice := range cfg.Derived.ApplicationServices {
-		for key, namespaceMaps := range appservice.NamespaceMap {
-			if key == "aliases" {
-				for _, namespace := range namespaceMaps {
-					if namespace.Exclusive && namespace.RegexpObject.MatchString(alias) {
-						return util.JSONResponse{
-							Code: http.StatusBadRequest,
-							JSON: jsonerror.ASExclusive("Alias is reserved by an application service"),
-						}
+		if userNamespaces, ok := appservice.NamespaceMap["users"]; ok {
+			for _, namespace := range userNamespaces {
+				if namespace.Exclusive && namespace.RegexpObject.MatchString(alias) {
+					return util.JSONResponse{
+						Code: http.StatusBadRequest,
+						JSON: jsonerror.ASExclusive("Alias is reserved by an application service"),
 					}
 				}
 			}

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
@@ -363,7 +363,7 @@ func validateApplicationService(
 	if !UsernameIsWithinApplicationServiceNamespace(cfg, username, matchedApplicationService) {
 		// If we didn't find any matches, return M_EXCLUSIVE
 		return "", &util.JSONResponse{
-			Code: http.StatusUnauthorized,
+			Code: http.StatusBadRequest,
 			JSON: jsonerror.ASExclusive(fmt.Sprintf(
 				"Supplied username %s did not match any namespaces for application service ID: %s", username, matchedApplicationService.ID)),
 		}
@@ -372,7 +372,7 @@ func validateApplicationService(
 	// Check this user does not fit multiple application service namespaces
 	if UsernameMatchesMultipleExclusiveNamespaces(cfg, username) {
 		return "", &util.JSONResponse{
-			Code: http.StatusUnauthorized,
+			Code: http.StatusBadRequest,
 			JSON: jsonerror.ASExclusive(fmt.Sprintf(
 				"Supplied username %s matches multiple exclusive application service namespaces. Only 1 match allowed", username)),
 		}


### PR DESCRIPTION
Fixes #451, includes fix from #479.

Users should not be allowed to create a room alias in an application service's exclusive namespace. We now return an `M_EXCLUSIVE` if they attempt to do so.

Also, according to the spec, `M_EXCLUSIVE` should return a status `400`, not a `403`.