### PR TITLE
Implement GET /rooms/{roomAlias}

### DIFF
--- a/src/github.com/matrix-org/dendrite/appservice/appservice.go
+++ b/src/github.com/matrix-org/dendrite/appservice/appservice.go
@@ -74,15 +74,13 @@ func SetupAppServiceAPIComponent(
 		}
 	}
 
-	// Create a HTTP client that this component will use for all outbound and
-	// inbound requests (inbound only for the internal API)
-	httpClient := &http.Client{
-		Timeout: time.Second * 30,
-	}
-
+	// Create appserivce query API with an HTTP client that will be used for all
+	// outbound and inbound requests (inbound only for the internal API)
 	appserviceQueryAPI := query.AppServiceQueryAPI{
-		HTTPClient: httpClient,
-		Cfg:        base.Cfg,
+		HTTPClient: &http.Client{
+			Timeout: time.Second * 30,
+		},
+		Cfg: base.Cfg,
 	}
 
 	appserviceQueryAPI.SetupHTTP(http.DefaultServeMux)

--- a/src/github.com/matrix-org/dendrite/appservice/consumers/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/appservice/consumers/roomserver.go
@@ -185,6 +185,7 @@ func (s *OutputRoomEventConsumer) appserviceIsInterestedInEvent(ctx context.Cont
 		return false
 	}
 
+	// Check Room ID and Sender of the event
 	if appservice.IsInterestedInUserID(event.Sender()) ||
 		appservice.IsInterestedInRoomID(event.RoomID()) {
 		return true

--- a/src/github.com/matrix-org/dendrite/appservice/query/query.go
+++ b/src/github.com/matrix-org/dendrite/appservice/query/query.go
@@ -18,6 +18,7 @@ package query
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -106,6 +107,12 @@ func (a *AppServiceQueryAPI) RoomAliasExists(
 func makeHTTPClient() *http.Client {
 	return &http.Client{
 		Timeout: time.Second * 30,
+		// TODO: Verify certificates
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, // nolint: gas
+			},
+		},
 	}
 }
 

--- a/src/github.com/matrix-org/dendrite/appservice/query/query.go
+++ b/src/github.com/matrix-org/dendrite/appservice/query/query.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
 
 	"github.com/matrix-org/dendrite/appservice/api"
 	"github.com/matrix-org/dendrite/common"
@@ -51,8 +52,9 @@ func (a *AppServiceQueryAPI) RoomAliasExists(
 	for _, appservice := range a.Cfg.Derived.ApplicationServices {
 		if appservice.URL != "" && appservice.IsInterestedInRoomAlias(request.Alias) {
 			// The full path to the rooms API, includes hs token
-			apiURL := appservice.URL +
-				remoteAppServiceRoomAliasExistsPath + request.Alias + "?access_token=" + appservice.HSToken
+			URL, err := url.Parse(appservice.URL)
+			URL.Path += request.Alias
+			apiURL := URL.String() + "?access_token=" + appservice.HSToken
 
 			// Send a request to each application service. If one responds that it has
 			// created the room, immediately return.

--- a/src/github.com/matrix-org/dendrite/appservice/query/query.go
+++ b/src/github.com/matrix-org/dendrite/appservice/query/query.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/matrix-org/dendrite/appservice/api"
 	"github.com/matrix-org/dendrite/common"
@@ -47,6 +48,11 @@ func (a *AppServiceQueryAPI) RoomAliasExists(
 ) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "ApplicationServiceRoomAlias")
 	defer span.Finish()
+
+	// Create an HTTP client if one does not already exist
+	if a.HTTPClient == nil {
+		a.HTTPClient = makeHTTPClient()
+	}
 
 	// Determine which application service should handle this request
 	for _, appservice := range a.Cfg.Derived.ApplicationServices {
@@ -94,6 +100,13 @@ func (a *AppServiceQueryAPI) RoomAliasExists(
 
 	response.AliasExists = false
 	return nil
+}
+
+// makeHTTPClient creates an HTTP client with certain options that will be used for all query requests to application services
+func makeHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout: time.Second * 30,
+	}
 }
 
 // SetupHTTP adds the AppServiceQueryPAI handlers to the http.ServeMux. This

--- a/src/github.com/matrix-org/dendrite/appservice/query/query.go
+++ b/src/github.com/matrix-org/dendrite/appservice/query/query.go
@@ -30,7 +30,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const remoteAppServiceRoomAliasExistsPath = "/rooms/"
+const roomAliasExistsPath = "/rooms/"
 
 // AppServiceQueryAPI is an implementation of api.AppServiceQueryAPI
 type AppServiceQueryAPI struct {
@@ -52,7 +52,7 @@ func (a *AppServiceQueryAPI) RoomAliasExists(
 	for _, appservice := range a.Cfg.Derived.ApplicationServices {
 		if appservice.URL != "" && appservice.IsInterestedInRoomAlias(request.Alias) {
 			// The full path to the rooms API, includes hs token
-			URL, err := url.Parse(appservice.URL)
+			URL, err := url.Parse(appservice.URL + roomAliasExistsPath)
 			URL.Path += request.Alias
 			apiURL := URL.String() + "?access_token=" + appservice.HSToken
 

--- a/src/github.com/matrix-org/dendrite/appservice/query/query.go
+++ b/src/github.com/matrix-org/dendrite/appservice/query/query.go
@@ -17,10 +17,19 @@
 package query
 
 import (
+	"context"
+	"encoding/json"
 	"net/http"
 
+	"github.com/matrix-org/dendrite/appservice/api"
+	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/config"
+	"github.com/matrix-org/util"
+	opentracing "github.com/opentracing/opentracing-go"
+	log "github.com/sirupsen/logrus"
 )
+
+const remoteAppServiceRoomAliasExistsPath = "/rooms/"
 
 // AppServiceQueryAPI is an implementation of api.AppServiceQueryAPI
 type AppServiceQueryAPI struct {
@@ -28,7 +37,78 @@ type AppServiceQueryAPI struct {
 	Cfg        *config.Dendrite
 }
 
+// RoomAliasExists performs a request to '/room/{roomAlias}' on all known
+// handling application services until one admits to owning the room
+func (a *AppServiceQueryAPI) RoomAliasExists(
+	ctx context.Context,
+	request *api.RoomAliasExistsRequest,
+	response *api.RoomAliasExistsResponse,
+) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "ApplicationServiceRoomAlias")
+	defer span.Finish()
+
+	// Determine which application service should handle this request
+	for _, appservice := range a.Cfg.Derived.ApplicationServices {
+		if appservice.URL != "" && appservice.IsInterestedInRoomAlias(request.Alias) {
+			// The full path to the rooms API, includes hs token
+			apiURL := appservice.URL +
+				remoteAppServiceRoomAliasExistsPath + request.Alias + "?access_token=" + appservice.HSToken
+
+			// Send a request to each application service. If one responds that it has
+			// created the room, immediately return.
+			req, err := http.NewRequest(http.MethodGet, apiURL, nil)
+			if err != nil {
+				return err
+			}
+			resp, err := a.HTTPClient.Do(req.WithContext(ctx))
+			if resp != nil {
+				defer func() {
+					err = resp.Body.Close()
+					if err != nil {
+						log.WithFields(log.Fields{
+							"appservice_id": appservice.ID,
+							"status_code":   resp.StatusCode,
+						}).Error("Unable to close application service response body")
+					}
+				}()
+			}
+			if err != nil {
+				log.WithError(err).Errorf("Issue querying room alias on application service %s", appservice.ID)
+				return err
+			}
+			if resp.StatusCode == http.StatusOK {
+				// StatusOK received from appservice. Room exists
+				response.AliasExists = true
+				return nil
+			}
+
+			// Log non OK
+			log.WithFields(log.Fields{
+				"appservice_id": appservice.ID,
+				"status_code":   resp.StatusCode,
+			}).Warn("Application service responded with non-OK status code")
+		}
+	}
+
+	response.AliasExists = false
+	return nil
+}
+
 // SetupHTTP adds the AppServiceQueryPAI handlers to the http.ServeMux. This
 // handles and muxes incoming api requests the to internal AppServiceQueryAPI.
 func (a *AppServiceQueryAPI) SetupHTTP(servMux *http.ServeMux) {
+	servMux.Handle(
+		api.AppServiceRoomAliasExistsPath,
+		common.MakeInternalAPI("appserviceRoomAliasExists", func(req *http.Request) util.JSONResponse {
+			var request api.RoomAliasExistsRequest
+			var response api.RoomAliasExistsResponse
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.ErrorResponse(err)
+			}
+			if err := a.RoomAliasExists(req.Context(), &request, &response); err != nil {
+				return util.ErrorResponse(err)
+			}
+			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
+		}),
+	)
 }

--- a/src/github.com/matrix-org/dendrite/appservice/query/query.go
+++ b/src/github.com/matrix-org/dendrite/appservice/query/query.go
@@ -69,7 +69,9 @@ func (a *AppServiceQueryAPI) RoomAliasExists(
 			if err != nil {
 				return err
 			}
-			resp, err := a.HTTPClient.Do(req.WithContext(ctx))
+			req := req.WithContent(ctx)
+
+			resp, err := a.HTTPClient.Do(req)
 			if resp != nil {
 				defer func() {
 					err = resp.Body.Close()

--- a/src/github.com/matrix-org/dendrite/appservice/query/query.go
+++ b/src/github.com/matrix-org/dendrite/appservice/query/query.go
@@ -18,7 +18,6 @@ package query
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -69,7 +68,7 @@ func (a *AppServiceQueryAPI) RoomAliasExists(
 			if err != nil {
 				return err
 			}
-			req := req.WithContent(ctx)
+			req = req.WithContext(ctx)
 
 			resp, err := a.HTTPClient.Do(req)
 			if resp != nil {

--- a/src/github.com/matrix-org/dendrite/appservice/query/query.go
+++ b/src/github.com/matrix-org/dendrite/appservice/query/query.go
@@ -77,7 +77,7 @@ func (a *AppServiceQueryAPI) RoomAliasExists(
 						log.WithFields(log.Fields{
 							"appservice_id": appservice.ID,
 							"status_code":   resp.StatusCode,
-						}).Error("Unable to close application service response body")
+						}).WithError(err).Error("Unable to close application service response body")
 					}
 				}()
 			}
@@ -107,12 +107,6 @@ func (a *AppServiceQueryAPI) RoomAliasExists(
 func makeHTTPClient() *http.Client {
 	return &http.Client{
 		Timeout: time.Second * 30,
-		// TODO: Verify certificates
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true, // nolint: gas
-			},
-		},
 	}
 }
 

--- a/src/github.com/matrix-org/dendrite/appservice/query/query.go
+++ b/src/github.com/matrix-org/dendrite/appservice/query/query.go
@@ -86,17 +86,20 @@ func (a *AppServiceQueryAPI) RoomAliasExists(
 				log.WithError(err).Errorf("Issue querying room alias on application service %s", appservice.ID)
 				return err
 			}
-			if resp.StatusCode == http.StatusOK {
-				// StatusOK received from appservice. Room exists
+			switch resp.StatusCode {
+			case http.StatusOK:
+				// OK received from appservice. Room exists
 				response.AliasExists = true
 				return nil
+			case http.StatusNotFound:
+				// Room does not exist
+			default:
+				// Application service reported an error. Warn
+				log.WithFields(log.Fields{
+					"appservice_id": appservice.ID,
+					"status_code":   resp.StatusCode,
+				}).Warn("Application service responded with non-OK status code")
 			}
-
-			// Log non OK
-			log.WithFields(log.Fields{
-				"appservice_id": appservice.ID,
-				"status_code":   resp.StatusCode,
-			}).Warn("Application service responded with non-OK status code")
 		}
 	}
 

--- a/src/github.com/matrix-org/dendrite/appservice/workers/transaction_scheduler.go
+++ b/src/github.com/matrix-org/dendrite/appservice/workers/transaction_scheduler.go
@@ -17,7 +17,6 @@ package workers
 import (
 	"bytes"
 	"context"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"math"

--- a/src/github.com/matrix-org/dendrite/appservice/workers/transaction_scheduler.go
+++ b/src/github.com/matrix-org/dendrite/appservice/workers/transaction_scheduler.go
@@ -68,12 +68,6 @@ func worker(db *storage.Database, ws types.ApplicationServiceWorkerState) {
 	// Create a HTTP client for sending requests to app services
 	client := &http.Client{
 		Timeout: transactionTimeout,
-		// TODO: Verify certificates
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true, // nolint: gas
-			},
-		},
 	}
 
 	// Initial check for any leftover events to send from last time

--- a/src/github.com/matrix-org/dendrite/clientapi/clientapi.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/clientapi.go
@@ -15,6 +15,7 @@
 package clientapi
 
 import (
+	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
 	"github.com/matrix-org/dendrite/clientapi/consumers"
@@ -40,6 +41,7 @@ func SetupClientAPIComponent(
 	inputAPI roomserverAPI.RoomserverInputAPI,
 	queryAPI roomserverAPI.RoomserverQueryAPI,
 	typingInputAPI typingServerAPI.TypingServerInputAPI,
+	asAPI appserviceAPI.AppServiceQueryAPI,
 	transactionsCache *transactions.Cache,
 ) {
 	roomserverProducer := producers.NewRoomserverProducer(inputAPI)
@@ -63,7 +65,7 @@ func SetupClientAPIComponent(
 	}
 
 	routing.Setup(
-		base.APIMux, *base.Cfg, roomserverProducer, queryAPI, aliasAPI,
+		base.APIMux, *base.Cfg, roomserverProducer, queryAPI, asAPI, aliasAPI,
 		accountsDB, deviceDB, federation, *keyRing, userUpdateProducer,
 		syncProducer, typingProducer, transactionsCache,
 	)

--- a/src/github.com/matrix-org/dendrite/clientapi/clientapi.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/clientapi.go
@@ -15,7 +15,6 @@
 package clientapi
 
 import (
-	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
 	"github.com/matrix-org/dendrite/clientapi/consumers"
@@ -41,7 +40,6 @@ func SetupClientAPIComponent(
 	inputAPI roomserverAPI.RoomserverInputAPI,
 	queryAPI roomserverAPI.RoomserverQueryAPI,
 	typingInputAPI typingServerAPI.TypingServerInputAPI,
-	asAPI appserviceAPI.AppServiceQueryAPI,
 	transactionsCache *transactions.Cache,
 ) {
 	roomserverProducer := producers.NewRoomserverProducer(inputAPI)
@@ -65,7 +63,7 @@ func SetupClientAPIComponent(
 	}
 
 	routing.Setup(
-		base.APIMux, *base.Cfg, roomserverProducer, queryAPI, asAPI, aliasAPI,
+		base.APIMux, *base.Cfg, roomserverProducer, queryAPI, aliasAPI,
 		accountsDB, deviceDB, federation, *keyRing, userUpdateProducer,
 		syncProducer, typingProducer, transactionsCache,
 	)

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
-	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"
 	"github.com/matrix-org/dendrite/clientapi/auth"
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
@@ -43,8 +42,9 @@ const pathPrefixUnstable = "/_matrix/client/unstable"
 // to clients which need to make outbound HTTP requests.
 func Setup(
 	apiMux *mux.Router, cfg config.Dendrite,
-	producer *producers.RoomserverProducer, queryAPI roomserverAPI.RoomserverQueryAPI,
-	appserviceAPI appserviceAPI.AppServiceQueryAPI, aliasAPI roomserverAPI.RoomserverAliasAPI,
+	producer *producers.RoomserverProducer,
+	queryAPI roomserverAPI.RoomserverQueryAPI,
+	aliasAPI roomserverAPI.RoomserverAliasAPI,
 	accountDB *accounts.Database,
 	deviceDB *devices.Database,
 	federation *gomatrixserverlib.FederationClient,
@@ -145,7 +145,7 @@ func Setup(
 	r0mux.Handle("/directory/room/{roomAlias}",
 		common.MakeExternalAPI("directory_room", func(req *http.Request) util.JSONResponse {
 			vars := mux.Vars(req)
-			return DirectoryRoom(req, vars["roomAlias"], federation, &cfg, aliasAPI, appserviceAPI)
+			return DirectoryRoom(req, vars["roomAlias"], federation, &cfg, aliasAPI)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"
 	"github.com/matrix-org/dendrite/clientapi/auth"
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
@@ -29,7 +30,7 @@ import (
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/config"
 	"github.com/matrix-org/dendrite/common/transactions"
-	"github.com/matrix-org/dendrite/roomserver/api"
+	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 )
@@ -42,8 +43,8 @@ const pathPrefixUnstable = "/_matrix/client/unstable"
 // to clients which need to make outbound HTTP requests.
 func Setup(
 	apiMux *mux.Router, cfg config.Dendrite,
-	producer *producers.RoomserverProducer, queryAPI api.RoomserverQueryAPI,
-	aliasAPI api.RoomserverAliasAPI,
+	producer *producers.RoomserverProducer, queryAPI roomserverAPI.RoomserverQueryAPI,
+	appserviceAPI appserviceAPI.AppServiceQueryAPI, aliasAPI roomserverAPI.RoomserverAliasAPI,
 	accountDB *accounts.Database,
 	deviceDB *devices.Database,
 	federation *gomatrixserverlib.FederationClient,
@@ -142,9 +143,9 @@ func Setup(
 	})).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/directory/room/{roomAlias}",
-		common.MakeAuthAPI("directory_room", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		common.MakeExternalAPI("directory_room", func(req *http.Request) util.JSONResponse {
 			vars := mux.Vars(req)
-			return DirectoryRoom(req, vars["roomAlias"], federation, &cfg, aliasAPI)
+			return DirectoryRoom(req, vars["roomAlias"], federation, &cfg, aliasAPI, appserviceAPI)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-client-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-client-api-server/main.go
@@ -19,6 +19,8 @@ import (
 	"github.com/matrix-org/dendrite/common/basecomponent"
 	"github.com/matrix-org/dendrite/common/keydb"
 	"github.com/matrix-org/dendrite/common/transactions"
+	"github.com/matrix-org/dendrite/typingserver"
+	"github.com/matrix-org/dendrite/typingserver/cache"
 )
 
 func main() {
@@ -34,13 +36,11 @@ func main() {
 	keyRing := keydb.CreateKeyRing(federation.Client, keyDB)
 
 	alias, input, query := base.CreateHTTPRoomserverAPIs()
-	typingInputAPI := base.CreateHTTPTypingServerAPIs()
-	asQuery := base.CreateHTTPAppServiceAPIs()
-	cache := transactions.New()
+	typingInputAPI := typingserver.SetupTypingServerComponent(base, cache.NewTypingCache())
 
 	clientapi.SetupClientAPIComponent(
 		base, deviceDB, accountDB, federation, &keyRing,
-		alias, input, query, typingInputAPI, asQuery, cache,
+		alias, input, query, typingInputAPI, transactions.New(),
 	)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Listen.ClientAPI))

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-client-api-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-client-api-server/main.go
@@ -35,11 +35,12 @@ func main() {
 
 	alias, input, query := base.CreateHTTPRoomserverAPIs()
 	typingInputAPI := base.CreateHTTPTypingServerAPIs()
+	asQuery := base.CreateHTTPAppServiceAPIs()
 	cache := transactions.New()
 
 	clientapi.SetupClientAPIComponent(
 		base, deviceDB, accountDB, federation, &keyRing,
-		alias, input, query, typingInputAPI, cache,
+		alias, input, query, typingInputAPI, asQuery, cache,
 	)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Listen.ClientAPI))

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
@@ -58,9 +58,13 @@ func main() {
 	alias, input, query := roomserver.SetupRoomServerComponent(base)
 	typingInputAPI := typingserver.SetupTypingServerComponent(base, cache.NewTypingCache())
 
+	asQuery := appservice.SetupAppServiceAPIComponent(
+		base, accountDB, deviceDB, federation, alias, query, transactions.New(),
+	)
+
 	clientapi.SetupClientAPIComponent(
 		base, deviceDB, accountDB,
-		federation, &keyRing, alias, input, query, typingInputAPI,
+		federation, &keyRing, alias, input, query, typingInputAPI, asQuery,
 		transactions.New(),
 	)
 	federationapi.SetupFederationAPIComponent(base, accountDB, deviceDB, federation, &keyRing, alias, input, query)
@@ -68,7 +72,6 @@ func main() {
 	mediaapi.SetupMediaAPIComponent(base, deviceDB)
 	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB)
 	syncapi.SetupSyncAPIComponent(base, deviceDB, accountDB, query)
-	appservice.SetupAppServiceAPIComponent(base, accountDB, deviceDB, federation, alias, query, transactions.New())
 
 	httpHandler := common.WrapHandlerInCORS(base.APIMux)
 

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
@@ -18,7 +18,6 @@ import (
 	"flag"
 	"net/http"
 
-	"github.com/matrix-org/dendrite/appservice"
 	"github.com/matrix-org/dendrite/clientapi"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/basecomponent"
@@ -58,13 +57,9 @@ func main() {
 	alias, input, query := roomserver.SetupRoomServerComponent(base)
 	typingInputAPI := typingserver.SetupTypingServerComponent(base, cache.NewTypingCache())
 
-	asQuery := appservice.SetupAppServiceAPIComponent(
-		base, accountDB, deviceDB, federation, alias, query, transactions.New(),
-	)
-
 	clientapi.SetupClientAPIComponent(
 		base, deviceDB, accountDB,
-		federation, &keyRing, alias, input, query, typingInputAPI, asQuery,
+		federation, &keyRing, alias, input, query, typingInputAPI,
 		transactions.New(),
 	)
 	federationapi.SetupFederationAPIComponent(base, accountDB, deviceDB, federation, &keyRing, alias, input, query)

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/query.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/query.go
@@ -21,7 +21,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/common/config"
-	"github.com/matrix-org/dendrite/roomserver/api"
+	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrix"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
@@ -32,7 +32,7 @@ func RoomAliasToID(
 	httpReq *http.Request,
 	federation *gomatrixserverlib.FederationClient,
 	cfg config.Dendrite,
-	aliasAPI api.RoomserverAliasAPI,
+	aliasAPI roomserverAPI.RoomserverAliasAPI,
 ) util.JSONResponse {
 	roomAlias := httpReq.FormValue("alias")
 	if roomAlias == "" {
@@ -52,8 +52,8 @@ func RoomAliasToID(
 	var resp gomatrixserverlib.RespDirectory
 
 	if domain == cfg.Matrix.ServerName {
-		queryReq := api.GetRoomIDForAliasRequest{Alias: roomAlias}
-		var queryRes api.GetRoomIDForAliasResponse
+		queryReq := roomserverAPI.GetRoomIDForAliasRequest{Alias: roomAlias}
+		var queryRes roomserverAPI.GetRoomIDForAliasResponse
 		if err = aliasAPI.GetRoomIDForAlias(httpReq.Context(), &queryReq, &queryRes); err != nil {
 			return httputil.LogThenError(httpReq, err)
 		}

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
@@ -23,7 +23,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/producers"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/config"
-	"github.com/matrix-org/dendrite/roomserver/api"
+	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 )
@@ -37,8 +37,8 @@ const (
 func Setup(
 	apiMux *mux.Router,
 	cfg config.Dendrite,
-	query api.RoomserverQueryAPI,
-	aliasAPI api.RoomserverAliasAPI,
+	query roomserverAPI.RoomserverQueryAPI,
+	aliasAPI roomserverAPI.RoomserverAliasAPI,
 	producer *producers.RoomserverProducer,
 	keys gomatrixserverlib.KeyRing,
 	federation *gomatrixserverlib.FederationClient,

--- a/src/github.com/matrix-org/dendrite/roomserver/alias/alias.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/alias/alias.go
@@ -44,7 +44,7 @@ type RoomserverAliasAPIDatabase interface {
 	RemoveRoomAlias(ctx context.Context, alias string) error
 }
 
-// RoomserverAliasAPI is an implementation of api.RoomserverAliasAPI
+// RoomserverAliasAPI is an implementation of alias.RoomserverAliasAPI
 type RoomserverAliasAPI struct {
 	DB       RoomserverAliasAPIDatabase
 	Cfg      *config.Dendrite
@@ -52,7 +52,7 @@ type RoomserverAliasAPI struct {
 	QueryAPI api.RoomserverQueryAPI
 }
 
-// SetRoomAlias implements api.RoomserverAliasAPI
+// SetRoomAlias implements alias.RoomserverAliasAPI
 func (r *RoomserverAliasAPI) SetRoomAlias(
 	ctx context.Context,
 	request *api.SetRoomAliasRequest,
@@ -82,7 +82,7 @@ func (r *RoomserverAliasAPI) SetRoomAlias(
 	return r.sendUpdatedAliasesEvent(context.TODO(), request.UserID, request.RoomID)
 }
 
-// GetRoomIDForAlias implements api.RoomserverAliasAPI
+// GetRoomIDForAlias implements alias.RoomserverAliasAPI
 func (r *RoomserverAliasAPI) GetRoomIDForAlias(
 	ctx context.Context,
 	request *api.GetRoomIDForAliasRequest,
@@ -98,7 +98,7 @@ func (r *RoomserverAliasAPI) GetRoomIDForAlias(
 	return nil
 }
 
-// GetAliasesForRoomID implements api.RoomserverAliasAPI
+// GetAliasesForRoomID implements alias.RoomserverAliasAPI
 func (r *RoomserverAliasAPI) GetAliasesForRoomID(
 	ctx context.Context,
 	request *api.GetAliasesForRoomIDRequest,
@@ -114,7 +114,7 @@ func (r *RoomserverAliasAPI) GetAliasesForRoomID(
 	return nil
 }
 
-// RemoveRoomAlias implements api.RoomserverAliasAPI
+// RemoveRoomAlias implements alias.RoomserverAliasAPI
 func (r *RoomserverAliasAPI) RemoveRoomAlias(
 	ctx context.Context,
 	request *api.RemoveRoomAliasRequest,

--- a/src/github.com/matrix-org/dendrite/roomserver/roomserver.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/roomserver.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/matrix-org/dendrite/roomserver/api"
 
+	asQuery "github.com/matrix-org/dendrite/appservice/query"
 	"github.com/matrix-org/dendrite/common/basecomponent"
 	"github.com/matrix-org/dendrite/roomserver/alias"
 	"github.com/matrix-org/dendrite/roomserver/input"
@@ -51,11 +52,14 @@ func SetupRoomServerComponent(
 
 	queryAPI.SetupHTTP(http.DefaultServeMux)
 
+	asAPI := asQuery.AppServiceQueryAPI{Cfg: base.Cfg}
+
 	aliasAPI := alias.RoomserverAliasAPI{
-		DB:       roomserverDB,
-		Cfg:      base.Cfg,
-		InputAPI: &inputAPI,
-		QueryAPI: &queryAPI,
+		DB:            roomserverDB,
+		Cfg:           base.Cfg,
+		InputAPI:      &inputAPI,
+		QueryAPI:      &queryAPI,
+		AppserviceAPI: &asAPI,
 	}
 
 	aliasAPI.SetupHTTP(http.DefaultServeMux)


### PR DESCRIPTION
Closes #452 

This PR implements a method for querying /rooms/{roomAlias} on an appservice, as defined in [the spec](https://matrix.org/docs/spec/application_service/unstable.html#get-rooms-roomalias).

This PR depends on #541