### PR TITLE
Don't require preset to create room

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/routing/createroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/createroom.go
@@ -169,7 +169,7 @@ func createRoom(req *http.Request, device *authtypes.Device,
 
 	var joinRules, historyVisibility string
 	switch r.Preset {
-	case presetPrivateChat, "":
+	case presetPrivateChat:
 		joinRules = joinRuleInvite
 		historyVisibility = historyVisibilityShared
 	case presetTrustedPrivateChat:
@@ -178,6 +178,11 @@ func createRoom(req *http.Request, device *authtypes.Device,
 		// TODO If trusted_private_chat, all invitees are given the same power level as the room creator.
 	case presetPublicChat:
 		joinRules = joinRulePublic
+		historyVisibility = historyVisibilityShared
+	default:
+		// Default room rules, r.Preset was previously checked for valid values so
+		// only a request with no preset should end up here.
+		joinRules = joinRuleInvite
 		historyVisibility = historyVisibilityShared
 	}
 

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/createroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/createroom.go
@@ -87,15 +87,12 @@ func (r createRoomRequest) Validate() *util.JSONResponse {
 			}
 		}
 	}
-	if r.Preset != "" {
-		switch r.Preset {
-		case presetPrivateChat, presetTrustedPrivateChat, presetPublicChat:
-			break
-		default:
-			return &util.JSONResponse{
-				Code: http.StatusBadRequest,
-				JSON: jsonerror.BadJSON("preset must be any of 'private_chat', 'trusted_private_chat', 'public_chat'"),
-			}
+	switch r.Preset {
+	case presetPrivateChat, presetTrustedPrivateChat, presetPublicChat, "":
+	default:
+		return &util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.BadJSON("preset must be any of 'private_chat', 'trusted_private_chat', 'public_chat'"),
 		}
 	}
 
@@ -172,7 +169,7 @@ func createRoom(req *http.Request, device *authtypes.Device,
 
 	var joinRules, historyVisibility string
 	switch r.Preset {
-	case presetPrivateChat:
+	case presetPrivateChat, "":
 		joinRules = joinRuleInvite
 		historyVisibility = historyVisibilityShared
 	case presetTrustedPrivateChat:

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/createroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/createroom.go
@@ -87,13 +87,15 @@ func (r createRoomRequest) Validate() *util.JSONResponse {
 			}
 		}
 	}
-	switch r.Preset {
-	case presetPrivateChat, presetTrustedPrivateChat, presetPublicChat:
-		break
-	default:
-		return &util.JSONResponse{
-			Code: http.StatusBadRequest,
-			JSON: jsonerror.BadJSON("preset must be any of 'private_chat', 'trusted_private_chat', 'public_chat'"),
+	if r.Preset != "" {
+		switch r.Preset {
+		case presetPrivateChat, presetTrustedPrivateChat, presetPublicChat:
+			break
+		default:
+			return &util.JSONResponse{
+				Code: http.StatusBadRequest,
+				JSON: jsonerror.BadJSON("preset must be any of 'private_chat', 'trusted_private_chat', 'public_chat'"),
+			}
 		}
 	}
 


### PR DESCRIPTION
**Spec:** https://matrix.org/docs/spec/client_server/r0.3.0.html#post-matrix-client-r0-createroom

The `preset` field is not required for `/createRoom`. It is only a convenience.