### PR TITLE
Generate SenderLocalpart AS user

### DIFF
--- a/src/github.com/matrix-org/dendrite/appservice/appservice.go
+++ b/src/github.com/matrix-org/dendrite/appservice/appservice.go
@@ -54,6 +54,9 @@ func SetupAppServiceAPIComponent(
 		logrus.WithError(err).Panicf("failed to connect to appservice db")
 	}
 
+	// Wrap application services in a type that relates the application service and
+	// a sync.Cond object that can be used to notify workers when there are new
+	// events to be sent out.
 	workerStates := make([]types.ApplicationServiceWorkerState, len(base.Cfg.Derived.ApplicationServices))
 	for i, appservice := range base.Cfg.Derived.ApplicationServices {
 		m := sync.Mutex{}

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-appservice-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-appservice-server/main.go
@@ -26,12 +26,13 @@ func main() {
 
 	defer base.Close() // nolint: errcheck
 	accountDB := base.CreateAccountsDB()
+	deviceDB := base.CreateDeviceDB()
 	federation := base.CreateFederationClient()
 	alias, _, query := base.CreateHTTPRoomserverAPIs()
 	cache := transactions.New()
 
 	appservice.SetupAppServiceAPIComponent(
-		base, accountDB, federation, alias, query, cache,
+		base, accountDB, deviceDB, federation, alias, query, cache,
 	)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Listen.FederationSender))

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/matrix-org/dendrite/common/keydb"
 	"github.com/matrix-org/dendrite/common/transactions"
 
+	"github.com/matrix-org/dendrite/appservice"
 	"github.com/matrix-org/dendrite/clientapi"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/basecomponent"
@@ -65,6 +66,7 @@ func main() {
 	mediaapi.SetupMediaAPIComponent(base, deviceDB)
 	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB)
 	syncapi.SetupSyncAPIComponent(base, deviceDB, accountDB, query)
+	appservice.SetupAppServiceAPIComponent(base, accountDB, deviceDB, federation, alias, query, transactions.New())
 
 	httpHandler := common.WrapHandlerInCORS(base.APIMux)
 


### PR DESCRIPTION
The SenderLocalpart user is a special user that the appservice acts as whenever it calls the Client-Server API without a `user_id` parameter. `sender_localpart` is specified as part of the [application service registration file](https://matrix.org/docs/spec/application_service/unstable.html#registration).

This PR generates the user on startup, along with a dummy device, as long as the user does not already exist.

Depends on #477