### PR TITLE
Remove redundant federation request verification

### DIFF
--- a/src/github.com/matrix-org/dendrite/federationapi/routing/events.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/events.go
@@ -17,9 +17,7 @@ package routing
 import (
 	"context"
 	"net/http"
-	"time"
 
-	"github.com/matrix-org/dendrite/common/config"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
@@ -29,10 +27,7 @@ import (
 func GetEvent(
 	ctx context.Context,
 	request *gomatrixserverlib.FederationRequest,
-	_ config.Dendrite,
 	query api.RoomserverQueryAPI,
-	_ time.Time,
-	_ gomatrixserverlib.KeyRing,
 	eventID string,
 ) util.JSONResponse {
 	var authResponse api.QueryServerAllowedToSeeEventResponse

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
@@ -16,7 +16,6 @@ package routing
 
 import (
 	"net/http"
-	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
@@ -75,7 +74,7 @@ func Setup(
 			vars := mux.Vars(httpReq)
 			return Invite(
 				httpReq, request, vars["roomID"], vars["eventID"],
-				cfg, producer, keys,
+				cfg, producer,
 			)
 		},
 	)).Methods(http.MethodPut, http.MethodOptions)
@@ -101,7 +100,7 @@ func Setup(
 		func(httpReq *http.Request, request *gomatrixserverlib.FederationRequest) util.JSONResponse {
 			vars := mux.Vars(httpReq)
 			return GetEvent(
-				httpReq.Context(), request, cfg, query, time.Now(), keys, vars["eventID"],
+				httpReq.Context(), request, query, vars["eventID"],
 			)
 		},
 	)).Methods(http.MethodGet)
@@ -143,7 +142,7 @@ func Setup(
 			roomID := vars["roomID"]
 			userID := vars["userID"]
 			return SendJoin(
-				httpReq.Context(), httpReq, request, cfg, query, producer, keys, roomID, userID,
+				httpReq.Context(), httpReq, request, cfg, query, producer, roomID, userID,
 			)
 		},
 	)).Methods(http.MethodPut)


### PR DESCRIPTION
Fixes #509 
Since makeFedAPI checks signatures, we don't need to do that again.
No need to pass the keyring.

`Signed-off-by: Anant Prakash <anantprakashjsr@gmail.com>`