### PR TITLE
[federation] Fix state API endpoints

### DIFF
--- a/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
@@ -108,24 +108,24 @@ func Setup(
 		},
 	)).Methods(http.MethodGet)
 
-	v1fedmux.Handle("/state/{roomID}/{eventID}", common.MakeFedAPI(
+	v1fedmux.Handle("/state/{roomID}", common.MakeFedAPI(
 		"federation_get_event_auth", cfg.Matrix.ServerName, keys,
 		func(httpReq *http.Request, request *gomatrixserverlib.FederationRequest) util.JSONResponse {
 			vars := mux.Vars(httpReq)
 			return GetState(
 				httpReq.Context(), request, cfg, query, time.Now(),
-				keys, vars["roomID"], vars["eventID"],
+				keys, vars["roomID"],
 			)
 		},
 	)).Methods(http.MethodGet)
 
-	v1fedmux.Handle("/state_ids/{roomID}/{eventID}", common.MakeFedAPI(
+	v1fedmux.Handle("/state_ids/{roomID}", common.MakeFedAPI(
 		"federation_get_event_auth", cfg.Matrix.ServerName, keys,
 		func(httpReq *http.Request, request *gomatrixserverlib.FederationRequest) util.JSONResponse {
 			vars := mux.Vars(httpReq)
 			return GetStateIDs(
 				httpReq.Context(), request, cfg, query, time.Now(),
-				keys, vars["roomID"], vars["eventID"],
+				keys, vars["roomID"],
 			)
 		},
 	)).Methods(http.MethodGet)

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/state.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/state.go
@@ -35,7 +35,7 @@ func GetState(
 	_ gomatrixserverlib.KeyRing,
 	roomID string,
 ) util.JSONResponse {
-	eventID, err := parseParams(request)
+	eventID, err := parseEventIDParam(request)
 	if err != nil {
 		return *err
 	}
@@ -58,7 +58,7 @@ func GetStateIDs(
 	_ gomatrixserverlib.KeyRing,
 	roomID string,
 ) util.JSONResponse {
-	eventID, err := parseParams(request)
+	eventID, err := parseEventIDParam(request)
 	if err != nil {
 		return *err
 	}
@@ -78,7 +78,7 @@ func GetStateIDs(
 	}
 }
 
-func parseParams(
+func parseEventIDParam(
 	request *gomatrixserverlib.FederationRequest,
 ) (eventID string, resErr *util.JSONResponse) {
 	URL, err := url.Parse(request.RequestURI())

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/state.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/state.go
@@ -15,8 +15,10 @@ package routing
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"time"
 
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/common/config"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -32,8 +34,12 @@ func GetState(
 	_ time.Time,
 	_ gomatrixserverlib.KeyRing,
 	roomID string,
-	eventID string,
 ) util.JSONResponse {
+	eventID, err := parseParams(request)
+	if err != nil {
+		return *err
+	}
+
 	state, err := getState(ctx, request, query, roomID, eventID)
 	if err != nil {
 		return *err
@@ -51,8 +57,12 @@ func GetStateIDs(
 	_ time.Time,
 	_ gomatrixserverlib.KeyRing,
 	roomID string,
-	eventID string,
 ) util.JSONResponse {
+	eventID, err := parseParams(request)
+	if err != nil {
+		return *err
+	}
+
 	state, err := getState(ctx, request, query, roomID, eventID)
 	if err != nil {
 		return *err
@@ -66,6 +76,26 @@ func GetStateIDs(
 		AuthEventIDs:  authEventIDs,
 	},
 	}
+}
+
+func parseParams(
+	request *gomatrixserverlib.FederationRequest,
+) (eventID string, resErr *util.JSONResponse) {
+	URL, err := url.Parse(request.RequestURI())
+	if err != nil {
+		*resErr = util.ErrorResponse(err)
+		return
+	}
+
+	eventID = URL.Query().Get("event_id")
+	if eventID == "" {
+		resErr = &util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.MissingArgument("event_id missing"),
+		}
+	}
+
+	return
 }
 
 func getState(


### PR DESCRIPTION
event_id should be given as parameter.

sytest is still failing. I reckon it's a URI enconding issues with federation Client of gomatrixserverlib.