### PR TITLE
AppServices: Implement /users/{userID}

### DIFF
--- a/src/github.com/matrix-org/dendrite/appservice/query/query.go
+++ b/src/github.com/matrix-org/dendrite/appservice/query/query.go
@@ -109,7 +109,7 @@ func (a *AppServiceQueryAPI) RoomAliasExists(
 }
 
 // UserIDExists performs a request to '/users/{userID}' on all known
-// handling application services until one admits to owning the room
+// handling application services until one admits to owning the user ID
 func (a *AppServiceQueryAPI) UserIDExists(
 	ctx context.Context,
 	request *api.UserIDExistsRequest,


### PR DESCRIPTION
Implements https://matrix.org/docs/spec/application_service/unstable.html#get-users-userid

Query application services about the existence of a given userID. Application services should create this user if it exists in their namespace, in which case we will query for the user locally again - at which point they should exist.

Currently nothing uses this. Hookups are coming in a later PR.

Depends on #494 