### PR TITLE
[WIP] Improve /query/directory endpoint

### DIFF
--- a/src/github.com/matrix-org/dendrite/federationapi/routing/query.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/query.go
@@ -34,7 +34,7 @@ func RoomAliasToID(
 	cfg config.Dendrite,
 	aliasAPI api.RoomserverAliasAPI,
 ) util.JSONResponse {
-	roomAlias := httpReq.FormValue("alias")
+	roomAlias := httpReq.FormValue("room_alias")
 	if roomAlias == "" {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
@@ -58,14 +58,14 @@ func RoomAliasToID(
 			return httputil.LogThenError(httpReq, err)
 		}
 
-		if queryRes.RoomID == "" {
+		if queryRes.RoomID != "" {
 			// TODO: List servers that are aware of this room alias
 			resp = gomatrixserverlib.RespDirectory{
 				RoomID:  queryRes.RoomID,
 				Servers: []gomatrixserverlib.ServerName{},
 			}
 		} else {
-			// If the response doesn't contain a non-empty string, return an error
+			// If no alias was found, return an error
 			return util.JSONResponse{
 				Code: http.StatusNotFound,
 				JSON: jsonerror.NotFound(fmt.Sprintf("Room alias %s not found", roomAlias)),

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
@@ -130,7 +130,7 @@ func Setup(
 		},
 	)).Methods(http.MethodGet)
 
-	v1fedmux.Handle("/query/directory/", common.MakeFedAPI(
+	v1fedmux.Handle("/query/directory", common.MakeFedAPI(
 		"federation_query_room_alias", cfg.Matrix.ServerName, keys,
 		func(httpReq *http.Request, request *gomatrixserverlib.FederationRequest) util.JSONResponse {
 			return RoomAliasToID(


### PR DESCRIPTION
WIP for fixing #519 

Attempts to make `11query-directory.pl` pass.

All that's left is returning the other servers that are aware of the given room alias, as per this comment:

https://github.com/matrix-org/dendrite/blob/7f2db95a06f31a96bae8f9f1a072861fe8d5545f/src/github.com/matrix-org/dendrite/federationapi/routing/query.go#L62-L66