### PR TITLE
Add missing prev_state field

### DIFF
--- a/vendor/src/github.com/matrix-org/gomatrixserverlib/event.go
+++ b/vendor/src/github.com/matrix-org/gomatrixserverlib/event.go
@@ -61,6 +61,8 @@ type EventBuilder struct {
 	StateKey *string `json:"state_key,omitempty"`
 	// The events that immediately preceded this event in the room history.
 	PrevEvents []EventReference `json:"prev_events"`
+	// TODO: A deprecated, empty but yet still expected key.
+	PrevState string `json:"prev_state"`
 	// The events needed to authenticate this event.
 	AuthEvents []EventReference `json:"auth_events"`
 	// The event ID of the event being redacted if this event is a "m.room.redaction".


### PR DESCRIPTION
WIP for #519 

Allows `30room-join.pl` to pass.

This field has been deprecated, and Synapse doesn't even use it, but it does check that it exists.

Put in a TODO for us to hopefully remove it in the future on a spec upgrade.