### PR TITLE
Run TravisCI with Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 go:
  - 1.8.x
  - 1.9.x
+ - 1.10.x
 
 env:
 - TEST_SUITE="lint"


### PR DESCRIPTION
Go 1.10 is out. We should test with it.

Only downside is this makes CI jobs a couple minutes longer.