### PR TITLE
Internal API for Appservices

### DIFF
--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -113,7 +113,7 @@ listen:
     media_api: "localhost:7774"
     public_rooms_api: "localhost:7775"
     federation_sender: "localhost:7776"
-    appservice: "localhost:7777"
+    appservice_api: "localhost:7777"
 
 # The configuration for tracing the dendrite components.
 tracing:

--- a/src/github.com/matrix-org/dendrite/appservice/api/query.go
+++ b/src/github.com/matrix-org/dendrite/appservice/api/query.go
@@ -1,0 +1,49 @@
+// Copyright 2018 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package api contains methods used by dendrite components in multi-process
+// mode to send requests to the appservice component, typically in order to ask
+// an application service for some information.
+package api
+
+import (
+	"net/http"
+)
+
+// AppServiceQueryAPI is used to query user and room alias data from application
+// services
+type AppServiceQueryAPI interface {
+	// TODO: Check whether a room alias exists within any application service namespaces
+	// TODO: QueryUserIDExists
+}
+
+// httpAppServiceQueryAPI contains the URL to an appservice query API and a
+// reference to a httpClient used to reach it
+type httpAppServiceQueryAPI struct {
+	appserviceURL string
+	httpClient    *http.Client
+}
+
+// NewAppServiceQueryAPIHTTP creates a AppServiceQueryAPI implemented by talking
+// to a HTTP POST API.
+// If httpClient is nil then it uses http.DefaultClient
+func NewAppServiceQueryAPIHTTP(
+	appserviceURL string,
+	httpClient *http.Client,
+) AppServiceQueryAPI {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &httpAppServiceQueryAPI{appserviceURL, httpClient}
+}

--- a/src/github.com/matrix-org/dendrite/appservice/query/query.go
+++ b/src/github.com/matrix-org/dendrite/appservice/query/query.go
@@ -1,0 +1,34 @@
+// Copyright 2018 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package query handles requests from other internal dendrite components when
+// they interact with the AppServiceQueryAPI.
+package query
+
+import (
+	"net/http"
+
+	"github.com/matrix-org/dendrite/common/config"
+)
+
+// AppServiceQueryAPI is an implementation of api.AppServiceQueryAPI
+type AppServiceQueryAPI struct {
+	HTTPClient *http.Client
+	Cfg        *config.Dendrite
+}
+
+// SetupHTTP adds the AppServiceQueryPAI handlers to the http.ServeMux. This
+// handles and muxes incoming api requests the to internal AppServiceQueryAPI.
+func (a *AppServiceQueryAPI) SetupHTTP(servMux *http.ServeMux) {
+}

--- a/src/github.com/matrix-org/dendrite/appservice/workers/transaction_scheduler.go
+++ b/src/github.com/matrix-org/dendrite/appservice/workers/transaction_scheduler.go
@@ -65,7 +65,7 @@ func worker(db *storage.Database, ws types.ApplicationServiceWorkerState) {
 	}).Info("starting application service")
 	ctx := context.Background()
 
-	// Grab the HTTP client for sending requests to app services
+	// Create a HTTP client for sending requests to app services
 	client := &http.Client{
 		Timeout: transactionTimeout,
 		// TODO: Verify certificates

--- a/src/github.com/matrix-org/dendrite/clientapi/clientapi.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/clientapi.go
@@ -22,7 +22,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/routing"
 	"github.com/matrix-org/dendrite/common/basecomponent"
 	"github.com/matrix-org/dendrite/common/transactions"
-	"github.com/matrix-org/dendrite/roomserver/api"
+	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/sirupsen/logrus"
 )
@@ -35,9 +35,9 @@ func SetupClientAPIComponent(
 	accountsDB *accounts.Database,
 	federation *gomatrixserverlib.FederationClient,
 	keyRing *gomatrixserverlib.KeyRing,
-	aliasAPI api.RoomserverAliasAPI,
-	inputAPI api.RoomserverInputAPI,
-	queryAPI api.RoomserverQueryAPI,
+	aliasAPI roomserverAPI.RoomserverAliasAPI,
+	inputAPI roomserverAPI.RoomserverInputAPI,
+	queryAPI roomserverAPI.RoomserverQueryAPI,
 	transactionsCache *transactions.Cache,
 ) {
 	roomserverProducer := producers.NewRoomserverProducer(inputAPI)
@@ -60,10 +60,8 @@ func SetupClientAPIComponent(
 	}
 
 	routing.Setup(
-		base.APIMux, *base.Cfg, roomserverProducer,
-		queryAPI, aliasAPI, accountsDB, deviceDB,
-		federation, *keyRing,
-		userUpdateProducer, syncProducer,
-		transactionsCache,
+		base.APIMux, *base.Cfg, roomserverProducer, queryAPI, aliasAPI,
+		accountsDB, deviceDB, federation, *keyRing, userUpdateProducer,
+		syncProducer, transactionsCache,
 	)
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
@@ -318,8 +318,8 @@ func UserIDIsWithinApplicationServiceNamespace(
 	}
 
 	// Loop through all known application service's namespaces and see if any match
-	for _, knownAppservice := range cfg.Derived.ApplicationServices {
-		for _, namespace := range knownAppservice.NamespaceMap["users"] {
+	for _, knownAppService := range cfg.Derived.ApplicationServices {
+		for _, namespace := range knownAppService.NamespaceMap["users"] {
 			// AS namespaces are checked for validity in config
 			if namespace.RegexpObject.MatchString(userID) {
 				return true

--- a/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
+++ b/src/github.com/matrix-org/dendrite/cmd/dendrite-monolith-server/main.go
@@ -21,7 +21,6 @@ import (
 	"github.com/matrix-org/dendrite/common/keydb"
 	"github.com/matrix-org/dendrite/common/transactions"
 
-	"github.com/matrix-org/dendrite/appservice"
 	"github.com/matrix-org/dendrite/clientapi"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/basecomponent"
@@ -66,7 +65,6 @@ func main() {
 	mediaapi.SetupMediaAPIComponent(base, deviceDB)
 	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB)
 	syncapi.SetupSyncAPIComponent(base, deviceDB, accountDB, query)
-	appservice.SetupAppServiceAPIComponent(base, accountDB, federation, alias, query, transactions.New())
 
 	httpHandler := common.WrapHandlerInCORS(base.APIMux)
 

--- a/src/github.com/matrix-org/dendrite/common/basecomponent/base.go
+++ b/src/github.com/matrix-org/dendrite/common/basecomponent/base.go
@@ -30,8 +30,9 @@ import (
 	"github.com/gorilla/mux"
 	sarama "gopkg.in/Shopify/sarama.v1"
 
+	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"
 	"github.com/matrix-org/dendrite/common/config"
-	"github.com/matrix-org/dendrite/roomserver/api"
+	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/sirupsen/logrus"
 )
 
@@ -80,12 +81,22 @@ func (b *BaseDendrite) Close() error {
 	return b.tracerCloser.Close()
 }
 
-// CreateHTTPRoomserverAPIs returns the AliasAPI, InputAPI and QueryAPI to hit
+// CreateHTTPAppServiceAPIs returns the QueryAPI for hitting the appservice
+// component over HTTP.
+func (b *BaseDendrite) CreateHTTPAppServiceAPIs() appserviceAPI.AppServiceQueryAPI {
+	return appserviceAPI.NewAppServiceQueryAPIHTTP(b.Cfg.AppServiceURL(), nil)
+}
+
+// CreateHTTPRoomserverAPIs returns the AliasAPI, InputAPI and QueryAPI for hitting
 // the roomserver over HTTP.
-func (b *BaseDendrite) CreateHTTPRoomserverAPIs() (api.RoomserverAliasAPI, api.RoomserverInputAPI, api.RoomserverQueryAPI) {
-	alias := api.NewRoomserverAliasAPIHTTP(b.Cfg.RoomServerURL(), nil)
-	input := api.NewRoomserverInputAPIHTTP(b.Cfg.RoomServerURL(), nil)
-	query := api.NewRoomserverQueryAPIHTTP(b.Cfg.RoomServerURL(), nil)
+func (b *BaseDendrite) CreateHTTPRoomserverAPIs() (
+	roomserverAPI.RoomserverAliasAPI,
+	roomserverAPI.RoomserverInputAPI,
+	roomserverAPI.RoomserverQueryAPI,
+) {
+	alias := roomserverAPI.NewRoomserverAliasAPIHTTP(b.Cfg.RoomServerURL(), nil)
+	input := roomserverAPI.NewRoomserverInputAPIHTTP(b.Cfg.RoomServerURL(), nil)
+	query := roomserverAPI.NewRoomserverQueryAPIHTTP(b.Cfg.RoomServerURL(), nil)
 	return alias, input, query
 }
 

--- a/src/github.com/matrix-org/dendrite/common/config/appservice.go
+++ b/src/github.com/matrix-org/dendrite/common/config/appservice.go
@@ -114,9 +114,9 @@ func (a *ApplicationService) IsInterestedInRoomAlias(
 	return false
 }
 
-// loadAppservices iterates through all application service config files
+// loadAppServices iterates through all application service config files
 // and loads their data into the config object for later access.
-func loadAppservices(config *Dendrite) error {
+func loadAppServices(config *Dendrite) error {
 	for _, configPath := range config.ApplicationServices.ConfigFiles {
 		// Create a new application service with default options
 		appservice := ApplicationService{

--- a/src/github.com/matrix-org/dendrite/common/config/config.go
+++ b/src/github.com/matrix-org/dendrite/common/config/config.go
@@ -198,6 +198,7 @@ type Dendrite struct {
 		MediaAPI         Address `yaml:"media_api"`
 		ClientAPI        Address `yaml:"client_api"`
 		FederationAPI    Address `yaml:"federation_api"`
+		AppServiceAPI    Address `yaml:"appservice_api"`
 		SyncAPI          Address `yaml:"sync_api"`
 		RoomServer       Address `yaml:"room_server"`
 		FederationSender Address `yaml:"federation_sender"`
@@ -408,7 +409,7 @@ func (config *Dendrite) derive() error {
 	}
 
 	// Load application service configuration files
-	if err := loadAppservices(config); err != nil {
+	if err := loadAppServices(config); err != nil {
 		return err
 	}
 
@@ -638,6 +639,15 @@ func fingerprintPEM(data []byte) *gomatrixserverlib.TLSFingerprint {
 			return &gomatrixserverlib.TLSFingerprint{SHA256: digest[:]}
 		}
 	}
+}
+
+// AppServiceURL returns a HTTP URL for where the appservice component is listening.
+func (config *Dendrite) AppServiceURL() string {
+	// Hard code the roomserver to talk HTTP for now.
+	// If we support HTTPS we need to think of a practical way to do certificate validation.
+	// People setting up servers shouldn't need to get a certificate valid for the public
+	// internet for an internal API.
+	return "http://" + string(config.Listen.AppServiceAPI)
 }
 
 // RoomServerURL returns an HTTP URL for where the roomserver is listening.

--- a/src/github.com/matrix-org/dendrite/common/http/http.go
+++ b/src/github.com/matrix-org/dendrite/common/http/http.go
@@ -1,0 +1,57 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+)
+
+// PostJSON performs a POST request with JSON on an internal HTTP API
+func PostJSON(
+	ctx context.Context, span opentracing.Span, httpClient *http.Client,
+	apiURL string, request, response interface{},
+) error {
+	jsonBytes, err := json.Marshal(request)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, apiURL, bytes.NewReader(jsonBytes))
+	if err != nil {
+		return err
+	}
+
+	// Mark the span as being an RPC client.
+	ext.SpanKindRPCClient.Set(span)
+	carrier := opentracing.HTTPHeadersCarrier(req.Header)
+	tracer := opentracing.GlobalTracer()
+
+	if err = tracer.Inject(span.Context(), opentracing.HTTPHeaders, carrier); err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := httpClient.Do(req.WithContext(ctx))
+	if res != nil {
+		defer (func() { err = res.Body.Close() })()
+	}
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != http.StatusOK {
+		var errorBody struct {
+			Message string `json:"message"`
+		}
+		if err = json.NewDecoder(res.Body).Decode(&errorBody); err != nil {
+			return err
+		}
+		return fmt.Errorf("api: %d: %s", res.StatusCode, errorBody.Message)
+	}
+	return json.NewDecoder(res.Body).Decode(response)
+}

--- a/src/github.com/matrix-org/dendrite/roomserver/api/alias.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/api/alias.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"net/http"
 
+	commonHTTP "github.com/matrix-org/dendrite/common/http"
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
@@ -139,7 +140,7 @@ func (h *httpRoomserverAliasAPI) SetRoomAlias(
 	defer span.Finish()
 
 	apiURL := h.roomserverURL + RoomserverSetRoomAliasPath
-	return postJSON(ctx, span, h.httpClient, apiURL, request, response)
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }
 
 // GetRoomIDForAlias implements RoomserverAliasAPI
@@ -152,7 +153,7 @@ func (h *httpRoomserverAliasAPI) GetRoomIDForAlias(
 	defer span.Finish()
 
 	apiURL := h.roomserverURL + RoomserverGetRoomIDForAliasPath
-	return postJSON(ctx, span, h.httpClient, apiURL, request, response)
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }
 
 // GetAliasesForRoomID implements RoomserverAliasAPI
@@ -165,7 +166,7 @@ func (h *httpRoomserverAliasAPI) GetAliasesForRoomID(
 	defer span.Finish()
 
 	apiURL := h.roomserverURL + RoomserverGetAliasesForRoomIDPath
-	return postJSON(ctx, span, h.httpClient, apiURL, request, response)
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }
 
 // RemoveRoomAlias implements RoomserverAliasAPI
@@ -178,5 +179,5 @@ func (h *httpRoomserverAliasAPI) RemoveRoomAlias(
 	defer span.Finish()
 
 	apiURL := h.roomserverURL + RoomserverRemoveRoomAliasPath
-	return postJSON(ctx, span, h.httpClient, apiURL, request, response)
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }

--- a/src/github.com/matrix-org/dendrite/roomserver/api/input.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/api/input.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"net/http"
 
+	commonHTTP "github.com/matrix-org/dendrite/common/http"
 	"github.com/matrix-org/gomatrixserverlib"
 	opentracing "github.com/opentracing/opentracing-go"
 )
@@ -134,5 +135,5 @@ func (h *httpRoomserverInputAPI) InputRoomEvents(
 	defer span.Finish()
 
 	apiURL := h.roomserverURL + RoomserverInputRoomEventsPath
-	return postJSON(ctx, span, h.httpClient, apiURL, request, response)
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }

--- a/src/github.com/matrix-org/dendrite/roomserver/api/query.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/api/query.go
@@ -15,16 +15,12 @@
 package api
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
 	"net/http"
 
-	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/opentracing/opentracing-go/ext"
-
+	commonHTTP "github.com/matrix-org/dendrite/common/http"
 	"github.com/matrix-org/gomatrixserverlib"
+	opentracing "github.com/opentracing/opentracing-go"
 )
 
 // QueryLatestEventsAndStateRequest is a request to QueryLatestEventsAndState
@@ -337,7 +333,7 @@ func (h *httpRoomserverQueryAPI) QueryLatestEventsAndState(
 	defer span.Finish()
 
 	apiURL := h.roomserverURL + RoomserverQueryLatestEventsAndStatePath
-	return postJSON(ctx, span, h.httpClient, apiURL, request, response)
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }
 
 // QueryStateAfterEvents implements RoomserverQueryAPI
@@ -350,7 +346,7 @@ func (h *httpRoomserverQueryAPI) QueryStateAfterEvents(
 	defer span.Finish()
 
 	apiURL := h.roomserverURL + RoomserverQueryStateAfterEventsPath
-	return postJSON(ctx, span, h.httpClient, apiURL, request, response)
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }
 
 // QueryEventsByID implements RoomserverQueryAPI
@@ -363,7 +359,7 @@ func (h *httpRoomserverQueryAPI) QueryEventsByID(
 	defer span.Finish()
 
 	apiURL := h.roomserverURL + RoomserverQueryEventsByIDPath
-	return postJSON(ctx, span, h.httpClient, apiURL, request, response)
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }
 
 // QueryMembershipForUser implements RoomserverQueryAPI
@@ -376,7 +372,7 @@ func (h *httpRoomserverQueryAPI) QueryMembershipForUser(
 	defer span.Finish()
 
 	apiURL := h.roomserverURL + RoomserverQueryMembershipForUserPath
-	return postJSON(ctx, span, h.httpClient, apiURL, request, response)
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }
 
 // QueryMembershipsForRoom implements RoomserverQueryAPI
@@ -389,7 +385,7 @@ func (h *httpRoomserverQueryAPI) QueryMembershipsForRoom(
 	defer span.Finish()
 
 	apiURL := h.roomserverURL + RoomserverQueryMembershipsForRoomPath
-	return postJSON(ctx, span, h.httpClient, apiURL, request, response)
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }
 
 // QueryInvitesForUser implements RoomserverQueryAPI
@@ -402,7 +398,7 @@ func (h *httpRoomserverQueryAPI) QueryInvitesForUser(
 	defer span.Finish()
 
 	apiURL := h.roomserverURL + RoomserverQueryInvitesForUserPath
-	return postJSON(ctx, span, h.httpClient, apiURL, request, response)
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }
 
 // QueryServerAllowedToSeeEvent implements RoomserverQueryAPI
@@ -415,7 +411,7 @@ func (h *httpRoomserverQueryAPI) QueryServerAllowedToSeeEvent(
 	defer span.Finish()
 
 	apiURL := h.roomserverURL + RoomserverQueryServerAllowedToSeeEventPath
-	return postJSON(ctx, span, h.httpClient, apiURL, request, response)
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }
 
 // QueryMissingEvents implements RoomServerQueryAPI
@@ -428,7 +424,7 @@ func (h *httpRoomserverQueryAPI) QueryMissingEvents(
 	defer span.Finish()
 
 	apiURL := h.roomserverURL + RoomserverQueryMissingEventsPath
-	return postJSON(ctx, span, h.httpClient, apiURL, request, response)
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }
 
 // QueryStateAndAuthChain implements RoomserverQueryAPI
@@ -441,49 +437,5 @@ func (h *httpRoomserverQueryAPI) QueryStateAndAuthChain(
 	defer span.Finish()
 
 	apiURL := h.roomserverURL + RoomserverQueryStateAndAuthChainPath
-	return postJSON(ctx, span, h.httpClient, apiURL, request, response)
-}
-
-func postJSON(
-	ctx context.Context, span opentracing.Span, httpClient *http.Client,
-	apiURL string, request, response interface{},
-) error {
-	jsonBytes, err := json.Marshal(request)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest(http.MethodPost, apiURL, bytes.NewReader(jsonBytes))
-	if err != nil {
-		return err
-	}
-
-	// Mark the span as being an RPC client.
-	ext.SpanKindRPCClient.Set(span)
-	carrier := opentracing.HTTPHeadersCarrier(req.Header)
-	tracer := opentracing.GlobalTracer()
-
-	if err = tracer.Inject(span.Context(), opentracing.HTTPHeaders, carrier); err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-
-	res, err := httpClient.Do(req.WithContext(ctx))
-	if res != nil {
-		defer (func() { err = res.Body.Close() })()
-	}
-	if err != nil {
-		return err
-	}
-	if res.StatusCode != http.StatusOK {
-		var errorBody struct {
-			Message string `json:"message"`
-		}
-		if err = json.NewDecoder(res.Body).Decode(&errorBody); err != nil {
-			return err
-		}
-		return fmt.Errorf("api: %d: %s", res.StatusCode, errorBody.Message)
-	}
-	return json.NewDecoder(res.Body).Decode(response)
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }


### PR DESCRIPTION
This provides an internal API for the appservices component, so that other dendrite components may query it for various AS-related tasks.

Depends on #539