### PR TITLE
AppServices: Implement Timestamp Massaging

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/auth/auth.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/auth.go
@@ -68,7 +68,7 @@ func VerifyUserFromRequest(
 	// Try to find local user from device database
 	dev, devErr := verifyAccessToken(req, data.DeviceDB)
 	if devErr == nil {
-		return dev, nil
+		return dev, verifyUserParameters(req)
 	}
 
 	// Try to find the Application Service user
@@ -132,6 +132,18 @@ func VerifyUserFromRequest(
 		Code: http.StatusUnauthorized,
 		JSON: jsonerror.UnknownToken("Unrecognized access token"),
 	}
+}
+
+// verifyUserParameters ensures that a request coming from a regular user is not
+// using any query parameters reserved for an application service
+func verifyUserParameters(req *http.Request) *util.JSONResponse {
+	if req.URL.Query().Get("ts") != "" {
+		return &util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.Unknown("parameter 'ts' not allowed without valid parameter 'access_token'"),
+		}
+	}
+	return nil
 }
 
 // verifyAccessToken verifies that an access token was supplied in the given HTTP request

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/joinroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/joinroom.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
@@ -215,7 +214,7 @@ func (r joinRoomReq) joinRoomUsingServers(
 	}
 
 	var queryRes roomserverAPI.QueryLatestEventsAndStateResponse
-	event, err := common.BuildEvent(r.req.Context(), &eb, r.cfg, r.queryAPI, &queryRes)
+	event, err := common.BuildEvent(r.req, &eb, r.cfg, r.queryAPI, &queryRes)
 	if err == nil {
 		if _, err = r.producer.SendEvents(r.req.Context(), []gomatrixserverlib.Event{*event}, r.cfg.Matrix.ServerName, nil); err != nil {
 			return httputil.LogThenError(r.req, err)
@@ -285,10 +284,10 @@ func (r joinRoomReq) joinRoomUsingServer(roomID string, server gomatrixserverlib
 		return nil, err
 	}
 
-	now := time.Now()
 	eventID := fmt.Sprintf("$%s:%s", util.RandomString(16), r.cfg.Matrix.ServerName)
+	eventTime := common.ParseTSParam(r.req)
 	event, err := respMakeJoin.JoinEvent.Build(
-		eventID, now, r.cfg.Matrix.ServerName, r.cfg.Matrix.KeyID, r.cfg.Matrix.PrivateKey,
+		eventID, eventTime, r.cfg.Matrix.ServerName, r.cfg.Matrix.KeyID, r.cfg.Matrix.PrivateKey,
 	)
 	if err != nil {
 		res := httputil.LogThenError(r.req, err)

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/membership.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/membership.go
@@ -48,8 +48,7 @@ func SendMembership(
 	}
 
 	inviteStored, err := threepid.CheckAndProcessInvite(
-		req.Context(),
-		device, &body, cfg, queryAPI, accountDB, producer, membership, roomID,
+		req, device, &body, cfg, queryAPI, accountDB, producer, membership, roomID,
 	)
 	if err == threepid.ErrMissingParameter {
 		return util.JSONResponse{
@@ -81,7 +80,7 @@ func SendMembership(
 	}
 
 	event, err := buildMembershipEvent(
-		req.Context(), body, accountDB, device, membership, roomID, cfg, queryAPI,
+		req, body, accountDB, device, membership, roomID, cfg, queryAPI,
 	)
 	if err == errMissingUserID {
 		return util.JSONResponse{
@@ -110,7 +109,7 @@ func SendMembership(
 }
 
 func buildMembershipEvent(
-	ctx context.Context,
+	req *http.Request,
 	body threepid.MembershipRequest, accountDB *accounts.Database,
 	device *authtypes.Device, membership string, roomID string, cfg config.Dendrite,
 	queryAPI api.RoomserverQueryAPI,
@@ -120,7 +119,7 @@ func buildMembershipEvent(
 		return nil, err
 	}
 
-	profile, err := loadProfile(ctx, stateKey, cfg, accountDB)
+	profile, err := loadProfile(req.Context(), stateKey, cfg, accountDB)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +147,7 @@ func buildMembershipEvent(
 		return nil, err
 	}
 
-	return common.BuildEvent(ctx, &builder, cfg, queryAPI, nil)
+	return common.BuildEvent(req, &builder, cfg, queryAPI, nil)
 }
 
 // loadProfile lookups the profile of a given user from the database and returns

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/profile.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/profile.go
@@ -15,7 +15,6 @@
 package routing
 
 import (
-	"context"
 	"database/sql"
 	"net/http"
 
@@ -151,7 +150,7 @@ func SetAvatarURL(
 		AvatarURL:   r.AvatarURL,
 	}
 
-	events, err := buildMembershipEvents(req.Context(), memberships, newProfile, userID, cfg, queryAPI)
+	events, err := buildMembershipEvents(req, memberships, newProfile, userID, cfg, queryAPI)
 	if err != nil {
 		return httputil.LogThenError(req, err)
 	}
@@ -239,7 +238,7 @@ func SetDisplayName(
 		AvatarURL:   oldProfile.AvatarURL,
 	}
 
-	events, err := buildMembershipEvents(req.Context(), memberships, newProfile, userID, cfg, queryAPI)
+	events, err := buildMembershipEvents(req, memberships, newProfile, userID, cfg, queryAPI)
 	if err != nil {
 		return httputil.LogThenError(req, err)
 	}
@@ -259,7 +258,7 @@ func SetDisplayName(
 }
 
 func buildMembershipEvents(
-	ctx context.Context,
+	req *http.Request,
 	memberships []authtypes.Membership,
 	newProfile authtypes.Profile, userID string, cfg *config.Dendrite,
 	queryAPI api.RoomserverQueryAPI,
@@ -285,7 +284,7 @@ func buildMembershipEvents(
 			return nil, err
 		}
 
-		event, err := common.BuildEvent(ctx, &builder, *cfg, queryAPI, nil)
+		event, err := common.BuildEvent(req, &builder, *cfg, queryAPI, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/sendevent.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/sendevent.go
@@ -76,7 +76,7 @@ func SendEvent(
 	}
 
 	var queryRes api.QueryLatestEventsAndStateResponse
-	e, err := common.BuildEvent(req.Context(), &builder, cfg, queryAPI, &queryRes)
+	e, err := common.BuildEvent(req, &builder, cfg, queryAPI, &queryRes)
 	if err == common.ErrRoomNoExists {
 		return util.JSONResponse{
 			Code: http.StatusNotFound,

--- a/src/github.com/matrix-org/dendrite/clientapi/threepid/invites.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/threepid/invites.go
@@ -85,7 +85,7 @@ var (
 // fills the Matrix ID in the request body so a normal invite membership event
 // can be emitted.
 func CheckAndProcessInvite(
-	ctx context.Context,
+	req *http.Request,
 	device *authtypes.Device, body *MembershipRequest, cfg config.Dendrite,
 	queryAPI api.RoomserverQueryAPI, db *accounts.Database,
 	producer *producers.RoomserverProducer, membership string, roomID string,
@@ -101,7 +101,7 @@ func CheckAndProcessInvite(
 		return
 	}
 
-	lookupRes, storeInviteRes, err := queryIDServer(ctx, db, cfg, device, body, roomID)
+	lookupRes, storeInviteRes, err := queryIDServer(req.Context(), db, cfg, device, body, roomID)
 	if err != nil {
 		return
 	}
@@ -110,7 +110,7 @@ func CheckAndProcessInvite(
 		// No Matrix ID could be found for this 3PID, meaning that a
 		// "m.room.third_party_invite" have to be emitted from the data in
 		// storeInviteRes.
-		err = emit3PIDInviteEvent(ctx, body, storeInviteRes, device, roomID, cfg, queryAPI, producer)
+		err = emit3PIDInviteEvent(req, body, storeInviteRes, device, roomID, cfg, queryAPI, producer)
 		inviteStoredOnIDServer = err == nil
 
 		return
@@ -325,7 +325,7 @@ func checkIDServerSignatures(
 // emit3PIDInviteEvent builds and sends a "m.room.third_party_invite" event.
 // Returns an error if something failed in the process.
 func emit3PIDInviteEvent(
-	ctx context.Context,
+	req *http.Request,
 	body *MembershipRequest, res *idServerStoreInviteResponse,
 	device *authtypes.Device, roomID string, cfg config.Dendrite,
 	queryAPI api.RoomserverQueryAPI, producer *producers.RoomserverProducer,
@@ -350,11 +350,11 @@ func emit3PIDInviteEvent(
 	}
 
 	var queryRes *api.QueryLatestEventsAndStateResponse
-	event, err := common.BuildEvent(ctx, builder, cfg, queryAPI, queryRes)
+	event, err := common.BuildEvent(req, builder, cfg, queryAPI, queryRes)
 	if err != nil {
 		return err
 	}
 
-	_, err = producer.SendEvents(ctx, []gomatrixserverlib.Event{*event}, cfg.Matrix.ServerName, nil)
+	_, err = producer.SendEvents(req.Context(), []gomatrixserverlib.Event{*event}, cfg.Matrix.ServerName, nil)
 	return err
 }

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/join.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/join.go
@@ -31,7 +31,6 @@ import (
 
 // MakeJoin implements the /make_join API
 func MakeJoin(
-	ctx context.Context,
 	httpReq *http.Request,
 	request *gomatrixserverlib.FederationRequest,
 	cfg config.Dendrite,
@@ -65,7 +64,7 @@ func MakeJoin(
 	}
 
 	var queryRes api.QueryLatestEventsAndStateResponse
-	event, err := common.BuildEvent(ctx, &builder, cfg, query, &queryRes)
+	event, err := common.BuildEvent(httpReq, &builder, cfg, query, &queryRes)
 	if err == common.ErrRoomNoExists {
 		return util.JSONResponse{
 			Code: http.StatusNotFound,

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/leave.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/leave.go
@@ -61,7 +61,7 @@ func MakeLeave(
 	}
 
 	var queryRes api.QueryLatestEventsAndStateResponse
-	event, err := common.BuildEvent(httpReq.Context(), &builder, cfg, query, &queryRes)
+	event, err := common.BuildEvent(httpReq, &builder, cfg, query, &queryRes)
 	if err == common.ErrRoomNoExists {
 		return util.JSONResponse{
 			Code: http.StatusNotFound,

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
@@ -165,7 +165,7 @@ func Setup(
 			roomID := vars["roomID"]
 			userID := vars["userID"]
 			return MakeJoin(
-				httpReq.Context(), httpReq, request, cfg, query, roomID, userID,
+				httpReq, request, cfg, query, roomID, userID,
 			)
 		},
 	)).Methods(http.MethodGet)


### PR DESCRIPTION
Timestamp massaging allows for an AS to send events with a custom `origin_server_ts` parameter.

Spec: https://matrix.org/docs/spec/application_service/unstable.html#timestamp-massaging

Closes #456. Depends on #427 