### PR TITLE
Remove trailing slashes from appservice url

### DIFF
--- a/src/github.com/matrix-org/dendrite/common/config/appservice.go
+++ b/src/github.com/matrix-org/dendrite/common/config/appservice.go
@@ -188,6 +188,11 @@ func checkErrors(config *Dendrite) (err error) {
 			}
 		}
 
+		// Check if the url has trailing /'s. If so, remove them
+		for strings.HasSuffix(appservice.URL, "/") {
+			appservice.URL = strings.TrimSuffix(appservice.URL, "/")
+		}
+
 		// Check if we've already seen this ID. No two application services
 		// can have the same ID or token.
 		if idMap[appservice.ID] {


### PR DESCRIPTION
User had their appservice broken from an extra trailing slash in the `url` field of their application service registration file.

While this is a user problem, it's nice to handle automatically.