### PR TITLE
Third Party Lookup Support

### DIFF
--- a/src/github.com/matrix-org/dendrite/appservice/api/query.go
+++ b/src/github.com/matrix-org/dendrite/appservice/api/query.go
@@ -27,6 +27,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
 	"github.com/matrix-org/gomatrixserverlib"
 
+	"github.com/matrix-org/dendrite/appservice/types"
 	commonHTTP "github.com/matrix-org/dendrite/common/http"
 	opentracing "github.com/opentracing/opentracing-go"
 )
@@ -65,6 +66,29 @@ type UserIDExistsResponse struct {
 	UserIDExists bool `json:"exists"`
 }
 
+// GetProtocolDefinitionRequest is a request to the appservice component asking
+// for the definition of a single third party protocol
+type GetProtocolDefinitionRequest struct {
+	ProtocolID string `json:"protocol_definition"`
+}
+
+// GetProtocolDefinitionResponse is a response providing a protocol definition
+// for the given protocol ID
+type GetProtocolDefinitionResponse struct {
+	ProtocolDefinition string `json:"protocol_definition"`
+}
+
+// GetAllProtocolDefinitionsRequest is a request to the appservice component
+// asking for what third party protocols are known and their definitions
+type GetAllProtocolDefinitionsRequest struct {
+}
+
+// GetAllProtocolDefinitionsResponse is a response containing all known third
+// party IDs and their definitions
+type GetAllProtocolDefinitionsResponse struct {
+	Protocols types.ThirdPartyProtocols `json:"protocols"`
+}
+
 // AppServiceQueryAPI is used to query user and room alias data from application
 // services
 type AppServiceQueryAPI interface {
@@ -80,10 +104,28 @@ type AppServiceQueryAPI interface {
 		req *UserIDExistsRequest,
 		resp *UserIDExistsResponse,
 	) error
+	// Get the definition of a given single third party protocol
+	GetProtocolDefinition(
+		ctx context.Context,
+		req *GetProtocolDefinitionRequest,
+		response *GetProtocolDefinitionResponse,
+	) error
+	// Get the definition of all known third party protocols
+	GetAllProtocolDefinitions(
+		ctx context.Context,
+		req *GetAllProtocolDefinitionsRequest,
+		response *GetAllProtocolDefinitionsResponse,
+	) error
 }
 
-// AppServiceRoomAliasExistsPath is the HTTP path for the RoomAliasExists API
-const AppServiceRoomAliasExistsPath = "/api/appservice/RoomAliasExists"
+// RoomAliasExistsPath is the HTTP path for the RoomAliasExists API
+const RoomAliasExistsPath = "/api/appservice/RoomAliasExists"
+
+// GetProtocolDefinitionPath is the HTTP path for the GetProtocolDefinition API
+const GetProtocolDefinitionPath = "/api/appservice/GetProtocolDefinition"
+
+// GetAllProtocolDefinitionsPath is the HTTP path for the GetAllProtocolDefinitions API
+const GetAllProtocolDefinitionsPath = "/api/appservice/GetAllProtocolDefinitions"
 
 // AppServiceUserIDExistsPath is the HTTP path for the UserIDExists API
 const AppServiceUserIDExistsPath = "/api/appservice/UserIDExists"
@@ -117,7 +159,33 @@ func (h *httpAppServiceQueryAPI) RoomAliasExists(
 	span, ctx := opentracing.StartSpanFromContext(ctx, "appserviceRoomAliasExists")
 	defer span.Finish()
 
-	apiURL := h.appserviceURL + AppServiceRoomAliasExistsPath
+	apiURL := h.appserviceURL + RoomAliasExistsPath
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+}
+
+// GetProtocolDefinition implements AppServiceQueryAPI
+func (h *httpAppServiceQueryAPI) GetProtocolDefinition(
+	ctx context.Context,
+	request *GetProtocolDefinitionRequest,
+	response *GetProtocolDefinitionResponse,
+) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "appserviceGetProtocolDefinition")
+	defer span.Finish()
+
+	apiURL := h.appserviceURL + GetProtocolDefinitionPath
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+}
+
+// GetAllProtocolDefinitions implements AppServiceQueryAPI
+func (h *httpAppServiceQueryAPI) GetAllProtocolDefinitions(
+	ctx context.Context,
+	request *GetAllProtocolDefinitionsRequest,
+	response *GetAllProtocolDefinitionsResponse,
+) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "appserviceGetAllProtocolDefinitions")
+	defer span.Finish()
+
+	apiURL := h.appserviceURL + GetAllProtocolDefinitionsPath
 	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }
 

--- a/src/github.com/matrix-org/dendrite/appservice/appservice.go
+++ b/src/github.com/matrix-org/dendrite/appservice/appservice.go
@@ -133,7 +133,10 @@ func setupWorkers(
 	workerStates []types.ApplicationServiceWorkerState,
 ) {
 	// Clear all old protocol definitions on startup
-	appserviceDB.ClearProtocolDefinitions(context.TODO())
+	err := appserviceDB.ClearProtocolDefinitions(context.TODO())
+	if err != nil {
+		log.WithError(err).Fatalf("unable to clear appservice protocol definitions from db")
+	}
 
 	// Create a worker that handles transmitting events to a single homeserver
 	for _, workerState := range workerStates {

--- a/src/github.com/matrix-org/dendrite/appservice/appservice.go
+++ b/src/github.com/matrix-org/dendrite/appservice/appservice.go
@@ -68,7 +68,7 @@ func SetupAppServiceAPIComponent(
 		// Create bot account for this AS if it doesn't already exist
 		if err = generateAppServiceAccount(accountsDB, deviceDB, appservice); err != nil {
 			log.WithFields(log.Fields{
-				"appservice": appservice.ID,
+				"appservice_id": appservice.ID,
 			}).WithError(err).Panicf("failed to generate bot account for appservice")
 		}
 	}
@@ -141,7 +141,7 @@ func setupWorkers(
 	// Create a worker that handles transmitting events to a single homeserver
 	for _, workerState := range workerStates {
 		log.WithFields(log.Fields{
-			"appservice": workerState.AppService.ID,
+			"appservice_id": workerState.AppService.ID,
 		}).Info("starting application service")
 
 		// Don't create a worker if this AS doesn't want to receive events

--- a/src/github.com/matrix-org/dendrite/appservice/query/query.go
+++ b/src/github.com/matrix-org/dendrite/appservice/query/query.go
@@ -90,8 +90,8 @@ func (a *AppServiceQueryAPI) RoomAliasExists(
 					err = resp.Body.Close()
 					if err != nil {
 						log.WithFields(log.Fields{
-							"appservice":  appservice.ID,
-							"status_code": resp.StatusCode,
+							"appservice_id": appservice.ID,
+							"status_code":   resp.StatusCode,
 						}).WithError(err).Error("Unable to close application service response body")
 					}
 				}()
@@ -110,8 +110,8 @@ func (a *AppServiceQueryAPI) RoomAliasExists(
 			default:
 				// Application service reported an error. Warn
 				log.WithFields(log.Fields{
-					"appservice":  appservice.ID,
-					"status_code": resp.StatusCode,
+					"appservice_id": appservice.ID,
+					"status_code":   resp.StatusCode,
 				}).Warn("Application service responded with non-OK status code")
 			}
 		}
@@ -159,7 +159,7 @@ func (a *AppServiceQueryAPI) UserIDExists(
 			}
 			if err != nil {
 				log.WithFields(log.Fields{
-					"appservice": appservice.ID,
+					"appservice_id": appservice.ID,
 				}).WithError(err).Error("issue querying user ID on application service")
 				return err
 			}
@@ -172,8 +172,8 @@ func (a *AppServiceQueryAPI) UserIDExists(
 
 			// Log if return code is not OK
 			log.WithFields(log.Fields{
-				"appservice":  appservice.ID,
-				"status_code": resp.StatusCode,
+				"appservice_id": appservice.ID,
+				"status_code":   resp.StatusCode,
 			}).Warn("application service responded with non-OK status code")
 		}
 	}
@@ -305,7 +305,7 @@ func contactApplicationService(
 	req, err := http.NewRequest(http.MethodGet, requestURL, bytes.NewReader(request.Content))
 	if err != nil {
 		log.WithFields(log.Fields{
-			"appservice": as.ID,
+			"appservice_id": as.ID,
 		}).WithError(err).Error("problem building proxy request to application service")
 		return
 	}
@@ -318,15 +318,15 @@ func contactApplicationService(
 	}
 	if err != nil {
 		log.WithFields(log.Fields{
-			"appservice": as.ID,
+			"appservice_id": as.ID,
 		}).WithError(err).Warn("unable to proxy request to application service")
 		return
 	}
 
 	if resp.StatusCode != http.StatusOK {
 		log.WithFields(log.Fields{
-			"appservice":  as.ID,
-			"status_code": resp.StatusCode,
+			"appservice_id": as.ID,
+			"status_code":   resp.StatusCode,
 		}).Warn("non-OK response from application server while proxying request")
 		return
 	}
@@ -336,7 +336,7 @@ func contactApplicationService(
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.WithFields(log.Fields{
-			"appservice": as.ID,
+			"appservice_id": as.ID,
 		}).WithError(err).Warn("unable to read response from application server while proxying request")
 		return
 	}
@@ -346,7 +346,7 @@ func contactApplicationService(
 	err = json.Unmarshal(body, &querySlice)
 	if err != nil {
 		log.WithFields(log.Fields{
-			"appservice": as.ID,
+			"appservice_id": as.ID,
 		}).WithError(err).Warn("unable to unmarshal response from application server while proxying request")
 		return
 	}

--- a/src/github.com/matrix-org/dendrite/appservice/query/query.go
+++ b/src/github.com/matrix-org/dendrite/appservice/query/query.go
@@ -359,7 +359,7 @@ func makeHTTPClient() *http.Client {
 	}
 }
 
-// SetupHTTP adds the AppServiceQueryPAI handlers to the http.ServeMux. This
+// SetupHTTP adds the AppServiceQueryAPI handlers to the http.ServeMux. This
 // handles and muxes incoming api requests the to internal AppServiceQueryAPI.
 func (a *AppServiceQueryAPI) SetupHTTP(servMux *http.ServeMux) {
 	servMux.Handle(

--- a/src/github.com/matrix-org/dendrite/appservice/query/query.go
+++ b/src/github.com/matrix-org/dendrite/appservice/query/query.go
@@ -86,15 +86,7 @@ func (a *AppServiceQueryAPI) RoomAliasExists(
 			req = req.WithContext(ctx)
 			resp, err := a.HTTPClient.Do(req)
 			if resp != nil {
-				defer func() {
-					err = resp.Body.Close()
-					if err != nil {
-						log.WithFields(log.Fields{
-							"appservice_id": appservice.ID,
-							"status_code":   resp.StatusCode,
-						}).WithError(err).Error("Unable to close application service response body")
-					}
-				}()
+				defer resp.Body.Close() // nolint: errcheck
 			}
 			if err != nil {
 				log.WithError(err).Errorf("Issue querying room alias on application service %s", appservice.ID)
@@ -141,6 +133,10 @@ func (a *AppServiceQueryAPI) UserIDExists(
 		if appservice.URL != "" && appservice.IsInterestedInUserID(request.UserID) {
 			// The full path to the rooms API, includes hs token
 			URL, err := url.Parse(appservice.URL + userIDExistsPath)
+			if err != nil {
+				return err
+			}
+
 			URL.Path += request.UserID
 			apiURL := URL.String() + "?access_token=" + appservice.HSToken
 

--- a/src/github.com/matrix-org/dendrite/appservice/query/query.go
+++ b/src/github.com/matrix-org/dendrite/appservice/query/query.go
@@ -17,67 +17,37 @@
 package query
 
 import (
+	"bytes"
 	"context"
+	"database/sql"
 	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/matrix-org/dendrite/appservice/api"
 	"github.com/matrix-org/dendrite/appservice/storage"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/config"
+	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 	opentracing "github.com/opentracing/opentracing-go"
 	log "github.com/sirupsen/logrus"
 )
 
-const roomAliasExistsPath = "/rooms/"
-const userIDExistsPath = "/users/"
+const (
+	roomAliasExistsPath = "/rooms/"
+	userIDExistsPath    = "/users/"
+)
 
 // AppServiceQueryAPI is an implementation of api.AppServiceQueryAPI
 type AppServiceQueryAPI struct {
 	HTTPClient *http.Client
 	Cfg        *config.Dendrite
 	Db         *storage.Database
-}
-
-// GetProtocolDefinition queries the database for the protocol definition of a
-// protocol with given ID
-func (a *AppServiceQueryAPI) GetProtocolDefinition(
-	ctx context.Context,
-	request *api.GetProtocolDefinitionRequest,
-	response *api.GetProtocolDefinitionResponse,
-) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ApplicationServiceGetProtocolDefinition")
-	defer span.Finish()
-
-	protocolDefinition, err := a.Db.GetProtocolDefinition(ctx, request.ProtocolID)
-	if err != nil {
-		return err
-	}
-
-	response.ProtocolDefinition = protocolDefinition
-	return nil
-}
-
-// GetAllProtocolDefinitions queries the database for all known protocol
-// definitions and their IDs
-func (a *AppServiceQueryAPI) GetAllProtocolDefinitions(
-	ctx context.Context,
-	request *api.GetAllProtocolDefinitionsRequest,
-	response *api.GetAllProtocolDefinitionsResponse,
-) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "ApplicationServiceGetAllProtocolDefinitions")
-	defer span.Finish()
-
-	protocolDefinitions, err := a.Db.GetAllProtocolDefinitions(ctx)
-	if err != nil {
-		return err
-	}
-
-	response.Protocols = protocolDefinitions
-	return nil
 }
 
 // RoomAliasExists performs a request to '/room/{roomAlias}' on all known
@@ -100,6 +70,10 @@ func (a *AppServiceQueryAPI) RoomAliasExists(
 		if appservice.URL != "" && appservice.IsInterestedInRoomAlias(request.Alias) {
 			// The full path to the rooms API, includes hs token
 			URL, err := url.Parse(appservice.URL + roomAliasExistsPath)
+			if err != nil {
+				return err
+			}
+
 			URL.Path += request.Alias
 			apiURL := URL.String() + "?access_token=" + appservice.HSToken
 
@@ -110,15 +84,14 @@ func (a *AppServiceQueryAPI) RoomAliasExists(
 				return err
 			}
 			req = req.WithContext(ctx)
-
 			resp, err := a.HTTPClient.Do(req)
 			if resp != nil {
 				defer func() {
 					err = resp.Body.Close()
 					if err != nil {
 						log.WithFields(log.Fields{
-							"appservice_id": appservice.ID,
-							"status_code":   resp.StatusCode,
+							"appservice":  appservice.ID,
+							"status_code": resp.StatusCode,
 						}).WithError(err).Error("Unable to close application service response body")
 					}
 				}()
@@ -137,8 +110,8 @@ func (a *AppServiceQueryAPI) RoomAliasExists(
 			default:
 				// Application service reported an error. Warn
 				log.WithFields(log.Fields{
-					"appservice_id": appservice.ID,
-					"status_code":   resp.StatusCode,
+					"appservice":  appservice.ID,
+					"status_code": resp.StatusCode,
 				}).Warn("Application service responded with non-OK status code")
 			}
 		}
@@ -177,40 +150,210 @@ func (a *AppServiceQueryAPI) UserIDExists(
 			if err != nil {
 				return err
 			}
-			resp, err := a.HTTPClient.Do(req.WithContext(ctx))
+			req = req.WithContext(ctx)
+
+			// Make a request to the application service
+			resp, err := a.HTTPClient.Do(req)
 			if resp != nil {
-				defer func() {
-					err = resp.Body.Close()
-					if err != nil {
-						log.WithFields(log.Fields{
-							"appservice_id": appservice.ID,
-							"status_code":   resp.StatusCode,
-						}).Error("Unable to close application service response body")
-					}
-				}()
+				defer resp.Body.Close() // nolint: errcheck
 			}
 			if err != nil {
 				log.WithFields(log.Fields{
-					"appservice_id": appservice.ID,
+					"appservice": appservice.ID,
 				}).WithError(err).Error("issue querying user ID on application service")
 				return err
 			}
+
 			if resp.StatusCode == http.StatusOK {
 				// StatusOK received from appservice. User ID exists
 				response.UserIDExists = true
 				return nil
 			}
 
-			// Log non OK
+			// Log if return code is not OK
 			log.WithFields(log.Fields{
-				"appservice_id": appservice.ID,
-				"status_code":   resp.StatusCode,
+				"appservice":  appservice.ID,
+				"status_code": resp.StatusCode,
 			}).Warn("application service responded with non-OK status code")
 		}
 	}
 
 	response.UserIDExists = false
 	return nil
+}
+
+// GetProtocolDefinition queries the database for the protocol definition of a
+// protocol with given ID
+func (a *AppServiceQueryAPI) GetProtocolDefinition(
+	ctx context.Context,
+	request *api.GetProtocolDefinitionRequest,
+	response *api.GetProtocolDefinitionResponse,
+) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "ApplicationServiceGetProtocolDefinition")
+	defer span.Finish()
+
+	protocolDefinition, err := a.Db.GetProtocolDefinition(ctx, request.ProtocolID)
+	if err != nil && err != sql.ErrNoRows {
+		return err
+	}
+
+	response.ProtocolDefinition = gomatrixserverlib.RawJSON(protocolDefinition)
+	return nil
+}
+
+// GetAllProtocolDefinitions queries the database for all known protocol
+// definitions and their IDs
+func (a *AppServiceQueryAPI) GetAllProtocolDefinitions(
+	ctx context.Context,
+	request *api.GetAllProtocolDefinitionsRequest,
+	response *api.GetAllProtocolDefinitionsResponse,
+) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "ApplicationServiceGetAllProtocolDefinitions")
+	defer span.Finish()
+
+	protocolDefinitions, err := a.Db.GetAllProtocolDefinitions(ctx)
+	if err != nil {
+		return err
+	}
+
+	response.Protocols = protocolDefinitions
+	return nil
+}
+
+// ThirdPartyProxy will proxy a request for third party lookup information from
+// a client to a connected application service. If a protocol ID is specified,
+// the application service that handles it will solely be contacted, otherwise
+// all application services will be contacted and their responses concatenated
+func (a *AppServiceQueryAPI) ThirdPartyProxy(
+	ctx context.Context,
+	request *api.ThirdPartyProxyRequest,
+	response *api.ThirdPartyProxyResponse,
+) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "ApplicationServiceGetAllProtocolDefinitions")
+	defer span.Finish()
+
+	// Create an HTTP client if one does not already exist
+	if a.HTTPClient == nil {
+		a.HTTPClient = makeHTTPClient()
+	}
+
+	appservicesToContact := make([]config.ApplicationService, 0, len(a.Cfg.Derived.ApplicationServices))
+	if request.ProtocolID == "" {
+		// If no protocol ID was specified, send the request to all known application
+		// services in parallel and stitch together the results
+		appservicesToContact = a.Cfg.Derived.ApplicationServices
+	} else {
+		// Otherwise simply proxy the request to the application services handling
+		// this protocol and return the result
+		for _, as := range a.Cfg.Derived.ApplicationServices {
+			for _, protocol := range as.Protocols {
+				if request.ProtocolID == protocol {
+					appservicesToContact = append(appservicesToContact, as)
+					break
+				}
+			}
+		}
+	}
+
+	// Contact each application service in parallel, wait for all to finish before continuing
+	var wg sync.WaitGroup
+	var err error
+	responseSlice := make([]interface{}, 0)
+	for _, appservice := range appservicesToContact {
+		// Increment goroutine waitgroup counter
+		wg.Add(1)
+
+		go func(ctx context.Context,
+			h *http.Client,
+			req *api.ThirdPartyProxyRequest,
+			as config.ApplicationService,
+			r *[]interface{},
+		) {
+			// Decrement waitgroup counter once the request has finished
+			defer wg.Done()
+
+			// Contact the application service, return nil or error if something went wrong
+			contactApplicationService(ctx, h, req, as, r)
+		}(ctx, a.HTTPClient, request, appservice, &responseSlice)
+	}
+
+	// Wait for all requests to finish
+	wg.Wait()
+
+	// Convert the slice of responses back to JSON
+	response.Content, err = json.Marshal(responseSlice)
+	return err
+}
+
+// contactApplicationService proxies a third party lookup request to an
+// application service
+func contactApplicationService(
+	ctx context.Context,
+	httpClient *http.Client,
+	request *api.ThirdPartyProxyRequest,
+	as config.ApplicationService,
+	responseSlice *[]interface{},
+) {
+	// Build the request with body and parameters to the application service
+	if as.URL == "" {
+		return
+	}
+
+	// Send a request to each application service. If one responds that it has
+	// created the room, immediately return.
+	requestURL := as.URL + request.Path
+	req, err := http.NewRequest(http.MethodGet, requestURL, bytes.NewReader(request.Content))
+	if err != nil {
+		log.WithFields(log.Fields{
+			"appservice": as.ID,
+		}).WithError(err).Error("problem building proxy request to application service")
+		return
+	}
+	req = req.WithContext(ctx)
+
+	// Make a request to the application service
+	resp, err := httpClient.Do(req)
+	if resp != nil {
+		defer resp.Body.Close() // nolint: errcheck
+	}
+	if err != nil {
+		log.WithFields(log.Fields{
+			"appservice": as.ID,
+		}).WithError(err).Warn("unable to proxy request to application service")
+		return
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		log.WithFields(log.Fields{
+			"appservice":  as.ID,
+			"status_code": resp.StatusCode,
+		}).Warn("non-OK response from application server while proxying request")
+		return
+	}
+
+	// Unmarshal response body into a generic slice and append to the slice of
+	// existing responses, to eventually be returned to the client
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"appservice": as.ID,
+		}).WithError(err).Warn("unable to read response from application server while proxying request")
+		return
+	}
+
+	// Temporary slice to unmarshal into
+	querySlice := make([]interface{}, 0)
+	err = json.Unmarshal(body, &querySlice)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"appservice": as.ID,
+		}).WithError(err).Warn("unable to unmarshal response from application server while proxying request")
+		return
+	}
+
+	// Append to existing responses
+	fmt.Println("Adding", querySlice)
+	*responseSlice = append(*responseSlice, querySlice...)
 }
 
 // makeHTTPClient creates an HTTP client with certain options that will be used for all query requests to application services
@@ -274,6 +417,23 @@ func (a *AppServiceQueryAPI) SetupHTTP(servMux *http.ServeMux) {
 				return util.ErrorResponse(err)
 			}
 			if err := a.GetAllProtocolDefinitions(req.Context(), &request, &response); err != nil {
+				return util.ErrorResponse(err)
+			}
+			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
+		}),
+	)
+	servMux.Handle(
+		api.ThirdPartyProxyPath,
+		common.MakeInternalAPI("appserviceThirdPartyProxy", func(req *http.Request) util.JSONResponse {
+			var request api.ThirdPartyProxyRequest
+			var response api.ThirdPartyProxyResponse
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.ErrorResponse(err)
+			}
+			if err := a.ThirdPartyProxy(req.Context(), &request, &response); err != nil {
+				if err == sql.ErrNoRows {
+					return util.JSONResponse{Code: http.StatusNotFound, JSON: &response}
+				}
 				return util.ErrorResponse(err)
 			}
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}

--- a/src/github.com/matrix-org/dendrite/appservice/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/appservice/routing/routing.go
@@ -27,7 +27,12 @@ import (
 	"github.com/matrix-org/util"
 )
 
-const pathPrefixApp = "/_matrix/app/r0"
+const (
+	// PathPrefixApp for current stable application services API version
+	PathPrefixApp = "/_matrix/app/r0"
+	// PathPrefixAppUnstable is the unstable application services API version
+	PathPrefixAppUnstable = "/_matrix/app/unstable"
+)
 
 // Setup registers HTTP handlers with the given ServeMux. It also supplies the given http.Client
 // to clients which need to make outbound HTTP requests.
@@ -38,7 +43,7 @@ func Setup(
 	federation *gomatrixserverlib.FederationClient, // nolint: unparam
 	transactionsCache *transactions.Cache, // nolint: unparam
 ) {
-	appMux := apiMux.PathPrefix(pathPrefixApp).Subrouter()
+	appMux := apiMux.PathPrefix(PathPrefixApp).Subrouter()
 
 	appMux.Handle("/alias",
 		common.MakeExternalAPI("alias", func(req *http.Request) util.JSONResponse {

--- a/src/github.com/matrix-org/dendrite/appservice/storage/appservice_events_table.go
+++ b/src/github.com/matrix-org/dendrite/appservice/storage/appservice_events_table.go
@@ -119,7 +119,7 @@ func (s *eventsStatements) selectEventsByApplicationServiceID(
 		err = eventRows.Close()
 		if err != nil {
 			log.WithFields(log.Fields{
-				"appservice": applicationServiceID,
+				"appservice_id": applicationServiceID,
 			}).WithError(err).Fatalf("appservice unable to select new events to send")
 		}
 	}()

--- a/src/github.com/matrix-org/dendrite/appservice/storage/storage.go
+++ b/src/github.com/matrix-org/dendrite/appservice/storage/storage.go
@@ -139,7 +139,7 @@ func (d *Database) StoreProtocolDefinition(
 	return d.thirdparty.insertProtocolDefinition(ctx, protocolID, protocolDefinition)
 }
 
-// ClearProtocolDefinition clears all protocol definition entries in the
+// ClearProtocolDefinitions clears all protocol definition entries in the
 // database. This is done on each startup to wipe old protocol definitions from
 // previous application services.
 func (d *Database) ClearProtocolDefinitions(

--- a/src/github.com/matrix-org/dendrite/appservice/storage/third_party_table.go
+++ b/src/github.com/matrix-org/dendrite/appservice/storage/third_party_table.go
@@ -1,0 +1,151 @@
+// Copyright 2018 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storage
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/matrix-org/dendrite/appservice/types"
+	"github.com/matrix-org/gomatrixserverlib"
+	log "github.com/sirupsen/logrus"
+)
+
+const thirdPartySchema = `
+-- Stores protocol definitions for clients to later request
+CREATE TABLE IF NOT EXISTS appservice_third_party_protocol_def (
+	-- The ID of the procotol
+	protocol_id TEXT NOT NULL PRIMARY KEY,
+	-- The JSON-encoded protocol definition
+	protocol_definition TEXT NOT NULL,
+	UNIQUE(protocol_id)
+);
+
+CREATE INDEX IF NOT EXISTS appservice_third_party_protocol_def_id
+ON appservice_third_party_protocol_def(protocol_id);
+`
+
+const selectProtocolDefinitionSQL = "" +
+	"SELECT protocol_definition FROM appservice_third_party_protocol_def " +
+	"WHERE protocol_id = $1"
+
+const selectAllProtocolDefinitionsSQL = "" +
+	"SELECT protocol_id, protocol_definition FROM appservice_third_party_protocol_def"
+
+const insertProtocolDefinitionSQL = "" +
+	"INSERT INTO appservice_third_party_protocol_def(protocol_id, protocol_definition) " +
+	"VALUES ($1, $2)"
+
+const clearProtocolDefinitionsSQL = "" +
+	"TRUNCATE appservice_third_party_protocol_def"
+
+type thirdPartyStatements struct {
+	selectProtocolDefinitionStmt     *sql.Stmt
+	selectAllProtocolDefinitionsStmt *sql.Stmt
+	insertProtocolDefinitionStmt     *sql.Stmt
+	clearProtocolDefinitionsStmt     *sql.Stmt
+}
+
+func (s *thirdPartyStatements) prepare(db *sql.DB) (err error) {
+	_, err = db.Exec(thirdPartySchema)
+	if err != nil {
+		return
+	}
+
+	if s.selectProtocolDefinitionStmt, err = db.Prepare(selectProtocolDefinitionSQL); err != nil {
+		return
+	}
+
+	if s.selectAllProtocolDefinitionsStmt, err = db.Prepare(selectAllProtocolDefinitionsSQL); err != nil {
+		return
+	}
+
+	if s.insertProtocolDefinitionStmt, err = db.Prepare(insertProtocolDefinitionSQL); err != nil {
+		return
+	}
+
+	if s.clearProtocolDefinitionsStmt, err = db.Prepare(clearProtocolDefinitionsSQL); err != nil {
+		return
+	}
+
+	return
+}
+
+// selectProtocolDefinition returns a single protocol definition for a given ID.
+// Returns an empty string if the ID was not found.
+func (s *thirdPartyStatements) selectProtocolDefinition(
+	ctx context.Context,
+	protocolID string,
+) (protocolDefinition string, err error) {
+	err = s.selectProtocolDefinitionStmt.QueryRowContext(
+		ctx, protocolID,
+	).Scan(&protocolDefinition)
+
+	if err != nil && err != sql.ErrNoRows {
+		return "", err
+	}
+
+	return
+}
+
+// selectAllProtocolDefinitions returns all protcol IDs and definitions in the
+// database. Returns an empty map if no definitions were found.
+func (s *thirdPartyStatements) selectAllProtocolDefinitions(
+	ctx context.Context,
+) (protocols types.ThirdPartyProtocols, err error) {
+	protocolDefinitionRows, err := s.selectAllProtocolDefinitionsStmt.QueryContext(ctx)
+	if err != nil && err != sql.ErrNoRows {
+		return
+	}
+	defer func() {
+		err = protocolDefinitionRows.Close()
+		if err != nil {
+			log.WithError(err).Fatalf("unable to close protocol definitions")
+		}
+	}()
+
+	for protocolDefinitionRows.Next() {
+		var protocolID, protocolDefinition string
+		if err = protocolDefinitionRows.Scan(&protocolID, &protocolDefinition); err != nil {
+			return nil, err
+		}
+
+		protocols[protocolID] = gomatrixserverlib.RawJSON(protocolDefinition)
+	}
+
+	return protocols, nil
+}
+
+// insertProtocolDefinition inserts a protocol ID along with its definition in
+// order for clients to later retreive it from the client-server API.
+func (s *thirdPartyStatements) insertProtocolDefinition(
+	ctx context.Context,
+	protocolID, protocolDefinition string,
+) (err error) {
+	_, err = s.insertProtocolDefinitionStmt.ExecContext(
+		ctx,
+		protocolID,
+		protocolDefinition,
+	)
+	return
+}
+
+// clearProtocolDefinitions removes all protocol definitions from the database.
+func (s *thirdPartyStatements) clearProtocolDefinitions(
+	ctx context.Context,
+) (err error) {
+	_, err = s.clearProtocolDefinitionsStmt.ExecContext(ctx)
+	return
+}

--- a/src/github.com/matrix-org/dendrite/appservice/types/third_party.go
+++ b/src/github.com/matrix-org/dendrite/appservice/types/third_party.go
@@ -1,0 +1,23 @@
+// Copyright 2018 New Vector Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"github.com/matrix-org/gomatrixserverlib"
+)
+
+// ThirdPartyProtocols is a map of all third party protocols supported by
+// connected application services.
+type ThirdPartyProtocols map[string]gomatrixserverlib.RawJSON

--- a/src/github.com/matrix-org/dendrite/appservice/workers/third_party.go
+++ b/src/github.com/matrix-org/dendrite/appservice/workers/third_party.go
@@ -1,0 +1,151 @@
+// Copyright 2018 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workers
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"net/http"
+	"time"
+
+	"github.com/matrix-org/dendrite/appservice/storage"
+	"github.com/matrix-org/dendrite/common/config"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	// Timeout for requests to an application service to complete
+	requestTimeout = time.Second * 300
+)
+
+const protocolPath = "/_matrix/app/unstable/thirdparty/protocol/"
+
+// ThirdPartyWorker interfaces with a given application service on third party
+// network related information.
+// At the moment it simply asks for information on protocols that an application
+// service supports, then exits.
+func ThirdPartyWorker(
+	db *storage.Database,
+	appservice config.ApplicationService,
+) {
+	ctx := context.Background()
+
+	// Grab the HTTP client for sending requests to app services
+	client := &http.Client{
+		Timeout: requestTimeout,
+		// TODO: Verify certificates
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true, // nolint: gas
+			},
+		},
+	}
+
+	backoffCount := 0
+
+	// Retrieve protocol information from the application service
+	for i := 0; i < len(appservice.Protocols); i++ {
+		protocolID := appservice.Protocols[i]
+		protocolDefinition, err := retreiveProtocolInformation(
+			ctx, client, appservice, protocolID,
+		)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"appservice":       appservice.ID,
+				"backoff_exponent": backoffCount,
+			}).WithError(err).Warn("error contacting appservice thirdparty endpoints")
+
+			// Backoff before contacting again
+			backoff(&backoffCount)
+
+			// Try this protocol again
+			i--
+			continue
+		}
+
+		// Cache protocol definition for clients to request later
+		storeProtocolDefinition(ctx, db, appservice, protocolID, protocolDefinition)
+	}
+}
+
+// backoff for the request amount of 2^number seconds
+// We want to support a few different use cases. Application services that don't
+// implement these endpoints and thus will always return an error. Application
+// services that are not currently up when Dendrite starts. Application services
+// that are broken for a while but will come back online later.
+// We can support all of these without being too resource intensive with
+// exponential backoff.
+func backoff(exponent *int) {
+	// Calculate how long to backoff for
+	backoffDuration := time.Duration(math.Pow(2, float64(*exponent)))
+	backoffSeconds := time.Second * backoffDuration
+
+	if *exponent < 6 {
+		*exponent++
+	}
+
+	// Backoff
+	time.Sleep(backoffSeconds)
+}
+
+// retreiveProtocolInformation contacts an application service and asks for
+// information about a given protocol.
+func retreiveProtocolInformation(
+	ctx context.Context,
+	httpClient *http.Client,
+	appservice config.ApplicationService,
+	protocol string,
+) (string, error) {
+	// Create a request to the application service
+	requestURL := appservice.URL + protocolPath + protocol
+	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	// Perform the request
+	resp, err := httpClient.Do(req.WithContext(ctx))
+	if err != nil {
+		return "", err
+	}
+
+	// Check that the request was successful
+	if resp.StatusCode != http.StatusOK {
+		// TODO: Handle non-200 error codes from application services
+		return "", fmt.Errorf("non-OK status code %d returned from AS", resp.StatusCode)
+	}
+
+	// Read the response body
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+// storeProtocolDefinition stores a protocol definition along with the protocol
+// ID in the database
+func storeProtocolDefinition(
+	ctx context.Context,
+	db *storage.Database,
+	appservice config.ApplicationService,
+	protocolID, protocolDefinition string,
+) error {
+	return db.StoreProtocolDefinition(ctx, protocolID, protocolDefinition)
+}

--- a/src/github.com/matrix-org/dendrite/appservice/workers/third_party.go
+++ b/src/github.com/matrix-org/dendrite/appservice/workers/third_party.go
@@ -66,7 +66,7 @@ func ThirdPartyWorker(
 		)
 		if err != nil {
 			log.WithFields(log.Fields{
-				"appservice":       appservice.ID,
+				"appservice_id":    appservice.ID,
 				"backoff_exponent": backoffCount,
 			}).WithError(err).Warn("error contacting appservice thirdparty endpoints")
 
@@ -82,8 +82,8 @@ func ThirdPartyWorker(
 		err = storeProtocolDefinition(ctx, db, protocolID, protocolDefinition)
 		if err != nil {
 			log.WithFields(log.Fields{
-				"appservice": appservice.ID,
-				"definition": protocolDefinition,
+				"appservice_id": appservice.ID,
+				"definition":    protocolDefinition,
 			}).WithError(err).Fatalf("unable to store appservice protocol definition in db")
 		}
 	}

--- a/src/github.com/matrix-org/dendrite/appservice/workers/third_party.go
+++ b/src/github.com/matrix-org/dendrite/appservice/workers/third_party.go
@@ -79,7 +79,13 @@ func ThirdPartyWorker(
 		}
 
 		// Cache protocol definition for clients to request later
-		storeProtocolDefinition(ctx, db, appservice, protocolID, protocolDefinition)
+		err = storeProtocolDefinition(ctx, db, protocolID, protocolDefinition)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"appservice": appservice.ID,
+				"definition": protocolDefinition,
+			}).WithError(err).Fatalf("unable to store appservice protocol definition in db")
+		}
 	}
 }
 
@@ -144,7 +150,6 @@ func retreiveProtocolInformation(
 func storeProtocolDefinition(
 	ctx context.Context,
 	db *storage.Database,
-	appservice config.ApplicationService,
 	protocolID, protocolDefinition string,
 ) error {
 	return db.StoreProtocolDefinition(ctx, protocolID, protocolDefinition)

--- a/src/github.com/matrix-org/dendrite/appservice/workers/transaction_scheduler.go
+++ b/src/github.com/matrix-org/dendrite/appservice/workers/transaction_scheduler.go
@@ -53,7 +53,7 @@ func TransactionWorker(db *storage.Database, ws types.ApplicationServiceWorkerSt
 	eventCount, err := db.CountEventsWithAppServiceID(ctx, ws.AppService.ID)
 	if err != nil {
 		log.WithFields(log.Fields{
-			"appservice": ws.AppService.ID,
+			"appservice_id": ws.AppService.ID,
 		}).WithError(err).Fatal("appservice worker unable to read queued events from DB")
 		return
 	}
@@ -70,7 +70,7 @@ func TransactionWorker(db *storage.Database, ws types.ApplicationServiceWorkerSt
 		transactionJSON, txnID, maxEventID, eventsRemaining, err := createTransaction(ctx, db, ws.AppService.ID)
 		if err != nil {
 			log.WithFields(log.Fields{
-				"appservice": ws.AppService.ID,
+				"appservice_id": ws.AppService.ID,
 			}).WithError(err).Fatal("appservice worker unable to create transaction")
 
 			return
@@ -81,7 +81,7 @@ func TransactionWorker(db *storage.Database, ws types.ApplicationServiceWorkerSt
 		err = send(client, ws.AppService, txnID, transactionJSON)
 		if err != nil {
 			log.WithFields(log.Fields{
-				"appservice":       ws.AppService.ID,
+				"appservice_id":    ws.AppService.ID,
 				"backoff_exponent": ws.Backoff,
 			}).WithError(err).Warnf("unable to send transactions successfully, backing off")
 
@@ -103,7 +103,7 @@ func TransactionWorker(db *storage.Database, ws types.ApplicationServiceWorkerSt
 		err = db.RemoveEventsBeforeAndIncludingID(ctx, ws.AppService.ID, maxEventID)
 		if err != nil {
 			log.WithFields(log.Fields{
-				"appservice": ws.AppService.ID,
+				"appservice_id": ws.AppService.ID,
 			}).WithError(err).Fatal("unable to remove appservice events from the database")
 			return
 		}
@@ -126,7 +126,7 @@ func createTransaction(
 	txnID, maxID, events, eventsRemaining, err := db.GetEventsWithAppServiceID(ctx, appserviceID, transactionBatchSize)
 	if err != nil {
 		log.WithFields(log.Fields{
-			"appservice": appserviceID,
+			"appservice_id": appserviceID,
 		}).WithError(err).Fatalf("appservice worker unable to read queued events from DB")
 
 		return
@@ -177,7 +177,7 @@ func send(
 		err := resp.Body.Close()
 		if err != nil {
 			log.WithFields(log.Fields{
-				"appservice": appservice.ID,
+				"appservice_id": appservice.ID,
 			}).WithError(err).Error("unable to close response body from application service")
 		}
 	}()

--- a/src/github.com/matrix-org/dendrite/clientapi/auth/auth.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/auth/auth.go
@@ -158,6 +158,7 @@ func verifyAccessToken(req *http.Request, deviceDB DeviceDatabase) (device *auth
 		}
 		return
 	}
+	fmt.Println("Got token:", token)
 	device, err = deviceDB.GetDeviceByAccessToken(req.Context(), token)
 	if err != nil {
 		if err == sql.ErrNoRows {

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/routing.go
@@ -388,6 +388,20 @@ func Setup(
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 
+	// Third party lookups
+	r0mux.Handle("/thirdparty/protocol/{protocolID}",
+		common.MakeExternalAPI("get_protocols", func(req *http.Request) util.JSONResponse {
+			vars := mux.Vars(req)
+			return GetThirdPartyProtocol(req, asAPI, vars["protocolID"])
+		}),
+	).Methods(http.MethodGet, http.MethodOptions)
+
+	r0mux.Handle("/thirdparty/protocols",
+		common.MakeExternalAPI("get_protocols", func(req *http.Request) util.JSONResponse {
+			return GetThirdPartyProtocols(req, asAPI)
+		}),
+	).Methods(http.MethodGet, http.MethodOptions)
+
 	// Stub implementations for sytest
 	r0mux.Handle("/events",
 		common.MakeExternalAPI("events", func(req *http.Request) util.JSONResponse {

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/third_party.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/third_party.go
@@ -1,0 +1,74 @@
+// Copyright 2018 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"encoding/json"
+	"net/http"
+
+	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"
+	"github.com/matrix-org/dendrite/clientapi/httputil"
+	"github.com/matrix-org/util"
+)
+
+// GetThirdPartyProtocol returns the protocol definition of a single, given
+// protocol ID
+func GetThirdPartyProtocol(
+	req *http.Request,
+	asAPI appserviceAPI.AppServiceQueryAPI,
+	protocolID string,
+) util.JSONResponse {
+	// Retrieve a single protocol definition from the appservice component
+	queryReq := appserviceAPI.GetProtocolDefinitionRequest{
+		ProtocolID: protocolID,
+	}
+	var queryRes appserviceAPI.GetProtocolDefinitionResponse
+	if err := asAPI.GetProtocolDefinition(req.Context(), &queryReq, &queryRes); err != nil {
+		return httputil.LogThenError(req, err)
+	}
+
+	return util.JSONResponse{
+		Code: http.StatusOK,
+		JSON: queryRes.ProtocolDefinition,
+	}
+}
+
+// GetThirdPartyProtocols returns all known third party protocols provided by
+// application services connected to this homeserver
+func GetThirdPartyProtocols(
+	req *http.Request,
+	asAPI appserviceAPI.AppServiceQueryAPI,
+) util.JSONResponse {
+	// Retrieve all known protocols from appservice component
+	queryReq := appserviceAPI.GetAllProtocolDefinitionsRequest{}
+	var queryRes appserviceAPI.GetAllProtocolDefinitionsResponse
+	if err := asAPI.GetAllProtocolDefinitions(req.Context(), &queryReq, &queryRes); err != nil {
+		return httputil.LogThenError(req, err)
+	}
+
+	// TODO: Check what we get if no protocols defined by anyone
+
+	// Marshal protocols to JSON
+	protocolJSON, err := json.Marshal(queryRes.Protocols)
+	if err != nil {
+		return httputil.LogThenError(req, err)
+	}
+
+	// Return protocol IDs along with definitions
+	return util.JSONResponse{
+		Code: http.StatusOK,
+		JSON: protocolJSON,
+	}
+}

--- a/src/github.com/matrix-org/dendrite/common/config/appservice.go
+++ b/src/github.com/matrix-org/dendrite/common/config/appservice.go
@@ -231,8 +231,8 @@ func checkErrors(config *Dendrite) (err error) {
 		// Namespace-related checks
 		for key, namespaceSlice := range appservice.NamespaceMap {
 			for _, namespace := range namespaceSlice {
-				if err := validateNamespace(&appservice, key, &namespace, groupIDRegexp); err != nil {
-					return err
+				if err = validateNamespace(&appservice, key, &namespace, groupIDRegexp); err != nil {
+					return
 				}
 			}
 		}
@@ -240,7 +240,7 @@ func checkErrors(config *Dendrite) (err error) {
 		// Check if the url has trailing /'s. If so, remove them
 		appservice.URL = strings.TrimRight(appservice.URL, "/")
 		if err = duplicationCheck(appservice, &idMap, &tokenMap, &protocolMap); err != nil {
-			return err
+			return
 		}
 
 		// TODO: Remove once rate_limited is implemented

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
@@ -30,8 +30,10 @@ import (
 )
 
 const (
-	pathPrefixV2Keys       = "/_matrix/key/v2"
-	pathPrefixV1Federation = "/_matrix/federation/v1"
+	// PathPrefixKeys is the current Key API version
+	PathPrefixKeys = "/_matrix/key/v2"
+	// PathPrefixFederation is the current Federation API version
+	PathPrefixFederation = "/_matrix/federation/v1"
 )
 
 // Setup registers HTTP handlers with the given ServeMux.
@@ -47,8 +49,8 @@ func Setup(
 	accountDB *accounts.Database,
 	deviceDB *devices.Database,
 ) {
-	v2keysmux := apiMux.PathPrefix(pathPrefixV2Keys).Subrouter()
-	v1fedmux := apiMux.PathPrefix(pathPrefixV1Federation).Subrouter()
+	v2keysmux := apiMux.PathPrefix(PathPrefixKeys).Subrouter()
+	v1fedmux := apiMux.PathPrefix(PathPrefixFederation).Subrouter()
 
 	localKeys := common.MakeExternalAPI("localkeys", func(req *http.Request) util.JSONResponse {
 		return LocalKeys(cfg)

--- a/src/github.com/matrix-org/dendrite/mediaapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/mediaapi/routing/routing.go
@@ -31,7 +31,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const pathPrefixR0 = "/_matrix/media/v1"
+const (
+	// PathPrefixMedia is the current Media API version
+	PathPrefixMedia = "/_matrix/media/v1"
+)
 
 // Setup registers the media API HTTP handlers
 func Setup(
@@ -41,7 +44,7 @@ func Setup(
 	deviceDB *devices.Database,
 	client *gomatrixserverlib.Client,
 ) {
-	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
+	r0mux := apiMux.PathPrefix(PathPrefixMedia).Subrouter()
 
 	activeThumbnailGeneration := &types.ActiveThumbnailGeneration{
 		PathToResult: map[string]*types.ThumbnailGenerationResult{},

--- a/src/github.com/matrix-org/dendrite/publicroomsapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/publicroomsapi/routing/routing.go
@@ -27,12 +27,14 @@ import (
 	"github.com/matrix-org/util"
 )
 
-const pathPrefixR0 = "/_matrix/client/r0"
+const (
+	// PathPrefixClientPublicRooms is the current Client-Server Public Rooms API version
+	PathPrefixClientPublicRooms = "/_matrix/client/r0"
+)
 
 // Setup configures the given mux with publicroomsapi server listeners
 func Setup(apiMux *mux.Router, deviceDB *devices.Database, publicRoomsDB *storage.PublicRoomsServerDatabase) {
-	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
-
+	r0mux := apiMux.PathPrefix(PathPrefixClientPublicRooms).Subrouter()
 	authData := auth.Data{nil, deviceDB, nil}
 
 	r0mux.Handle("/directory/list/room/{roomID}",

--- a/src/github.com/matrix-org/dendrite/syncapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/routing/routing.go
@@ -27,11 +27,14 @@ import (
 	"github.com/matrix-org/util"
 )
 
-const pathPrefixR0 = "/_matrix/client/r0"
+const (
+	// PathPrefixClientSync is the current Client-Server Sync API version
+	PathPrefixClientSync = "/_matrix/client/r0"
+)
 
 // Setup configures the given mux with sync-server listeners
 func Setup(apiMux *mux.Router, srp *sync.RequestPool, syncDB *storage.SyncServerDatabase, deviceDB *devices.Database) {
-	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
+	r0mux := apiMux.PathPrefix(PathPrefixClientSync).Subrouter()
 
 	authData := auth.Data{nil, deviceDB, nil}
 


### PR DESCRIPTION
This PR implements the Third Party Lookup API as defined by https://matrix.org/docs/spec/client_server/unstable.html#id127

Third party lookups allow clients to provide rich bridging interfaces by using the homeserver as a proxy to retrieve third party network metadata from application services acting as bridges.

These endpoints are mostly designed to simply be proxied by the homeserver to the application service, and thus the majority of them use the same handler function. New internal API endpoints for appservices were created to allow communication between the C-S and AS components.

This PR depends on #522. Needs a rebase onto master.