### PR TITLE
Differentiate between users and AS upon registration

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
@@ -497,7 +497,8 @@ func Register(
 	// Application services can register users with no auth type, but require
 	// access token. Differentiate from users who are initially hitting register
 	// without an auth type
-	if r.Auth.Type == "" && req.URL.Query().Get("access_token") == "" {
+	if r.Auth.Type == "" && req.URL.Query().Get("access_token") == "" &&
+		req.Header.Get("Authorization") == "" {
 		return util.JSONResponse{
 			Code: http.StatusUnauthorized,
 			JSON: newUserInteractiveResponse(sessionID,

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
@@ -485,6 +485,17 @@ func Register(
 		}
 	}
 
+	// Application services can register users with no auth type, but require
+	// access token. Differentiate from users who are initially hitting register
+	// without an auth type
+	if r.Auth.Type == "" && req.URL.Query().Get("access_token") == "" {
+		return util.JSONResponse{
+			Code: http.StatusUnauthorized,
+			JSON: newUserInteractiveResponse(sessionID,
+				cfg.Derived.Registration.Flows, cfg.Derived.Registration.Params),
+		}
+	}
+
 	logger := util.GetLogger(req.Context())
 	logger.WithFields(log.Fields{
 		"username":   r.Username,

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
@@ -180,6 +180,18 @@ type recaptchaResponse struct {
 	ErrorCodes  []int     `json:"error-codes"`
 }
 
+// validateUsernameAndPassword is a convenience function that returns an error
+// response if either the username or password is invalid
+func validateUsernameAndPassword(username, password string) *util.JSONResponse {
+	if err := validateUsername(username); err != nil {
+		return err
+	}
+	if err := validatePassword(password); err != nil {
+		return err
+	}
+	return nil
+}
+
 // validateUsername returns an error response if the username is invalid
 func validateUsername(username string) *util.JSONResponse {
 	// https://github.com/matrix-org/synapse/blob/v0.20.0/synapse/rest/client/v2_alpha/register.py#L161
@@ -467,10 +479,7 @@ func Register(
 	// Squash username to all lowercase letters
 	r.Username = strings.ToLower(r.Username)
 
-	if resErr = validateUsername(r.Username); resErr != nil {
-		return *resErr
-	}
-	if resErr = validatePassword(r.Password); resErr != nil {
+	if resErr = validateUsernameAndPassword(r.Username, r.Password); resErr != nil {
 		return *resErr
 	}
 
@@ -679,10 +688,7 @@ func parseAndValidateLegacyLogin(req *http.Request, r *legacyRegisterRequest) *u
 	// Squash username to all lowercase letters
 	r.Username = strings.ToLower(r.Username)
 
-	if resErr = validateUsername(r.Username); resErr != nil {
-		return resErr
-	}
-	if resErr = validatePassword(r.Password); resErr != nil {
+	if resErr = validateUsernameAndPassword(r.Username, r.Password); resErr != nil {
 		return resErr
 	}
 

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
@@ -497,8 +497,7 @@ func Register(
 	// Application services can register users with no auth type, but require
 	// access token. Differentiate from users who are initially hitting register
 	// without an auth type
-	if r.Auth.Type == "" && req.URL.Query().Get("access_token") == "" &&
-		req.Header.Get("Authorization") == "" {
+	if initialUserInteractiveRequest(req, r) {
 		return util.JSONResponse{
 			Code: http.StatusUnauthorized,
 			JSON: newUserInteractiveResponse(sessionID,
@@ -780,6 +779,17 @@ func completeRegistration(
 			DeviceID:    dev.ID,
 		},
 	}
+}
+
+// initialUserInteractiveRequest returns true or false based on whether the
+// request should have User Interactive Authentication Flows returned. This is
+// the case if a user is requesting registration first without specifying a
+// registration type. This method also differentiates between application
+// services and users, as application services can register with no type and an
+// access token, either included as part of the query parameters or an
+// Authorization header
+func initialUserInteractiveRequest(req *http.Request, r registerRequest) bool {
+	return r.Auth.Type == "" && req.URL.Query().Get("access_token") == "" && req.Header.Get("Authorization") == ""
 }
 
 // Used for shared secret registration.


### PR DESCRIPTION
#548 unfortunately broke registration as users also register without an auth type initially, while AS's also do so when they are acting as their SenderLocalpart user.

We now check beforehand if this is occurring before we switch over auth types.