### PR TITLE
Add detail to room alias name error message

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/routing/createroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/createroom.go
@@ -70,7 +70,7 @@ func (r createRoomRequest) Validate() *util.JSONResponse {
 	if strings.ContainsAny(r.RoomAliasName, whitespace+":") {
 		return &util.JSONResponse{
 			Code: http.StatusBadRequest,
-			JSON: jsonerror.BadJSON("room_alias_name cannot contain whitespace"),
+			JSON: jsonerror.BadJSON("room_alias_name cannot contain whitespace or ':'"),
 		}
 	}
 	for _, userID := range r.Invite {


### PR DESCRIPTION
I tried to register a room alias name `#abc:localhost`, but `:` is not allowed in the room name alias as this gets transformed into `#abc:localhost:localhost`.

The error presented to me was `room_alias_name cannot contain whitespace`, which wasn't relevant. The error is now `room_alias_name cannot contain whitespace or ':'` which is.