### PR TITLE
URI to UID API

### DIFF
--- a/src/github.com/matrix-org/dendrite/appservice/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/appservice/routing/routing.go
@@ -51,7 +51,7 @@ func Setup(
 	).Methods(http.MethodGet, http.MethodOptions)
 	appMux.Handle("/user",
 		common.MakeExternalAPI("user", func(req *http.Request) util.JSONResponse {
-			return URIToUID(req)
+			return URIToUID(req, cfg)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 }

--- a/src/github.com/matrix-org/dendrite/appservice/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/appservice/routing/routing.go
@@ -51,11 +51,7 @@ func Setup(
 	).Methods(http.MethodGet, http.MethodOptions)
 	appMux.Handle("/user",
 		common.MakeExternalAPI("user", func(req *http.Request) util.JSONResponse {
-			// TODO: Implement
-			return util.JSONResponse{
-				Code: http.StatusOK,
-				JSON: nil,
-			}
+			return URIToUID(req)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 }

--- a/src/github.com/matrix-org/dendrite/appservice/routing/user.go
+++ b/src/github.com/matrix-org/dendrite/appservice/routing/user.go
@@ -16,8 +16,9 @@ type URIToUIDResponse struct {
 // URI and turning it into a Matrix ID on the homeserver.
 // https://matrix.org/docs/spec/application_service/unstable.html#user-ids
 
-func URIToUID(req *http.Request) util.JSONResponse {
+func URIToUID(req *http.Request, cfg config.Dendrite) util.JSONResponse {
 	// TODO: Implement
+	homeserver := cfg.Matrix.ServerName
 	return util.JSONResponse{
 		Code: http.StatusOK,
 		JSON: nil,

--- a/src/github.com/matrix-org/dendrite/appservice/routing/user.go
+++ b/src/github.com/matrix-org/dendrite/appservice/routing/user.go
@@ -1,0 +1,25 @@
+package routing
+
+import (
+	"github.com/matrix-org/util"
+	"net/http"
+)
+
+// represents response to an AppService URI to User Id
+// (/_matrix/app/r0/user?uri={url_encoded_uri}) request
+type URIToUIDResponse struct {
+	UserID string `json:"user_id"`
+}
+
+// URIToUID implements `/_matrix/app/r0/user?uri={url_encoded_uri}`, which
+// enables users to contact appservice users directly by taking an encoded
+// URI and turning it into a Matrix ID on the homeserver.
+// https://matrix.org/docs/spec/application_service/unstable.html#user-ids
+
+func URIToUID(req *http.Request) util.JSONResponse {
+	// TODO: Implement
+	return util.JSONResponse{
+		Code: http.StatusOK,
+		JSON: nil,
+	}
+}

--- a/src/github.com/matrix-org/dendrite/appservice/routing/user.go
+++ b/src/github.com/matrix-org/dendrite/appservice/routing/user.go
@@ -27,14 +27,14 @@ func URIToUID(req *http.Request, cfg config.Dendrite) util.JSONResponse {
 			JSON: nil,
 		}
 	}
-	baseReqURL := "http://" + string(cfg.Matrix.ServerName) + "/_matrix/app/unstable/thirdparty/user/"
 	for _, appservice := range cfg.Derived.ApplicationServices {
 		// Check all the fields associated with each application service
 		if !appservice.IsInterestedInUserID(uri) {
 			continue
 		}
 		// call the application service
-		reqURL := baseReqURL + appservice.ID + "?access_token=" + appservice.HSToken +
+		reqURL := "http://" + appservice.URL + "/_matrix/app/unstable/thirdparty/user/" +
+			appservice.ID + "?access_token=" + appservice.HSToken +
 			"&fields=" + uri
 		resp, err := http.Get(reqURL)
 		// take the first successful match and send that back to the user

--- a/src/github.com/matrix-org/dendrite/appservice/routing/user.go
+++ b/src/github.com/matrix-org/dendrite/appservice/routing/user.go
@@ -14,7 +14,7 @@ type URIToUIDResponse struct {
 }
 
 // URIToUID implements `/_matrix/app/r0/user?uri={url_encoded_uri}`, which
-// enables users to contact appservice users directly by taking an encoded
+// enables users to contact App Service users directly by taking an encoded
 // URI and turning it into a Matrix ID on the homeserver.
 // https://matrix.org/docs/spec/application_service/unstable.html#user-ids
 // tel://123.1234 -> @tel_//123.1234:matrix.org

--- a/src/github.com/matrix-org/dendrite/appservice/routing/user.go
+++ b/src/github.com/matrix-org/dendrite/appservice/routing/user.go
@@ -17,7 +17,7 @@ type URIToUIDResponse struct {
 	UserID string `json:"user_id"`
 }
 
-const PathPrefixUnstableThirdPartyUser = "/_matrix/app/unstable/thirdparty/user/"
+const pathPrefixUnstableThirdPartyUser = "/_matrix/app/unstable/thirdparty/user/"
 
 // URIToUID implements `/_matrix/app/r0/user?uri={url_encoded_uri}`, which
 // enables users to contact App Service users directly by taking an encoded
@@ -43,7 +43,7 @@ func URIToUID(req *http.Request, cfg config.Dendrite) util.JSONResponse {
 		// call the applicable application services in parallel
 		go func(as config.ApplicationService, ids *[]string) {
 			defer wg.Done()
-			reqURL, err := url.Parse(as.URL + PathPrefixUnstableThirdPartyUser + as.ID +
+			reqURL, err := url.Parse(as.URL + pathPrefixUnstableThirdPartyUser + as.ID +
 				"?access_token=" + as.HSToken +
 				"&fields=" + uri)
 			if err != nil {

--- a/src/github.com/matrix-org/dendrite/appservice/routing/user.go
+++ b/src/github.com/matrix-org/dendrite/appservice/routing/user.go
@@ -3,9 +3,11 @@ package routing
 import (
 	"github.com/matrix-org/util"
 	"net/http"
+	"strings"
+	"unicode"
 )
 
-// represents response to an AppService URI to User Id
+// URIToUIDResponse represents response to an AppService URI to User Id
 // (/_matrix/app/r0/user?uri={url_encoded_uri}) request
 type URIToUIDResponse struct {
 	UserID string `json:"user_id"`
@@ -15,9 +17,9 @@ type URIToUIDResponse struct {
 // enables users to contact appservice users directly by taking an encoded
 // URI and turning it into a Matrix ID on the homeserver.
 // https://matrix.org/docs/spec/application_service/unstable.html#user-ids
-
+// tel://123.1234 -> @tel_//123.1234:matrix.org
+// mailto:test@matrix.org -> @mailto_test_matrix.org:matrix.org
 func URIToUID(req *http.Request, cfg config.Dendrite) util.JSONResponse {
-	// TODO: Implement
 	homeserver := cfg.Matrix.ServerName
 	uri := req.URL.Query().Get("uri")
 	if uri == "" {
@@ -26,8 +28,25 @@ func URIToUID(req *http.Request, cfg config.Dendrite) util.JSONResponse {
 			JSON: nil,
 		}
 	}
+	// V1 just replaces the illegal characters (from
+	// https://matrix.org/docs/spec/appendices.html#id12) with _
+	// TODO: Come up with a better way to turn URIs into User IDs
+	w := strings.FieldsFunc(strings.ToLower(uri), func(r rune) bool {
+		if unicode.IsDigit(r) || unicode.IsLetter(r) {
+			return false
+		}
+		switch r {
+		case '.', '_', '=', '-', '/':
+			return false
+		}
+		return true
+	})
+
+	// compile user ID and return
+	userID := "@" + strings.Join(w, "_") + ":" + homeserver
+
 	return util.JSONResponse{
 		Code: http.StatusOK,
-		JSON: nil,
+		JSON: URIToUIDResponse{UserID: userID},
 	}
 }

--- a/src/github.com/matrix-org/dendrite/appservice/routing/user.go
+++ b/src/github.com/matrix-org/dendrite/appservice/routing/user.go
@@ -19,6 +19,13 @@ type URIToUIDResponse struct {
 func URIToUID(req *http.Request, cfg config.Dendrite) util.JSONResponse {
 	// TODO: Implement
 	homeserver := cfg.Matrix.ServerName
+	uri := req.URL.Query().Get("uri")
+	if uri == "" {
+		return util.JSONResponse{
+			Code: http.StatusOK,
+			JSON: nil,
+		}
+	}
 	return util.JSONResponse{
 		Code: http.StatusOK,
 		JSON: nil,

--- a/src/github.com/matrix-org/dendrite/appservice/routing/user.go
+++ b/src/github.com/matrix-org/dendrite/appservice/routing/user.go
@@ -40,7 +40,10 @@ func URIToUID(req *http.Request, cfg config.Dendrite) util.JSONResponse {
 			if err == nil {
 				body, _ := ioutil.ReadAll(resp.Body)
 				respMap := map[string]interface{}{}
-				json.Unmarshal(body, &respMap)
+				err := json.Unmarshal(body, &respMap)
+				if err != nil {
+					panic(err)
+				}
 				if userID, ok := respMap["userid"].(string); ok {
 					return util.JSONResponse{
 						Code: http.StatusOK,


### PR DESCRIPTION
I'm looking for guidance on how to properly implement the URI-to-User ID mapping since the [spec](https://matrix.org/docs/spec/application_service/unstable.html#user-ids) leaves the implementation pretty open-ended. I tried looking to synapse and matrix-docs for guidance, but I couldn't find anything substantial or definitive. Am I missing anything? If I am, I'd appreciate a link to the agreed-upon mapping.  If not, what are your thoughts on mapping URIs to User IDs? Right now, I just replace all the illegal characters with underscores. I'm guessing this isn't good enough, but it's a starting point for a discussion (if one is necessary). Thank you!

(Fixes #457 )