### PR TITLE
Propagate error with wrong ?ts= param back to client

### DIFF
--- a/linter-fast.json
+++ b/linter-fast.json
@@ -1,6 +1,6 @@
 {
     "Vendor": true,
-    "Cyclo": 12,
+    "Cyclo": 13,
     "Deadline": "5m",
     "Enable": [
         "vetshadow",

--- a/linter-fast.json
+++ b/linter-fast.json
@@ -1,6 +1,6 @@
 {
     "Vendor": true,
-    "Cyclo": 13,
+    "Cyclo": 12,
     "Deadline": "5m",
     "Enable": [
         "vetshadow",

--- a/src/github.com/matrix-org/dendrite/clientapi/httputil/parse.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/httputil/parse.go
@@ -13,26 +13,49 @@
 package httputil
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
+
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"github.com/matrix-org/util"
 )
+
+// ParseIntParam takes a request and parses the query param to an int
+// returns 0 when not present and -1 when parsing failed as int
+func ParseIntParam(req *http.Request, param string) (int64, *util.JSONResponse) {
+	paramStr := req.URL.Query().Get(param)
+	if paramStr == "" {
+		return 0, &util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.MissingArgument(fmt.Sprintf("Param %s not found", param)),
+		}
+	}
+	paramInt, err := strconv.ParseInt(paramStr, 0, 64)
+	if err != nil {
+		return -1, &util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.InvalidArgumentValue(
+				fmt.Sprintf("Param %s is no valid int (%s)", param, err.Error()),
+			),
+		}
+	}
+	return paramInt, nil
+}
 
 // ParseTSParam takes a req (typically from an application service) and parses a Time object
 // from the req if it exists in the query parameters. If it doesn't exist, the
 // current time is returned.
-func ParseTSParam(req *http.Request) time.Time {
-	// Use the ts parameter's value for event time if present
-	tsStr := req.URL.Query().Get("ts")
-	if tsStr == "" {
-		return time.Now()
-	}
-
-	// The parameter exists, parse into a Time object
-	ts, err := strconv.ParseInt(tsStr, 10, 64)
+func ParseTSParam(req *http.Request) (time.Time, *util.JSONResponse) {
+	ts, err := ParseIntParam(req, "ts")
 	if err != nil {
-		return time.Unix(ts/1000, 0)
+		if ts == 0 {
+			// param was not available
+			return time.Now(), nil
+		}
+		return time.Time{}, err
 	}
 
-	return time.Unix(ts/1000, 0)
+	return time.Unix(ts/1000, 0), nil
 }

--- a/src/github.com/matrix-org/dendrite/clientapi/httputil/parse.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/httputil/parse.go
@@ -17,15 +17,12 @@ import (
 	"net/http"
 	"strconv"
 	"time"
-
-	"github.com/matrix-org/dendrite/clientapi/jsonerror"
-	"github.com/matrix-org/util"
 )
 
 // ParseTSParam takes a req (typically from an application service) and parses a Time object
 // from the req if it exists in the query parameters. If it doesn't exist, the
 // current time is returned.
-func ParseTSParam(req *http.Request) (time.Time, *util.JSONResponse) {
+func ParseTSParam(req *http.Request) (time.Time, error) {
 	// Use the ts parameter's value for event time if present
 	tsStr := req.URL.Query().Get("ts")
 	if tsStr == "" {
@@ -35,12 +32,7 @@ func ParseTSParam(req *http.Request) (time.Time, *util.JSONResponse) {
 	// The parameter exists, parse into a Time object
 	ts, err := strconv.ParseInt(tsStr, 10, 64)
 	if err != nil {
-		return time.Time{}, &util.JSONResponse{
-			Code: http.StatusBadRequest,
-			JSON: jsonerror.InvalidArgumentValue(
-				fmt.Sprintf("Param 'ts' is no valid int (%s)", err.Error()),
-			),
-		}
+		return time.Time{}, fmt.Errorf("Param 'ts' is no valid int (%s)", err.Error())
 	}
 
 	return time.Unix(ts/1000, 0), nil

--- a/src/github.com/matrix-org/dendrite/clientapi/httputil/parse.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/httputil/parse.go
@@ -22,39 +22,25 @@ import (
 	"github.com/matrix-org/util"
 )
 
-// ParseIntParam takes a request and parses the query param to an int
-// returns 0 when not present and -1 when parsing failed as int
-func ParseIntParam(req *http.Request, param string) (int64, *util.JSONResponse) {
-	paramStr := req.URL.Query().Get(param)
-	if paramStr == "" {
-		return 0, &util.JSONResponse{
-			Code: http.StatusBadRequest,
-			JSON: jsonerror.MissingArgument(fmt.Sprintf("Param %s not found", param)),
-		}
-	}
-	paramInt, err := strconv.ParseInt(paramStr, 0, 64)
-	if err != nil {
-		return -1, &util.JSONResponse{
-			Code: http.StatusBadRequest,
-			JSON: jsonerror.InvalidArgumentValue(
-				fmt.Sprintf("Param %s is no valid int (%s)", param, err.Error()),
-			),
-		}
-	}
-	return paramInt, nil
-}
-
 // ParseTSParam takes a req (typically from an application service) and parses a Time object
 // from the req if it exists in the query parameters. If it doesn't exist, the
 // current time is returned.
 func ParseTSParam(req *http.Request) (time.Time, *util.JSONResponse) {
-	ts, err := ParseIntParam(req, "ts")
+	// Use the ts parameter's value for event time if present
+	tsStr := req.URL.Query().Get("ts")
+	if tsStr == "" {
+		return time.Now(), nil
+	}
+
+	// The parameter exists, parse into a Time object
+	ts, err := strconv.ParseInt(tsStr, 10, 64)
 	if err != nil {
-		if ts == 0 {
-			// param was not available
-			return time.Now(), nil
+		return time.Time{}, &util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.InvalidArgumentValue(
+				fmt.Sprintf("Param 'ts' is no valid int (%s)", err.Error()),
+			),
 		}
-		return time.Time{}, err
 	}
 
 	return time.Unix(ts/1000, 0), nil

--- a/src/github.com/matrix-org/dendrite/clientapi/jsonerror/jsonerror.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/jsonerror/jsonerror.go
@@ -28,7 +28,7 @@ type MatrixError struct {
 	Err     string `json:"error"`
 }
 
-func (e *MatrixError) Error() string {
+func (e MatrixError) Error() string {
 	return fmt.Sprintf("%s: %s", e.ErrCode, e.Err)
 }
 

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/createroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/createroom.go
@@ -147,9 +147,12 @@ func createRoom(
 		return *resErr
 	}
 
-	evTime, resErr := httputil.ParseTSParam(req)
-	if resErr != nil {
-		return *resErr
+	evTime, err := httputil.ParseTSParam(req)
+	if err != nil {
+		return util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.InvalidArgumentValue(err.Error()),
+		}
 	}
 	// TODO: visibility/presets/raw initial state/creation content
 	// TODO: Create room alias association

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/createroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/createroom.go
@@ -147,7 +147,10 @@ func createRoom(
 		return *resErr
 	}
 
-	evTime := httputil.ParseTSParam(req)
+	evTime, resErr := httputil.ParseTSParam(req)
+	if resErr != nil {
+		return *resErr
+	}
 	// TODO: visibility/presets/raw initial state/creation content
 	// TODO: Create room alias association
 	// Make sure this doesn't fall into an application service's namespace though!

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/joinroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/joinroom.go
@@ -52,9 +52,12 @@ func JoinRoomByIDOrAlias(
 		return *resErr
 	}
 
-	evTime, resErr := httputil.ParseTSParam(req)
-	if resErr != nil {
-		return *resErr
+	evTime, err := httputil.ParseTSParam(req)
+	if err != nil {
+		return util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.InvalidArgumentValue(err.Error()),
+		}
 	}
 
 	localpart, _, err := gomatrixserverlib.SplitID('@', device.UserID)

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/membership.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/membership.go
@@ -50,7 +50,11 @@ func SendMembership(
 		return *reqErr
 	}
 
-	evTime := httputil.ParseTSParam(req)
+	evTime, resErr := httputil.ParseTSParam(req)
+	if resErr != nil {
+		return *resErr
+	}
+
 	inviteStored, err := threepid.CheckAndProcessInvite(
 		req.Context(), device, &body, cfg, queryAPI, accountDB, producer,
 		membership, roomID, evTime,

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/membership.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/membership.go
@@ -50,9 +50,12 @@ func SendMembership(
 		return *reqErr
 	}
 
-	evTime, resErr := httputil.ParseTSParam(req)
-	if resErr != nil {
-		return *resErr
+	evTime, err := httputil.ParseTSParam(req)
+	if err != nil {
+		return util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.InvalidArgumentValue(err.Error()),
+		}
 	}
 
 	inviteStored, err := threepid.CheckAndProcessInvite(

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/profile.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/profile.go
@@ -107,9 +107,12 @@ func SetAvatarURL(
 		return httputil.LogThenError(req, err)
 	}
 
-	evTime, resErr := httputil.ParseTSParam(req)
-	if resErr != nil {
-		return *resErr
+	evTime, err := httputil.ParseTSParam(req)
+	if err != nil {
+		return util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.InvalidArgumentValue(err.Error()),
+		}
 	}
 
 	oldProfile, err := accountDB.GetProfileByLocalpart(req.Context(), localpart)
@@ -201,9 +204,12 @@ func SetDisplayName(
 		return httputil.LogThenError(req, err)
 	}
 
-	evTime, resErr := httputil.ParseTSParam(req)
-	if resErr != nil {
-		return *resErr
+	evTime, err := httputil.ParseTSParam(req)
+	if err != nil {
+		return util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.InvalidArgumentValue(err.Error()),
+		}
 	}
 
 	oldProfile, err := accountDB.GetProfileByLocalpart(req.Context(), localpart)

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/profile.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/profile.go
@@ -107,6 +107,11 @@ func SetAvatarURL(
 		return httputil.LogThenError(req, err)
 	}
 
+	evTime, resErr := httputil.ParseTSParam(req)
+	if resErr != nil {
+		return *resErr
+	}
+
 	oldProfile, err := accountDB.GetProfileByLocalpart(req.Context(), localpart)
 	if err != nil {
 		return httputil.LogThenError(req, err)
@@ -128,7 +133,7 @@ func SetAvatarURL(
 	}
 
 	events, err := buildMembershipEvents(
-		req.Context(), memberships, newProfile, userID, cfg, httputil.ParseTSParam(req), queryAPI,
+		req.Context(), memberships, newProfile, userID, cfg, evTime, queryAPI,
 	)
 	if err != nil {
 		return httputil.LogThenError(req, err)
@@ -196,6 +201,11 @@ func SetDisplayName(
 		return httputil.LogThenError(req, err)
 	}
 
+	evTime, resErr := httputil.ParseTSParam(req)
+	if resErr != nil {
+		return *resErr
+	}
+
 	oldProfile, err := accountDB.GetProfileByLocalpart(req.Context(), localpart)
 	if err != nil {
 		return httputil.LogThenError(req, err)
@@ -217,7 +227,7 @@ func SetDisplayName(
 	}
 
 	events, err := buildMembershipEvents(
-		req.Context(), memberships, newProfile, userID, cfg, httputil.ParseTSParam(req), queryAPI,
+		req.Context(), memberships, newProfile, userID, cfg, evTime, queryAPI,
 	)
 	if err != nil {
 		return httputil.LogThenError(req, err)

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/sendevent.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/sendevent.go
@@ -104,9 +104,12 @@ func generateSendEvent(
 		return nil, resErr
 	}
 
-	evTime, resErr := httputil.ParseTSParam(req)
-	if resErr != nil {
-		return nil, resErr
+	evTime, err := httputil.ParseTSParam(req)
+	if err != nil {
+		return nil, &util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.InvalidArgumentValue(err.Error()),
+		}
 	}
 
 	// create the new event and set all the fields we can
@@ -116,7 +119,7 @@ func generateSendEvent(
 		Type:     eventType,
 		StateKey: stateKey,
 	}
-	err := builder.SetContent(r)
+	err = builder.SetContent(r)
 	if err != nil {
 		resErr := httputil.LogThenError(req, err)
 		return nil, &resErr

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/sendevent.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/sendevent.go
@@ -63,7 +63,10 @@ func SendEvent(
 		return *resErr
 	}
 
-	evTime := httputil.ParseTSParam(req)
+	evTime, resErr := httputil.ParseTSParam(req)
+	if resErr != nil {
+		return *resErr
+	}
 
 	// create the new event and set all the fields we can
 	builder := gomatrixserverlib.EventBuilder{


### PR DESCRIPTION
Fixes #575

This as well introduces `ParseIntParam()` which might be used for other values as well.

Signed-Off-by: Matthias Kesler <krombel@krombel.de>