### PR TITLE
Federation: Add event_auth endpoint

### DIFF
--- a/src/github.com/matrix-org/dendrite/federationapi/routing/eventauth.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/eventauth.go
@@ -1,0 +1,41 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/util"
+)
+
+// GetEventAuth returns event auth for the roomID and eventID
+func GetEventAuth(
+	ctx context.Context,
+	request *gomatrixserverlib.FederationRequest,
+	query api.RoomserverQueryAPI,
+	roomID string,
+	eventID string,
+) util.JSONResponse {
+	state, err := getState(ctx, request, query, roomID, eventID)
+	if err != nil {
+		return *err
+	}
+
+	return util.JSONResponse{
+		Code: http.StatusOK,
+		JSON: gomatrixserverlib.RespEventAuth{AuthEvents: state.AuthEvents},
+	}
+}

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
@@ -129,6 +129,16 @@ func Setup(
 		},
 	)).Methods(http.MethodGet)
 
+	v1fedmux.Handle("/event_auth/{roomID}/{eventID}", common.MakeFedAPI(
+		"federation_get_event_auth", cfg.Matrix.ServerName, keys,
+		func(httpReq *http.Request, request *gomatrixserverlib.FederationRequest) util.JSONResponse {
+			vars := mux.Vars(httpReq)
+			return GetEventAuth(
+				httpReq.Context(), request, query, vars["roomID"], vars["eventID"],
+			)
+		},
+	)).Methods(http.MethodGet)
+
 	v1fedmux.Handle("/query/directory", common.MakeFedAPI(
 		"federation_query_room_alias", cfg.Matrix.ServerName, keys,
 		func(httpReq *http.Request, request *gomatrixserverlib.FederationRequest) util.JSONResponse {

--- a/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
@@ -110,7 +110,7 @@ func Setup(
 	)).Methods(http.MethodGet)
 
 	v1fedmux.Handle("/state/{roomID}", common.MakeFedAPI(
-		"federation_get_event_auth", cfg.Matrix.ServerName, keys,
+		"federation_get_state", cfg.Matrix.ServerName, keys,
 		func(httpReq *http.Request, request *gomatrixserverlib.FederationRequest) util.JSONResponse {
 			vars := mux.Vars(httpReq)
 			return GetState(
@@ -120,7 +120,7 @@ func Setup(
 	)).Methods(http.MethodGet)
 
 	v1fedmux.Handle("/state_ids/{roomID}", common.MakeFedAPI(
-		"federation_get_event_auth", cfg.Matrix.ServerName, keys,
+		"federation_get_state_ids", cfg.Matrix.ServerName, keys,
 		func(httpReq *http.Request, request *gomatrixserverlib.FederationRequest) util.JSONResponse {
 			vars := mux.Vars(httpReq)
 			return GetStateIDs(


### PR DESCRIPTION
Adds the endpoint `/_matrix/federation/v1/event_auth/{roomID}/{eventID}` 
Fixes #482 
Signed-off-by: Sudhanshu Jaiswal <sudsjaiswal@gmail.com> 