### PR TITLE
Fix interactive registration failing

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/register.go
@@ -369,7 +369,6 @@ func UsernameMatchesExclusiveNamespaces(
 // two requirements are met, no error will be returned.
 func validateApplicationService(
 	cfg *config.Dendrite,
-	req *http.Request,
 	username string,
 	accessToken string,
 ) (string, *util.JSONResponse) {
@@ -558,7 +557,7 @@ func handleRegistrationFlow(
 			// Check application service register user request is valid.
 			// The application service's ID is returned if so.
 			appserviceID, err := validateApplicationService(
-				cfg, req, r.Username, accessToken,
+				cfg, r.Username, accessToken,
 			)
 			if err != nil {
 				return *err

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/register_test.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/register_test.go
@@ -15,8 +15,6 @@
 package routing
 
 import (
-	"net/http"
-	"net/url"
 	"regexp"
 	"testing"
 
@@ -186,47 +184,26 @@ func TestValidationOfApplicationServices(t *testing.T) {
 	fakeConfig.Derived.ApplicationServices = []config.ApplicationService{fakeApplicationService}
 
 	// Access token is correct, user_id omitted so we are acting as SenderLocalpart
-	URL, _ := url.Parse("http://localhost/register?access_token=1234")
-	fakeHTTPRequest := http.Request{
-		Method: "POST",
-		URL:    URL,
-	}
-	asID, resp := validateApplicationService(&fakeConfig, &fakeHTTPRequest, fakeSenderLocalpart)
+	asID, resp := validateApplicationService(&fakeConfig, fakeSenderLocalpart, "1234")
 	if resp != nil || asID != fakeID {
 		t.Errorf("appservice should have validated and returned correct ID: %s", resp.JSON)
 	}
 
 	// Access token is incorrect, user_id omitted so we are acting as SenderLocalpart
-	URL, _ = url.Parse("http://localhost/register?access_token=xxxx")
-	fakeHTTPRequest = http.Request{
-		Method: "POST",
-		URL:    URL,
-	}
-	asID, resp = validateApplicationService(&fakeConfig, &fakeHTTPRequest, fakeSenderLocalpart)
+	asID, resp = validateApplicationService(&fakeConfig, fakeSenderLocalpart, "xxxx")
 	if resp == nil || asID == fakeID {
 		t.Errorf("access_token should have been marked as invalid")
 	}
 
 	// Access token is correct, acting as valid user_id
-	URL, _ = url.Parse("http://localhost/register?access_token=1234&user_id=@_appservice_bob:localhost")
-	fakeHTTPRequest = http.Request{
-		Method: "POST",
-		URL:    URL,
-	}
-	asID, resp = validateApplicationService(&fakeConfig, &fakeHTTPRequest, "_appservice_bob")
+	asID, resp = validateApplicationService(&fakeConfig, "_appservice_bob", "1234")
 	if resp != nil || asID != fakeID {
 		t.Errorf("access_token and user_id should've been valid: %s", resp.JSON)
 	}
 
 	// Access token is correct, acting as invalid user_id
-	URL, _ = url.Parse("http://localhost/register?access_token=1234&user_id=@_something_else:localhost")
-	fakeHTTPRequest = http.Request{
-		Method: "POST",
-		URL:    URL,
-	}
-	asID, resp = validateApplicationService(&fakeConfig, &fakeHTTPRequest, "_something_else")
+	asID, resp = validateApplicationService(&fakeConfig, "_something_else", "1234")
 	if resp == nil || asID == fakeID {
-		t.Errorf("user_id should not have been valid: %s",
-			fakeHTTPRequest.URL.Query().Get("user_id"))
+		t.Errorf("user_id should not have been valid: @_something_else:localhost")
 	}
 }


### PR DESCRIPTION
Registration using the User-Interactive auth was failing because it was being confused with AS registration, thus expecting an access token. This PR moves the check on whether a token is present earlier in the workflow and details the case in which we should consider the registration request as coming from an AS.