### PR TITLE
Fill the prev_batch property in responses from /sync

### DIFF
--- a/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
@@ -310,6 +310,11 @@ func (d *SyncServerDatabase) CompleteSync(
 
 		stateEvents = removeDuplicates(stateEvents, recentEvents)
 		jr := types.NewJoinResponse()
+		if prevBatch := recentStreamEvents[0].streamPosition - 1; prevBatch > 0 {
+			jr.Timeline.PrevBatch = types.StreamPosition(prevBatch).String()
+		} else {
+			jr.Timeline.PrevBatch = recentStreamEvents[0].streamPosition.String()
+		}
 		jr.Timeline.Events = gomatrixserverlib.ToClientEvents(recentEvents, gomatrixserverlib.FormatSync)
 		jr.Timeline.Limited = true
 		jr.State.Events = gomatrixserverlib.ToClientEvents(stateEvents, gomatrixserverlib.FormatSync)
@@ -439,6 +444,11 @@ func (d *SyncServerDatabase) addRoomDeltaToResponse(
 	switch delta.membership {
 	case "join":
 		jr := types.NewJoinResponse()
+		if prevBatch := recentStreamEvents[0].streamPosition - 1; prevBatch > 0 {
+			jr.Timeline.PrevBatch = types.StreamPosition(prevBatch).String()
+		} else {
+			jr.Timeline.PrevBatch = recentStreamEvents[0].streamPosition.String()
+		}
 		jr.Timeline.Events = gomatrixserverlib.ToClientEvents(recentEvents, gomatrixserverlib.FormatSync)
 		jr.Timeline.Limited = false // TODO: if len(events) >= numRecents + 1 and then set limited:true
 		jr.State.Events = gomatrixserverlib.ToClientEvents(delta.stateEvents, gomatrixserverlib.FormatSync)
@@ -449,6 +459,11 @@ func (d *SyncServerDatabase) addRoomDeltaToResponse(
 		// TODO: recentEvents may contain events that this user is not allowed to see because they are
 		//       no longer in the room.
 		lr := types.NewLeaveResponse()
+		if prevBatch := recentStreamEvents[0].streamPosition - 1; prevBatch > 0 {
+			lr.Timeline.PrevBatch = types.StreamPosition(prevBatch).String()
+		} else {
+			lr.Timeline.PrevBatch = recentStreamEvents[0].streamPosition.String()
+		}
 		lr.Timeline.Events = gomatrixserverlib.ToClientEvents(recentEvents, gomatrixserverlib.FormatSync)
 		lr.Timeline.Limited = false // TODO: if len(events) >= numRecents + 1 and then set limited:true
 		lr.State.Events = gomatrixserverlib.ToClientEvents(delta.stateEvents, gomatrixserverlib.FormatSync)

--- a/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/storage/syncserver.go
@@ -313,7 +313,7 @@ func (d *SyncServerDatabase) CompleteSync(
 		if prevBatch := recentStreamEvents[0].streamPosition - 1; prevBatch > 0 {
 			jr.Timeline.PrevBatch = types.StreamPosition(prevBatch).String()
 		} else {
-			jr.Timeline.PrevBatch = recentStreamEvents[0].streamPosition.String()
+			jr.Timeline.PrevBatch = types.StreamPosition(1).String()
 		}
 		jr.Timeline.Events = gomatrixserverlib.ToClientEvents(recentEvents, gomatrixserverlib.FormatSync)
 		jr.Timeline.Limited = true
@@ -447,7 +447,7 @@ func (d *SyncServerDatabase) addRoomDeltaToResponse(
 		if prevBatch := recentStreamEvents[0].streamPosition - 1; prevBatch > 0 {
 			jr.Timeline.PrevBatch = types.StreamPosition(prevBatch).String()
 		} else {
-			jr.Timeline.PrevBatch = recentStreamEvents[0].streamPosition.String()
+			jr.Timeline.PrevBatch = types.StreamPosition(1).String()
 		}
 		jr.Timeline.Events = gomatrixserverlib.ToClientEvents(recentEvents, gomatrixserverlib.FormatSync)
 		jr.Timeline.Limited = false // TODO: if len(events) >= numRecents + 1 and then set limited:true
@@ -462,7 +462,7 @@ func (d *SyncServerDatabase) addRoomDeltaToResponse(
 		if prevBatch := recentStreamEvents[0].streamPosition - 1; prevBatch > 0 {
 			lr.Timeline.PrevBatch = types.StreamPosition(prevBatch).String()
 		} else {
-			lr.Timeline.PrevBatch = recentStreamEvents[0].streamPosition.String()
+			lr.Timeline.PrevBatch = types.StreamPosition(1).String()
 		}
 		lr.Timeline.Events = gomatrixserverlib.ToClientEvents(recentEvents, gomatrixserverlib.FormatSync)
 		lr.Timeline.Limited = false // TODO: if len(events) >= numRecents + 1 and then set limited:true


### PR DESCRIPTION
For each room, fill the `prev_batch` property with the position in the stream of the earliest event in the response -1. If that equals to 0 (which wouldn't match anything since stream positions start at 1), uses the position of the earliest event in the response (which is, as far as I've observed, what synapse does).