### PR TITLE
Fix build conflict between docker environment and host - #596

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 /_obj
 /_test
 /vendor/bin
+/docker/build
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     build: ./
     volumes:
       - ..:/build
+      - ./build/pkg:/build/pkg
+      - ./build/bin:/build/bin
     networks:
       - internal
     depends_on:


### PR DESCRIPTION
This PR isolates the `pkg` and `bin` directories inside the docker build environment from the host environment.

Before these changes, because `golang:alpine3.6` may have a different version of go from that of the host environment and some different shared libraries, unexpected errors may occur when dendrite is built or when the binaries are run, for example `object is [linux amd64 go1.11 X:framepointer] expected [linux amd64 go1.9.4 X:framepointer]` and `/build/bin/generate-keys: No such file or directory`.

This should fix #596.

Signed-off-by: Alex Chen <minecnly@gmail.com>