### PR TITLE
Fix POST /get_missing_events/{roomId} #622

### DIFF
--- a/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/federationapi/routing/routing.go
@@ -212,13 +212,13 @@ func Setup(
 		},
 	)).Methods(http.MethodGet)
 
-	v1fedmux.Handle("get_missing_events/{roomID}", common.MakeFedAPI(
+	v1fedmux.Handle("/get_missing_events/{roomID}", common.MakeFedAPI(
 		"federation_get_missing_events", cfg.Matrix.ServerName, keys,
 		func(httpReq *http.Request, request *gomatrixserverlib.FederationRequest) util.JSONResponse {
 			vars := mux.Vars(httpReq)
 			return GetMissingEvents(httpReq, request, query, vars["roomID"])
 		},
-	)).Methods(http.MethodGet)
+	)).Methods(http.MethodPost)
 
 	v1fedmux.Handle("/backfill/{roomID}/", common.MakeFedAPI(
 		"federation_backfill", cfg.Matrix.ServerName, keys,

--- a/src/github.com/matrix-org/dendrite/roomserver/query/query.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/query/query.go
@@ -438,7 +438,7 @@ func (r *RoomserverQueryAPI) QueryMissingEvents(
 	response *api.QueryMissingEventsResponse,
 ) error {
 	var front []string
-	eventsToFilter := make(map[string]bool)
+	eventsToFilter := make(map[string]bool, len(request.LatestEvents))
 	visited := make(map[string]bool, request.Limit) // request.Limit acts as a hint to size.
 	for _, id := range request.EarliestEvents {
 		visited[id] = true

--- a/src/github.com/matrix-org/dendrite/roomserver/query/query.go
+++ b/src/github.com/matrix-org/dendrite/roomserver/query/query.go
@@ -438,6 +438,7 @@ func (r *RoomserverQueryAPI) QueryMissingEvents(
 	response *api.QueryMissingEventsResponse,
 ) error {
 	var front []string
+	eventsToFilter := make(map[string]bool)
 	visited := make(map[string]bool, request.Limit) // request.Limit acts as a hint to size.
 	for _, id := range request.EarliestEvents {
 		visited[id] = true
@@ -446,6 +447,7 @@ func (r *RoomserverQueryAPI) QueryMissingEvents(
 	for _, id := range request.LatestEvents {
 		if !visited[id] {
 			front = append(front, id)
+			eventsToFilter[id] = true
 		}
 	}
 
@@ -454,7 +456,18 @@ func (r *RoomserverQueryAPI) QueryMissingEvents(
 		return err
 	}
 
-	response.Events, err = r.loadEvents(ctx, resultNIDs)
+	loadedEvents, err := r.loadEvents(ctx, resultNIDs)
+	if err != nil {
+		return err
+	}
+
+	response.Events = make([]gomatrixserverlib.Event, 0, len(loadedEvents)-len(eventsToFilter))
+	for _, event := range loadedEvents {
+		if !eventsToFilter[event.EventID()] {
+			response.Events = append(response.Events, event)
+		}
+	}
+
 	return err
 }
 


### PR DESCRIPTION
This PR should fix #622. It

- [x] Changes accepted method from GET to POST
- [x] Fixes starting slash in route
- [x] Filters events referenced in the request out of the response
