### PR TITLE
Fix default timeout for /sync (#615)

### DIFF
--- a/src/github.com/matrix-org/dendrite/syncapi/sync/request.go
+++ b/src/github.com/matrix-org/dendrite/syncapi/sync/request.go
@@ -27,7 +27,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const defaultSyncTimeout = time.Duration(30) * time.Second
+const defaultSyncTimeout = time.Duration(0)
 const defaultTimelineLimit = 20
 
 // syncRequest represents a /sync request, with sensible defaults/sanity checks applied.


### PR DESCRIPTION
The sync timeout should be 0 according to the spec[1]

[1] https://matrix.org/docs/spec/client_server/r0.4.0.html#get-matrix-client-r0-sync

Signed-off-by: Reto Brunner <brunnre8@gmail.com>