### PR TITLE
"v1" replaced with "r0" in pathPrefixR0 in mediaapi's routing

### DIFF
--- a/src/github.com/matrix-org/dendrite/mediaapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/mediaapi/routing/routing.go
@@ -31,7 +31,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const pathPrefixR0 = "/_matrix/media/v1"
+const pathPrefixR0 = "/_matrix/media/r0"
 
 // Setup registers the media API HTTP handlers
 func Setup(


### PR DESCRIPTION
Hello here !
I Am just started, i am really enthusiastic about dendrite. I made this pull request to fix #627 