### PR TITLE
Fix response to /rooms/{roomId}/join #607

### DIFF
--- a/src/github.com/matrix-org/dendrite/clientapi/routing/joinroom.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/joinroom.go
@@ -108,7 +108,7 @@ func (r joinRoomReq) joinRoomByID(roomID string) util.JSONResponse {
 	// A client should only join a room by room ID when it has an invite
 	// to the room. If the server is already in the room then we can
 	// lookup the invite and process the request as a normal state event.
-	// If the server is not in the room the we will need to look up the
+	// If the server is not in the room then we will need to look up the
 	// remote server the invite came from in order to request a join event
 	// from that server.
 	queryReq := roomserverAPI.QueryInvitesForUserRequest{

--- a/src/github.com/matrix-org/dendrite/clientapi/routing/membership.go
+++ b/src/github.com/matrix-org/dendrite/clientapi/routing/membership.go
@@ -114,6 +114,14 @@ func SendMembership(
 		return httputil.LogThenError(req, err)
 	}
 
+	if membership == "join" {
+		return util.JSONResponse{
+			Code: http.StatusOK,
+			JSON: struct {
+				RoomID string `json:"room_id"`
+			}{roomID},
+		}
+	}
 	return util.JSONResponse{
 		Code: http.StatusOK,
 		JSON: struct{}{},

--- a/src/github.com/matrix-org/dendrite/mediaapi/routing/routing.go
+++ b/src/github.com/matrix-org/dendrite/mediaapi/routing/routing.go
@@ -31,7 +31,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const pathPrefixR0 = "/_matrix/media/v1"
+const pathPrefixR0 = "/_matrix/media/r0"
 
 // Setup registers the media API HTTP handlers
 func Setup(


### PR DESCRIPTION
when user successfully joined the room, he receive an object having a room_id attribute containing the room's ID, [ described in the specs](https://matrix.org/docs/spec/client_server/r0.4.0.html#post-matrix-client-r0-rooms-roomid-join).

Signed-off-by: Kouame Behouba Manasse behouba@gmail.com