### PR TITLE
Fix PR templates and use matrix.to instead of riot.im/develop

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### Pull Request Checklist
 
-<!-- Please read CONTRIBUTING.rst before submitting your pull request -->
+<!-- Please read CONTRIBUTING.md before submitting your pull request -->
 
 * [ ] I have made sure any new dependencies have been checked into the `vendor/` directory
-* [ ] Pull request includes a [sign off](/CONTRIBUTING.rst#sign-off)
+* [ ] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/CONTRIBUTING.md#sign-off)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,10 +48,10 @@ with the `vendor/manifest` file), name it with the command you just ran (ie
 ## Getting Help
 
 For questions related to developing on Dendrite we have a dedicated room on
-Matrix [#dendrite-dev:matrix.org](https://riot.im/develop/#/room/#dendrite-dev:matrix.org)
+Matrix [#dendrite-dev:matrix.org](https://matrix.to/#/#dendrite-dev:matrix.org)
 where we're happy to help.
 
-For more general questions please use [#dendrite:matrix.org](https://riot.im/develop/#/room/#dendrite:matrix.org).
+For more general questions please use [#dendrite:matrix.org](https://matrix.to/#/#dendrite:matrix.org).
 
 ## Sign off
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ We aim to try and make it as easy as possible to jump in.
 # Discussion
 
 For questions about Dendrite we have a dedicated room on Matrix
-[#dendrite:matrix.org](https://riot.im/develop/#/room/#dendrite:matrix.org).
+[#dendrite:matrix.org](https://matrix.to/#/#dendrite:matrix.org).
 
 # Progress
 


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] I have made sure any new dependencies have been checked into the `vendor/` directory
* [x] Pull request includes a [sign off](/CONTRIBUTING.rst#sign-off)

As I mentioned here https://github.com/matrix-org/dendrite/pull/686#pullrequestreview-196648112 I tried to use relative links initially for Synapse's PR templates but they don't actually work. Until GitHub improves this you need to use absolute links.