### PR TITLE
Remove riot.im from the list of trusted ID servers in the default config

### DIFF
--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -17,7 +17,6 @@ matrix:
     trusted_third_party_id_servers:
       - vector.im
       - matrix.org
-      - riot.im
 
 # The media repository config
 media:

--- a/docker/dendrite-docker.yml
+++ b/docker/dendrite-docker.yml
@@ -17,7 +17,6 @@ matrix:
     trusted_third_party_id_servers:
       - vector.im
       - matrix.org
-      - riot.im
 
 # The media repository config
 media:


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.rst before submitting your pull request -->

* [x] I have made sure any new dependencies have been checked into the `vendor/` directory
* [x] Pull request includes a [sign off](/CONTRIBUTING.rst#sign-off)

Synapse removed it here https://github.com/matrix-org/synapse/commit/78ba0e7ab8f1d57eee6aa56e9d496d838a24c6f3#diff-e23363fca80aa05eb0f8068551166e94 because it doesn't actually exist and was causing issues with deactivating accounts. Maybe Dendrite's way of doing things allows it to be here even though it doesn't exist in which case feel free to close this.

Also the comment above it seems to lie. "Defaults to no trusted servers.", isn't this the list of default trusted ID servers?