### PR TITLE
Add back the HTTP handler for getAliasesForRoomID in aliasAPI

### DIFF
--- a/roomserver/alias/alias.go
+++ b/roomserver/alias/alias.go
@@ -269,6 +269,20 @@ func (r *RoomserverAliasAPI) SetupHTTP(servMux *http.ServeMux) {
 		}),
 	)
 	servMux.Handle(
+		roomserverAPI.RoomserverGetAliasesForRoomIDPath,
+		common.MakeInternalAPI("getAliasesForRoomID", func(req *http.Request) util.JSONResponse {
+			var request roomserverAPI.GetAliasesForRoomIDRequest
+			var response roomserverAPI.GetAliasesForRoomIDResponse
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.ErrorResponse(err)
+			}
+			if err := r.GetAliasesForRoomID(req.Context(), &request, &response); err != nil {
+				return util.ErrorResponse(err)
+			}
+			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
+		}),
+	)
+	servMux.Handle(
 		roomserverAPI.RoomserverRemoveRoomAliasPath,
 		common.MakeInternalAPI("removeRoomAlias", func(req *http.Request) util.JSONResponse {
 			var request roomserverAPI.RemoveRoomAliasRequest


### PR DESCRIPTION
This PR adds back the HTTP handler for internal API `GetAliasesForRoomID` in roomserver, which seemed to be missing.

Signed-off-by: Alex Chen <minecnly@gmail.com>

### Pull Request Checklist

* [x] I have added any new tests that need to pass to `testfile` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/CONTRIBUTING.md#sign-off)
