### PR TITLE
Add go_import_path for Travis to let forks build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: go
+
+go_import_path: github.com/matrix-org/dendrite
+
 go:
  - 1.11.x
  - 1.12.x


### PR DESCRIPTION
Before this change, Travis build for a fork always downloads and uses the dendrite package from https://github.com/matrix-org/dendrite, thus may fail if there are new symbols added and referenced in the fork. This PR adds the [`go_import_path`](https://docs.travis-ci.com/user/languages/go/#go-import-path) option for Travis so it uses the code in the fork for the dendrite package instead.

Signed-off-by: Alex Chen <minecnly@gmail.com>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] ~I have added any new tests that need to pass to `testfile` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)~
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/CONTRIBUTING.md#sign-off)
