### PR TITLE
Run CircleCI on pull request branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,4 @@ workflows:
   version: 2
   build:
     jobs:
-      - dendrite:
-          filters:
-            branches:
-              only: master
+      - dendrite


### PR DESCRIPTION
We were previously only running CircleCI on master, but we want it to PRs as well.