### PR TITLE
Fix testfile path hardcoded in show-expected-fail-tests.sh

### DIFF
--- a/docs/sytest.md
+++ b/docs/sytest.md
@@ -59,7 +59,7 @@ Once the tests are complete, run the helper script to see if you need to add
 any newly passing test names to `testfile` in the project's root directory:
 
 ```sh
-../dendrite/show-expected-fail-tests.sh results.tap
+../dendrite/show-expected-fail-tests.sh results.tap ../dendrite/testfile
 ```
 
 If the script prints nothing/exits with 0, then you're good to go.

--- a/show-expected-fail-tests.sh
+++ b/show-expected-fail-tests.sh
@@ -1,13 +1,28 @@
 #! /bin/bash
 
 results_file=$1
+testfile=$2
+
+fail_build=0
+
+if [ ! -f "$results_file" ]; then
+	echo "ERROR: Specified results file ${results_file} doesn't exist."
+	fail_build=1
+fi
+
+if [ ! -f "$testfile" ]; then
+	echo "ERROR: Specified testfile ${testfile} doesn't exist."
+	fail_build=1
+fi
+
+[ "$fail_build" = 0 ] || exit 1
+
 passed_but_expected_fail=$(grep ' # TODO passed but expected fail' ${results_file} | sed -E 's/^ok [0-9]+ (\(expected fail\) )?//' | sed -E 's/( \([0-9]+ subtests\))? # TODO passed but expected fail$//')
 tests_to_add=""
 already_in_testfile=""
 
-fail_build=0
 while read -r test_id; do
-	grep "${test_id}" testfile > /dev/null 2>&1
+	grep "${test_id}" "${testfile}" > /dev/null 2>&1
 	if [ "$?" != "0" ]; then
 		tests_to_add="${tests_to_add}${test_id}\n"
 		fail_build=1


### PR DESCRIPTION
Previously, the path for `testfile` in `show-expected-fail-tests.sh` is hardcoded and may cause failures. This PR fixes that.

Signed-off-by: Alex Chen <minecnly@gmail.com>

### Pull Request Checklist

* ~[ ] I have added any new tests that need to pass to `testfile` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)~
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/CONTRIBUTING.md#sign-off)
