### PR TITLE
Switch build.sh to use `sh` in it's shebang

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 GOBIN=$PWD/`dirname $0`/bin go install -v ./cmd/...


### PR DESCRIPTION
As not all systems have bash.

Helpful for not making debugging alpine docker images a pain :>