### PR TITLE
Don't print Sending EDU if there is noone to send to

### DIFF
--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -96,9 +96,11 @@ func (oqs *OutgoingQueues) SendEDU(
 	// Remove our own server from the list of destinations.
 	destinations = filterDestinations(oqs.origin, destinations)
 
-	log.WithFields(log.Fields{
-		"destinations": destinations, "edu_type": e.Type,
-	}).Info("Sending EDU event")
+	if len(destinations) > 0 {
+		log.WithFields(log.Fields{
+			"destinations": destinations, "edu_type": e.Type,
+		}).Info("Sending EDU event")
+	}
 
 	oqs.queuesMutex.Lock()
 	defer oqs.queuesMutex.Unlock()


### PR DESCRIPTION
The logs had a lot of:

```
Sending EDU event                             destinations="[]" edu_type=m.typing
```

Which is useless if it isn't actually sending the event anywhere (destinations is empty).