### PR TITLE
Fix test POST /rooms/:room_id/join can join a room

### DIFF
--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -99,6 +99,14 @@ func Setup(
 	r0mux.Handle("/rooms/{roomID}/{membership:(?:join|kick|ban|unban|leave|invite)}",
 		common.MakeAuthAPI("membership", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars := mux.Vars(req)
+
+			// If this is a join, reuse the JoinRoomByIDOrAlias method
+			if vars["membership"] == "join" {
+				return JoinRoomByIDOrAlias(
+					req, device, vars["roomID"], cfg, federation, producer, queryAPI, aliasAPI, keyRing, accountDB,
+				)
+			}
+
 			return SendMembership(req, accountDB, device, vars["roomID"], vars["membership"], cfg, queryAPI, asAPI, producer)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)

--- a/testfile
+++ b/testfile
@@ -42,6 +42,7 @@ POST /join/:room_alias can join a room
 POST /join/:room_id can join a room
 POST /join/:room_id can join a room with custom content
 POST /join/:room_alias can join a room with custom content
+POST /rooms/:room_id/join can join a room
 POST /rooms/:room_id/leave can leave a room
 POST /rooms/:room_id/invite can send an invite
 POST /rooms/:room_id/ban can ban a user


### PR DESCRIPTION
There's not much point in reusing SendMembership (which doesn't seem to probably support join) if we already have a method specifically for joining.

However, this may not be the cleanest way to fix this issue, so let me know if there's a nicer method of doing so.