### PR TITLE
Update testfile and fix empty warning in show-expected-fail-tests.sh

### DIFF
--- a/show-expected-fail-tests.sh
+++ b/show-expected-fail-tests.sh
@@ -22,6 +22,7 @@ tests_to_add=""
 already_in_testfile=""
 
 while read -r test_id; do
+	[ "${test_id}" = "" ] && continue
 	grep "${test_id}" "${testfile}" > /dev/null 2>&1
 	if [ "$?" != "0" ]; then
 		tests_to_add="${tests_to_add}${test_id}\n"

--- a/testfile
+++ b/testfile
@@ -142,3 +142,4 @@ Trying to get push rules with unknown rule_id fails with 404
 Events come down the correct room
 local user can join room with version 5
 User can invite local user to room with version 5
+Inbound federation can receive room-join requests


### PR DESCRIPTION
This PR adds the test that https://github.com/matrix-org/sytest/pull/642 will allow to pass to `testfile` and also contains a minor fix for `show-expected-fail-tests.sh` so it doesn't show an empty warning.

Signed-off-by: Alex Chen <minecnly@gmail.com>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] I have added any new tests that need to pass to `testfile` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/CONTRIBUTING.md#sign-off)
