### PR TITLE
Fix #661 appservice can't set aliases in its own namespace

### DIFF
--- a/clientapi/routing/directory.go
+++ b/clientapi/routing/directory.go
@@ -117,12 +117,14 @@ func SetLocalAlias(
 	// 1. The new method for checking for things matching an AS's namespace
 	// 2. Using an overall Regex object for all AS's just like we did for usernames
 	for _, appservice := range cfg.Derived.ApplicationServices {
-		if aliasNamespaces, ok := appservice.NamespaceMap["aliases"]; ok {
-			for _, namespace := range aliasNamespaces {
-				if namespace.Exclusive && namespace.RegexpObject.MatchString(alias) {
-					return util.JSONResponse{
-						Code: http.StatusBadRequest,
-						JSON: jsonerror.ASExclusive("Alias is reserved by an application service"),
+		if device.UserID != appservice.SenderLocalpart {
+			if aliasNamespaces, ok := appservice.NamespaceMap["aliases"]; ok {
+				for _, namespace := range aliasNamespaces {
+					if namespace.Exclusive && namespace.RegexpObject.MatchString(alias) {
+						return util.JSONResponse{
+							Code: http.StatusBadRequest,
+							JSON: jsonerror.ASExclusive("Alias is reserved by an application service"),
+						}
 					}
 				}
 			}

--- a/clientapi/routing/directory.go
+++ b/clientapi/routing/directory.go
@@ -117,6 +117,8 @@ func SetLocalAlias(
 	// 1. The new method for checking for things matching an AS's namespace
 	// 2. Using an overall Regex object for all AS's just like we did for usernames
 	for _, appservice := range cfg.Derived.ApplicationServices {
+		// Don't prevent AS from creating aliases in its own namespace
+		// Note that Dendrite uses SenderLocalpart as UserID for AS users
 		if device.UserID != appservice.SenderLocalpart {
 			if aliasNamespaces, ok := appservice.NamespaceMap["aliases"]; ok {
 				for _, namespace := range aliasNamespaces {


### PR DESCRIPTION
Fixes #661.

This should allow new tests to pass after #659 is also fixed.

Signed-off-by: Alex Chen <minecnly@gmail.com>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] I have added any new tests that need to pass to `testfile` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/CONTRIBUTING.md#sign-off)
