### PR TITLE
Backup and restore go.mod & go.sum during linting

### DIFF
--- a/scripts/find-lint.sh
+++ b/scripts/find-lint.sh
@@ -22,7 +22,15 @@ then args="--fast"
 fi
 
 echo "Installing golangci-lint..."
+
+# Make a backup of go.{mod,sum} first
+# TODO: Once go 1.13 is out, use go get's -mod=readonly option
+# https://github.com/golang/go/issues/30667
+cp go.mod go.mod.bak && cp go.sum go.sum.bak
 go get github.com/golangci/golangci-lint/cmd/golangci-lint
 
 echo "Looking for lint..."
 golangci-lint run $args
+
+# Restore go.{mod,sum}
+mv go.mod.bak go.mod && mv go.sum.bak go.sum


### PR DESCRIPTION
Every time before sending a PR I like to run `./scripts/build-test-lint.sh` to make sure the CI won't complain about anything.

The problem is that this script attempts to install golangci-lint, which causes modifications to go.mod/go.sum. This PR backs up and restores those files before and after linting.

Ideally instead of this hacky backing up/restoring we'd use `go get`s `-mod=readonly` option, but that still modifies `go.sum`. This will be fixed in go 1.13 apparently. https://github.com/golang/go/issues/30667