### PR TITLE
Prevent duplicate entries in the completed registration flows

### DIFF
--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -85,6 +85,12 @@ func (d sessionsDict) GetCompletedStages(sessionID string) []authtypes.LoginType
 
 // AddCompletedStage records that a session has completed an auth stage.
 func (d *sessionsDict) AddCompletedStage(sessionID string, stage authtypes.LoginType) {
+	// Return if the stage is already present
+	for _, completedStage := range d.GetCompletedStages(sessionID) {
+		if completedStage == stage {
+			return
+		}
+	}
 	d.sessions[sessionID] = append(d.GetCompletedStages(sessionID), stage)
 }
 


### PR DESCRIPTION
https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-register

At the moment it's possible to complete a registration stage multiple times and end up with duplicate entries in the `completed` dict returned to the user.

This prevents an entry from making it into the `completed` dict if it already exists.

Fixes https://github.com/matrix-org/dendrite/issues/739