### PR TITLE
Clarify that Filter is only taken into account for POST requests on /publicRooms

### DIFF
--- a/publicroomsapi/directory/public_rooms.go
+++ b/publicroomsapi/directory/public_rooms.go
@@ -89,6 +89,7 @@ func GetPublicRooms(
 
 // fillPublicRoomsReq fills the Limit, Since and Filter attributes of a GET or POST request
 // on /publicRooms by parsing the incoming HTTP request
+// Filter is only filled for POST requests
 func fillPublicRoomsReq(httpReq *http.Request, request *publicRoomReq) *util.JSONResponse {
 	if httpReq.Method == http.MethodGet {
 		limit, err := strconv.Atoi(httpReq.FormValue("limit"))


### PR DESCRIPTION
https://github.com/matrix-org/dendrite/issues/639 mentioned that `filter` should not be accepted on GET requests, but indeed they aren't. The method does make this a little non-transparent however.

Add a comment to explicitly state that this is the case.