### PR TITLE
Clarify that POST publicRooms is implemented

### DIFF
--- a/publicroomsapi/directory/public_rooms.go
+++ b/publicroomsapi/directory/public_rooms.go
@@ -42,8 +42,8 @@ type publicRoomRes struct {
 	Estimate  int64              `json:"total_room_count_estimate,omitempty"`
 }
 
-// GetPublicRooms implements GET /publicRooms
-func GetPublicRooms(
+// GetPostPublicRooms implements GET and POST /publicRooms
+func GetPostPublicRooms(
 	req *http.Request, publicRoomDatabase *storage.PublicRoomsServerDatabase,
 ) util.JSONResponse {
 	var limit int16

--- a/publicroomsapi/routing/routing.go
+++ b/publicroomsapi/routing/routing.go
@@ -64,7 +64,7 @@ func Setup(apiMux *mux.Router, deviceDB *devices.Database, publicRoomsDB *storag
 	).Methods(http.MethodPut, http.MethodOptions)
 	r0mux.Handle("/publicRooms",
 		common.MakeExternalAPI("public_rooms", func(req *http.Request) util.JSONResponse {
-			return directory.GetPublicRooms(req, publicRoomsDB)
+			return directory.GetPostPublicRooms(req, publicRoomsDB)
 		}),
 	).Methods(http.MethodGet, http.MethodPost, http.MethodOptions)
 }


### PR DESCRIPTION
As a response to https://github.com/matrix-org/dendrite/issues/638, it seems that `POST /publicRooms` is already implemented. It is, however, unclear from the code that it is.

Add some comments and change a method name to make this more clear.