### PR TITLE
Remove the trailing slash from /send/{txnID} and /backfill/{roomID}

### DIFF
--- a/federationapi/routing/routing.go
+++ b/federationapi/routing/routing.go
@@ -65,7 +65,7 @@ func Setup(
 	v2keysmux.Handle("/server/{keyID}", localKeys).Methods(http.MethodGet)
 	v2keysmux.Handle("/server/", localKeys).Methods(http.MethodGet)
 
-	v1fedmux.Handle("/send/{txnID}/", common.MakeFedAPI(
+	v1fedmux.Handle("/send/{txnID}", common.MakeFedAPI(
 		"federation_send", cfg.Matrix.ServerName, keys,
 		func(httpReq *http.Request, request *gomatrixserverlib.FederationRequest) util.JSONResponse {
 			vars, err := common.URLDecodeMapValues(mux.Vars(httpReq))

--- a/federationapi/routing/routing.go
+++ b/federationapi/routing/routing.go
@@ -260,7 +260,7 @@ func Setup(
 		},
 	)).Methods(http.MethodPost)
 
-	v1fedmux.Handle("/backfill/{roomID}/", common.MakeFedAPI(
+	v1fedmux.Handle("/backfill/{roomID}", common.MakeFedAPI(
 		"federation_backfill", cfg.Matrix.ServerName, keys,
 		func(httpReq *http.Request, request *gomatrixserverlib.FederationRequest) util.JSONResponse {
 			vars, err := common.URLDecodeMapValues(mux.Vars(httpReq))

--- a/testfile
+++ b/testfile
@@ -147,3 +147,5 @@ Inbound federation can receive room-join requests
 Typing events appear in initial sync
 Typing events appear in incremental sync
 Typing events appear in gapped sync
+Inbound federation of state requires event_id as a mandatory paramater
+Inbound federation of state_ids requires event_id as a mandatory paramater


### PR DESCRIPTION
In conjunction with https://github.com/matrix-org/sytest/pull/651, `/send/{txnID}` and `/backfill/{roomID}` should not have trailing slashes [according to the spec](https://matrix.org/docs/spec/server_server/unstable#put-matrix-federation-v1-send-txnid).