### PR TITLE
Remove unnecessary http method checks

### DIFF
--- a/clientapi/routing/account_data.go
+++ b/clientapi/routing/account_data.go
@@ -33,13 +33,6 @@ func SaveAccountData(
 	req *http.Request, accountDB *accounts.Database, device *authtypes.Device,
 	userID string, roomID string, dataType string, syncProducer *producers.SyncAPIProducer,
 ) util.JSONResponse {
-	if req.Method != http.MethodPut {
-		return util.JSONResponse{
-			Code: http.StatusMethodNotAllowed,
-			JSON: jsonerror.NotFound("Bad method"),
-		}
-	}
-
 	if userID != device.UserID {
 		return util.JSONResponse{
 			Code: http.StatusForbidden,

--- a/clientapi/routing/device.go
+++ b/clientapi/routing/device.go
@@ -106,13 +106,6 @@ func UpdateDeviceByID(
 	req *http.Request, deviceDB *devices.Database, device *authtypes.Device,
 	deviceID string,
 ) util.JSONResponse {
-	if req.Method != http.MethodPut {
-		return util.JSONResponse{
-			Code: http.StatusMethodNotAllowed,
-			JSON: jsonerror.NotFound("Bad Method"),
-		}
-	}
-
 	localpart, _, err := gomatrixserverlib.SplitID('@', device.UserID)
 	if err != nil {
 		return httputil.LogThenError(req, err)

--- a/clientapi/routing/filter.go
+++ b/clientapi/routing/filter.go
@@ -32,12 +32,6 @@ import (
 func GetFilter(
 	req *http.Request, device *authtypes.Device, accountDB *accounts.Database, userID string, filterID string,
 ) util.JSONResponse {
-	if req.Method != http.MethodGet {
-		return util.JSONResponse{
-			Code: http.StatusMethodNotAllowed,
-			JSON: jsonerror.NotFound("Bad method"),
-		}
-	}
 	if userID != device.UserID {
 		return util.JSONResponse{
 			Code: http.StatusForbidden,
@@ -79,12 +73,6 @@ type filterResponse struct {
 func PutFilter(
 	req *http.Request, device *authtypes.Device, accountDB *accounts.Database, userID string,
 ) util.JSONResponse {
-	if req.Method != http.MethodPost {
-		return util.JSONResponse{
-			Code: http.StatusMethodNotAllowed,
-			JSON: jsonerror.NotFound("Bad method"),
-		}
-	}
 	if userID != device.UserID {
 		return util.JSONResponse{
 			Code: http.StatusForbidden,

--- a/clientapi/routing/logout.go
+++ b/clientapi/routing/logout.go
@@ -20,7 +20,6 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
 	"github.com/matrix-org/dendrite/clientapi/httputil"
-	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 )

--- a/clientapi/routing/logout.go
+++ b/clientapi/routing/logout.go
@@ -29,13 +29,6 @@ import (
 func Logout(
 	req *http.Request, deviceDB *devices.Database, device *authtypes.Device,
 ) util.JSONResponse {
-	if req.Method != http.MethodPost {
-		return util.JSONResponse{
-			Code: http.StatusMethodNotAllowed,
-			JSON: jsonerror.NotFound("Bad method"),
-		}
-	}
-
 	localpart, _, err := gomatrixserverlib.SplitID('@', device.UserID)
 	if err != nil {
 		return httputil.LogThenError(req, err)

--- a/clientapi/routing/profile.go
+++ b/clientapi/routing/profile.go
@@ -37,12 +37,6 @@ import (
 func GetProfile(
 	req *http.Request, accountDB *accounts.Database, userID string, asAPI appserviceAPI.AppServiceQueryAPI,
 ) util.JSONResponse {
-	if req.Method != http.MethodGet {
-		return util.JSONResponse{
-			Code: http.StatusMethodNotAllowed,
-			JSON: jsonerror.NotFound("Bad method"),
-		}
-	}
 	profile, err := appserviceAPI.RetrieveUserProfile(req.Context(), userID, asAPI, accountDB)
 	if err != nil {
 		return httputil.LogThenError(req, err)

--- a/mediaapi/routing/download.go
+++ b/mediaapi/routing/download.go
@@ -55,7 +55,7 @@ type downloadRequest struct {
 	Logger             *log.Entry
 }
 
-// Download implements /download amd /thumbnail
+// Download implements GET /download and GET /thumbnail
 // Files from this server (i.e. origin == cfg.ServerName) are served directly
 // Files from remote servers (i.e. origin != cfg.ServerName) are cached locally.
 // If they are present in the cache, they are served directly.
@@ -107,14 +107,6 @@ func Download(
 	}
 
 	// request validation
-	if req.Method != http.MethodGet {
-		dReq.jsonErrorResponse(w, util.JSONResponse{
-			Code: http.StatusMethodNotAllowed,
-			JSON: jsonerror.Unknown("request method must be GET"),
-		})
-		return
-	}
-
 	if resErr := dReq.Validate(); resErr != nil {
 		dReq.jsonErrorResponse(w, *resErr)
 		return

--- a/mediaapi/routing/upload.go
+++ b/mediaapi/routing/upload.go
@@ -48,7 +48,7 @@ type uploadResponse struct {
 	ContentURI string `json:"content_uri"`
 }
 
-// Upload implements /upload
+// Upload implements POST /upload
 // This endpoint involves uploading potentially significant amounts of data to the homeserver.
 // This implementation supports a configurable maximum file size limit in bytes. If a user tries to upload more than this, they will receive an error that their upload is too large.
 // Uploaded files are processed piece-wise to avoid DoS attacks which would starve the server of memory.
@@ -75,13 +75,6 @@ func Upload(req *http.Request, cfg *config.Dendrite, db *storage.Database, activ
 // all the metadata about the media being uploaded.
 // Returns either an uploadRequest or an error formatted as a util.JSONResponse
 func parseAndValidateRequest(req *http.Request, cfg *config.Dendrite) (*uploadRequest, *util.JSONResponse) {
-	if req.Method != http.MethodPost {
-		return nil, &util.JSONResponse{
-			Code: http.StatusMethodNotAllowed,
-			JSON: jsonerror.Unknown("HTTP request method must be POST."),
-		}
-	}
-
 	r := &uploadRequest{
 		MediaMetadata: &types.MediaMetadata{
 			Origin:        cfg.Matrix.ServerName,


### PR DESCRIPTION
Closes https://github.com/matrix-org/dendrite/issues/523

There were a lot of unnecessary checks for HTTP methods of requests. gorilla/mux makes sure that these methods will only be called if certain HTTP methods are used, thus there's no reason to have these extra checks.