### PR TITLE
Add newly passing tests from matrix-org/sytest@56de891

### DIFF
--- a/testfile
+++ b/testfile
@@ -154,3 +154,5 @@ POST /login returns the same device_id as that in the request
 POST /createRoom with creation content
 User can create and send/receive messages in a room with version 1
 POST /createRoom ignores attempts to set the room version via creation_content
+Inbound federation rejects remote attempts to join local users to rooms
+Inbound federation rejects remote attempts to kick local users to rooms


### PR DESCRIPTION
SyTest added two tests that Dendrite already passes: https://github.com/matrix-org/sytest/commit/56de891e628daaee8471f88fe7e76744cde22075

Signed-off-by: Alex Chen <minecnly@gmail.com>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] I have added any new tests that need to pass to `testfile` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/CONTRIBUTING.md#sign-off)
