### PR TITLE
Add new passing test "/event/ on non world readable room does not work"

### DIFF
--- a/testfile
+++ b/testfile
@@ -165,3 +165,4 @@ Can list tags for a room
 Tags appear in an initial v2 /sync
 Newly updated tags appear in an incremental v2 /sync
 Deleted tags appear in an incremental v2 /sync
+/event/ on non world readable room does not work


### PR DESCRIPTION
New test that passes due to https://github.com/matrix-org/sytest/pull/668