### PR TITLE
Error when recaptcha configs are not present

### DIFF
--- a/clientapi/clientapi.go
+++ b/clientapi/clientapi.go
@@ -44,17 +44,6 @@ func SetupClientAPIComponent(
 	asAPI appserviceAPI.AppServiceQueryAPI,
 	transactionsCache *transactions.Cache,
 ) {
-	if base.Cfg.Matrix.RecaptchaEnabled &&
-		(base.Cfg.Matrix.RecaptchaPublicKey == "" ||
-		base.Cfg.Matrix.RecaptchaPrivateKey == "" ||
-		base.Cfg.Matrix.RecaptchaSiteVerifyAPI == "") {
-		logrus.Panicf(
-			"Recaptcha configs are missing. " +
-				"Ensure that recaptcha_public_key, recaptcha_private_key and " +
-				"recaptcha_siteverify_api are specified",
-		)
-	}
-
 	roomserverProducer := producers.NewRoomserverProducer(inputAPI)
 	typingProducer := producers.NewTypingServerProducer(typingInputAPI)
 

--- a/clientapi/clientapi.go
+++ b/clientapi/clientapi.go
@@ -44,6 +44,17 @@ func SetupClientAPIComponent(
 	asAPI appserviceAPI.AppServiceQueryAPI,
 	transactionsCache *transactions.Cache,
 ) {
+	if base.Cfg.Matrix.RecaptchaEnabled &&
+		(base.Cfg.Matrix.RecaptchaPublicKey == "" ||
+		base.Cfg.Matrix.RecaptchaPrivateKey == "" ||
+		base.Cfg.Matrix.RecaptchaSiteVerifyAPI == "") {
+		logrus.Panicf(
+			"Recaptcha configs are missing. " +
+				"Ensure that recaptcha_public_key, recaptcha_private_key and " +
+				"recaptcha_siteverify_api are specified",
+		)
+	}
+
 	roomserverProducer := producers.NewRoomserverProducer(inputAPI)
 	typingProducer := producers.NewTypingServerProducer(typingInputAPI)
 

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -498,6 +498,11 @@ func (config *Dendrite) checkMatrix(configErrs *configErrors) {
 	checkNotEmpty(configErrs, "matrix.server_name", string(config.Matrix.ServerName))
 	checkNotEmpty(configErrs, "matrix.private_key", string(config.Matrix.PrivateKeyPath))
 	checkNotZero(configErrs, "matrix.federation_certificates", int64(len(config.Matrix.FederationCertificatePaths)))
+	if config.Matrix.RecaptchaEnabled {
+		checkNotEmpty(configErrs, "matrix.recaptcha_public_key", string(config.Matrix.RecaptchaPublicKey))
+		checkNotEmpty(configErrs, "matrix.recaptcha_private_key", string(config.Matrix.RecaptchaPrivateKey))
+		checkNotEmpty(configErrs, "matrix.recaptcha_siteverify_api", string(config.Matrix.RecaptchaSiteVerifyAPI))
+	}
 }
 
 // checkMedia verifies the parameters media.* are valid.


### PR DESCRIPTION
During setup of Client API if recaptcha is enabled but the settings are missing, error is logged and panic is raised.

Testing:
Enabled enable_registration_captcha, causes error.
Providing keys and api url passes the check and server starts.
