### PR TITLE
patch dendrite microservices with bind config

### DIFF
--- a/cmd/dendrite-appservice-server/main.go
+++ b/cmd/dendrite-appservice-server/main.go
@@ -35,9 +35,6 @@ func main() {
 		base, accountDB, deviceDB, federation, alias, query, cache,
 	)
 
-	if base.Cfg.Bind.AppServiceAPI != "" {
-		base.SetupAndServeHTTP(string(base.Cfg.Bind.AppServiceAPI))
-	} else {
-		base.SetupAndServeHTTP(string(base.Cfg.Listen.AppServiceAPI))
-	}
+	base.SetupAndServeHTTP(string(base.Cfg.Bind.AppServiceAPI), string(base.Cfg.Listen.AppServiceAPI))
+
 }

--- a/cmd/dendrite-appservice-server/main.go
+++ b/cmd/dendrite-appservice-server/main.go
@@ -35,5 +35,5 @@ func main() {
 		base, accountDB, deviceDB, federation, alias, query, cache,
 	)
 
-	base.SetupAndServeHTTP(string(base.Cfg.Listen.FederationSender))
+	base.SetupAndServeHTTP(string(base.Cfg.Bind.FederationSender))
 }

--- a/cmd/dendrite-appservice-server/main.go
+++ b/cmd/dendrite-appservice-server/main.go
@@ -35,5 +35,9 @@ func main() {
 		base, accountDB, deviceDB, federation, alias, query, cache,
 	)
 
-	base.SetupAndServeHTTP(string(base.Cfg.Bind.FederationSender))
+	if base.Cfg.Bind.AppServiceAPI != "" {
+		base.SetupAndServeHTTP(string(base.Cfg.Bind.AppServiceAPI))
+	} else {
+		base.SetupAndServeHTTP(string(base.Cfg.Listen.AppServiceAPI))
+	}
 }

--- a/cmd/dendrite-client-api-server/main.go
+++ b/cmd/dendrite-client-api-server/main.go
@@ -44,5 +44,5 @@ func main() {
 		alias, input, query, typingInputAPI, asQuery, transactions.New(),
 	)
 
-	base.SetupAndServeHTTP(string(base.Cfg.Listen.ClientAPI))
+	base.SetupAndServeHTTP(string(base.Cfg.Bind.ClientAPI))
 }

--- a/cmd/dendrite-client-api-server/main.go
+++ b/cmd/dendrite-client-api-server/main.go
@@ -44,9 +44,6 @@ func main() {
 		alias, input, query, typingInputAPI, asQuery, transactions.New(),
 	)
 
-	if base.Cfg.Bind.ClientAPI != "" {
-		base.SetupAndServeHTTP(string(base.Cfg.Bind.ClientAPI))
-	} else {
-		base.SetupAndServeHTTP(string(base.Cfg.Listen.ClientAPI))
-	}
+	base.SetupAndServeHTTP(string(base.Cfg.Bind.ClientAPI), string(base.Cfg.Listen.ClientAPI))
+
 }

--- a/cmd/dendrite-client-api-server/main.go
+++ b/cmd/dendrite-client-api-server/main.go
@@ -44,5 +44,9 @@ func main() {
 		alias, input, query, typingInputAPI, asQuery, transactions.New(),
 	)
 
-	base.SetupAndServeHTTP(string(base.Cfg.Bind.ClientAPI))
+	if base.Cfg.Bind.ClientAPI != "" {
+		base.SetupAndServeHTTP(string(base.Cfg.Bind.ClientAPI))
+	} else {
+		base.SetupAndServeHTTP(string(base.Cfg.Listen.ClientAPI))
+	}
 }

--- a/cmd/dendrite-federation-api-server/main.go
+++ b/cmd/dendrite-federation-api-server/main.go
@@ -39,5 +39,5 @@ func main() {
 		alias, input, query, asQuery,
 	)
 
-	base.SetupAndServeHTTP(string(base.Cfg.Listen.FederationAPI))
+	base.SetupAndServeHTTP(string(base.Cfg.Bind.FederationAPI))
 }

--- a/cmd/dendrite-federation-api-server/main.go
+++ b/cmd/dendrite-federation-api-server/main.go
@@ -39,9 +39,6 @@ func main() {
 		alias, input, query, asQuery,
 	)
 
-	if base.Cfg.Bind.FederationAPI != "" {
-		base.SetupAndServeHTTP(string(base.Cfg.Bind.FederationAPI))
-	} else {
-		base.SetupAndServeHTTP(string(base.Cfg.Listen.FederationAPI))
-	}
+	base.SetupAndServeHTTP(string(base.Cfg.Bind.FederationAPI), string(base.Cfg.Listen.FederationAPI))
+
 }

--- a/cmd/dendrite-federation-api-server/main.go
+++ b/cmd/dendrite-federation-api-server/main.go
@@ -39,5 +39,9 @@ func main() {
 		alias, input, query, asQuery,
 	)
 
-	base.SetupAndServeHTTP(string(base.Cfg.Bind.FederationAPI))
+	if base.Cfg.Bind.FederationAPI != "" {
+		base.SetupAndServeHTTP(string(base.Cfg.Bind.FederationAPI))
+	} else {
+		base.SetupAndServeHTTP(string(base.Cfg.Listen.FederationAPI))
+	}
 }

--- a/cmd/dendrite-federation-sender-server/main.go
+++ b/cmd/dendrite-federation-sender-server/main.go
@@ -32,5 +32,9 @@ func main() {
 		base, federation, query,
 	)
 
-	base.SetupAndServeHTTP(string(base.Cfg.Bind.FederationSender))
+	if base.Cfg.Bind.FederationSender != "" {
+		base.SetupAndServeHTTP(string(base.Cfg.Bind.FederationSender))
+	} else {
+		base.SetupAndServeHTTP(string(base.Cfg.Listen.FederationSender))
+	}
 }

--- a/cmd/dendrite-federation-sender-server/main.go
+++ b/cmd/dendrite-federation-sender-server/main.go
@@ -32,9 +32,6 @@ func main() {
 		base, federation, query,
 	)
 
-	if base.Cfg.Bind.FederationSender != "" {
-		base.SetupAndServeHTTP(string(base.Cfg.Bind.FederationSender))
-	} else {
-		base.SetupAndServeHTTP(string(base.Cfg.Listen.FederationSender))
-	}
+	base.SetupAndServeHTTP(string(base.Cfg.Bind.FederationSender), string(base.Cfg.Listen.FederationSender))
+
 }

--- a/cmd/dendrite-federation-sender-server/main.go
+++ b/cmd/dendrite-federation-sender-server/main.go
@@ -32,5 +32,5 @@ func main() {
 		base, federation, query,
 	)
 
-	base.SetupAndServeHTTP(string(base.Cfg.Listen.FederationSender))
+	base.SetupAndServeHTTP(string(base.Cfg.Bind.FederationSender))
 }

--- a/cmd/dendrite-media-api-server/main.go
+++ b/cmd/dendrite-media-api-server/main.go
@@ -28,9 +28,6 @@ func main() {
 
 	mediaapi.SetupMediaAPIComponent(base, deviceDB)
 
-	if base.Cfg.Bind.MediaAPI != "" {
-		base.SetupAndServeHTTP(string(base.Cfg.Bind.MediaAPI))
-	} else {
-		base.SetupAndServeHTTP(string(base.Cfg.Listen.MediaAPI))
-	}
+	base.SetupAndServeHTTP(string(base.Cfg.Bind.MediaAPI), string(base.Cfg.Listen.MediaAPI))
+
 }

--- a/cmd/dendrite-media-api-server/main.go
+++ b/cmd/dendrite-media-api-server/main.go
@@ -28,5 +28,9 @@ func main() {
 
 	mediaapi.SetupMediaAPIComponent(base, deviceDB)
 
-	base.SetupAndServeHTTP(string(base.Cfg.Bind.MediaAPI))
+	if base.Cfg.Bind.MediaAPI != "" {
+		base.SetupAndServeHTTP(string(base.Cfg.Bind.MediaAPI))
+	} else {
+		base.SetupAndServeHTTP(string(base.Cfg.Listen.MediaAPI))
+	}
 }

--- a/cmd/dendrite-media-api-server/main.go
+++ b/cmd/dendrite-media-api-server/main.go
@@ -28,5 +28,5 @@ func main() {
 
 	mediaapi.SetupMediaAPIComponent(base, deviceDB)
 
-	base.SetupAndServeHTTP(string(base.Cfg.Listen.MediaAPI))
+	base.SetupAndServeHTTP(string(base.Cfg.Bind.MediaAPI))
 }

--- a/cmd/dendrite-public-rooms-api-server/main.go
+++ b/cmd/dendrite-public-rooms-api-server/main.go
@@ -28,5 +28,9 @@ func main() {
 
 	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB)
 
-	base.SetupAndServeHTTP(string(base.Cfg.Bind.PublicRoomsAPI))
+	if base.Cfg.Bind.PublicRoomsAPI != "" {
+		base.SetupAndServeHTTP(string(base.Cfg.Bind.PublicRoomsAPI))
+	} else {
+		base.SetupAndServeHTTP(string(base.Cfg.Listen.PublicRoomsAPI))
+	}
 }

--- a/cmd/dendrite-public-rooms-api-server/main.go
+++ b/cmd/dendrite-public-rooms-api-server/main.go
@@ -28,5 +28,5 @@ func main() {
 
 	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB)
 
-	base.SetupAndServeHTTP(string(base.Cfg.Listen.PublicRoomsAPI))
+	base.SetupAndServeHTTP(string(base.Cfg.Bind.PublicRoomsAPI))
 }

--- a/cmd/dendrite-public-rooms-api-server/main.go
+++ b/cmd/dendrite-public-rooms-api-server/main.go
@@ -28,9 +28,6 @@ func main() {
 
 	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB)
 
-	if base.Cfg.Bind.PublicRoomsAPI != "" {
-		base.SetupAndServeHTTP(string(base.Cfg.Bind.PublicRoomsAPI))
-	} else {
-		base.SetupAndServeHTTP(string(base.Cfg.Listen.PublicRoomsAPI))
-	}
+	base.SetupAndServeHTTP(string(base.Cfg.Bind.PublicRoomsAPI), string(base.Cfg.Listen.PublicRoomsAPI))
+
 }

--- a/cmd/dendrite-room-server/main.go
+++ b/cmd/dendrite-room-server/main.go
@@ -28,5 +28,5 @@ func main() {
 
 	roomserver.SetupRoomServerComponent(base)
 
-	base.SetupAndServeHTTP(string(base.Cfg.Listen.RoomServer))
+	base.SetupAndServeHTTP(string(base.Cfg.Bind.RoomServer))
 }

--- a/cmd/dendrite-room-server/main.go
+++ b/cmd/dendrite-room-server/main.go
@@ -28,9 +28,6 @@ func main() {
 
 	roomserver.SetupRoomServerComponent(base)
 
-	if base.Cfg.Bind.RoomServer != "" {
-		base.SetupAndServeHTTP(string(base.Cfg.Bind.RoomServer))
-	} else {
-		base.SetupAndServeHTTP(string(base.Cfg.Listen.RoomServer))
-	}
+	base.SetupAndServeHTTP(string(base.Cfg.Bind.RoomServer), string(base.Cfg.Listen.RoomServer))
+
 }

--- a/cmd/dendrite-room-server/main.go
+++ b/cmd/dendrite-room-server/main.go
@@ -28,5 +28,9 @@ func main() {
 
 	roomserver.SetupRoomServerComponent(base)
 
-	base.SetupAndServeHTTP(string(base.Cfg.Bind.RoomServer))
+	if base.Cfg.Bind.RoomServer != "" {
+		base.SetupAndServeHTTP(string(base.Cfg.Bind.RoomServer))
+	} else {
+		base.SetupAndServeHTTP(string(base.Cfg.Listen.RoomServer))
+	}
 }

--- a/cmd/dendrite-sync-api-server/main.go
+++ b/cmd/dendrite-sync-api-server/main.go
@@ -31,5 +31,9 @@ func main() {
 
 	syncapi.SetupSyncAPIComponent(base, deviceDB, accountDB, query)
 
-	base.SetupAndServeHTTP(string(base.Cfg.Bind.SyncAPI))
+	if base.Cfg.Bind.SyncAPI != "" {
+		base.SetupAndServeHTTP(string(base.Cfg.Bind.SyncAPI))
+	} else {
+		base.SetupAndServeHTTP(string(base.Cfg.Listen.SyncAPI))
+	}
 }

--- a/cmd/dendrite-sync-api-server/main.go
+++ b/cmd/dendrite-sync-api-server/main.go
@@ -31,5 +31,5 @@ func main() {
 
 	syncapi.SetupSyncAPIComponent(base, deviceDB, accountDB, query)
 
-	base.SetupAndServeHTTP(string(base.Cfg.Listen.SyncAPI))
+	base.SetupAndServeHTTP(string(base.Cfg.Bind.SyncAPI))
 }

--- a/cmd/dendrite-sync-api-server/main.go
+++ b/cmd/dendrite-sync-api-server/main.go
@@ -31,9 +31,6 @@ func main() {
 
 	syncapi.SetupSyncAPIComponent(base, deviceDB, accountDB, query)
 
-	if base.Cfg.Bind.SyncAPI != "" {
-		base.SetupAndServeHTTP(string(base.Cfg.Bind.SyncAPI))
-	} else {
-		base.SetupAndServeHTTP(string(base.Cfg.Listen.SyncAPI))
-	}
+	base.SetupAndServeHTTP(string(base.Cfg.Bind.SyncAPI), string(base.Cfg.Listen.SyncAPI))
+
 }

--- a/cmd/dendrite-typing-server/main.go
+++ b/cmd/dendrite-typing-server/main.go
@@ -32,9 +32,6 @@ func main() {
 
 	typingserver.SetupTypingServerComponent(base, cache.NewTypingCache())
 
-	if base.Cfg.Bind.TypingServer != "" {
-		base.SetupAndServeHTTP(string(base.Cfg.Bind.TypingServer))
-	} else {
-		base.SetupAndServeHTTP(string(base.Cfg.Listen.TypingServer))
-	}
+	base.SetupAndServeHTTP(string(base.Cfg.Bind.TypingServer), string(base.Cfg.Listen.TypingServer))
+
 }

--- a/cmd/dendrite-typing-server/main.go
+++ b/cmd/dendrite-typing-server/main.go
@@ -32,5 +32,5 @@ func main() {
 
 	typingserver.SetupTypingServerComponent(base, cache.NewTypingCache())
 
-	base.SetupAndServeHTTP(string(base.Cfg.Listen.TypingServer))
+	base.SetupAndServeHTTP(string(base.Cfg.Bind.TypingServer))
 }

--- a/cmd/dendrite-typing-server/main.go
+++ b/cmd/dendrite-typing-server/main.go
@@ -32,5 +32,9 @@ func main() {
 
 	typingserver.SetupTypingServerComponent(base, cache.NewTypingCache())
 
-	base.SetupAndServeHTTP(string(base.Cfg.Bind.TypingServer))
+	if base.Cfg.Bind.TypingServer != "" {
+		base.SetupAndServeHTTP(string(base.Cfg.Bind.TypingServer))
+	} else {
+		base.SetupAndServeHTTP(string(base.Cfg.Listen.TypingServer))
+	}
 }

--- a/common/basecomponent/base.go
+++ b/common/basecomponent/base.go
@@ -150,7 +150,15 @@ func (b *BaseDendrite) CreateFederationClient() *gomatrixserverlib.FederationCli
 
 // SetupAndServeHTTP sets up the HTTP server to serve endpoints registered on
 // ApiMux under /api/ and adds a prometheus handler under /metrics.
-func (b *BaseDendrite) SetupAndServeHTTP(addr string) {
+func (b *BaseDendrite) SetupAndServeHTTP(bindaddr string, listenaddr string) {
+
+	var addr string
+	if bindaddr != "" {
+		addr = bindaddr
+	} else {
+		addr = listenaddr
+	}
+
 	common.SetupHTTPAPI(http.DefaultServeMux, common.WrapHandlerInCORS(b.APIMux))
 	logrus.Infof("Starting %s server on %s", b.componentName, addr)
 

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -194,8 +194,7 @@ type Dendrite struct {
 		Password string `yaml:"turn_password"`
 	} `yaml:"turn"`
 
-	// The internal addresses the components will listen on.
-	// These should not be exposed externally as they expose metrics and debugging APIs.
+	// The addresses for talking to other microservices.
 	Listen struct {
 		MediaAPI         Address `yaml:"media_api"`
 		ClientAPI        Address `yaml:"client_api"`
@@ -207,6 +206,20 @@ type Dendrite struct {
 		PublicRoomsAPI   Address `yaml:"public_rooms_api"`
 		TypingServer     Address `yaml:"typing_server"`
 	} `yaml:"listen"`
+
+	// The internal addresses the components will listen on.
+	// These should not be exposed externally as they expose metrics and debugging APIs.
+	Bind struct {
+		MediaAPI         Address `yaml:"media_api"`
+		ClientAPI        Address `yaml:"client_api"`
+		FederationAPI    Address `yaml:"federation_api"`
+		AppServiceAPI    Address `yaml:"appservice_api"`
+		SyncAPI          Address `yaml:"sync_api"`
+		RoomServer       Address `yaml:"room_server"`
+		FederationSender Address `yaml:"federation_sender"`
+		PublicRoomsAPI   Address `yaml:"public_rooms_api"`
+		TypingServer     Address `yaml:"typing_server"`
+	} `yaml:"bind"`
 
 	// The config for tracing the dendrite servers.
 	Tracing struct {

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -194,6 +194,21 @@ type Dendrite struct {
 		Password string `yaml:"turn_password"`
 	} `yaml:"turn"`
 
+	// The internal addresses the components will listen on.
+	// These should not be exposed externally as they expose metrics and debugging APIs.
+	// Falls back to addresses listed in Listen if not specified
+	Bind struct {
+		MediaAPI         Address `yaml:"media_api"`
+		ClientAPI        Address `yaml:"client_api"`
+		FederationAPI    Address `yaml:"federation_api"`
+		AppServiceAPI    Address `yaml:"appservice_api"`
+		SyncAPI          Address `yaml:"sync_api"`
+		RoomServer       Address `yaml:"room_server"`
+		FederationSender Address `yaml:"federation_sender"`
+		PublicRoomsAPI   Address `yaml:"public_rooms_api"`
+		TypingServer     Address `yaml:"typing_server"`
+	} `yaml:"bind"`
+
 	// The addresses for talking to other microservices.
 	Listen struct {
 		MediaAPI         Address `yaml:"media_api"`
@@ -206,20 +221,6 @@ type Dendrite struct {
 		PublicRoomsAPI   Address `yaml:"public_rooms_api"`
 		TypingServer     Address `yaml:"typing_server"`
 	} `yaml:"listen"`
-
-	// The internal addresses the components will listen on.
-	// These should not be exposed externally as they expose metrics and debugging APIs.
-	Bind struct {
-		MediaAPI         Address `yaml:"media_api"`
-		ClientAPI        Address `yaml:"client_api"`
-		FederationAPI    Address `yaml:"federation_api"`
-		AppServiceAPI    Address `yaml:"appservice_api"`
-		SyncAPI          Address `yaml:"sync_api"`
-		RoomServer       Address `yaml:"room_server"`
-		FederationSender Address `yaml:"federation_sender"`
-		PublicRoomsAPI   Address `yaml:"public_rooms_api"`
-		TypingServer     Address `yaml:"typing_server"`
-	} `yaml:"bind"`
 
 	// The config for tracing the dendrite servers.
 	Tracing struct {

--- a/common/test/config.go
+++ b/common/test/config.go
@@ -106,6 +106,16 @@ func MakeConfig(configDir, kafkaURI, database, host string, startPort int) (*con
 	cfg.Listen.PublicRoomsAPI = assignAddress()
 	cfg.Listen.TypingServer = assignAddress()
 
+	// Bind to the same address as the listen address
+	// All microservices are run on the same host in testing
+	cfg.Bind.ClientAPI = cfg.Listen.ClientAPI
+	cfg.Bind.FederationAPI = cfg.Listen.FederationAPI
+	cfg.Bind.MediaAPI = cfg.Listen.MediaAPI
+	cfg.Bind.RoomServer = cfg.Listen.RoomServer
+	cfg.Bind.SyncAPI = cfg.Listen.SyncAPI
+	cfg.Bind.PublicRoomsAPI = cfg.Listen.PublicRoomsAPI
+	cfg.Bind.TypingServer = cfg.Listen.TypingServer
+
 	return &cfg, port, nil
 }
 


### PR DESCRIPTION
This PR adds a block in the dendrite config for the services to bind to. The microservices should bind to the addresses in the bind block, and will be contacted at the address in the listen block.

This fixes an issue with the microservices and kubernetes services. 

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] I have added any new tests that need to pass to `testfile` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/CONTRIBUTING.md#sign-off)
