### PR TITLE
Add 'Can paginate public room list' to testfile

### DIFF
--- a/testfile
+++ b/testfile
@@ -171,3 +171,4 @@ Outbound federation can query profile data
 /event/ on joined room works
 /event/ does not allow access to events before the user joined
 Federation key API allows unsigned requests for keys
+Can paginate public room list


### PR DESCRIPTION
Dendrite has passed this test since it's CI went down, likely due to changes in Sytest itself. Add it to the testfile.