### PR TITLE
Adding publicRooms endpoint to federation API (#626)

### DIFF
--- a/cmd/dendrite-federation-api-server/main.go
+++ b/cmd/dendrite-federation-api-server/main.go
@@ -27,6 +27,7 @@ func main() {
 
 	accountDB := base.CreateAccountsDB()
 	deviceDB := base.CreateDeviceDB()
+	publicRoomsDB := base.CreatePublicRoomsDB()
 	keyDB := base.CreateKeyDB()
 	federation := base.CreateFederationClient()
 	keyRing := keydb.CreateKeyRing(federation.Client, keyDB)
@@ -35,7 +36,7 @@ func main() {
 	asQuery := base.CreateHTTPAppServiceAPIs()
 
 	federationapi.SetupFederationAPIComponent(
-		base, accountDB, deviceDB, federation, &keyRing,
+		base, accountDB, deviceDB, publicRoomsDB, federation, &keyRing,
 		alias, input, query, asQuery,
 	)
 

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -51,6 +51,7 @@ func main() {
 
 	accountDB := base.CreateAccountsDB()
 	deviceDB := base.CreateDeviceDB()
+	publicRoomsDB := base.CreatePublicRoomsDB()
 	keyDB := base.CreateKeyDB()
 	federation := base.CreateFederationClient()
 	keyRing := keydb.CreateKeyRing(federation.Client, keyDB)
@@ -67,9 +68,9 @@ func main() {
 		federation, &keyRing, alias, input, query,
 		typingInputAPI, asQuery, transactions.New(), fedSenderAPI,
 	)
-	federationapi.SetupFederationAPIComponent(base, accountDB, deviceDB, federation, &keyRing, alias, input, query, asQuery)
+	federationapi.SetupFederationAPIComponent(base, accountDB, deviceDB, publicRoomsDB, federation, &keyRing, alias, input, query, asQuery)
 	mediaapi.SetupMediaAPIComponent(base, deviceDB)
-	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB)
+	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB, publicRoomsDB)
 	syncapi.SetupSyncAPIComponent(base, deviceDB, accountDB, query)
 
 	httpHandler := common.WrapHandlerInCORS(base.APIMux)

--- a/cmd/dendrite-public-rooms-api-server/main.go
+++ b/cmd/dendrite-public-rooms-api-server/main.go
@@ -25,8 +25,9 @@ func main() {
 	defer base.Close() // nolint: errcheck
 
 	deviceDB := base.CreateDeviceDB()
+	publicRoomsDB := base.CreatePublicRoomsDB()
 
-	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB)
+	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB, publicRoomsDB)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.PublicRoomsAPI), string(base.Cfg.Listen.PublicRoomsAPI))
 

--- a/common/basecomponent/base.go
+++ b/common/basecomponent/base.go
@@ -19,6 +19,8 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/matrix-org/dendrite/publicroomsapi/storage"
+
 	"github.com/matrix-org/dendrite/common/keydb"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/naffka"
@@ -28,7 +30,7 @@ import (
 	"github.com/matrix-org/dendrite/common"
 
 	"github.com/gorilla/mux"
-	sarama "gopkg.in/Shopify/sarama.v1"
+	"gopkg.in/Shopify/sarama.v1"
 
 	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"
 	"github.com/matrix-org/dendrite/common/config"
@@ -133,6 +135,14 @@ func (b *BaseDendrite) CreateAccountsDB() *accounts.Database {
 		logrus.WithError(err).Panicf("failed to connect to accounts db")
 	}
 
+	return db
+}
+
+func (b *BaseDendrite) CreatePublicRoomsDB() *storage.PublicRoomsServerDatabase {
+	db, err := storage.NewPublicRoomsServerDatabase(string(b.Cfg.Database.PublicRoomsAPI))
+	if err != nil {
+		logrus.WithError(err).Panicf("failed to connect to public rooms db")
+	}
 	return db
 }
 

--- a/federationapi/federationapi.go
+++ b/federationapi/federationapi.go
@@ -19,6 +19,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
 	"github.com/matrix-org/dendrite/common/basecomponent"
+	"github.com/matrix-org/dendrite/publicroomsapi/storage"
 	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
 
 	// TODO: Are we really wanting to pull in the producer from clientapi
@@ -33,6 +34,7 @@ func SetupFederationAPIComponent(
 	base *basecomponent.BaseDendrite,
 	accountsDB *accounts.Database,
 	deviceDB *devices.Database,
+	publicRoomsDB *storage.PublicRoomsServerDatabase,
 	federation *gomatrixserverlib.FederationClient,
 	keyRing *gomatrixserverlib.KeyRing,
 	aliasAPI roomserverAPI.RoomserverAliasAPI,
@@ -44,6 +46,6 @@ func SetupFederationAPIComponent(
 
 	routing.Setup(
 		base.APIMux, *base.Cfg, queryAPI, aliasAPI, asAPI,
-		roomserverProducer, *keyRing, federation, accountsDB, deviceDB,
+		roomserverProducer, *keyRing, federation, accountsDB, deviceDB, publicRoomsDB,
 	)
 }

--- a/federationapi/routing/routing.go
+++ b/federationapi/routing/routing.go
@@ -17,6 +17,9 @@ package routing
 import (
 	"net/http"
 
+	"github.com/matrix-org/dendrite/publicroomsapi/directory"
+	"github.com/matrix-org/dendrite/publicroomsapi/storage"
+
 	"github.com/gorilla/mux"
 	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
@@ -50,6 +53,7 @@ func Setup(
 	federation *gomatrixserverlib.FederationClient,
 	accountDB *accounts.Database,
 	deviceDB *devices.Database,
+	publicRoomsDB *storage.PublicRoomsServerDatabase,
 ) {
 	v2keysmux := apiMux.PathPrefix(pathPrefixV2Keys).Subrouter()
 	v1fedmux := apiMux.PathPrefix(pathPrefixV1Federation).Subrouter()
@@ -271,4 +275,11 @@ func Setup(
 			return Backfill(httpReq, request, query, vars["roomID"], cfg)
 		},
 	)).Methods(http.MethodGet)
+
+	v1fedmux.Handle("/publicRooms", common.MakeFedAPI(
+		"federation_publicRooms", cfg.Matrix.ServerName, keys,
+		func(httpReq *http.Request, request *gomatrixserverlib.FederationRequest) util.JSONResponse {
+			return directory.GetPostPublicRooms(httpReq, publicRoomsDB)
+		},
+	)).Methods(http.MethodGet, http.MethodPost)
 }

--- a/publicroomsapi/publicroomsapi.go
+++ b/publicroomsapi/publicroomsapi.go
@@ -19,7 +19,6 @@ import (
 	"github.com/matrix-org/dendrite/common/basecomponent"
 	"github.com/matrix-org/dendrite/publicroomsapi/routing"
 	"github.com/matrix-org/dendrite/publicroomsapi/storage"
-	"github.com/sirupsen/logrus"
 )
 
 // SetupPublicRoomsAPIComponent sets up and registers HTTP handlers for the PublicRoomsAPI
@@ -27,11 +26,8 @@ import (
 func SetupPublicRoomsAPIComponent(
 	base *basecomponent.BaseDendrite,
 	deviceDB *devices.Database,
+	publicRoomsDB *storage.PublicRoomsServerDatabase,
 ) {
-	publicRoomsDB, err := storage.NewPublicRoomsServerDatabase(string(base.Cfg.Database.PublicRoomsAPI))
-	if err != nil {
-		logrus.WithError(err).Panicf("failed to connect to public rooms db")
-	}
 
 	routing.Setup(base.APIMux, deviceDB, publicRoomsDB)
 }


### PR DESCRIPTION
Hi, I added the /publicRooms Endpoint to the federation server. #626

Let me know what you think.

I also tried to run SyTest with the docker image matrixdotorg/sytest-dendrite:latest, but after a few hundred tests I got the following error: 

```
+ TEST_STATUS=1
+ /src/show-expected-fail-tests.sh results.tap /src/testfile
+ mkdir -p /logs
+ cp results.tap /logs/results.tap
+ rsync --ignore-missing-args --min-size=1B -av server-0 server-1 /logs --include '*/' '--include=*.log.*' '--include=*.log' '--exclude=*'
sending incremental file list
server-0/
server-0/dendrite-logs/
server-0/dendrite-logs/Monolith.log
server-1/

sent 38,462,469 bytes  received 47 bytes  76,925,032.00 bytes/sec
total size is 38,452,881  speedup is 1.00
+ mkdir -p /logs/sytest
+ perl ./tap-to-junit-xml.pl --puretap --input=/logs/results.tap --output=/logs/sytest/results.xml SyTest
+ exit 1
```
