### PR TITLE
selectAccountDataByType shouldn't error when no rows

### DIFF
--- a/clientapi/auth/storage/accounts/account_data_table.go
+++ b/clientapi/auth/storage/accounts/account_data_table.go
@@ -125,6 +125,10 @@ func (s *accountDataStatements) selectAccountDataByType(
 	var content []byte
 
 	if err = stmt.QueryRowContext(ctx, localpart, roomID, dataType).Scan(&content); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+
 		return
 	}
 


### PR DESCRIPTION
A little bug introduced in #798 but got through the tests.

Signed-off-by: Alex Chen <minecnly@gmail.com>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] I have added any new tests that need to pass to `testfile` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/CONTRIBUTING.md#sign-off)
