### PR TITLE
Pin golangci-lint version to non-broken one

### DIFF
--- a/scripts/find-lint.sh
+++ b/scripts/find-lint.sh
@@ -27,7 +27,7 @@ echo "Installing golangci-lint..."
 # TODO: Once go 1.13 is out, use go get's -mod=readonly option
 # https://github.com/golang/go/issues/30667
 cp go.mod go.mod.bak && cp go.sum go.sum.bak
-go get github.com/golangci/golangci-lint/cmd/golangci-lint
+go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.19.1
 
 echo "Looking for lint..."
 golangci-lint run $args


### PR DESCRIPTION
golangci-lint `v1.20.0` looks to [be breaking CI currently](https://buildkite.com/matrix-dot-org/dendrite/builds/308#266eb5ca-9aef-4497-a924-c91e4dcd72ee).

Pinning to `v1.19.1` until the breakage is fixed (or we find another way to fix it on our side).