### PR TITLE
Move files back if linting fails

### DIFF
--- a/scripts/find-lint.sh
+++ b/scripts/find-lint.sh
@@ -31,12 +31,12 @@ go get github.com/golangci/golangci-lint/cmd/golangci-lint
 
 # Run linting
 echo "Looking for lint..."
-# If we're running in CI, a linting fail should fail the CI step
-if [ -n "${CI}" ]; then
-    golangci-lint run $args 
-else
-    # Otherwise continue the script even if linting fails
+# If we're running locally, continue the script even if linting fails
+if [ -z ${CI+x} ]; then
     golangci-lint run $args || echo "Linting script failed, removing module backups"
+else
+    # Otherwise, a linting fail should fail the CI step
+    golangci-lint run $args 
 fi
 
 # Restore go.{mod,sum}

--- a/scripts/find-lint.sh
+++ b/scripts/find-lint.sh
@@ -30,7 +30,9 @@ cp go.mod go.mod.bak && cp go.sum go.sum.bak
 go get github.com/golangci/golangci-lint/cmd/golangci-lint
 
 echo "Looking for lint..."
-golangci-lint run $args
+# Run linting
+# Ensure module files or moved back even if the linting command fails
+golangci-lint run $args || echo "Linting execution failed..."
 
 # Restore go.{mod,sum}
 mv go.mod.bak go.mod && mv go.sum.bak go.sum

--- a/scripts/find-lint.sh
+++ b/scripts/find-lint.sh
@@ -31,13 +31,13 @@ go get github.com/golangci/golangci-lint/cmd/golangci-lint
 
 # Run linting
 echo "Looking for lint..."
-# If we're running locally, continue the script even if linting fails
-if [ -z ${CI+x} ]; then
-    golangci-lint run $args || echo "Linting script failed, removing module backups"
-else
-    # Otherwise, a linting fail should fail the CI step
-    golangci-lint run $args 
-fi
+
+# Capture exit code to ensure go.{mod,sum} is restored before exiting
+exit_code=0
+
+golangci-lint run $args || exit_code=1
 
 # Restore go.{mod,sum}
 mv go.mod.bak go.mod && mv go.sum.bak go.sum
+
+exit $exit_code

--- a/scripts/find-lint.sh
+++ b/scripts/find-lint.sh
@@ -29,10 +29,15 @@ echo "Installing golangci-lint..."
 cp go.mod go.mod.bak && cp go.sum go.sum.bak
 go get github.com/golangci/golangci-lint/cmd/golangci-lint
 
-echo "Looking for lint..."
 # Run linting
-# Ensure module files or moved back even if the linting command fails
-golangci-lint run $args || echo "Linting execution failed..."
+echo "Looking for lint..."
+# If we're running in CI, a linting fail should fail the CI step
+if [ -n "$CI" ]; then
+    golangci-lint run $args 
+else
+    # Otherwise continue the script even if linting fails
+    golangci-lint run $args || echo "Linting script failed, removing module backups"
+fi
 
 # Restore go.{mod,sum}
 mv go.mod.bak go.mod && mv go.sum.bak go.sum

--- a/scripts/find-lint.sh
+++ b/scripts/find-lint.sh
@@ -32,7 +32,7 @@ go get github.com/golangci/golangci-lint/cmd/golangci-lint
 # Run linting
 echo "Looking for lint..."
 # If we're running in CI, a linting fail should fail the CI step
-if [ -n "$CI" ]; then
+if [ -n "${CI}" ]; then
     golangci-lint run $args 
 else
     # Otherwise continue the script even if linting fails


### PR DESCRIPTION
Prevents `go.{mod,sum}.bak` files from being left around if the linting command fails.

This PR makes it so the rest of the script will run even if linting fails.