### PR TITLE
Add newly passing test 'Newly joined room is included in an incremental sync after invite'

### DIFF
--- a/testfile
+++ b/testfile
@@ -182,3 +182,4 @@ Regular users cannot create room aliases within the AS namespace
 Deleting a non-existent alias should return a 404
 Users can't delete other's aliases
 Outbound federation can query room alias directory
+Newly joined room is included in an incremental sync after invite


### PR DESCRIPTION
Looks like a SyTest change has brought this.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] I have added any new tests that need to pass to `testfile` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/CONTRIBUTING.md#sign-off)
