### PR TITLE
check for nil body prior to unmarshal

### DIFF
--- a/clientapi/routing/membership.go
+++ b/clientapi/routing/membership.go
@@ -45,6 +45,12 @@ func SendMembership(
 	queryAPI roomserverAPI.RoomserverQueryAPI, asAPI appserviceAPI.AppServiceQueryAPI,
 	producer *producers.RoomserverProducer,
 ) util.JSONResponse {
+	if req.Body==nil {
+		return util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.NotJSON("Content is nil"),
+		}
+	}
 	var body threepid.MembershipRequest
 	if reqErr := httputil.UnmarshalJSONRequest(req, &body); reqErr != nil {
 		return *reqErr


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] I have added any new tests that need to pass to `testfile` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/CONTRIBUTING.md#sign-off)

This is a redo of https://github.com/matrix-org/dendrite/pull/790 regarding issue https://github.com/matrix-org/dendrite/issues/767.

I'm not entirely certain that checking that the body is nil in this way will work. According to the go documentation in [request.go](https://golang.org/src/net/http/request.go) it says that 
```
	// For client requests, a nil body means the request has no
	// body, such as a GET request. The HTTP Client's Transport
	// is responsible for calling the Close method.
```
which seems like the use case that the issue is referring to. 

I haven't added any tests yet, I would like some guidance on how tests work for this project.
