### PR TITLE
AS should use the v1 endpoint, rather than r0

### DIFF
--- a/appservice/routing/routing.go
+++ b/appservice/routing/routing.go
@@ -27,7 +27,7 @@ import (
 	"github.com/matrix-org/util"
 )
 
-const pathPrefixApp = "/_matrix/app/r0"
+const pathPrefixApp = "/_matrix/app/v1"
 
 // Setup registers HTTP handlers with the given ServeMux. It also supplies the given http.Client
 // to clients which need to make outbound HTTP requests.


### PR DESCRIPTION
There was never a r0 endpoint, just v1.