### PR TITLE
add identifier field to login

### DIFF
--- a/clientapi/routing/login.go
+++ b/clientapi/routing/login.go
@@ -89,7 +89,7 @@ func Login(
 			// go over identifier types
 			switch r.Identifier.Type {
 			case "m.type.user":
-				// depreciate user in favor of identifier field
+				// depreciate user in favour of identifier field
 				// https://matrix.org/docs/spec/client_server/unstable#post-matrix-client-r0-login
 				r.User = r.Identifier.User
 			default:


### PR DESCRIPTION
Signed-off-by: mohitks <mohitkumarsingh907@gmail.com>
Addresses #750. Checks for identifier field and its type and extracts user favouring it over `user` field.

I am a bit confused about logging, should I use separate logging formats for login using identifier and login using depreciated `user` field or log both `user` and `identifier` field [here](https://github.com/matrix-org/dendrite/blob/master/clientapi/routing/login.go#L89) only.