### PR TITLE
Return server names 

### DIFF
--- a/cmd/dendrite-federation-api-server/main.go
+++ b/cmd/dendrite-federation-api-server/main.go
@@ -29,6 +29,7 @@ func main() {
 	deviceDB := base.CreateDeviceDB()
 	keyDB := base.CreateKeyDB()
 	federation := base.CreateFederationClient()
+	federationSender := base.CreateHTTPFederationSenderAPIs()
 	keyRing := keydb.CreateKeyRing(federation.Client, keyDB)
 
 	alias, input, query := base.CreateHTTPRoomserverAPIs()
@@ -36,7 +37,7 @@ func main() {
 
 	federationapi.SetupFederationAPIComponent(
 		base, accountDB, deviceDB, federation, &keyRing,
-		alias, input, query, asQuery,
+		alias, input, query, asQuery, federationSender,
 	)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.FederationAPI), string(base.Cfg.Listen.FederationAPI))

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -67,7 +67,7 @@ func main() {
 		federation, &keyRing, alias, input, query,
 		typingInputAPI, asQuery, transactions.New(), fedSenderAPI,
 	)
-	federationapi.SetupFederationAPIComponent(base, accountDB, deviceDB, federation, &keyRing, alias, input, query, asQuery)
+	federationapi.SetupFederationAPIComponent(base, accountDB, deviceDB, federation, &keyRing, alias, input, query, asQuery, fedSenderAPI)
 	mediaapi.SetupMediaAPIComponent(base, deviceDB)
 	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB)
 	syncapi.SetupSyncAPIComponent(base, deviceDB, accountDB, query)

--- a/federationapi/federationapi.go
+++ b/federationapi/federationapi.go
@@ -19,6 +19,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
 	"github.com/matrix-org/dendrite/common/basecomponent"
+	federationSenderAPI "github.com/matrix-org/dendrite/federationsender/api"
 	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
 
 	// TODO: Are we really wanting to pull in the producer from clientapi
@@ -39,11 +40,13 @@ func SetupFederationAPIComponent(
 	inputAPI roomserverAPI.RoomserverInputAPI,
 	queryAPI roomserverAPI.RoomserverQueryAPI,
 	asAPI appserviceAPI.AppServiceQueryAPI,
+	federationSenderAPI federationSenderAPI.FederationSenderQueryAPI,
 ) {
 	roomserverProducer := producers.NewRoomserverProducer(inputAPI)
 
 	routing.Setup(
 		base.APIMux, *base.Cfg, queryAPI, aliasAPI, asAPI,
-		roomserverProducer, *keyRing, federation, accountsDB, deviceDB,
+		roomserverProducer, federationSenderAPI, *keyRing, federation, accountsDB,
+		deviceDB,
 	)
 }

--- a/federationapi/routing/query.go
+++ b/federationapi/routing/query.go
@@ -21,6 +21,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/common/config"
+	federationSenderAPI "github.com/matrix-org/dendrite/federationsender/api"
 	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrix"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -33,6 +34,7 @@ func RoomAliasToID(
 	federation *gomatrixserverlib.FederationClient,
 	cfg config.Dendrite,
 	aliasAPI roomserverAPI.RoomserverAliasAPI,
+	senderAPI federationSenderAPI.FederationSenderQueryAPI,
 ) util.JSONResponse {
 	roomAlias := httpReq.FormValue("room_alias")
 	if roomAlias == "" {
@@ -59,10 +61,16 @@ func RoomAliasToID(
 		}
 
 		if queryRes.RoomID != "" {
+			serverQueryReq := federationSenderAPI.QueryJoinedHostServerNamesInRoomRequest{RoomID: queryRes.RoomID}
+			var serverQueryRes federationSenderAPI.QueryJoinedHostServerNamesInRoomResponse
+			if err = senderAPI.QueryJoinedHostServerNamesInRoom(httpReq.Context(), &serverQueryReq, &serverQueryRes); err != nil {
+				return httputil.LogThenError(httpReq, err)
+			}
+
 			// TODO: List servers that are aware of this room alias
 			resp = gomatrixserverlib.RespDirectory{
 				RoomID:  queryRes.RoomID,
-				Servers: []gomatrixserverlib.ServerName{},
+				Servers: serverQueryRes.ServerNames,
 			}
 		} else {
 			// If no alias was found, return an error

--- a/federationapi/routing/query.go
+++ b/federationapi/routing/query.go
@@ -67,7 +67,6 @@ func RoomAliasToID(
 				return httputil.LogThenError(httpReq, err)
 			}
 
-			// TODO: List servers that are aware of this room alias
 			resp = gomatrixserverlib.RespDirectory{
 				RoomID:  queryRes.RoomID,
 				Servers: serverQueryRes.ServerNames,

--- a/federationapi/routing/routing.go
+++ b/federationapi/routing/routing.go
@@ -24,6 +24,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/producers"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/config"
+	federationSenderAPI "github.com/matrix-org/dendrite/federationsender/api"
 	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
@@ -46,6 +47,7 @@ func Setup(
 	aliasAPI roomserverAPI.RoomserverAliasAPI,
 	asAPI appserviceAPI.AppServiceQueryAPI,
 	producer *producers.RoomserverProducer,
+	federationSenderAPI federationSenderAPI.FederationSenderQueryAPI,
 	keys gomatrixserverlib.KeyRing,
 	federation *gomatrixserverlib.FederationClient,
 	accountDB *accounts.Database,
@@ -156,7 +158,7 @@ func Setup(
 		"federation_query_room_alias", cfg.Matrix.ServerName, keys,
 		func(httpReq *http.Request, request *gomatrixserverlib.FederationRequest) util.JSONResponse {
 			return RoomAliasToID(
-				httpReq, federation, cfg, aliasAPI,
+				httpReq, federation, cfg, aliasAPI, federationSenderAPI,
 			)
 		},
 	)).Methods(http.MethodGet)

--- a/federationsender/query/query.go
+++ b/federationsender/query/query.go
@@ -45,14 +45,9 @@ func (f *FederationSenderQueryAPI) QueryJoinedHostServerNamesInRoom(
 		return
 	}
 
-	serverNamesSet := make(map[gomatrixserverlib.ServerName]bool, len(joinedHosts))
+	response.ServerNames = make([]gomatrixserverlib.ServerName, 0, len(joinedHosts))
 	for _, host := range joinedHosts {
-		serverNamesSet[host.ServerName] = true
-	}
-
-	response.ServerNames = make([]gomatrixserverlib.ServerName, 0, len(serverNamesSet))
-	for name := range serverNamesSet {
-		response.ServerNames = append(response.ServerNames, name)
+		response.ServerNames = append(response.ServerNames, host.ServerName)
 	}
 
 	return

--- a/federationsender/query/query.go
+++ b/federationsender/query/query.go
@@ -50,6 +50,8 @@ func (f *FederationSenderQueryAPI) QueryJoinedHostServerNamesInRoom(
 		response.ServerNames = append(response.ServerNames, host.ServerName)
 	}
 
+	// TODO: remove duplicates?
+
 	return
 }
 


### PR DESCRIPTION
This PR fixes the `/federation/v1/query/directory` endpoint so that server hostnames are returned as part of a Room ID query.
