### PR TITLE
Amend syncapi SQL queries to return missing columns

### DIFF
--- a/syncapi/storage/current_room_state_table.go
+++ b/syncapi/storage/current_room_state_table.go
@@ -84,10 +84,12 @@ const selectStateEventSQL = "" +
 	"SELECT event_json FROM syncapi_current_room_state WHERE room_id = $1 AND type = $2 AND state_key = $3"
 
 const selectEventsWithEventIDsSQL = "" +
-	// TODO: The session_id and transaction_id blanks are here because otherwise the rowsToStreamEvents
-	//       expects there to be exactly four columns. We need a better solution to this long term.
-	//       - neilalexander, 2 Jan 2020
-	"SELECT added_at, event_json, 0 AS session_id, '' AS transaction_id FROM syncapi_current_room_state WHERE event_id = ANY($1)"
+	// TODO: The session_id and transaction_id blanks are here because otherwise
+	// the rowsToStreamEvents expects there to be exactly four columns. We need to
+	// figure out if these really need to be in the DB, and if so, we need a
+	// better permanent fix for this. - neilalexander, 2 Jan 2020
+	"SELECT added_at, event_json, 0 AS session_id, '' AS transaction_id" +
+	" FROM syncapi_current_room_state WHERE event_id = ANY($1)"
 
 type currentRoomStateStatements struct {
 	upsertRoomStateStmt             *sql.Stmt

--- a/syncapi/storage/current_room_state_table.go
+++ b/syncapi/storage/current_room_state_table.go
@@ -84,7 +84,10 @@ const selectStateEventSQL = "" +
 	"SELECT event_json FROM syncapi_current_room_state WHERE room_id = $1 AND type = $2 AND state_key = $3"
 
 const selectEventsWithEventIDsSQL = "" +
-	"SELECT added_at, event_json FROM syncapi_current_room_state WHERE event_id = ANY($1)"
+	// TODO: The session_id and transaction_id blanks are here because otherwise the rowsToStreamEvents
+	//       expects there to be exactly four columns. We need a better solution to this long term.
+	//       - neilalexander, 2 Jan 2020
+	"SELECT added_at, event_json, 0 AS session_id, '' AS transaction_id FROM syncapi_current_room_state WHERE event_id = ANY($1)"
 
 type currentRoomStateStatements struct {
 	upsertRoomStateStmt             *sql.Stmt

--- a/syncapi/storage/output_room_events_table.go
+++ b/syncapi/storage/output_room_events_table.go
@@ -21,7 +21,6 @@ import (
 	"sort"
 
 	"github.com/matrix-org/dendrite/roomserver/api"
-	"github.com/matrix-org/gomatrix"
 
 	"github.com/lib/pq"
 	"github.com/matrix-org/dendrite/common"
@@ -127,7 +126,7 @@ func (s *outputRoomEventsStatements) prepare(db *sql.DB) (err error) {
 // two positions, only the most recent state is returned.
 func (s *outputRoomEventsStatements) selectStateInRange(
 	ctx context.Context, txn *sql.Tx, oldPos, newPos int64,
-	stateFilterPart *gomatrix.FilterPart,
+	stateFilterPart *gomatrixserverlib.FilterPart,
 ) (map[string]map[string]bool, map[string]streamEvent, error) {
 	stmt := common.TxStmt(txn, s.selectStateInRangeStmt)
 

--- a/syncapi/storage/output_room_events_table.go
+++ b/syncapi/storage/output_room_events_table.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/gomatrix"
 
 	"github.com/lib/pq"
 	"github.com/matrix-org/dendrite/common"
@@ -67,7 +68,7 @@ const insertEventSQL = "" +
 	") VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING id"
 
 const selectEventsSQL = "" +
-	"SELECT id, event_json FROM syncapi_output_room_events WHERE event_id = ANY($1)"
+	"SELECT id, event_json, session_id, transaction_id FROM syncapi_output_room_events WHERE event_id = ANY($1)"
 
 const selectRecentEventsSQL = "" +
 	"SELECT id, event_json, session_id, transaction_id FROM syncapi_output_room_events" +
@@ -126,7 +127,7 @@ func (s *outputRoomEventsStatements) prepare(db *sql.DB) (err error) {
 // two positions, only the most recent state is returned.
 func (s *outputRoomEventsStatements) selectStateInRange(
 	ctx context.Context, txn *sql.Tx, oldPos, newPos int64,
-	stateFilterPart *gomatrixserverlib.FilterPart,
+	stateFilterPart *gomatrix.FilterPart,
 ) (map[string]map[string]bool, map[string]streamEvent, error) {
 	stmt := common.TxStmt(txn, s.selectStateInRangeStmt)
 


### PR DESCRIPTION
The `transaction_id` and `session_id` column that were added in #367 have resulted in some breakage in the `/sync` endpoint. These columns are required/expected by `rowsToStreamEvents` in `output_room_events_table.go` - not supplying them results in things like:
```
sql: expected 2 destination arguments in Scan, not 4
```

It's not exactly clear to me yet what `transaction_id` and `session_id` do, but these being added means that state events break sync.

This is a temporary fix. We need to come up with a better solution.