### PR TITLE
Fall back to postgres when database connection string parsing fails

### DIFF
--- a/common/keydb/keydb.go
+++ b/common/keydb/keydb.go
@@ -16,6 +16,7 @@ package keydb
 
 import (
 	"context"
+	"errors"
 	"net/url"
 
 	"github.com/matrix-org/dendrite/common/keydb/postgres"
@@ -32,14 +33,14 @@ type Database interface {
 func NewDatabase(dataSourceName string) (Database, error) {
 	uri, err := url.Parse(dataSourceName)
 	if err != nil {
-		return nil, err
+		// if the scheme doesn't match, fall back to postgres in case the config has
+		// postgres key=value connection strings
+		return postgres.NewDatabase(dataSourceName)
 	}
 	switch uri.Scheme {
 	case "postgres":
 		return postgres.NewDatabase(dataSourceName)
 	default:
-		// if the scheme doesn't match, fall back to postgres in case the config has
-		// postgres key=value connection strings
-		return postgres.NewDatabase(dataSourceName)
+		return nil, errors.New("unknown schema")
 	}
 }

--- a/common/keydb/keydb.go
+++ b/common/keydb/keydb.go
@@ -16,7 +16,6 @@ package keydb
 
 import (
 	"context"
-	"errors"
 	"net/url"
 
 	"github.com/matrix-org/dendrite/common/keydb/postgres"
@@ -39,6 +38,8 @@ func NewDatabase(dataSourceName string) (Database, error) {
 	case "postgres":
 		return postgres.NewDatabase(dataSourceName)
 	default:
-		return nil, errors.New("unknown schema")
+		// if the scheme doesn't match, fall back to postgres in case the config has
+		// postgres key=value connection strings
+		return postgres.NewDatabase(dataSourceName)
 	}
 }

--- a/federationsender/storage/storage.go
+++ b/federationsender/storage/storage.go
@@ -16,7 +16,6 @@ package storage
 
 import (
 	"context"
-	"errors"
 	"net/url"
 
 	"github.com/matrix-org/dendrite/common"
@@ -40,6 +39,8 @@ func NewDatabase(dataSourceName string) (Database, error) {
 	case "postgres":
 		return postgres.NewDatabase(dataSourceName)
 	default:
-		return nil, errors.New("unknown schema")
+		// if the scheme doesn't match, fall back to postgres in case the config has
+		// postgres key=value connection strings
+		return postgres.NewDatabase(dataSourceName)
 	}
 }

--- a/federationsender/storage/storage.go
+++ b/federationsender/storage/storage.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"net/url"
 
 	"github.com/matrix-org/dendrite/common"
@@ -33,14 +34,14 @@ type Database interface {
 func NewDatabase(dataSourceName string) (Database, error) {
 	uri, err := url.Parse(dataSourceName)
 	if err != nil {
-		return nil, err
+		// if the scheme doesn't match, fall back to postgres in case the config has
+		// postgres key=value connection strings
+		return postgres.NewDatabase(dataSourceName)
 	}
 	switch uri.Scheme {
 	case "postgres":
 		return postgres.NewDatabase(dataSourceName)
 	default:
-		// if the scheme doesn't match, fall back to postgres in case the config has
-		// postgres key=value connection strings
-		return postgres.NewDatabase(dataSourceName)
+		return errors.New("unknown schema")
 	}
 }

--- a/mediaapi/storage/storage.go
+++ b/mediaapi/storage/storage.go
@@ -16,7 +16,6 @@ package storage
 
 import (
 	"context"
-	"errors"
 	"net/url"
 
 	"github.com/matrix-org/dendrite/mediaapi/storage/postgres"
@@ -42,6 +41,8 @@ func Open(dataSourceName string) (Database, error) {
 	case "postgres":
 		return postgres.Open(dataSourceName)
 	default:
-		return nil, errors.New("unknown schema")
+		// if the scheme doesn't match, fall back to postgres in case the config has
+		// postgres key=value connection strings
+		return postgres.Open(dataSourceName)
 	}
 }

--- a/mediaapi/storage/storage.go
+++ b/mediaapi/storage/storage.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"net/url"
 
 	"github.com/matrix-org/dendrite/mediaapi/storage/postgres"
@@ -35,14 +36,14 @@ type Database interface {
 func Open(dataSourceName string) (Database, error) {
 	uri, err := url.Parse(dataSourceName)
 	if err != nil {
-		return nil, err
+		// if the scheme doesn't match, fall back to postgres in case the config has
+		// postgres key=value connection strings
+		return postgres.Open(dataSourceName)
 	}
 	switch uri.Scheme {
 	case "postgres":
 		return postgres.Open(dataSourceName)
 	default:
-		// if the scheme doesn't match, fall back to postgres in case the config has
-		// postgres key=value connection strings
-		return postgres.Open(dataSourceName)
+		return nil, errors.New("unknown schema")
 	}
 }

--- a/publicroomsapi/storage/storage.go
+++ b/publicroomsapi/storage/storage.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"net/url"
 
 	"github.com/matrix-org/dendrite/common"
@@ -38,14 +39,14 @@ type Database interface {
 func NewPublicRoomsServerDatabase(dataSourceName string) (Database, error) {
 	uri, err := url.Parse(dataSourceName)
 	if err != nil {
-		return nil, err
+		// if the scheme doesn't match, fall back to postgres in case the config has
+		// postgres key=value connection strings
+		return postgres.NewPublicRoomsServerDatabase(dataSourceName)
 	}
 	switch uri.Scheme {
 	case "postgres":
 		return postgres.NewPublicRoomsServerDatabase(dataSourceName)
 	default:
-		// if the scheme doesn't match, fall back to postgres in case the config has
-		// postgres key=value connection strings
-		return postgres.NewPublicRoomsServerDatabase(dataSourceName)
+		return nil, errors.New("unknown schema")
 	}
 }

--- a/publicroomsapi/storage/storage.go
+++ b/publicroomsapi/storage/storage.go
@@ -16,7 +16,6 @@ package storage
 
 import (
 	"context"
-	"errors"
 	"net/url"
 
 	"github.com/matrix-org/dendrite/common"
@@ -45,6 +44,8 @@ func NewPublicRoomsServerDatabase(dataSourceName string) (Database, error) {
 	case "postgres":
 		return postgres.NewPublicRoomsServerDatabase(dataSourceName)
 	default:
-		return nil, errors.New("unknown schema")
+		// if the scheme doesn't match, fall back to postgres in case the config has
+		// postgres key=value connection strings
+		return postgres.NewPublicRoomsServerDatabase(dataSourceName)
 	}
 }

--- a/roomserver/storage/storage.go
+++ b/roomserver/storage/storage.go
@@ -16,7 +16,6 @@ package storage
 
 import (
 	"context"
-	"errors"
 	"net/url"
 
 	"github.com/matrix-org/dendrite/roomserver/api"
@@ -67,6 +66,8 @@ func Open(dataSourceName string) (Database, error) {
 	case "postgres":
 		return postgres.Open(dataSourceName)
 	default:
-		return nil, errors.New("unknown schema")
+		// if the scheme doesn't match, fall back to postgres in case the config has
+		// postgres key=value connection strings
+		return postgres.Open(dataSourceName)
 	}
 }

--- a/roomserver/storage/storage.go
+++ b/roomserver/storage/storage.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"net/url"
 
 	"github.com/matrix-org/dendrite/roomserver/api"
@@ -60,14 +61,14 @@ type Database interface {
 func Open(dataSourceName string) (Database, error) {
 	uri, err := url.Parse(dataSourceName)
 	if err != nil {
-		return nil, err
+		// if the scheme doesn't match, fall back to postgres in case the config has
+		// postgres key=value connection strings
+		return postgres.Open(dataSourceName)
 	}
 	switch uri.Scheme {
 	case "postgres":
 		return postgres.Open(dataSourceName)
 	default:
-		// if the scheme doesn't match, fall back to postgres in case the config has
-		// postgres key=value connection strings
-		return postgres.Open(dataSourceName)
+		return nil, errors.New("unknown schema")
 	}
 }

--- a/syncapi/storage/storage.go
+++ b/syncapi/storage/storage.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"net/url"
 	"time"
 
@@ -51,14 +52,14 @@ type Database interface {
 func NewSyncServerDatasource(dataSourceName string) (Database, error) {
 	uri, err := url.Parse(dataSourceName)
 	if err != nil {
-		return nil, err
+		// if the scheme doesn't match, fall back to postgres in case the config has
+		// postgres key=value connection strings
+		return postgres.NewSyncServerDatasource(dataSourceName)
 	}
 	switch uri.Scheme {
 	case "postgres":
 		return postgres.NewSyncServerDatasource(dataSourceName)
 	default:
-		// if the scheme doesn't match, fall back to postgres in case the config has
-		// postgres key=value connection strings
-		return postgres.NewSyncServerDatasource(dataSourceName)
+		return nil, errors.New("unknown schema")
 	}
 }

--- a/syncapi/storage/storage.go
+++ b/syncapi/storage/storage.go
@@ -16,7 +16,6 @@ package storage
 
 import (
 	"context"
-	"errors"
 	"net/url"
 	"time"
 
@@ -58,6 +57,8 @@ func NewSyncServerDatasource(dataSourceName string) (Database, error) {
 	case "postgres":
 		return postgres.NewSyncServerDatasource(dataSourceName)
 	default:
-		return nil, errors.New("unknown schema")
+		// if the scheme doesn't match, fall back to postgres in case the config has
+		// postgres key=value connection strings
+		return postgres.NewSyncServerDatasource(dataSourceName)
 	}
 }


### PR DESCRIPTION
This should mean that Postgres connection strings like `host=foo user=foo` etc work again by default, unbreaking some tests.