### PR TITLE
Wire up publicroomsapi for roomserver events

### DIFF
--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -69,7 +69,7 @@ func main() {
 	)
 	federationapi.SetupFederationAPIComponent(base, accountDB, deviceDB, federation, &keyRing, alias, input, query, asQuery, fedSenderAPI)
 	mediaapi.SetupMediaAPIComponent(base, deviceDB)
-	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB)
+	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB, query)
 	syncapi.SetupSyncAPIComponent(base, deviceDB, accountDB, query, federation, cfg)
 
 	httpHandler := common.WrapHandlerInCORS(base.APIMux)

--- a/cmd/dendrite-public-rooms-api-server/main.go
+++ b/cmd/dendrite-public-rooms-api-server/main.go
@@ -26,7 +26,9 @@ func main() {
 
 	deviceDB := base.CreateDeviceDB()
 
-	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB)
+	_, _, query := base.CreateHTTPRoomserverAPIs()
+
+	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB, query)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.PublicRoomsAPI), string(base.Cfg.Listen.PublicRoomsAPI))
 

--- a/publicroomsapi/publicroomsapi.go
+++ b/publicroomsapi/publicroomsapi.go
@@ -31,7 +31,7 @@ func SetupPublicRoomsAPIComponent(
 	deviceDB *devices.Database,
 	rsQueryAPI roomserverAPI.RoomserverQueryAPI,
 ) {
-	publicRoomsDB, err := storage.NewPublicRoomsServerDatabase(string(base.Cfg.Database.PublicRoomsAPI), base.LibP2PDHT)
+	publicRoomsDB, err := storage.NewPublicRoomsServerDatabase(string(base.Cfg.Database.PublicRoomsAPI))
 	if err != nil {
 		logrus.WithError(err).Panicf("failed to connect to public rooms db")
 	}

--- a/publicroomsapi/storage/postgres/storage.go
+++ b/publicroomsapi/storage/postgres/storage.go
@@ -42,15 +42,16 @@ func NewPublicRoomsServerDatabase(dataSourceName string) (*PublicRoomsServerData
 	if db, err = sql.Open("postgres", dataSourceName); err != nil {
 		return nil, err
 	}
-	partitions := common.PartitionOffsetStatements{}
-	if err = partitions.Prepare(db, "publicroomsapi"); err != nil {
+	storage := PublicRoomsServerDatabase{
+		db: db,
+	}
+	if err = storage.PartitionOffsetStatements.Prepare(db, "publicroomsapi"); err != nil {
 		return nil, err
 	}
-	statements := publicRoomsStatements{}
-	if err = statements.prepare(db); err != nil {
+	if err = storage.statements.prepare(db); err != nil {
 		return nil, err
 	}
-	return &PublicRoomsServerDatabase{db, partitions, statements}, nil
+	return &storage, nil
 }
 
 // GetRoomVisibility returns the room visibility as a boolean: true if the room

--- a/syncapi/routing/messages.go
+++ b/syncapi/routing/messages.go
@@ -344,6 +344,11 @@ func (r *messagesReq) handleNonEmptyEventsSlice(streamEvents []types.StreamEvent
 // considers the event itself a backward extremity if at least one of the parent
 // events doesn't exist in the database.
 // Returns an error if there was an issue with talking to the database.
+//
+// This function is unused but currently set to nolint for now until we are
+// absolutely sure that the changes in matrix-org/dendrite#847 are behaving
+// properly.
+// nolint:unused
 func (r *messagesReq) containsBackwardExtremity(events []types.StreamEvent) (bool, error) {
 	// Select the earliest retrieved event.
 	var ev *types.StreamEvent


### PR DESCRIPTION
The public rooms API component was not subscribed to room server events before, so it didn't work at all. Now it is and (mostly) does!