### PR TITLE
[WIP][RFC] Implement special case for m.room.canonical_alias

### DIFF
--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -55,7 +55,7 @@ func main() {
 	federation := base.CreateFederationClient()
 	keyRing := keydb.CreateKeyRing(federation.Client, keyDB)
 
-	alias, input, query := roomserver.SetupRoomServerComponent(base)
+	alias, _, input, query := roomserver.SetupRoomServerComponent(base)
 	typingInputAPI := typingserver.SetupTypingServerComponent(base, cache.NewTypingCache())
 	asQuery := appservice.SetupAppServiceAPIComponent(
 		base, accountDB, deviceDB, federation, alias, query, transactions.New(),

--- a/roomserver/api/canonical_alias.go
+++ b/roomserver/api/canonical_alias.go
@@ -34,10 +34,8 @@ type SetRoomCanonicalAliasRequest struct {
 
 // SetRoomCanonicalAliasResponse is a response to SetRoomCanonicalAlias
 type SetRoomCanonicalAliasResponse struct {
-	// Does the alias already refer to a room?
-	AliasExists bool `json:"alias_exists"`
-	// Does the alias refer to a different room?
-	DifferentRoom bool `json:"different_room"`
+	// Does the canonical alias already belong to a room?
+	CanonicalAliasExists bool `json:"canonical_alias_exists"`
 }
 
 // GetRoomIDForCanonicalAliasRequest is a request to GetRoomIDForCanonicalAlias

--- a/roomserver/api/canonical_alias.go
+++ b/roomserver/api/canonical_alias.go
@@ -1,0 +1,185 @@
+// Copyright 2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"net/http"
+
+	commonHTTP "github.com/matrix-org/dendrite/common/http"
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+// SetRoomCanonicalAliasRequest is a request to SetRoomCanonicalAlias
+type SetRoomCanonicalAliasRequest struct {
+	// ID of the user setting the alias
+	UserID string `json:"user_id"`
+	// New alias for the room
+	CanonicalAlias string `json:"alias"`
+	// The room ID the alias is referring to
+	RoomID string `json:"room_id"`
+}
+
+// SetRoomCanonicalAliasResponse is a response to SetRoomCanonicalAlias
+type SetRoomCanonicalAliasResponse struct {
+	// Does the alias already refer to a room?
+	AliasExists bool `json:"alias_exists"`
+	// Does the alias refer to a different room?
+	DifferentRoom bool `json:"different_room"`
+}
+
+// GetRoomIDForCanonicalAliasRequest is a request to GetRoomIDForCanonicalAlias
+type GetRoomIDForCanonicalAliasRequest struct {
+	// Canonical Alias we want to lookup
+	CanonicalAlias string `json:"alias"`
+}
+
+// GetRoomIDForCanonicalAliasResponse is a response to GetRoomIDForCanonicalAlias
+type GetRoomIDForCanonicalAliasResponse struct {
+	// The room ID the canonical alias refers to
+	RoomID string `json:"room_id"`
+}
+
+// GetCanonicalAliasForRoomIDRequest is a request to GetCanonicalAliasForRoomID
+type GetCanonicalAliasForRoomIDRequest struct {
+	// The room ID we want to find the canonical for
+	RoomID string `json:"room_id"`
+}
+
+// GetCanonicalForRoomIDResponse is a response to GetCanonicalAliasForRoomID
+type GetCanonicalAliasForRoomIDResponse struct {
+	CanonicalAlias string `json:"alias"`
+}
+
+// GetCreatorIDForCanonicalAliasRequest is a request to GetCreatorIDForCanonicalAlias
+type GetCreatorIDForCanonicalAliasRequest struct {
+	// The alias we want to find the creator of
+	CanonicalAlias string `json:"alias"`
+}
+
+// GetCreatorIDForCanonicalAliasResponse is a response to GetCreatorIDForCanonicalAlias
+type GetCreatorIDForAliasResponse struct {
+	// The user ID of the canonical alias creator
+	UserID string `json:"user_id"`
+}
+
+// RoomserverCanonicalAliasAPI is used to save, lookup or remove a room alias
+type RoomserverCanonicalAliasAPI interface {
+	// Set the room canonical alias
+	SetRoomCanonicalAlias(
+		ctx context.Context,
+		req *SetRoomCanonicalAliasRequest,
+		response *SetRoomCanonicalAliasResponse,
+	) error
+
+	// Get the room ID for an alias
+	GetRoomIDForCanonicalAlias(
+		ctx context.Context,
+		req *GetRoomIDForCanonicalAliasRequest,
+		response *GetRoomIDForCanonicalAliasResponse,
+	) error
+
+	// Get the canonical alias for a room ID
+	GetCanonicalAliasForRoomID(
+		ctx context.Context,
+		req *GetCanonicalAliasForRoomIDRequest,
+		response *GetCanonicalAliasForRoomIDResponse,
+	) error
+
+	// Get the user ID of the creator of a canonical alias
+	GetCreatorIDForCanonicalAlias(
+		ctx context.Context,
+		req *GetCreatorIDForCanonicalAliasRequest,
+		response *GetCreatorIDForCanonicalAliasAliasResponse,
+	) error
+}
+
+// RoomserverSetRoomCanonicalAliasPath is the HTTP path for the SetRoomCanonicalAlias API.
+const RoomserverSetRoomCanonicalAliasPath = "/api/roomserver/setRoomCanonicalAlias"
+
+// RoomserverGetRoomIDForCanonicalAliasPath is the HTTP path for the GetRoomIDForCanonicalAlias API.
+const RoomserverGetRoomIDForCanonicalAliasPath = "/api/roomserver/GetRoomIDForCanonicalAlias"
+
+// RoomserverGetCanonicalAliasForRoomIDPath is the HTTP path for the GetCanonicalAliasForRoomID API.
+const RoomserverGetCanonicalAliasForRoomIDPath = "/api/roomserver/GetCanonicalAliasForRoomID"
+
+// RoomserverGetCreatorIDForCanonicalAliasPath is the HTTP path for the GetCreatorIDForCanonicalAlias API.
+const RoomserverGetCreatorIDForCanonicalAliasPath = "/api/roomserver/GetCreatorIDForCanonicalAlias"
+
+// NewRoomserverCanonicalAliasAPIHTTP creates a RoomserverCanonicalAliasAPI implemented by talking to a HTTP POST API.
+// If httpClient is nil then it uses the http.DefaultClient
+func NewRoomserverCanonicalAliasAPIHTTP(roomserverURL string, httpClient *http.Client) RoomserverCanonicalAliasAPI {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &httpRoomserverCanonicalAliasAPI{roomserverURL, httpClient}
+}
+
+type httpRoomserverCanonicalAliasAPI struct {
+	roomserverURL string
+	httpClient    *http.Client
+}
+
+// SetRoomCanonicalAlias implements RoomserverCanonicalAliasAPI
+func (h *httpRoomserverCanonicalAliasAPI) SetRoomCanonicalAlias(
+	ctx context.Context,
+	request *SetRoomCanonicalAliasRequest,
+	response *SetRoomCanonicalAliasResponse,
+) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "SetRoomCanonicalAlias")
+	defer span.Finish()
+
+	apiURL := h.roomserverURL + RoomserverSetRoomCanonicalAliasPath
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+}
+
+// GetRoomIDForCanonicalAlias implements RoomserverCanonicalAliasAPI
+func (h *httpRoomserverCanonicalAliasAPI) GetRoomIDForCanonicalAlias(
+	ctx context.Context,
+	request *GetRoomIDForCanonicalAliasRequest,
+	response *GetRoomIDForCanonicalAliasResponse,
+) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "GetRoomIDForCanonicalAlias")
+	defer span.Finish()
+
+	apiURL := h.roomserverURL + RoomserverGetRoomIDForCanonicalAliasPath
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+}
+
+// GetCanonicalAliasForRoomID implements RoomserverCanonicalAliasAPI
+func (h *httpRoomserverCanonicalAliasAPI) GetCanonicalAliasForRoomID(
+	ctx context.Context,
+	request *GetCanonicalAliasForRoomIDRequest,
+	response *GetCanonicalAliasForRoomIDResponse,
+) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "GetCanonicalAliasForRoomID")
+	defer span.Finish()
+
+	apiURL := h.roomserverURL + RoomserverGetCanonicalAliasForRoomIDPath
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+}
+
+// GetCreatorIDForAlias implements RoomserverCanonicalAliasAPI
+func (h *httpRoomserverCanonicalAliasAPI) GetCreatorIDForCanonicalAlias(
+	ctx context.Context,
+	request *GetCreatorIDForCanonicalAliasRequest,
+	response *GetCreatorIDForCanonicalAliasResponse,
+) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "GetCreatorIDForCanonicalAlias")
+	defer span.Finish()
+
+	apiURL := h.roomserverURL + RoomserverGetCreatorIDForCanonicalAliasPath
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+}

--- a/roomserver/api/canonical_alias.go
+++ b/roomserver/api/canonical_alias.go
@@ -70,7 +70,7 @@ type GetCreatorIDForCanonicalAliasRequest struct {
 }
 
 // GetCreatorIDForCanonicalAliasResponse is a response to GetCreatorIDForCanonicalAlias
-type GetCreatorIDForAliasResponse struct {
+type GetCreatorIDForCanonicalAliasResponse struct {
 	// The user ID of the canonical alias creator
 	UserID string `json:"user_id"`
 }
@@ -102,7 +102,7 @@ type RoomserverCanonicalAliasAPI interface {
 	GetCreatorIDForCanonicalAlias(
 		ctx context.Context,
 		req *GetCreatorIDForCanonicalAliasRequest,
-		response *GetCreatorIDForCanonicalAliasAliasResponse,
+		response *GetCreatorIDForCanonicalAliasResponse,
 	) error
 }
 

--- a/roomserver/canonical_alias/canonical_alias.go
+++ b/roomserver/canonical_alias/canonical_alias.go
@@ -17,15 +17,12 @@ package canonical_alias
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"time"
 
 	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/common/config"
 	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
-	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 )
 
@@ -58,7 +55,7 @@ type RoomserverCanonicalAliasAPI struct {
 }
 
 // SetRoomCanonicalAlias implements alias.RoomserverCanonicalAliasAPI
-func (r *RoomserverCanonicalAliasAPI) SetRoomAlias(
+func (r *RoomserverCanonicalAliasAPI) SetRoomCanonicalAlias(
 	ctx context.Context,
 	request *roomserverAPI.SetRoomCanonicalAliasRequest,
 	response *roomserverAPI.SetRoomCanonicalAliasResponse,
@@ -66,7 +63,7 @@ func (r *RoomserverCanonicalAliasAPI) SetRoomAlias(
 	// SPEC: Room with `m.room.canonical_alias` with empty alias field should be
 	// treated same as room without a canonical alias.
 	if request.CanonicalAlias == "" {
-		return r.db.RemoveCanonicalAlias(ctx, request.RoomID)
+		return r.DB.RemoveCanonicalAlias(ctx, request.RoomID)
 	}
 
 	roomID, err := r.DB.GetRoomIDForAlias(ctx, request.CanonicalAlias)

--- a/roomserver/canonical_alias/canonical_alias.go
+++ b/roomserver/canonical_alias/canonical_alias.go
@@ -84,11 +84,11 @@ func (r *RoomserverCanonicalAliasAPI) SetRoomAlias(
 	// The alias belongs to a different room
 	if roomID != request.roomID {
 		// RFC: Is there a standard bool for wrong room?
-		response.CorrectRoom = false
+		response.DifferentRoom = true
 		return nil
 	}
 
-	response.CorrectRoom = true
+	response.DifferentRoom = false
 
 	// Save the new canonical alias
 	if err := r.DB.SetRoomCanonicalAlias(ctx, request.CanonicalAlias, request.RoomID, request.UserID); err != nil {

--- a/roomserver/roomserver.go
+++ b/roomserver/roomserver.go
@@ -22,6 +22,7 @@ import (
 	asQuery "github.com/matrix-org/dendrite/appservice/query"
 	"github.com/matrix-org/dendrite/common/basecomponent"
 	"github.com/matrix-org/dendrite/roomserver/alias"
+	"github.com/matrix-org/dendrite/roomserver/canonical_alias"
 	"github.com/matrix-org/dendrite/roomserver/input"
 	"github.com/matrix-org/dendrite/roomserver/query"
 	"github.com/matrix-org/dendrite/roomserver/storage"

--- a/roomserver/roomserver.go
+++ b/roomserver/roomserver.go
@@ -34,7 +34,7 @@ import (
 // APIs directly instead of having to use HTTP.
 func SetupRoomServerComponent(
 	base *basecomponent.BaseDendrite,
-) (api.RoomserverAliasAPI, api.RoomserverInputAPI, api.RoomserverQueryAPI) {
+) (api.RoomserverAliasAPI, api.RoomserverCanonicalAliasAPI, api.RoomserverInputAPI, api.RoomserverQueryAPI) {
 	roomserverDB, err := storage.Open(string(base.Cfg.Database.RoomServer))
 	if err != nil {
 		logrus.WithError(err).Panicf("failed to connect to room server db")
@@ -64,5 +64,14 @@ func SetupRoomServerComponent(
 
 	aliasAPI.SetupHTTP(http.DefaultServeMux)
 
-	return &aliasAPI, &inputAPI, &queryAPI
+	canonicalAliasAPI := canonicalAlias.RoomserverCanonicalAliasAPI{
+		DB:            roomserverDB,
+		Cfg:           base.Cfg,
+		InputAPI:      &inputAPI,
+		QueryAPI:      &queryAPI,
+		AppserviceAPI: &asAPI,
+	}
+	canonicalAliasAPI.SetupHTTP(http.DefaultServeMux)
+
+	return &aliasAPI, &canonicalAliasAPI, &inputAPI, &queryAPI
 }

--- a/roomserver/roomserver.go
+++ b/roomserver/roomserver.go
@@ -65,12 +65,10 @@ func SetupRoomServerComponent(
 
 	aliasAPI.SetupHTTP(http.DefaultServeMux)
 
-	canonicalAliasAPI := canonicalAlias.RoomserverCanonicalAliasAPI{
-		DB:            roomserverDB,
-		Cfg:           base.Cfg,
-		InputAPI:      &inputAPI,
-		QueryAPI:      &queryAPI,
-		AppserviceAPI: &asAPI,
+	canonicalAliasAPI := canonical_alias.RoomserverCanonicalAliasAPI{
+		DB:       roomserverDB,
+		Cfg:      base.Cfg,
+		AliasAPI: &aliasAPI,
 	}
 	canonicalAliasAPI.SetupHTTP(http.DefaultServeMux)
 

--- a/roomserver/storage/postgres/room_canonical_aliases_table.go
+++ b/roomserver/storage/postgres/room_canonical_aliases_table.go
@@ -49,7 +49,7 @@ const selectCreatorIDFromCanonicalAliasSQL = "" +
 	"SELECT creator_id FROM roomserver_canonical_aliases WHERE canonical_alias = $1"
 
 const deleteRoomCanonicalAliasSQL = "" +
-	"DELETE FROM roomserver_canonical_aliases WHERE canonical_alias = $1"
+	"DELETE FROM roomserver_canonical_aliases WHERE room_id = $1"
 
 type roomCanonicalAliasStatements struct {
 	insertRoomCanonicalAliasStmt          *sql.Stmt

--- a/roomserver/storage/postgres/room_canonical_aliases_table.go
+++ b/roomserver/storage/postgres/room_canonical_aliases_table.go
@@ -1,0 +1,127 @@
+// Copyright 2017-2018 New Vector Ltd
+// Copyright 2019-2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+)
+
+const roomAliasesSchema = `
+-- Stores room aliases and room IDs they refer to
+CREATE TABLE IF NOT EXISTS roomserver_room_aliases (
+    -- Alias of the room
+    alias TEXT NOT NULL PRIMARY KEY,
+    -- Room ID the alias refers to
+    room_id TEXT NOT NULL,
+    -- User ID of the creator of this alias
+    creator_id TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS roomserver_room_id_idx ON roomserver_room_aliases(room_id);
+`
+
+const insertRoomAliasSQL = "" +
+	"INSERT INTO roomserver_room_aliases (alias, room_id, creator_id) VALUES ($1, $2, $3)"
+
+const selectRoomIDFromAliasSQL = "" +
+	"SELECT room_id FROM roomserver_room_aliases WHERE alias = $1"
+
+const selectAliasesFromRoomIDSQL = "" +
+	"SELECT alias FROM roomserver_room_aliases WHERE room_id = $1"
+
+const selectCreatorIDFromAliasSQL = "" +
+	"SELECT creator_id FROM roomserver_room_aliases WHERE alias = $1"
+
+const deleteRoomAliasSQL = "" +
+	"DELETE FROM roomserver_room_aliases WHERE alias = $1"
+
+type roomAliasesStatements struct {
+	insertRoomAliasStmt          *sql.Stmt
+	selectRoomIDFromAliasStmt    *sql.Stmt
+	selectAliasesFromRoomIDStmt  *sql.Stmt
+	selectCreatorIDFromAliasStmt *sql.Stmt
+	deleteRoomAliasStmt          *sql.Stmt
+}
+
+func (s *roomAliasesStatements) prepare(db *sql.DB) (err error) {
+	_, err = db.Exec(roomAliasesSchema)
+	if err != nil {
+		return
+	}
+	return statementList{
+		{&s.insertRoomAliasStmt, insertRoomAliasSQL},
+		{&s.selectRoomIDFromAliasStmt, selectRoomIDFromAliasSQL},
+		{&s.selectAliasesFromRoomIDStmt, selectAliasesFromRoomIDSQL},
+		{&s.selectCreatorIDFromAliasStmt, selectCreatorIDFromAliasSQL},
+		{&s.deleteRoomAliasStmt, deleteRoomAliasSQL},
+	}.prepare(db)
+}
+
+func (s *roomAliasesStatements) insertRoomAlias(
+	ctx context.Context, alias string, roomID string, creatorUserID string,
+) (err error) {
+	_, err = s.insertRoomAliasStmt.ExecContext(ctx, alias, roomID, creatorUserID)
+	return
+}
+
+func (s *roomAliasesStatements) selectRoomIDFromAlias(
+	ctx context.Context, alias string,
+) (roomID string, err error) {
+	err = s.selectRoomIDFromAliasStmt.QueryRowContext(ctx, alias).Scan(&roomID)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return
+}
+
+func (s *roomAliasesStatements) selectAliasesFromRoomID(
+	ctx context.Context, roomID string,
+) (aliases []string, err error) {
+	aliases = []string{}
+	rows, err := s.selectAliasesFromRoomIDStmt.QueryContext(ctx, roomID)
+	if err != nil {
+		return
+	}
+
+	for rows.Next() {
+		var alias string
+		if err = rows.Scan(&alias); err != nil {
+			return
+		}
+
+		aliases = append(aliases, alias)
+	}
+
+	return
+}
+
+func (s *roomAliasesStatements) selectCreatorIDFromAlias(
+	ctx context.Context, alias string,
+) (creatorID string, err error) {
+	err = s.selectCreatorIDFromAliasStmt.QueryRowContext(ctx, alias).Scan(&creatorID)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return
+}
+
+func (s *roomAliasesStatements) deleteRoomAlias(
+	ctx context.Context, alias string,
+) (err error) {
+	_, err = s.deleteRoomAliasStmt.ExecContext(ctx, alias)
+	return
+}

--- a/roomserver/storage/postgres/room_canonical_aliases_table.go
+++ b/roomserver/storage/postgres/room_canonical_aliases_table.go
@@ -111,8 +111,8 @@ func (s *roomCanonicalAliasStatements) selectCreatorIDFromCanonicalAlias(
 }
 
 func (s *roomCanonicalAliasStatements) deleteRoomCanonicalAlias(
-	ctx context.Context, canonical_alias string,
+	ctx context.Context, roomID string,
 ) (err error) {
-	_, err = s.deleteRoomCanonicalAliasStmt.ExecContext(ctx, canonical_alias)
+	_, err = s.deleteRoomCanonicalAliasStmt.ExecContext(ctx, roomID)
 	return
 }

--- a/roomserver/storage/postgres/sql.go
+++ b/roomserver/storage/postgres/sql.go
@@ -29,6 +29,7 @@ type statements struct {
 	stateBlockStatements
 	previousEventStatements
 	roomAliasesStatements
+	roomCanonicalStatements
 	inviteStatements
 	membershipStatements
 	transactionStatements
@@ -47,6 +48,7 @@ func (s *statements) prepare(db *sql.DB) error {
 		s.stateBlockStatements.prepare,
 		s.previousEventStatements.prepare,
 		s.roomAliasesStatements.prepare,
+		s.roomCanonicalAliasStatements.prepare,
 		s.inviteStatements.prepare,
 		s.membershipStatements.prepare,
 		s.transactionStatements.prepare,

--- a/roomserver/storage/postgres/sql.go
+++ b/roomserver/storage/postgres/sql.go
@@ -29,7 +29,7 @@ type statements struct {
 	stateBlockStatements
 	previousEventStatements
 	roomAliasesStatements
-	roomCanonicalStatements
+	roomCanonicalAliasStatements
 	inviteStatements
 	membershipStatements
 	transactionStatements

--- a/roomserver/storage/postgres/storage.go
+++ b/roomserver/storage/postgres/storage.go
@@ -468,6 +468,33 @@ func (d *Database) RemoveRoomAlias(ctx context.Context, alias string) error {
 	return d.statements.deleteRoomAlias(ctx, alias)
 }
 
+// SetRoomCanonicalAlias implements alias.RoomserverCanonicalAliasAPIDB
+func (d *Database) SetRoomCanonicalAlias(ctx context.Context, canonical_alias string, roomID string, creatorUserID string) error {
+	return d.statements.insertRoomCanonicalAlias(ctx, canonical_alias, roomID, creatorUserID)
+}
+
+// GetRoomIDForCanonicalAlias implements alias.RoomserverCanonicalAliasAPIDB
+func (d *Database) GetRoomIDForCanonicalAlias(ctx context.Context, canonical_alias string) (string, error) {
+	return d.statements.selectRoomIDFromCanonicalAlias(ctx, canonical_alias)
+}
+
+// GetCanonicalAliasForRoomID implements alias.RoomserverCanonicalAliasAPIDB
+func (d *Database) GetCanonicalAliasForRoomID(ctx context.Context, roomID string) (string, error) {
+	return d.statements.selectCanonicalAliasFromRoomID(ctx, roomID)
+}
+
+// GetCreatorIDForCanonicalAlias implements alias.RoomserverCanonicalAliasAPIDB
+func (d *Database) GetCreatorIDForCanonicalAlias(
+	ctx context.Context, canonical_alias string,
+) (string, error) {
+	return d.statements.selectCreatorIDFromCanonicalAlias(ctx, canonical_alias)
+}
+
+// RemoveRoomCanonicalAlias implements alias.RoomserverCanonicalAliasAPIDB
+func (d *Database) RemoveRoomCanonicalAlias(ctx context.Context, canonical_alias string) error {
+	return d.statements.deleteRoomCanonicalAlias(ctx, canonical_alias)
+}
+
 // StateEntriesForTuples implements state.RoomStateDatabase
 func (d *Database) StateEntriesForTuples(
 	ctx context.Context,

--- a/roomserver/storage/postgres/storage.go
+++ b/roomserver/storage/postgres/storage.go
@@ -491,8 +491,8 @@ func (d *Database) GetCreatorIDForCanonicalAlias(
 }
 
 // RemoveRoomCanonicalAlias implements alias.RoomserverCanonicalAliasAPIDB
-func (d *Database) RemoveRoomCanonicalAlias(ctx context.Context, canonical_alias string) error {
-	return d.statements.deleteRoomCanonicalAlias(ctx, canonical_alias)
+func (d *Database) RemoveRoomCanonicalAlias(ctx context.Context, roomID string) error {
+	return d.statements.deleteRoomCanonicalAlias(ctx, roomID)
 }
 
 // StateEntriesForTuples implements state.RoomStateDatabase

--- a/roomserver/storage/storage.go
+++ b/roomserver/storage/storage.go
@@ -49,6 +49,11 @@ type Database interface {
 	GetAliasesForRoomID(ctx context.Context, roomID string) ([]string, error)
 	GetCreatorIDForAlias(ctx context.Context, alias string) (string, error)
 	RemoveRoomAlias(ctx context.Context, alias string) error
+	SetRoomCanonicalAlias(ctx context.Context, canonical_alias string, roomID string, creatorUserID string) error
+	GetRoomIDForCanonicalAlias(ctx context.Context, canonical_alias string) (string, error)
+	GetCanonicalAliasForRoomID(ctx context.Context, roomID string) (string, error)
+	GetCreatorIDForCanonicalAlias(ctx context.Context, canonical_alias string) (string, error)
+	RemoveRoomCanonicalAlias(ctx context.Context, canonical_alias string) error
 	StateEntriesForTuples(ctx context.Context, stateBlockNIDs []types.StateBlockNID, stateKeyTuples []types.StateKeyTuple) ([]types.StateEntryList, error)
 	MembershipUpdater(ctx context.Context, roomID, targetUserID string) (types.MembershipUpdater, error)
 	GetMembership(ctx context.Context, roomNID types.RoomNID, requestSenderUserID string) (membershipEventNID types.EventNID, stillInRoom bool, err error)

--- a/roomserver/storage/storage.go
+++ b/roomserver/storage/storage.go
@@ -53,7 +53,7 @@ type Database interface {
 	GetRoomIDForCanonicalAlias(ctx context.Context, canonical_alias string) (string, error)
 	GetCanonicalAliasForRoomID(ctx context.Context, roomID string) (string, error)
 	GetCreatorIDForCanonicalAlias(ctx context.Context, canonical_alias string) (string, error)
-	RemoveRoomCanonicalAlias(ctx context.Context, canonical_alias string) error
+	RemoveRoomCanonicalAlias(ctx context.Context, roomID string) error
 	StateEntriesForTuples(ctx context.Context, stateBlockNIDs []types.StateBlockNID, stateKeyTuples []types.StateKeyTuple) ([]types.StateEntryList, error)
 	MembershipUpdater(ctx context.Context, roomID, targetUserID string) (types.MembershipUpdater, error)
 	GetMembership(ctx context.Context, roomNID types.RoomNID, requestSenderUserID string) (membershipEventNID types.EventNID, stillInRoom bool, err error)


### PR DESCRIPTION
## Description

Most of the changes are plumbing changes, ~~copied~~ inspired by `roomserver/alias`.

Adds the following endpoints for setting canonical alias:
- `/api/roomserver/setRoomCanonicalAlias`
- `/api/roomserver/getRoomIDForCanonicalAlias`
- `/api/roomserver/getCanonicalAliasForRoomID`
- `/api/roomserver/getCreatorIDForCanonicalAlias`

## Discuss
I noticed a lot of inconsistency between the implementation of alias for room server and public rooms. Correct me if I am wrong on the below points.

> TODO: Add inconsistencies

* [ ] I have added any new tests that need to pass to `testfile` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/CONTRIBUTING.md#sign-off)

Closes #618 