### PR TITLE
More sync fixes

### DIFF
--- a/syncapi/storage/postgres/output_room_events_topology_table.go
+++ b/syncapi/storage/postgres/output_room_events_topology_table.go
@@ -40,7 +40,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS syncapi_event_topological_position_idx ON sync
 const insertEventInTopologySQL = "" +
 	"INSERT INTO syncapi_output_room_events_topology (event_id, topological_position, room_id)" +
 	" VALUES ($1, $2, $3)" +
-	" ON CONFLICT DO NOTHING"
+	" ON CONFLICT (topological_position, room_id) DO UPDATE SET event_id = $1"
 
 const selectEventIDsInRangeASCSQL = "" +
 	"SELECT event_id FROM syncapi_output_room_events_topology" +

--- a/syncapi/storage/postgres/syncserver.go
+++ b/syncapi/storage/postgres/syncserver.go
@@ -446,6 +446,7 @@ func (d *SyncServerDatasource) addPDUDeltaToResponse(
 	for _, delta := range deltas {
 		err = d.addRoomDeltaToResponse(ctx, &device, txn, fromPos, toPos, delta, numRecentEventsPerRoom, res)
 		if err != nil {
+
 			return nil, err
 		}
 	}
@@ -602,7 +603,6 @@ func (d *SyncServerDatasource) getResponseWithPDUsForCompleteSync(
 		recentStreamEvents, err = d.events.selectRecentEvents(
 			ctx, txn, roomID, types.StreamPosition(0), toPos.PDUPosition,
 			numRecentEventsPerRoom, true, true,
-			//ctx, txn, roomID, 0, toPos.PDUPosition, numRecentEventsPerRoom,
 		)
 		if err != nil {
 			return
@@ -618,7 +618,7 @@ func (d *SyncServerDatasource) getResponseWithPDUsForCompleteSync(
 		if backwardTopologyPos-1 <= 0 {
 			backwardTopologyPos = types.StreamPosition(1)
 		} else {
-			backwardTopologyPos = backwardTopologyPos - 1
+			backwardTopologyPos--
 		}
 
 		// We don't include a device here as we don't need to send down
@@ -769,10 +769,7 @@ func (d *SyncServerDatasource) getBackwardTopologyPos(
 	events []types.StreamEvent,
 ) (pos types.StreamPosition, err error) {
 	if len(events) > 0 {
-		pos, err = d.topology.selectPositionInTopology(ctx, events[0].EventID())
-		if err != nil {
-			return
-		}
+		pos, _ = d.topology.selectPositionInTopology(ctx, events[0].EventID())
 	}
 	if pos-1 <= 0 {
 		pos = types.StreamPosition(1)

--- a/syncapi/storage/postgres/syncserver.go
+++ b/syncapi/storage/postgres/syncserver.go
@@ -766,7 +766,7 @@ func (d *SyncServerDatasource) addInvitesToResponse(
 func (d *SyncServerDatasource) getBackwardTopologyPos(
 	ctx context.Context,
 	events []types.StreamEvent,
-) (pos types.StreamPosition, err error) {
+) (pos types.StreamPosition) {
 	if len(events) > 0 {
 		pos, _ = d.topology.selectPositionInTopology(ctx, events[0].EventID())
 	}
@@ -807,12 +807,7 @@ func (d *SyncServerDatasource) addRoomDeltaToResponse(
 	}
 	recentEvents := d.StreamEventsToEvents(device, recentStreamEvents)
 	delta.stateEvents = removeDuplicates(delta.stateEvents, recentEvents) // roll back
-
-	var backwardTopologyPos types.StreamPosition
-	backwardTopologyPos, err = d.getBackwardTopologyPos(ctx, recentStreamEvents)
-	if err != nil {
-		return err
-	}
+	backwardTopologyPos := d.getBackwardTopologyPos(ctx, recentStreamEvents)
 
 	switch delta.membership {
 	case gomatrixserverlib.Join:

--- a/syncapi/storage/postgres/syncserver.go
+++ b/syncapi/storage/postgres/syncserver.go
@@ -446,7 +446,6 @@ func (d *SyncServerDatasource) addPDUDeltaToResponse(
 	for _, delta := range deltas {
 		err = d.addRoomDeltaToResponse(ctx, &device, txn, fromPos, toPos, delta, numRecentEventsPerRoom, res)
 		if err != nil {
-
 			return nil, err
 		}
 	}

--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -185,7 +185,7 @@ func (rp *RequestPool) appendAccountData(
 	// Sync is not initial, get all account data since the latest sync
 	dataTypes, err := rp.db.GetAccountDataInRange(
 		req.ctx, userID,
-		types.StreamPosition(currentPos), types.StreamPosition(req.since.PDUPosition),
+		types.StreamPosition(req.since.PDUPosition), types.StreamPosition(currentPos),
 		accountDataFilter,
 	)
 	if err != nil {

--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -185,7 +185,7 @@ func (rp *RequestPool) appendAccountData(
 	// Sync is not initial, get all account data since the latest sync
 	dataTypes, err := rp.db.GetAccountDataInRange(
 		req.ctx, userID,
-		types.StreamPosition(req.since.PDUPosition), types.StreamPosition(currentPos),
+		types.StreamPosition(currentPos), types.StreamPosition(req.since.PDUPosition),
 		accountDataFilter,
 	)
 	if err != nil {


### PR DESCRIPTION
This fixes a couple more bugs probably introduced by #847 or #850. Namely, that `getBackwardTopologyPos` should always return a usable number, even if it's the *beginning* of the topology. It should also stop being given the same topological event more than once from causing a panic.