### PR TITLE
Blacklist 'displayname updates affect room member events'

### DIFF
--- a/sytest-blacklist
+++ b/sytest-blacklist
@@ -8,6 +8,9 @@ POST /login can log in as a user with just the local part of the id
 avatar_url updates affect room member events
 
 # Blacklisted due to flakiness
+displayname updates affect room member events
+
+# Blacklisted due to flakiness
 Room members can override their displayname on a room-specific basis
 
 # Blacklisted due to flakiness

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -67,7 +67,6 @@ Can get rooms/{roomId}/members for a departed room (SPEC-216)
 3pid invite join valid signature but revoked keys are rejected
 3pid invite join valid signature but unreachable ID server are rejected
 Room members can join a room with an overridden displayname
-displayname updates affect room member events
 Real non-joined user cannot call /events on shared room
 Real non-joined user cannot call /events on invited room
 Real non-joined user cannot call /events on joined room


### PR DESCRIPTION
Due to apparent flakiness: https://buildkite.com/matrix-dot-org/dendrite/builds/508#7132a847-4547-4f2e-b292-e3358c07343c