### PR TITLE
Implement GET endpoints for account_data in clientapi

### DIFF
--- a/clientapi/routing/account_data.go
+++ b/clientapi/routing/account_data.go
@@ -31,7 +31,7 @@ import (
 
 // GetAccountData implements GET /user/{userId}/[rooms/{roomid}/]account_data/{type}
 func GetAccountData(
-	req *http.Request, accountDB accounts.Database, device *authtypes.Device,
+	req *http.Request, accountDB *accounts.Database, device *authtypes.Device,
 	userID string, roomID string, dataType string,
 ) util.JSONResponse {
 	if userID != device.UserID {

--- a/clientapi/routing/account_data.go
+++ b/clientapi/routing/account_data.go
@@ -15,7 +15,6 @@
 package routing
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net/http"
 
@@ -43,7 +42,6 @@ func GetAccountData(
 
 	localpart, _, err := gomatrixserverlib.SplitID('@', userID)
 	if err != nil {
-		fmt.Println("Failed to split ID:", err)
 		return httputil.LogThenError(req, err)
 	}
 

--- a/clientapi/routing/account_data.go
+++ b/clientapi/routing/account_data.go
@@ -15,6 +15,7 @@
 package routing
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 
@@ -27,6 +28,39 @@ import (
 
 	"github.com/matrix-org/util"
 )
+
+// GetAccountData implements GET /user/{userId}/[rooms/{roomid}/]account_data/{type}
+func GetAccountData(
+	req *http.Request, accountDB accounts.Database, device *authtypes.Device,
+	userID string, roomID string, dataType string,
+) util.JSONResponse {
+	if userID != device.UserID {
+		return util.JSONResponse{
+			Code: http.StatusForbidden,
+			JSON: jsonerror.Forbidden("userID does not match the current user"),
+		}
+	}
+
+	localpart, _, err := gomatrixserverlib.SplitID('@', userID)
+	if err != nil {
+		fmt.Println("Failed to split ID:", err)
+		return httputil.LogThenError(req, err)
+	}
+
+	if data, err := accountDB.GetAccountDataByType(
+		req.Context(), localpart, roomID, dataType,
+	); err == nil {
+		return util.JSONResponse{
+			Code: http.StatusOK,
+			JSON: data,
+		}
+	}
+
+	return util.JSONResponse{
+		Code: http.StatusNotFound,
+		JSON: jsonerror.Forbidden("data not found"),
+	}
+}
 
 // SaveAccountData implements PUT /user/{userId}/[rooms/{roomId}/]account_data/{type}
 func SaveAccountData(

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -430,6 +430,26 @@ func Setup(
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 
+	r0mux.Handle("/user/{userID}/account_data/{type}",
+		common.MakeAuthAPI("user_account_data", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+			vars, err := common.URLDecodeMapValues(mux.Vars(req))
+			if err != nil {
+				return util.ErrorResponse(err)
+			}
+			return GetAccountData(req, accountDB, device, vars["userID"], "", vars["type"])
+		}),
+	).Methods(http.MethodGet)
+
+	r0mux.Handle("/user/{userID}/rooms/{roomID}/account_data/{type}",
+		common.MakeAuthAPI("user_account_data", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+			vars, err := common.URLDecodeMapValues(mux.Vars(req))
+			if err != nil {
+				return util.ErrorResponse(err)
+			}
+			return GetAccountData(req, accountDB, device, vars["userID"], vars["roomID"], vars["type"])
+		}),
+	).Methods(http.MethodGet)
+
 	r0mux.Handle("/rooms/{roomID}/members",
 		common.MakeAuthAPI("rooms_members", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars, err := common.URLDecodeMapValues(mux.Vars(req))


### PR DESCRIPTION
This fixes logging in with the latest Riots. The `PUT` endpoints were implemented but the `GET` ones weren't.