### PR TITLE
Add empty push rules into account data on account creation

### DIFF
--- a/clientapi/auth/storage/accounts/storage.go
+++ b/clientapi/auth/storage/accounts/storage.go
@@ -140,6 +140,17 @@ func (d *Database) CreateAccount(
 		}
 		return nil, err
 	}
+	if err := d.SaveAccountData(ctx, localpart, "", "m.push_rules", `{
+		"global": {
+			"content": [],
+			"override": [],
+			"room": [],
+			"sender": [],
+			"underride": []
+		}
+	}`); err != nil {
+		return nil, err
+	}
 	return d.accounts.insertAccount(ctx, localpart, hash, appserviceID)
 }
 


### PR DESCRIPTION
Riot expects there to be push rules in the initial complete sync so that we don't hit problems loading the local sync cache back from IndexedDB, but since we don't implement the push rules API, the best thing we can do for now is to put empty global push rules into the account data when the account is created.