### PR TITLE
Implement room version capabilities in CS API

### DIFF
--- a/clientapi/routing/capabilities.go
+++ b/clientapi/routing/capabilities.go
@@ -1,0 +1,51 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"net/http"
+
+	"github.com/matrix-org/dendrite/clientapi/httputil"
+	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
+
+	"github.com/matrix-org/util"
+)
+
+// SendMembership implements PUT /rooms/{roomID}/(join|kick|ban|unban|leave|invite)
+// by building a m.room.member event then sending it to the room server
+func GetCapabilities(
+	req *http.Request, queryAPI roomserverAPI.RoomserverQueryAPI,
+) util.JSONResponse {
+	roomVersionsQueryReq := roomserverAPI.QueryRoomVersionCapabilitiesRequest{}
+	var roomVersionsQueryRes roomserverAPI.QueryRoomVersionCapabilitiesResponse
+	if err := queryAPI.QueryRoomVersionCapabilities(
+		req.Context(),
+		&roomVersionsQueryReq,
+		&roomVersionsQueryRes,
+	); err != nil {
+		return httputil.LogThenError(req, err)
+	}
+
+	response := map[string]interface{}{
+		"capabilities": map[string]interface{}{
+			"m.room_versions": roomVersionsQueryRes,
+		},
+	}
+
+	return util.JSONResponse{
+		Code: http.StatusOK,
+		JSON: response,
+	}
+}

--- a/clientapi/routing/capabilities.go
+++ b/clientapi/routing/capabilities.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Vector Creations Ltd
+// Copyright 2020 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -551,4 +551,10 @@ func Setup(
 			return DeleteTag(req, accountDB, device, vars["userId"], vars["roomId"], vars["tag"], syncProducer)
 		}),
 	).Methods(http.MethodDelete, http.MethodOptions)
+
+	r0mux.Handle("/capabilities",
+		common.MakeAuthAPI("capabilities", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+			return GetCapabilities(req, queryAPI)
+		}),
+	).Methods(http.MethodGet)
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.12.5-alpine3.9
+FROM docker.io/golang:1.13.6-alpine
 
 RUN mkdir /build
 

--- a/roomserver/api/query.go
+++ b/roomserver/api/query.go
@@ -244,6 +244,14 @@ type QueryServersInRoomAtEventResponse struct {
 	Servers []gomatrixserverlib.ServerName `json:"servers"`
 }
 
+// QueryDefaultRoomVersion asks for the default room version
+type QueryDefaultRoomVersionRequest struct{}
+
+// QueryDefaultRoomVersionResponse is a response to QueryServersInRoomAtEventResponse
+type QueryDefaultRoomVersionResponse struct {
+	RoomVersion int64
+}
+
 // RoomserverQueryAPI is used to query information from the room server.
 type RoomserverQueryAPI interface {
 	// Query the latest events and state for a room from the room server.
@@ -323,6 +331,13 @@ type RoomserverQueryAPI interface {
 		request *QueryServersInRoomAtEventRequest,
 		response *QueryServersInRoomAtEventResponse,
 	) error
+
+	// Asks for the default room version as preferred by the server.
+	QueryDefaultRoomVersion(
+		ctx context.Context,
+		request *QueryDefaultRoomVersionRequest,
+		response *QueryDefaultRoomVersionResponse,
+	) error
 }
 
 // RoomserverQueryLatestEventsAndStatePath is the HTTP path for the QueryLatestEventsAndState API.
@@ -357,6 +372,9 @@ const RoomserverQueryBackfillPath = "/api/roomserver/queryBackfill"
 
 // RoomserverQueryServersInRoomAtEventPath is the HTTP path for the QueryServersInRoomAtEvent API
 const RoomserverQueryServersInRoomAtEventPath = "/api/roomserver/queryServersInRoomAtEvents"
+
+// RoomserverQueryDefaultRoomVersionPath is the HTTP path for the QueryDefaultRoomVersion API
+const RoomserverQueryDefaultRoomVersionPath = "/api/roomserver/queryDefaultRoomVersion"
 
 // NewRoomserverQueryAPIHTTP creates a RoomserverQueryAPI implemented by talking to a HTTP POST API.
 // If httpClient is nil then it uses the http.DefaultClient
@@ -512,5 +530,18 @@ func (h *httpRoomserverQueryAPI) QueryServersInRoomAtEvent(
 	defer span.Finish()
 
 	apiURL := h.roomserverURL + RoomserverQueryServersInRoomAtEventPath
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+}
+
+// QueryServersInRoomAtEvent implements RoomServerQueryAPI
+func (h *httpRoomserverQueryAPI) QueryDefaultRoomVersion(
+	ctx context.Context,
+	request *QueryDefaultRoomVersionRequest,
+	response *QueryDefaultRoomVersionResponse,
+) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "QueryDefaultRoomVersion")
+	defer span.Finish()
+
+	apiURL := h.roomserverURL + RoomserverQueryDefaultRoomVersionPath
 	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }

--- a/roomserver/api/query.go
+++ b/roomserver/api/query.go
@@ -1,4 +1,6 @@
 // Copyright 2017 Vector Creations Ltd
+// Copyright 2018 New Vector Ltd
+// Copyright 2019-2020 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/roomserver/api/query.go
+++ b/roomserver/api/query.go
@@ -244,12 +244,13 @@ type QueryServersInRoomAtEventResponse struct {
 	Servers []gomatrixserverlib.ServerName `json:"servers"`
 }
 
-// QueryDefaultRoomVersion asks for the default room version
-type QueryDefaultRoomVersionRequest struct{}
+// QueryRoomVersionCapabilities asks for the default room version
+type QueryRoomVersionCapabilitiesRequest struct{}
 
-// QueryDefaultRoomVersionResponse is a response to QueryServersInRoomAtEventResponse
-type QueryDefaultRoomVersionResponse struct {
-	RoomVersion int64
+// QueryRoomVersionCapabilitiesResponse is a response to QueryServersInRoomAtEventResponse
+type QueryRoomVersionCapabilitiesResponse struct {
+	DefaultRoomVersion    string            `json:"default"`
+	AvailableRoomVersions map[string]string `json:"available"`
 }
 
 // RoomserverQueryAPI is used to query information from the room server.
@@ -333,10 +334,10 @@ type RoomserverQueryAPI interface {
 	) error
 
 	// Asks for the default room version as preferred by the server.
-	QueryDefaultRoomVersion(
+	QueryRoomVersionCapabilities(
 		ctx context.Context,
-		request *QueryDefaultRoomVersionRequest,
-		response *QueryDefaultRoomVersionResponse,
+		request *QueryRoomVersionCapabilitiesRequest,
+		response *QueryRoomVersionCapabilitiesResponse,
 	) error
 }
 
@@ -373,8 +374,8 @@ const RoomserverQueryBackfillPath = "/api/roomserver/queryBackfill"
 // RoomserverQueryServersInRoomAtEventPath is the HTTP path for the QueryServersInRoomAtEvent API
 const RoomserverQueryServersInRoomAtEventPath = "/api/roomserver/queryServersInRoomAtEvents"
 
-// RoomserverQueryDefaultRoomVersionPath is the HTTP path for the QueryDefaultRoomVersion API
-const RoomserverQueryDefaultRoomVersionPath = "/api/roomserver/queryDefaultRoomVersion"
+// RoomserverQueryRoomVersionCapabilitiesPath is the HTTP path for the QueryRoomVersionCapabilities API
+const RoomserverQueryRoomVersionCapabilitiesPath = "/api/roomserver/queryRoomVersionCapabilities"
 
 // NewRoomserverQueryAPIHTTP creates a RoomserverQueryAPI implemented by talking to a HTTP POST API.
 // If httpClient is nil then it uses the http.DefaultClient
@@ -534,14 +535,14 @@ func (h *httpRoomserverQueryAPI) QueryServersInRoomAtEvent(
 }
 
 // QueryServersInRoomAtEvent implements RoomServerQueryAPI
-func (h *httpRoomserverQueryAPI) QueryDefaultRoomVersion(
+func (h *httpRoomserverQueryAPI) QueryRoomVersionCapabilities(
 	ctx context.Context,
-	request *QueryDefaultRoomVersionRequest,
-	response *QueryDefaultRoomVersionResponse,
+	request *QueryRoomVersionCapabilitiesRequest,
+	response *QueryRoomVersionCapabilitiesResponse,
 ) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "QueryDefaultRoomVersion")
+	span, ctx := opentracing.StartSpanFromContext(ctx, "QueryRoomVersionCapabilities")
 	defer span.Finish()
 
-	apiURL := h.roomserverURL + RoomserverQueryDefaultRoomVersionPath
+	apiURL := h.roomserverURL + RoomserverQueryRoomVersionCapabilitiesPath
 	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }

--- a/roomserver/input/events.go
+++ b/roomserver/input/events.go
@@ -1,4 +1,6 @@
 // Copyright 2017 Vector Creations Ltd
+// Copyright 2018 New Vector Ltd
+// Copyright 2019-2020 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/roomserver/input/events.go
+++ b/roomserver/input/events.go
@@ -153,7 +153,7 @@ func calculateAndSetState(
 	event gomatrixserverlib.Event,
 ) error {
 	// TODO: get the correct room version
-	state, err := state.GetStateResolutionAlgorithm(state.StateResolutionAlgorithmV1, db)
+	roomState, err := state.GetStateResolutionAlgorithm(state.StateResolutionAlgorithmV1, db)
 	if err != nil {
 		return err
 	}
@@ -171,7 +171,7 @@ func calculateAndSetState(
 		}
 	} else {
 		// We haven't been told what the state at the event is so we need to calculate it from the prev_events
-		if stateAtEvent.BeforeStateSnapshotNID, err = state.CalculateAndStoreStateBeforeEvent(ctx, event, roomNID); err != nil {
+		if stateAtEvent.BeforeStateSnapshotNID, err = roomState.CalculateAndStoreStateBeforeEvent(ctx, event, roomNID); err != nil {
 			return err
 		}
 	}

--- a/roomserver/input/latest_events.go
+++ b/roomserver/input/latest_events.go
@@ -1,4 +1,6 @@
 // Copyright 2017 Vector Creations Ltd
+// Copyright 2018 New Vector Ltd
+// Copyright 2019-2020 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/roomserver/input/latest_events.go
+++ b/roomserver/input/latest_events.go
@@ -174,7 +174,7 @@ func (u *latestEventsUpdater) doUpdateLatestEvents() error {
 func (u *latestEventsUpdater) latestState() error {
 	var err error
 	// TODO: get the correct room version
-	state, err := state.GetStateResolutionAlgorithm(state.StateResolutionAlgorithmV1, u.db)
+	roomState, err := state.GetStateResolutionAlgorithm(state.StateResolutionAlgorithmV1, u.db)
 	if err != nil {
 		return err
 	}
@@ -183,21 +183,21 @@ func (u *latestEventsUpdater) latestState() error {
 	for i := range u.latest {
 		latestStateAtEvents[i] = u.latest[i].StateAtEvent
 	}
-	u.newStateNID, err = state.CalculateAndStoreStateAfterEvents(
+	u.newStateNID, err = roomState.CalculateAndStoreStateAfterEvents(
 		u.ctx, u.roomNID, latestStateAtEvents,
 	)
 	if err != nil {
 		return err
 	}
 
-	u.removed, u.added, err = state.DifferenceBetweeenStateSnapshots(
+	u.removed, u.added, err = roomState.DifferenceBetweeenStateSnapshots(
 		u.ctx, u.oldStateNID, u.newStateNID,
 	)
 	if err != nil {
 		return err
 	}
 
-	u.stateBeforeEventRemoves, u.stateBeforeEventAdds, err = state.DifferenceBetweeenStateSnapshots(
+	u.stateBeforeEventRemoves, u.stateBeforeEventAdds, err = roomState.DifferenceBetweeenStateSnapshots(
 		u.ctx, u.newStateNID, u.stateAtEvent.BeforeStateSnapshotNID,
 	)
 	return err

--- a/roomserver/query/query.go
+++ b/roomserver/query/query.go
@@ -103,7 +103,7 @@ func (r *RoomserverQueryAPI) QueryLatestEventsAndState(
 	response *api.QueryLatestEventsAndStateResponse,
 ) error {
 	// TODO: get the correct room version
-	state, err := state.GetStateResolutionAlgorithm(state.StateResolutionAlgorithmV1, r.DB)
+	roomState, err := state.GetStateResolutionAlgorithm(state.StateResolutionAlgorithmV1, r.DB)
 	if err != nil {
 		return err
 	}
@@ -124,7 +124,7 @@ func (r *RoomserverQueryAPI) QueryLatestEventsAndState(
 	}
 
 	// Look up the currrent state for the requested tuples.
-	stateEntries, err := state.LoadStateAtSnapshotForStringTuples(
+	stateEntries, err := roomState.LoadStateAtSnapshotForStringTuples(
 		ctx, currentStateSnapshotNID, request.StateToFetch,
 	)
 	if err != nil {
@@ -147,7 +147,7 @@ func (r *RoomserverQueryAPI) QueryStateAfterEvents(
 	response *api.QueryStateAfterEventsResponse,
 ) error {
 	// TODO: get the correct room version
-	state, err := state.GetStateResolutionAlgorithm(state.StateResolutionAlgorithmV1, r.DB)
+	roomState, err := state.GetStateResolutionAlgorithm(state.StateResolutionAlgorithmV1, r.DB)
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func (r *RoomserverQueryAPI) QueryStateAfterEvents(
 	response.PrevEventsExist = true
 
 	// Look up the currrent state for the requested tuples.
-	stateEntries, err := state.LoadStateAfterEventsForStringTuples(
+	stateEntries, err := roomState.LoadStateAfterEventsForStringTuples(
 		ctx, prevStates, request.StateToFetch,
 	)
 	if err != nil {
@@ -330,7 +330,7 @@ func (r *RoomserverQueryAPI) getMembershipsBeforeEventNID(
 	ctx context.Context, eventNID types.EventNID, joinedOnly bool,
 ) ([]types.Event, error) {
 	// TODO: get the correct room version
-	state, err := state.GetStateResolutionAlgorithm(state.StateResolutionAlgorithmV1, r.DB)
+	roomState, err := state.GetStateResolutionAlgorithm(state.StateResolutionAlgorithmV1, r.DB)
 	if err != nil {
 		return []types.Event{}, err
 	}
@@ -348,7 +348,7 @@ func (r *RoomserverQueryAPI) getMembershipsBeforeEventNID(
 	}
 
 	// Fetch the state as it was when this event was fired
-	stateEntries, err := state.LoadCombinedStateAfterEvents(ctx, prevState)
+	stateEntries, err := roomState.LoadCombinedStateAfterEvents(ctx, prevState)
 	if err != nil {
 		return nil, err
 	}
@@ -436,12 +436,12 @@ func (r *RoomserverQueryAPI) checkServerAllowedToSeeEvent(
 	ctx context.Context, eventID string, serverName gomatrixserverlib.ServerName,
 ) (bool, error) {
 	// TODO: get the correct room version
-	state, err := state.GetStateResolutionAlgorithm(state.StateResolutionAlgorithmV1, r.DB)
+	roomState, err := state.GetStateResolutionAlgorithm(state.StateResolutionAlgorithmV1, r.DB)
 	if err != nil {
 		return false, err
 	}
 
-	stateEntries, err := state.LoadStateAtEvent(ctx, eventID)
+	stateEntries, err := roomState.LoadStateAtEvent(ctx, eventID)
 	if err != nil {
 		return false, err
 	}
@@ -596,7 +596,7 @@ func (r *RoomserverQueryAPI) QueryStateAndAuthChain(
 	response *api.QueryStateAndAuthChainResponse,
 ) error {
 	// TODO: get the correct room version
-	state, err := state.GetStateResolutionAlgorithm(state.StateResolutionAlgorithmV1, r.DB)
+	roomState, err := state.GetStateResolutionAlgorithm(state.StateResolutionAlgorithmV1, r.DB)
 	if err != nil {
 		return err
 	}
@@ -623,7 +623,7 @@ func (r *RoomserverQueryAPI) QueryStateAndAuthChain(
 	response.PrevEventsExist = true
 
 	// Look up the currrent state for the requested tuples.
-	stateEntries, err := state.LoadCombinedStateAfterEvents(
+	stateEntries, err := roomState.LoadCombinedStateAfterEvents(
 		ctx, prevStates,
 	)
 	if err != nil {

--- a/roomserver/query/query.go
+++ b/roomserver/query/query.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strconv"
 
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/roomserver/api"
@@ -735,10 +736,11 @@ func (r *RoomserverQueryAPI) QueryRoomVersionCapabilities(
 	response.DefaultRoomVersion = string(version.GetDefaultRoomVersion())
 	response.AvailableRoomVersions = make(map[string]string)
 	for v, desc := range version.GetSupportedRoomVersions() {
+		sv := strconv.Itoa(v)
 		if desc.Stable {
-			response.AvailableRoomVersions[string(v)] = "stable"
+			response.AvailableRoomVersions[sv] = "stable"
 		} else {
-			response.AvailableRoomVersions[string(v)] = "unstable"
+			response.AvailableRoomVersions[sv] = "unstable"
 		}
 	}
 	return nil

--- a/roomserver/query/query.go
+++ b/roomserver/query/query.go
@@ -736,7 +736,7 @@ func (r *RoomserverQueryAPI) QueryRoomVersionCapabilities(
 	response.DefaultRoomVersion = string(version.GetDefaultRoomVersion())
 	response.AvailableRoomVersions = make(map[string]string)
 	for v, desc := range version.GetSupportedRoomVersions() {
-		sv := strconv.Itoa(v)
+		sv := strconv.Itoa(int(v))
 		if desc.Stable {
 			response.AvailableRoomVersions[sv] = "stable"
 		} else {

--- a/roomserver/query/query.go
+++ b/roomserver/query/query.go
@@ -1,4 +1,6 @@
 // Copyright 2017 Vector Creations Ltd
+// Copyright 2018 New Vector Ltd
+// Copyright 2019-2020 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/roomserver/query/query.go
+++ b/roomserver/query/query.go
@@ -25,6 +25,7 @@ import (
 	"github.com/matrix-org/dendrite/roomserver/state"
 	"github.com/matrix-org/dendrite/roomserver/state/database"
 	"github.com/matrix-org/dendrite/roomserver/types"
+	"github.com/matrix-org/dendrite/roomserver/version"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 )
@@ -720,6 +721,16 @@ func (r *RoomserverQueryAPI) QueryServersInRoomAtEvent(
 		response.Servers = append(response.Servers, server)
 	}
 
+	return nil
+}
+
+// QueryDefaultRoomVersion implements api.RoomserverQueryAPI
+func (r *RoomserverQueryAPI) QueryDefaultRoomVersion(
+	ctx context.Context,
+	request *api.QueryDefaultRoomVersionRequest,
+	response *api.QueryDefaultRoomVersionResponse,
+) error {
+	response.RoomVersion = int64(version.GetDefaultRoomVersion())
 	return nil
 }
 

--- a/roomserver/query/query.go
+++ b/roomserver/query/query.go
@@ -733,7 +733,7 @@ func (r *RoomserverQueryAPI) QueryRoomVersionCapabilities(
 	request *api.QueryRoomVersionCapabilitiesRequest,
 	response *api.QueryRoomVersionCapabilitiesResponse,
 ) error {
-	response.DefaultRoomVersion = string(version.GetDefaultRoomVersion())
+	response.DefaultRoomVersion = strconv.Itoa(int(version.GetDefaultRoomVersion()))
 	response.AvailableRoomVersions = make(map[string]string)
 	for v, desc := range version.GetSupportedRoomVersions() {
 		sv := strconv.Itoa(int(v))

--- a/roomserver/state/database/database.go
+++ b/roomserver/state/database/database.go
@@ -1,3 +1,19 @@
+// Copyright 2017 Vector Creations Ltd
+// Copyright 2018 New Vector Ltd
+// Copyright 2019-2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package database
 
 import (

--- a/roomserver/state/state.go
+++ b/roomserver/state/state.go
@@ -1,3 +1,19 @@
+// Copyright 2017 Vector Creations Ltd
+// Copyright 2018 New Vector Ltd
+// Copyright 2019-2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package state
 
 import (

--- a/roomserver/state/v1/state.go
+++ b/roomserver/state/v1/state.go
@@ -1,4 +1,6 @@
 // Copyright 2017 Vector Creations Ltd
+// Copyright 2018 New Vector Ltd
+// Copyright 2019-2020 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/roomserver/state/v1/state.go
+++ b/roomserver/state/v1/state.go
@@ -1,6 +1,4 @@
 // Copyright 2017 Vector Creations Ltd
-// Copyright 2018 New Vector Ltd
-// Copyright 2019-2020 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/roomserver/state/v1/state_test.go
+++ b/roomserver/state/v1/state_test.go
@@ -1,4 +1,6 @@
 // Copyright 2017 Vector Creations Ltd
+// Copyright 2018 New Vector Ltd
+// Copyright 2019-2020 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/roomserver/storage/storage.go
+++ b/roomserver/storage/storage.go
@@ -55,7 +55,6 @@ type Database interface {
 	GetMembershipEventNIDsForRoom(ctx context.Context, roomNID types.RoomNID, joinOnly bool) ([]types.EventNID, error)
 	EventsFromIDs(ctx context.Context, eventIDs []string) ([]types.Event, error)
 	GetRoomVersionForRoom(ctx context.Context, roomNID types.RoomNID) (int64, error)
-	//GetRoomVersionForEvent(ctx context.Context, eventNID types.EventNID) int64
 }
 
 // NewPublicRoomsServerDatabase opens a database connection.

--- a/roomserver/version/version.go
+++ b/roomserver/version/version.go
@@ -1,3 +1,17 @@
+// Copyright 2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package version
 
 import (

--- a/roomserver/version/version.go
+++ b/roomserver/version/version.go
@@ -83,6 +83,10 @@ var roomVersions = map[RoomVersionID]RoomVersionDescription{
 	},
 }
 
+func GetDefaultRoomVersion() RoomVersionID {
+	return RoomVersionV1
+}
+
 func GetRoomVersions() map[RoomVersionID]RoomVersionDescription {
 	return roomVersions
 }

--- a/sytest-blacklist
+++ b/sytest-blacklist
@@ -19,3 +19,6 @@ Alias creators can delete alias with no ops
 # Blacklisted because matrix-org/dendrite#847 might have broken it but we're not
 # really sure and we need it pretty badly anyway
 Real non-joined users can get individual state for world_readable rooms after leaving
+
+# Blacklisted until matrix-org/dendrite#862 is reverted due to Riot bug
+Latest account data appears in v2 /sync

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -112,7 +112,7 @@ User can invite local user to room with version 4
 Should reject keys claiming to belong to a different user
 Can add account data
 Can add account data to room
-Latest account data appears in v2 /sync
+#Latest account data appears in v2 /sync
 New account data appears in incremental v2 /sync
 Checking local federation server
 Inbound federation can query profile data
@@ -227,3 +227,5 @@ Guest users can sync from world_readable guest_access rooms if joined
 Guest users can sync from default guest_access rooms if joined
 Real non-joined users cannot room initalSync for non-world_readable rooms
 Push rules come down in an initial /sync
+Regular users can add and delete aliases in the default room configuration
+Regular users can add and delete aliases when m.room.aliases is restricted

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -229,3 +229,4 @@ Real non-joined users cannot room initalSync for non-world_readable rooms
 Push rules come down in an initial /sync
 Regular users can add and delete aliases in the default room configuration
 Regular users can add and delete aliases when m.room.aliases is restricted
+GET /r0/capabilities is not public


### PR DESCRIPTION
This implements `/capabilities` endpoint in the CS API, and includes all the room server internal wiring for getting the room version capabilities.

This is a continuation of #865 and should also fix copyright notices and sytest.