### PR TITLE
Update documentation for Go 1.13 requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,34 +20,40 @@ should pick up any unit test and run it). There are also [scripts](scripts) for
 [linting](scripts/find-lint.sh) and doing a [build/test/lint
 run](scripts/build-test-lint.sh).
 
+As of February 2020, we are deprecating support for Go 1.11 and Go 1.12 and are
+now targeting Go 1.13 or later. Please ensure that you are using at least Go
+1.13 when developing for Dendrite - our CI will lint and run tests against this
+version.
+
 ## Continuous Integration
 
 When a Pull Request is submitted, continuous integration jobs are run
-automatically to ensure the code builds and is relatively well-written. The
-jobs are run on [Buildkite](https://buildkite.com/matrix-dot-org/dendrite/),
-and the Buildkite pipeline configuration can be found in Matrix.org's
-[pipelines repository](https://github.com/matrix-org/pipelines).
+automatically to ensure the code builds and is relatively well-written. The jobs
+are run on [Buildkite](https://buildkite.com/matrix-dot-org/dendrite/), and the
+Buildkite pipeline configuration can be found in Matrix.org's [pipelines
+repository](https://github.com/matrix-org/pipelines).
 
 If a job fails, click the "details" button and you should be taken to the job's
 logs.
 
-![Click the details button on the failing build step](docs/images/details-button-location.jpg)
+![Click the details button on the failing build
+step](docs/images/details-button-location.jpg)
 
-Scroll down to the failing step and you should see some log output. Scan
-the logs until you find what it's complaining about, fix it, submit a new
-commit, then rinse and repeat until CI passes.
+Scroll down to the failing step and you should see some log output. Scan the
+logs until you find what it's complaining about, fix it, submit a new commit,
+then rinse and repeat until CI passes.
 
 ### Running CI Tests Locally
 
 To save waiting for CI to finish after every commit, it is ideal to run the
-checks locally before pushing, fixing errors first. This also saves other
-people time as only so many PRs can be tested at a given time.
+checks locally before pushing, fixing errors first. This also saves other people
+time as only so many PRs can be tested at a given time.
 
-To execute what Buildkite tests, first run `./scripts/build-test-lint.sh`;
-this script will build the code, lint it, and run `go test ./...` with race
-condition checking enabled. If something needs to be changed, fix it and then
-run the script again until it no longer complains. Be warned that the linting
-can take a significant amount of CPU and RAM.
+To execute what Buildkite tests, first run `./scripts/build-test-lint.sh`; this
+script will build the code, lint it, and run `go test ./...` with race condition
+checking enabled. If something needs to be changed, fix it and then run the
+script again until it no longer complains. Be warned that the linting can take a
+significant amount of CPU and RAM.
 
 Once the code builds, run [Sytest](https://github.com/matrix-org/sytest)
 according to the guide in
@@ -61,16 +67,18 @@ tests.
 
 ## Picking Things To Do
 
-If you're new then feel free to pick up an issue labelled [good first issue](https://github.com/matrix-org/dendrite/labels/good%20first%20issue).
+If you're new then feel free to pick up an issue labelled [good first
+issue](https://github.com/matrix-org/dendrite/labels/good%20first%20issue).
 These should be well-contained, small pieces of work that can be picked up to
 help you get familiar with the code base.
 
 Once you're comfortable with hacking on Dendrite there are issues lablled as
-[help wanted](https://github.com/matrix-org/dendrite/labels/help%20wanted), these
-are often slightly larger or more complicated pieces of work but are hopefully
-nonetheless fairly well-contained.
+[help wanted](https://github.com/matrix-org/dendrite/labels/help%20wanted),
+these are often slightly larger or more complicated pieces of work but are
+hopefully nonetheless fairly well-contained.
 
-We ask people who are familiar with Dendrite to leave the [good first issue](https://github.com/matrix-org/dendrite/labels/good%20first%20issue)
+We ask people who are familiar with Dendrite to leave the [good first
+issue](https://github.com/matrix-org/dendrite/labels/good%20first%20issue)
 issues so that there is always a way for new people to come and get involved.
 
 ## Getting Help
@@ -79,9 +87,11 @@ For questions related to developing on Dendrite we have a dedicated room on
 Matrix [#dendrite-dev:matrix.org](https://matrix.to/#/#dendrite-dev:matrix.org)
 where we're happy to help.
 
-For more general questions please use [#dendrite:matrix.org](https://matrix.to/#/#dendrite:matrix.org).
+For more general questions please use
+[#dendrite:matrix.org](https://matrix.to/#/#dendrite:matrix.org).
 
 ## Sign off
 
 We ask that everyone who contributes to the project signs off their
-contributions, in accordance with the [DCO](https://github.com/matrix-org/matrix-doc/blob/master/CONTRIBUTING.rst#sign-off).
+contributions, in accordance with the
+[DCO](https://github.com/matrix-org/matrix-doc/blob/master/CONTRIBUTING.rst#sign-off).

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,7 +12,7 @@ Dendrite can be run in one of two configurations:
 
 ## Requirements
 
- - Go 1.11+
+ - Go 1.13+
  - Postgres 9.5+
  - For Kafka (optional if using the monolith server):
    - Unix-based system (https://kafka.apache.org/documentation/#os)
@@ -22,7 +22,7 @@ Dendrite can be run in one of two configurations:
 
 ## Setting up a development environment
 
-Assumes Go 1.10+ and JDK 1.8+ are already installed and are on PATH.
+Assumes Go 1.13+ and JDK 1.8+ are already installed and are on PATH.
 
 ```bash
 # Get the code
@@ -101,7 +101,7 @@ Create config file, based on `dendrite-config.yaml`. Call it `dendrite.yaml`. Th
 
 It is possible to use 'naffka' as an in-process replacement to Kafka when using
 the monolith server. To do this, set `use_naffka: true` in `dendrite.yaml` and uncomment
-the necessary line related to naffka in the `database` section. Be sure to update the 
+the necessary line related to naffka in the `database` section. Be sure to update the
 database username and password if needed.
 
 The monolith server can be started as shown below. By default it listens for
@@ -255,7 +255,7 @@ you want to support federation.
 ./bin/dendrite-federation-sender-server --config dendrite.yaml
 ```
 
-### Run an appservice server 
+### Run an appservice server
 
 This sends events from the network to [application
 services](https://matrix.org/docs/spec/application_service/unstable.html)

--- a/README.md
+++ b/README.md
@@ -1,27 +1,30 @@
 # Dendrite [![Build Status](https://badge.buildkite.com/4be40938ab19f2bbc4a6c6724517353ee3ec1422e279faf374.svg?branch=master)](https://buildkite.com/matrix-dot-org/dendrite) [![Dendrite Dev on Matrix](https://img.shields.io/matrix/dendrite-dev:matrix.org.svg?label=%23dendrite-dev%3Amatrix.org&logo=matrix&server_fqdn=matrix.org)](https://matrix.to/#/#dendrite-dev:matrix.org) [![Dendrite on Matrix](https://img.shields.io/matrix/dendrite:matrix.org.svg?label=%23dendrite%3Amatrix.org&logo=matrix&server_fqdn=matrix.org)](https://matrix.to/#/#dendrite:matrix.org)
 
-Dendrite will be a matrix homeserver written in go.
+Dendrite will be a second-generation Matrix homeserver written in Go.
 
-It's still very much a work in progress, but installation instructions can
-be found in [INSTALL.md](INSTALL.md)
+It's still very much a work in progress, but installation instructions can be
+found in [INSTALL.md](INSTALL.md). It is not recommended to use Dendrite as a
+production homeserver at this time.
 
-An overview of the design can be found in [DESIGN.md](DESIGN.md)
+An overview of the design can be found in [DESIGN.md](DESIGN.md).
 
 # Contributing
 
-Everyone is welcome to help out and contribute! See [CONTRIBUTING.md](CONTRIBUTING.md)
-to get started!
+Everyone is welcome to help out and contribute! See
+[CONTRIBUTING.md](CONTRIBUTING.md) to get started!
 
-We aim to try and make it as easy as possible to jump in.
+Please note that, as of February 2020, Dendrite now only targets Go 1.13 or
+later. Please ensure that you are using at least Go 1.13 when developing for
+Dendrite.
 
 # Discussion
 
 For questions about Dendrite we have a dedicated room on Matrix
-[#dendrite:matrix.org](https://matrix.to/#/#dendrite:matrix.org).
-Development discussion should happen in
+[#dendrite:matrix.org](https://matrix.to/#/#dendrite:matrix.org). Development
+discussion should happen in
 [#dendrite-dev:matrix.org](https://matrix.to/#/#dendrite-dev:matrix.org).
 
 # Progress
 
-There's plenty still to do to make Dendrite usable! We're tracking progress in
-a [project board](https://github.com/matrix-org/dendrite/projects/2).
+There's plenty still to do to make Dendrite usable! We're tracking progress in a
+[project board](https://github.com/matrix-org/dendrite/projects/2).


### PR DESCRIPTION
We are now targeting Go 1.13 or later. This updates the install/readme/contributing documents to reflect that.