### PR TITLE
Queue and retry failed federation requests

### DIFF
--- a/federationsender/federationsender.go
+++ b/federationsender/federationsender.go
@@ -40,7 +40,7 @@ func SetupFederationSenderComponent(
 		logrus.WithError(err).Panic("failed to connect to federation sender db")
 	}
 
-	queues := queue.NewOutgoingQueues(base.Cfg.Matrix.ServerName, federation)
+	queues := queue.NewOutgoingQueues(federationSenderDB, base.Cfg.Matrix.ServerName, federation)
 
 	rsConsumer := consumers.NewOutputRoomEventConsumer(
 		base.Cfg, base.KafkaConsumer, queues,

--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -164,12 +164,13 @@ func (oqs *OutgoingQueues) SendEDU(
 func (oqs *OutgoingQueues) processRetries() {
 	ctx := context.Background()
 	for {
-		time.Sleep(retryInterval)
 		if err := oqs.db.DeleteRetryExpiredEvents(ctx); err != nil {
 			log.WithFields(log.Fields{
 				log.ErrorKey: err,
 			}).Warn("Error cleaning expired retry events")
 		}
+
+		time.Sleep(retryInterval)
 
 		retries, err := oqs.db.SelectRetryEventsPending(ctx)
 		if err != nil {

--- a/federationsender/storage/postgres/retries_table.go
+++ b/federationsender/storage/postgres/retries_table.go
@@ -1,0 +1,136 @@
+// Copyright 2017-2018 New Vector Ltd
+// Copyright 2019-2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/matrix-org/dendrite/common"
+	"github.com/matrix-org/dendrite/federationsender/types"
+)
+
+const retrySchema = `
+CREATE TABLE IF NOT EXISTS federationsender_retry (
+  retry_nid BIGSERIAL PRIMARY KEY,
+  origin_server_name TEXT NOT NULL,
+  destination_server_name TEXT NOT NULL,
+  event_json BYTEA NOT NULL,
+  attempts BIGINT DEFAULT 0,
+  retry_at BIGINT NOT NULL,
+  CONSTRAINT federationsender_retry_unique UNIQUE (origin_server_name, destination_server_name, event_json)
+);`
+
+const upsertEventSQL = `
+INSERT INTO federationsender_retry
+	(origin_server_name, destination_server_name, event_json, attempts, retry_at)
+	VALUES ($1, $2, $3, $4, $5)
+	ON CONFLICT ON CONSTRAINT federationsender_retry_unique
+  DO UPDATE SET attempts = $4, retry_at = $5
+`
+
+const deleteEventSQL = `
+	DELETE FROM federationsender_retry WHERE retry_nid = $1
+`
+
+const selectEventsForRetry = `
+  SELECT * FROM federationsender_retry WHERE retry_at >= $1 AND attempts < 5
+`
+
+const deleteExpiredEvents = `
+	DELETE FROM federationsender_retry WHERE attempts > 5
+`
+
+type retryStatements struct {
+	upsertEventStmt          *sql.Stmt
+	deleteEventStmt          *sql.Stmt
+	selectEventsForRetryStmt *sql.Stmt
+	deleteExpiredEventsStmt  *sql.Stmt
+}
+
+func (s *retryStatements) prepare(db *sql.DB) (err error) {
+	_, err = db.Exec(retrySchema)
+	if err != nil {
+		return
+	}
+
+	if s.upsertEventStmt, err = db.Prepare(upsertEventSQL); err != nil {
+		return
+	}
+	if s.deleteEventStmt, err = db.Prepare(deleteEventSQL); err != nil {
+		return
+	}
+	if s.selectEventsForRetryStmt, err = db.Prepare(selectEventsForRetry); err != nil {
+		return
+	}
+	if s.deleteExpiredEventsStmt, err = db.Prepare(deleteExpiredEvents); err != nil {
+		return
+	}
+	return
+}
+
+func (s *retryStatements) upsertRetryEvent(
+	ctx context.Context, txn *sql.Tx,
+	originServer string, destinationServer string, eventJSON []byte,
+	attempts int, retryAt int64,
+) error {
+	_, err := common.TxStmt(txn, s.upsertEventStmt).ExecContext(
+		ctx, originServer, destinationServer,
+		eventJSON, attempts, retryAt,
+	)
+	return err
+}
+
+func (s *retryStatements) deleteRetryEvent(
+	ctx context.Context, txn *sql.Tx, retryNID int64,
+) error {
+	_, err := common.TxStmt(txn, s.deleteEventStmt).ExecContext(
+		ctx, retryNID,
+	)
+	return err
+}
+
+func (s *retryStatements) selectRetryEventsPending(
+	ctx context.Context, txn *sql.Tx,
+) ([]*types.PendingPDU, error) {
+	var pending []*types.PendingPDU
+	stmt := common.TxStmt(txn, s.selectEventsForRetryStmt)
+	rows, err := stmt.QueryContext(ctx, time.Now().UTC().Unix())
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var entry types.PendingPDU
+		if err = rows.Scan(
+			&entry.RetryNID, &entry.Origin, &entry.Destination,
+			&entry.PDU, &entry.Attempts, &entry.Attempts,
+		); err != nil {
+			return nil, err
+		}
+		pending = append(pending, &entry)
+	}
+	return pending, err
+}
+
+func (s *retryStatements) deleteRetryExpiredEvents(
+	ctx context.Context, txn *sql.Tx,
+) error {
+	stmt := common.TxStmt(txn, s.deleteExpiredEventsStmt)
+	_, err := stmt.ExecContext(ctx)
+	return err
+}

--- a/federationsender/storage/postgres/retries_table.go
+++ b/federationsender/storage/postgres/retries_table.go
@@ -117,7 +117,7 @@ func (s *retryStatements) selectRetryEventsPending(
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer rows.Close() // nolint: errcheck
 	for rows.Next() {
 		var entry types.PendingPDU
 		var rawEvent []byte
@@ -127,7 +127,7 @@ func (s *retryStatements) selectRetryEventsPending(
 		); err != nil {
 			return nil, err
 		}
-		if err := json.Unmarshal(rawEvent, &entry.PDU); err != nil {
+		if err = json.Unmarshal(rawEvent, &entry.PDU); err != nil {
 			return nil, err
 		}
 		pending = append(pending, &entry)

--- a/federationsender/storage/storage.go
+++ b/federationsender/storage/storage.go
@@ -17,16 +17,21 @@ package storage
 import (
 	"context"
 	"net/url"
+	"time"
 
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/federationsender/storage/postgres"
 	"github.com/matrix-org/dendrite/federationsender/types"
+	"github.com/matrix-org/gomatrixserverlib"
 )
 
 type Database interface {
 	common.PartitionStorer
 	UpdateRoom(ctx context.Context, roomID, oldEventID, newEventID string, addHosts []types.JoinedHost, removeHosts []string) (joinedHosts []types.JoinedHost, err error)
 	GetJoinedHosts(ctx context.Context, roomID string) ([]types.JoinedHost, error)
+	QueueEventForRetry(ctx context.Context, originServer, destinationServer string, event gomatrixserverlib.Event, attempts int, retryAt time.Time) error
+	SelectRetryEventsPending(ctx context.Context) ([]*types.PendingPDU, error)
+	DeleteRetryExpiredEvents(ctx context.Context) error
 }
 
 // NewDatabase opens a new database

--- a/federationsender/types/types.go
+++ b/federationsender/types/types.go
@@ -16,6 +16,7 @@ package types
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/matrix-org/gomatrixserverlib"
 )
@@ -42,4 +43,22 @@ func (e EventIDMismatchError) Error() string {
 		"mismatched last sent event ID: had %q in database got %q from room server",
 		e.DatabaseID, e.RoomServerID,
 	)
+}
+
+type Queueable struct {
+	RetryNID    int64
+	Origin      gomatrixserverlib.ServerName
+	Destination gomatrixserverlib.ServerName
+	Attempts    int
+	LastAttempt time.Time
+}
+
+type PendingPDU struct {
+	Queueable
+	PDU *gomatrixserverlib.Event
+}
+
+type PendingEDU struct {
+	Queueable
+	EDU *gomatrixserverlib.EDU
 }


### PR DESCRIPTION
This PR adds a new table into the `federationsender` database where PDUs which failed to be sent over federation are queued. A task then runs every minute which looks up these events and then tries sending them again.

Still to do:
- [ ] Exponential backoff, rather than just queuing for another minute
- [ ] Determine what the best number of retries is before giving up and dropping the PDU altogether (currently 5 attempts)