### PR TITLE
Make sure transaction PDUs aren't null

### DIFF
--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -102,7 +102,10 @@ func (oq *destinationQueue) next() *gomatrixserverlib.Transaction {
 		return nil
 	}
 
-	var t gomatrixserverlib.Transaction
+	t := gomatrixserverlib.Transaction{
+		PDUs: []gomatrixserverlib.Event{},
+		EDUs: []gomatrixserverlib.EDU{},
+	}
 	now := gomatrixserverlib.AsTimestamp(time.Now())
 	t.TransactionID = gomatrixserverlib.TransactionID(fmt.Sprintf("%d-%d", now, oq.sentCounter))
 	t.Origin = oq.origin


### PR DESCRIPTION
This makes sure that the `PDUs` and `EDUs` field are given empty array values so that they don't marshal down into `null` in JSON when the federation sender processes events.

If they do then Synapse gets upset with them:
```
2020-02-28 13:31:35,075 - synapse.federation.transport.server - 419 - ERROR - PUT-1421 - object of type 'NoneType' has no len()
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/synapse/federation/transport/server.py", line 405, in on_PUT
    len(transaction_data.get("pdus", [])),
TypeError: object of type 'NoneType' has no len()
```

This seems to fix sending typing notifications to Synapse at least.