### PR TITLE
Fix bug in devices endpoint

### DIFF
--- a/clientapi/auth/authtypes/device.go
+++ b/clientapi/auth/authtypes/device.go
@@ -26,4 +26,5 @@ type Device struct {
 	// associated with access tokens.
 	SessionID int64
 	// TODO: display name, last used timestamp, keys, etc
+	DisplayName string
 }

--- a/clientapi/auth/storage/devices/postgres/devices_table.go
+++ b/clientapi/auth/storage/devices/postgres/devices_table.go
@@ -230,7 +230,7 @@ func (s *devicesStatements) selectDevicesByLocalpart(
 
 	for rows.Next() {
 		var dev authtypes.Device
-		err = rows.Scan(&dev.ID)
+		err = rows.Scan(&dev.ID, &dev.DisplayName)
 		if err != nil {
 			return devices, err
 		}

--- a/clientapi/auth/storage/devices/sqlite3/devices_table.go
+++ b/clientapi/auth/storage/devices/sqlite3/devices_table.go
@@ -231,7 +231,7 @@ func (s *devicesStatements) selectDevicesByLocalpart(
 
 	for rows.Next() {
 		var dev authtypes.Device
-		err = rows.Scan(&dev.ID)
+		err = rows.Scan(&dev.ID, &dev.DisplayName)
 		if err != nil {
 			return devices, err
 		}


### PR DESCRIPTION
This query returns two columns but we were only retrieving one.