### PR TITLE
Improve logging when sending events

### DIFF
--- a/clientapi/routing/sendevent.go
+++ b/clientapi/routing/sendevent.go
@@ -77,6 +77,7 @@ func SendEvent(
 		util.GetLogger(req.Context()).WithError(err).Error("producer.SendEvents failed")
 		return jsonerror.InternalServerError()
 	}
+	util.GetLogger(req.Context()).WithField("event_id", eventID).Info("Sent event")
 
 	res := util.JSONResponse{
 		Code: http.StatusOK,

--- a/common/httpapi.go
+++ b/common/httpapi.go
@@ -25,6 +25,10 @@ func MakeAuthAPI(
 		if err != nil {
 			return *err
 		}
+		// add the user ID to the logger
+		logger := util.GetLogger((req.Context()))
+		logger = logger.WithField("user_id", device.UserID)
+		req = req.WithContext(util.ContextWithLogger(req.Context(), logger))
 
 		return f(req, device)
 	}


### PR DESCRIPTION
We have some failing sytests on sqlite but it's very difficult to debug
due to lack of useful logging. This adds a log line for when a new event
is sent (incl. logging the event ID) as well as adding a user_id field
for all contextual logs so we know who initiated certain actions.

A typical log line now looks like:
```
time="2020-03-09T12:22:37.519438200Z" level=info msg="Sent event" func=github.com/matrix-org/dendrite/clientapi/routing.SendEvent file="/src/clientapi/routing/sendevent.go:80" event_id="$JR9BaVfliHYW0RHd:localhost:8800" req.id=wNLQTKU3xvTr req.method=PUT req.path="/_matrix/client/r0/rooms/!avzcCRbjetxdc5S9:localhost:8800/state/m.room.name" user_id="@anon-20200309_122021-133:localhost:8800"
```