### PR TITLE
Update room version descriptors, add error handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/matrix-org/go-http-js-libp2p v0.0.0-20200310180544-7f3fad43b51c
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20200304164012-aa524245b658
 	github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20200306154041-df6bb9a3e424
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20200316144058-cc6847798a3f
 	github.com/matrix-org/naffka v0.0.0-20200127221512-0716baaabaf1
 	github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7
 	github.com/mattn/go-sqlite3 v2.0.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,10 @@ github.com/matrix-org/gomatrixserverlib v0.0.0-20200124100636-0c2ec91d1df5 h1:km
 github.com/matrix-org/gomatrixserverlib v0.0.0-20200124100636-0c2ec91d1df5/go.mod h1:FsKa2pWE/bpQql9H7U4boOPXFoJX/QcqaZZ6ijLkaZI=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20200306154041-df6bb9a3e424 h1:H61lT6ckUFIDl9qb636qNomfo0B52lFt73ecioiqF10=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20200306154041-df6bb9a3e424/go.mod h1:FsKa2pWE/bpQql9H7U4boOPXFoJX/QcqaZZ6ijLkaZI=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200316100021-ac4a53d49690 h1:aQPPypOdoIsquJHhoalRYvKtDoiJfSyyJqOEn6R7yTY=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200316100021-ac4a53d49690/go.mod h1:FsKa2pWE/bpQql9H7U4boOPXFoJX/QcqaZZ6ijLkaZI=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200316144058-cc6847798a3f h1:JXSvzG4movqXT1KcdX+XZ9HM61m1FW4rIMFKUM9j/Dk=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200316144058-cc6847798a3f/go.mod h1:FsKa2pWE/bpQql9H7U4boOPXFoJX/QcqaZZ6ijLkaZI=
 github.com/matrix-org/naffka v0.0.0-20200127221512-0716baaabaf1 h1:osLoFdOy+ChQqVUn2PeTDETFftVkl4w9t/OW18g3lnk=
 github.com/matrix-org/naffka v0.0.0-20200127221512-0716baaabaf1/go.mod h1:cXoYQIENbdWIQHt1SyCo6Bl3C3raHwJ0wgVrXHSqf+A=
 github.com/matrix-org/util v0.0.0-20171127121716-2e2df66af2f5 h1:W7l5CP4V7wPyPb4tYE11dbmeAOwtFQBTW0rf4OonOS8=

--- a/roomserver/query/query.go
+++ b/roomserver/query/query.go
@@ -732,9 +732,9 @@ func (r *RoomserverQueryAPI) QueryRoomVersionCapabilities(
 	request *api.QueryRoomVersionCapabilitiesRequest,
 	response *api.QueryRoomVersionCapabilitiesResponse,
 ) error {
-	response.DefaultRoomVersion = string(version.GetDefaultRoomVersion())
+	response.DefaultRoomVersion = string(version.DefaultRoomVersion())
 	response.AvailableRoomVersions = make(map[string]string)
-	for v, desc := range version.GetSupportedRoomVersions() {
+	for v, desc := range version.SupportedRoomVersions() {
 		sv := string(v)
 		if desc.Stable {
 			response.AvailableRoomVersions[sv] = "stable"

--- a/roomserver/query/query.go
+++ b/roomserver/query/query.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"strconv"
 
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/roomserver/api"
@@ -733,10 +732,10 @@ func (r *RoomserverQueryAPI) QueryRoomVersionCapabilities(
 	request *api.QueryRoomVersionCapabilitiesRequest,
 	response *api.QueryRoomVersionCapabilitiesResponse,
 ) error {
-	response.DefaultRoomVersion = strconv.Itoa(int(version.GetDefaultRoomVersion()))
+	response.DefaultRoomVersion = string(version.GetDefaultRoomVersion())
 	response.AvailableRoomVersions = make(map[string]string)
 	for v, desc := range version.GetSupportedRoomVersions() {
-		sv := strconv.Itoa(int(v))
+		sv := string(v)
 		if desc.Stable {
 			response.AvailableRoomVersions[sv] = "stable"
 		} else {

--- a/roomserver/storage/interface.go
+++ b/roomserver/storage/interface.go
@@ -45,5 +45,5 @@ type Database interface {
 	GetMembership(ctx context.Context, roomNID types.RoomNID, requestSenderUserID string) (membershipEventNID types.EventNID, stillInRoom bool, err error)
 	GetMembershipEventNIDsForRoom(ctx context.Context, roomNID types.RoomNID, joinOnly bool) ([]types.EventNID, error)
 	EventsFromIDs(ctx context.Context, eventIDs []string) ([]types.Event, error)
-	GetRoomVersionForRoom(ctx context.Context, roomNID types.RoomNID) (int64, error)
+	GetRoomVersionForRoom(ctx context.Context, roomNID types.RoomNID) (gomatrixserverlib.RoomVersion, error)
 }

--- a/roomserver/storage/postgres/rooms_table.go
+++ b/roomserver/storage/postgres/rooms_table.go
@@ -93,11 +93,12 @@ func (s *roomStatements) prepare(db *sql.DB) (err error) {
 }
 
 func (s *roomStatements) insertRoomNID(
-	ctx context.Context, txn *sql.Tx, roomID string,
+	ctx context.Context, txn *sql.Tx,
+	roomID string, roomVersion gomatrixserverlib.RoomVersion,
 ) (types.RoomNID, error) {
 	var roomNID int64
 	stmt := common.TxStmt(txn, s.insertRoomNIDStmt)
-	err := stmt.QueryRowContext(ctx, roomID).Scan(&roomNID)
+	err := stmt.QueryRowContext(ctx, roomID, roomVersion).Scan(&roomNID)
 	return types.RoomNID(roomNID), err
 }
 

--- a/roomserver/storage/postgres/rooms_table.go
+++ b/roomserver/storage/postgres/rooms_table.go
@@ -22,6 +22,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/roomserver/types"
+	"github.com/matrix-org/gomatrixserverlib"
 )
 
 const roomsSchema = `
@@ -165,8 +166,8 @@ func (s *roomStatements) updateLatestEventNIDs(
 
 func (s *roomStatements) selectRoomVersionForRoomNID(
 	ctx context.Context, txn *sql.Tx, roomNID types.RoomNID,
-) (int64, error) {
-	var roomVersion int64
+) (gomatrixserverlib.RoomVersion, error) {
+	var roomVersion gomatrixserverlib.RoomVersion
 	stmt := common.TxStmt(txn, s.selectRoomVersionForRoomNIDStmt)
 	err := stmt.QueryRowContext(ctx, roomNID).Scan(&roomVersion)
 	return roomVersion, err

--- a/roomserver/storage/postgres/rooms_table.go
+++ b/roomserver/storage/postgres/rooms_table.go
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS roomserver_rooms (
     state_snapshot_nid BIGINT NOT NULL DEFAULT 0,
     -- The version of the room, which will assist in determining the state resolution
     -- algorithm, event ID format, etc.
-    room_version TEXT NOT NULL DEFAULT '1'
+    room_version TEXT NOT NULL
 );
 `
 

--- a/roomserver/storage/postgres/rooms_table.go
+++ b/roomserver/storage/postgres/rooms_table.go
@@ -42,13 +42,13 @@ CREATE TABLE IF NOT EXISTS roomserver_rooms (
     state_snapshot_nid BIGINT NOT NULL DEFAULT 0,
     -- The version of the room, which will assist in determining the state resolution
     -- algorithm, event ID format, etc.
-    room_version BIGINT NOT NULL DEFAULT 1
+    room_version TEXT NOT NULL DEFAULT '1'
 );
 `
 
 // Same as insertEventTypeNIDSQL
 const insertRoomNIDSQL = "" +
-	"INSERT INTO roomserver_rooms (room_id) VALUES ($1)" +
+	"INSERT INTO roomserver_rooms (room_id, room_version) VALUES ($1, $2)" +
 	" ON CONFLICT ON CONSTRAINT roomserver_room_id_unique" +
 	" DO NOTHING RETURNING (room_nid)"
 

--- a/roomserver/storage/postgres/storage.go
+++ b/roomserver/storage/postgres/storage.go
@@ -699,7 +699,7 @@ func (d *Database) EventsFromIDs(ctx context.Context, eventIDs []string) ([]type
 
 func (d *Database) GetRoomVersionForRoom(
 	ctx context.Context, roomNID types.RoomNID,
-) (int64, error) {
+) (gomatrixserverlib.RoomVersion, error) {
 	return d.statements.selectRoomVersionForRoomNID(
 		ctx, nil, roomNID,
 	)

--- a/roomserver/storage/postgres/storage.go
+++ b/roomserver/storage/postgres/storage.go
@@ -68,7 +68,8 @@ func (d *Database) StoreEvent(
 		}
 	}
 
-	if roomNID, err = d.assignRoomNID(ctx, nil, event.RoomID()); err != nil {
+	// TODO: Room version here
+	if roomNID, err = d.assignRoomNID(ctx, nil, event.RoomID(), "1"); err != nil {
 		return 0, types.StateAtEvent{}, err
 	}
 
@@ -121,13 +122,14 @@ func (d *Database) StoreEvent(
 }
 
 func (d *Database) assignRoomNID(
-	ctx context.Context, txn *sql.Tx, roomID string,
+	ctx context.Context, txn *sql.Tx,
+	roomID string, roomVersion gomatrixserverlib.RoomVersion,
 ) (types.RoomNID, error) {
 	// Check if we already have a numeric ID in the database.
 	roomNID, err := d.statements.selectRoomNID(ctx, txn, roomID)
 	if err == sql.ErrNoRows {
 		// We don't have a numeric ID so insert one into the database.
-		roomNID, err = d.statements.insertRoomNID(ctx, txn, roomID)
+		roomNID, err = d.statements.insertRoomNID(ctx, txn, roomID, roomVersion)
 		if err == sql.ErrNoRows {
 			// We raced with another insert so run the select again.
 			roomNID, err = d.statements.selectRoomNID(ctx, txn, roomID)
@@ -494,7 +496,8 @@ func (d *Database) MembershipUpdater(
 		}
 	}()
 
-	roomNID, err := d.assignRoomNID(ctx, txn, roomID)
+	// TODO: Room version here
+	roomNID, err := d.assignRoomNID(ctx, txn, roomID, "1")
 	if err != nil {
 		return nil, err
 	}

--- a/roomserver/storage/sqlite3/rooms_table.go
+++ b/roomserver/storage/sqlite3/rooms_table.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/roomserver/types"
+	"github.com/matrix-org/gomatrixserverlib"
 )
 
 const roomsSchema = `
@@ -157,8 +158,8 @@ func (s *roomStatements) updateLatestEventNIDs(
 
 func (s *roomStatements) selectRoomVersionForRoomNID(
 	ctx context.Context, txn *sql.Tx, roomNID types.RoomNID,
-) (int64, error) {
-	var roomVersion int64
+) (gomatrixserverlib.RoomVersion, error) {
+	var roomVersion gomatrixserverlib.RoomVersion
 	stmt := common.TxStmt(txn, s.selectRoomVersionForRoomNIDStmt)
 	err := stmt.QueryRowContext(ctx, roomNID).Scan(&roomVersion)
 	return roomVersion, err

--- a/roomserver/storage/sqlite3/rooms_table.go
+++ b/roomserver/storage/sqlite3/rooms_table.go
@@ -31,13 +31,13 @@ const roomsSchema = `
     latest_event_nids TEXT NOT NULL DEFAULT '[]',
     last_event_sent_nid INTEGER NOT NULL DEFAULT 0,
     state_snapshot_nid INTEGER NOT NULL DEFAULT 0,
-    room_version INTEGER NOT NULL DEFAULT 1
+    room_version TEXT NOT NULL DEFAULT '1'
   );
 `
 
 // Same as insertEventTypeNIDSQL
 const insertRoomNIDSQL = `
-	INSERT INTO roomserver_rooms (room_id) VALUES ($1)
+	INSERT INTO roomserver_rooms (room_id, room_version) VALUES ($1, $2)
 	  ON CONFLICT DO NOTHING;
 `
 

--- a/roomserver/storage/sqlite3/rooms_table.go
+++ b/roomserver/storage/sqlite3/rooms_table.go
@@ -82,11 +82,12 @@ func (s *roomStatements) prepare(db *sql.DB) (err error) {
 }
 
 func (s *roomStatements) insertRoomNID(
-	ctx context.Context, txn *sql.Tx, roomID string,
+	ctx context.Context, txn *sql.Tx,
+	roomID string, roomVersion gomatrixserverlib.RoomVersion,
 ) (types.RoomNID, error) {
 	var err error
 	insertStmt := common.TxStmt(txn, s.insertRoomNIDStmt)
-	if _, err = insertStmt.ExecContext(ctx, roomID); err == nil {
+	if _, err = insertStmt.ExecContext(ctx, roomID, roomVersion); err == nil {
 		return s.selectRoomNID(ctx, txn, roomID)
 	} else {
 		return types.RoomNID(0), err

--- a/roomserver/storage/sqlite3/rooms_table.go
+++ b/roomserver/storage/sqlite3/rooms_table.go
@@ -32,7 +32,7 @@ const roomsSchema = `
     latest_event_nids TEXT NOT NULL DEFAULT '[]',
     last_event_sent_nid INTEGER NOT NULL DEFAULT 0,
     state_snapshot_nid INTEGER NOT NULL DEFAULT 0,
-    room_version TEXT NOT NULL DEFAULT '1'
+    room_version TEXT NOT NULL
   );
 `
 

--- a/roomserver/storage/sqlite3/storage.go
+++ b/roomserver/storage/sqlite3/storage.go
@@ -853,7 +853,7 @@ func (d *Database) EventsFromIDs(ctx context.Context, eventIDs []string) ([]type
 
 func (d *Database) GetRoomVersionForRoom(
 	ctx context.Context, roomNID types.RoomNID,
-) (int64, error) {
+) (gomatrixserverlib.RoomVersion, error) {
 	return d.statements.selectRoomVersionForRoomNID(
 		ctx, nil, roomNID,
 	)

--- a/roomserver/storage/sqlite3/storage.go
+++ b/roomserver/storage/sqlite3/storage.go
@@ -90,7 +90,8 @@ func (d *Database) StoreEvent(
 			}
 		}
 
-		if roomNID, err = d.assignRoomNID(ctx, txn, event.RoomID()); err != nil {
+		// TODO: Room version here
+		if roomNID, err = d.assignRoomNID(ctx, txn, event.RoomID(), "1"); err != nil {
 			return err
 		}
 
@@ -150,13 +151,14 @@ func (d *Database) StoreEvent(
 }
 
 func (d *Database) assignRoomNID(
-	ctx context.Context, txn *sql.Tx, roomID string,
+	ctx context.Context, txn *sql.Tx,
+	roomID string, roomVersion gomatrixserverlib.RoomVersion,
 ) (roomNID types.RoomNID, err error) {
 	// Check if we already have a numeric ID in the database.
 	roomNID, err = d.statements.selectRoomNID(ctx, txn, roomID)
 	if err == sql.ErrNoRows {
 		// We don't have a numeric ID so insert one into the database.
-		roomNID, err = d.statements.insertRoomNID(ctx, txn, roomID)
+		roomNID, err = d.statements.insertRoomNID(ctx, txn, roomID, roomVersion)
 		if err == nil {
 			// Now get the numeric ID back out of the database
 			roomNID, err = d.statements.selectRoomNID(ctx, txn, roomID)
@@ -630,7 +632,8 @@ func (d *Database) MembershipUpdater(
 		}
 	}()
 
-	roomNID, err := d.assignRoomNID(ctx, txn, roomID)
+	// TODO: Room version here
+	roomNID, err := d.assignRoomNID(ctx, txn, roomID, "1")
 	if err != nil {
 		return nil, err
 	}

--- a/roomserver/version/version.go
+++ b/roomserver/version/version.go
@@ -51,23 +51,23 @@ var roomVersions = map[gomatrixserverlib.RoomVersion]RoomVersionDescription{
 	},
 }
 
-// GetDefaultRoomVersion contains the room version that will, by
+// DefaultRoomVersion contains the room version that will, by
 // default, be used to create new rooms on this server.
-func GetDefaultRoomVersion() gomatrixserverlib.RoomVersion {
+func DefaultRoomVersion() gomatrixserverlib.RoomVersion {
 	return gomatrixserverlib.RoomVersionV1
 }
 
-// GetRoomVersions returns a map of all known room versions to this
+// RoomVersions returns a map of all known room versions to this
 // server.
-func GetRoomVersions() map[gomatrixserverlib.RoomVersion]RoomVersionDescription {
+func RoomVersions() map[gomatrixserverlib.RoomVersion]RoomVersionDescription {
 	return roomVersions
 }
 
-// GetSupportedRoomVersions returns a map of descriptions for room
+// SupportedRoomVersions returns a map of descriptions for room
 // versions that are supported by this homeserver.
-func GetSupportedRoomVersions() map[gomatrixserverlib.RoomVersion]RoomVersionDescription {
+func SupportedRoomVersions() map[gomatrixserverlib.RoomVersion]RoomVersionDescription {
 	versions := make(map[gomatrixserverlib.RoomVersion]RoomVersionDescription)
-	for id, version := range GetRoomVersions() {
+	for id, version := range RoomVersions() {
 		if version.Supported {
 			versions[id] = version
 		}
@@ -75,22 +75,22 @@ func GetSupportedRoomVersions() map[gomatrixserverlib.RoomVersion]RoomVersionDes
 	return versions
 }
 
-// GetRoomVersion returns information about a specific room version.
+// RoomVersion returns information about a specific room version.
 // An UnknownVersionError is returned if the version is not known
 // to the server.
-func GetRoomVersion(version gomatrixserverlib.RoomVersion) (RoomVersionDescription, error) {
+func RoomVersion(version gomatrixserverlib.RoomVersion) (RoomVersionDescription, error) {
 	if version, ok := roomVersions[version]; ok {
 		return version, nil
 	}
 	return RoomVersionDescription{}, UnknownVersionError{version}
 }
 
-// GetSupportedRoomVersion returns information about a specific room
+// SupportedRoomVersion returns information about a specific room
 // version. An UnknownVersionError is returned if the version is not
 // known to the server, or an UnsupportedVersionError is returned if
 // the version is known but specifically marked as unsupported.
-func GetSupportedRoomVersion(version gomatrixserverlib.RoomVersion) (RoomVersionDescription, error) {
-	result, err := GetRoomVersion(version)
+func SupportedRoomVersion(version gomatrixserverlib.RoomVersion) (RoomVersionDescription, error) {
+	result, err := RoomVersion(version)
 	if err != nil {
 		return RoomVersionDescription{}, err
 	}

--- a/roomserver/version/version.go
+++ b/roomserver/version/version.go
@@ -15,84 +15,58 @@
 package version
 
 import (
-	"errors"
+	"fmt"
 
-	"github.com/matrix-org/dendrite/roomserver/state"
+	"github.com/matrix-org/gomatrixserverlib"
 )
 
-type RoomVersionID int
-type EventFormatID int
-
-const (
-	RoomVersionV1 RoomVersionID = iota + 1
-	RoomVersionV2
-	RoomVersionV3
-	RoomVersionV4
-	RoomVersionV5
-)
-
-const (
-	EventFormatV1 EventFormatID = iota + 1 // original event ID formatting
-	EventFormatV2                          // event ID is event hash
-	EventFormatV3                          // event ID is URL-safe base64 event hash
-)
-
+// RoomVersionDescription contains information about a room version,
+// namely whether it is marked as supported or stable in this server
+// version.
 type RoomVersionDescription struct {
-	Supported                 bool
-	Stable                    bool
-	StateResolution           state.StateResolutionVersion
-	EventFormat               EventFormatID
-	EnforceSigningKeyValidity bool
+	Supported bool
+	Stable    bool
 }
 
-var roomVersions = map[RoomVersionID]RoomVersionDescription{
-	RoomVersionV1: RoomVersionDescription{
-		Supported:                 true,
-		Stable:                    true,
-		StateResolution:           state.StateResolutionAlgorithmV1,
-		EventFormat:               EventFormatV1,
-		EnforceSigningKeyValidity: false,
+var roomVersions = map[gomatrixserverlib.RoomVersion]RoomVersionDescription{
+	gomatrixserverlib.RoomVersionV1: RoomVersionDescription{
+		Supported: true,
+		Stable:    true,
 	},
-	RoomVersionV2: RoomVersionDescription{
-		Supported:                 false,
-		Stable:                    true,
-		StateResolution:           state.StateResolutionAlgorithmV2,
-		EventFormat:               EventFormatV1,
-		EnforceSigningKeyValidity: false,
+	gomatrixserverlib.RoomVersionV2: RoomVersionDescription{
+		Supported: false,
+		Stable:    false,
 	},
-	RoomVersionV3: RoomVersionDescription{
-		Supported:                 false,
-		Stable:                    true,
-		StateResolution:           state.StateResolutionAlgorithmV2,
-		EventFormat:               EventFormatV2,
-		EnforceSigningKeyValidity: false,
+	gomatrixserverlib.RoomVersionV3: RoomVersionDescription{
+		Supported: false,
+		Stable:    false,
 	},
-	RoomVersionV4: RoomVersionDescription{
-		Supported:                 false,
-		Stable:                    true,
-		StateResolution:           state.StateResolutionAlgorithmV2,
-		EventFormat:               EventFormatV3,
-		EnforceSigningKeyValidity: false,
+	gomatrixserverlib.RoomVersionV4: RoomVersionDescription{
+		Supported: false,
+		Stable:    false,
 	},
-	RoomVersionV5: RoomVersionDescription{
-		Supported:                 false,
-		Stable:                    true,
-		StateResolution:           state.StateResolutionAlgorithmV2,
-		EventFormat:               EventFormatV3,
-		EnforceSigningKeyValidity: true,
+	gomatrixserverlib.RoomVersionV5: RoomVersionDescription{
+		Supported: false,
+		Stable:    false,
 	},
 }
 
-func GetDefaultRoomVersion() RoomVersionID {
-	return RoomVersionV1
+// GetDefaultRoomVersion contains the room version that will, by
+// default, be used to create new rooms on this server.
+func GetDefaultRoomVersion() gomatrixserverlib.RoomVersion {
+	return gomatrixserverlib.RoomVersionV1
 }
 
-func GetRoomVersions() map[RoomVersionID]RoomVersionDescription {
+// GetRoomVersions returns a map of all known room versions to this
+// server.
+func GetRoomVersions() map[gomatrixserverlib.RoomVersion]RoomVersionDescription {
 	return roomVersions
 }
 
-func GetSupportedRoomVersions() map[RoomVersionID]RoomVersionDescription {
-	versions := make(map[RoomVersionID]RoomVersionDescription)
+// GetSupportedRoomVersions returns a map of descriptions for room
+// versions that are supported by this homeserver.
+func GetSupportedRoomVersions() map[gomatrixserverlib.RoomVersion]RoomVersionDescription {
+	versions := make(map[gomatrixserverlib.RoomVersion]RoomVersionDescription)
 	for id, version := range GetRoomVersions() {
 		if version.Supported {
 			versions[id] = version
@@ -101,12 +75,46 @@ func GetSupportedRoomVersions() map[RoomVersionID]RoomVersionDescription {
 	return versions
 }
 
-func GetSupportedRoomVersion(version RoomVersionID) (desc RoomVersionDescription, err error) {
+// GetRoomVersion returns information about a specific room version.
+// An UnknownVersionError is returned if the version is not known
+// to the server.
+func GetRoomVersion(version gomatrixserverlib.RoomVersion) (RoomVersionDescription, error) {
 	if version, ok := roomVersions[version]; ok {
-		desc = version
+		return version, nil
 	}
-	if !desc.Supported {
-		err = errors.New("unsupported room version")
+	return RoomVersionDescription{}, UnknownVersionError{version}
+}
+
+// GetSupportedRoomVersion returns information about a specific room
+// version. An UnknownVersionError is returned if the version is not
+// known to the server, or an UnsupportedVersionError is returned if
+// the version is known but specifically marked as unsupported.
+func GetSupportedRoomVersion(version gomatrixserverlib.RoomVersion) (RoomVersionDescription, error) {
+	result, err := GetRoomVersion(version)
+	if err != nil {
+		return RoomVersionDescription{}, err
 	}
-	return
+	if !result.Supported {
+		return RoomVersionDescription{}, UnsupportedVersionError{version}
+	}
+	return result, nil
+}
+
+// UnknownVersionError is caused when the room version is not known.
+type UnknownVersionError struct {
+	Version gomatrixserverlib.RoomVersion
+}
+
+func (e UnknownVersionError) Error() string {
+	return fmt.Sprintf("room version '%s' is not known", e.Version)
+}
+
+// UnsupportedVersionError is caused when the room version is specifically
+// marked as unsupported.
+type UnsupportedVersionError struct {
+	Version gomatrixserverlib.RoomVersion
+}
+
+func (e UnsupportedVersionError) Error() string {
+	return fmt.Sprintf("room version '%s' is marked as unsupported", e.Version)
 }

--- a/roomserver/version/version.go
+++ b/roomserver/version/version.go
@@ -23,6 +23,11 @@ import (
 // RoomVersionDescription contains information about a room version,
 // namely whether it is marked as supported or stable in this server
 // version.
+// A version is supported if the server has some support for rooms
+// that are this version. A version is marked as stable or unstable
+// in order to hint whether the version should be used to clients
+// calling the /capabilities endpoint.
+// https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-capabilities
 type RoomVersionDescription struct {
 	Supported bool
 	Stable    bool


### PR DESCRIPTION
This updates the room version descriptors to use the new `gomatrixserverlib.RoomVersion` type, adds some error handling. 