### PR TITLE
Add room version to room create request, persist in storage

### DIFF
--- a/clientapi/jsonerror/jsonerror.go
+++ b/clientapi/jsonerror/jsonerror.go
@@ -124,6 +124,12 @@ func GuestAccessForbidden(msg string) *MatrixError {
 	return &MatrixError{"M_GUEST_ACCESS_FORBIDDEN", msg}
 }
 
+// UnsupportedRoomVersion is an error which is returned when the client
+// requests a room with a version that is unsupported.
+func UnsupportedRoomVersion(msg string) *MatrixError {
+	return &MatrixError{"M_UNSUPPORTED_ROOM_VERSION", msg}
+}
+
 // LimitExceededError is a rate-limiting error.
 type LimitExceededError struct {
 	MatrixError

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/matrix-org/go-http-js-libp2p v0.0.0-20200310180544-7f3fad43b51c
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20200304164012-aa524245b658
 	github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20200317103236-134415251e65
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20200317114945-9a368ea4620d
 	github.com/matrix-org/naffka v0.0.0-20200127221512-0716baaabaf1
 	github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7
 	github.com/mattn/go-sqlite3 v2.0.2+incompatible

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/matrix-org/go-http-js-libp2p v0.0.0-20200310180544-7f3fad43b51c
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20200304164012-aa524245b658
 	github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20200317114945-9a368ea4620d
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20200317140257-ddc7feaaf2fd
 	github.com/matrix-org/naffka v0.0.0-20200127221512-0716baaabaf1
 	github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7
 	github.com/mattn/go-sqlite3 v2.0.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,7 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVa
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tjxl5dIMyVM=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
@@ -263,6 +264,8 @@ github.com/matrix-org/gomatrixserverlib v0.0.0-20200316222111-b66d3b63dd85 h1:I7
 github.com/matrix-org/gomatrixserverlib v0.0.0-20200316222111-b66d3b63dd85/go.mod h1:FsKa2pWE/bpQql9H7U4boOPXFoJX/QcqaZZ6ijLkaZI=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20200317103236-134415251e65 h1:llq2yETQhD75ImQhCwHbnivSKOgzOP6QdUqH9sse7XM=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20200317103236-134415251e65/go.mod h1:FsKa2pWE/bpQql9H7U4boOPXFoJX/QcqaZZ6ijLkaZI=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200317114945-9a368ea4620d h1:0GYO2Jye1TNVzsn02IF5tqV80psDi0KIWC4+glH6+/Q=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200317114945-9a368ea4620d/go.mod h1:FsKa2pWE/bpQql9H7U4boOPXFoJX/QcqaZZ6ijLkaZI=
 github.com/matrix-org/naffka v0.0.0-20200127221512-0716baaabaf1 h1:osLoFdOy+ChQqVUn2PeTDETFftVkl4w9t/OW18g3lnk=
 github.com/matrix-org/naffka v0.0.0-20200127221512-0716baaabaf1/go.mod h1:cXoYQIENbdWIQHt1SyCo6Bl3C3raHwJ0wgVrXHSqf+A=
 github.com/matrix-org/util v0.0.0-20171127121716-2e2df66af2f5 h1:W7l5CP4V7wPyPb4tYE11dbmeAOwtFQBTW0rf4OonOS8=
@@ -453,6 +456,7 @@ go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.uber.org/atomic v1.3.0 h1:vs7fgriifsPbGdK3bNuMWapNn3qnZhCRXc19NRdq010=
 go.uber.org/atomic v1.3.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=

--- a/go.sum
+++ b/go.sum
@@ -266,6 +266,8 @@ github.com/matrix-org/gomatrixserverlib v0.0.0-20200317103236-134415251e65 h1:ll
 github.com/matrix-org/gomatrixserverlib v0.0.0-20200317103236-134415251e65/go.mod h1:FsKa2pWE/bpQql9H7U4boOPXFoJX/QcqaZZ6ijLkaZI=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20200317114945-9a368ea4620d h1:0GYO2Jye1TNVzsn02IF5tqV80psDi0KIWC4+glH6+/Q=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20200317114945-9a368ea4620d/go.mod h1:FsKa2pWE/bpQql9H7U4boOPXFoJX/QcqaZZ6ijLkaZI=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200317140257-ddc7feaaf2fd h1:n95A8YyiCZ8Nu2beqw4akCaPIRrZr/nesHYDZV8WkXI=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200317140257-ddc7feaaf2fd/go.mod h1:FsKa2pWE/bpQql9H7U4boOPXFoJX/QcqaZZ6ijLkaZI=
 github.com/matrix-org/naffka v0.0.0-20200127221512-0716baaabaf1 h1:osLoFdOy+ChQqVUn2PeTDETFftVkl4w9t/OW18g3lnk=
 github.com/matrix-org/naffka v0.0.0-20200127221512-0716baaabaf1/go.mod h1:cXoYQIENbdWIQHt1SyCo6Bl3C3raHwJ0wgVrXHSqf+A=
 github.com/matrix-org/util v0.0.0-20171127121716-2e2df66af2f5 h1:W7l5CP4V7wPyPb4tYE11dbmeAOwtFQBTW0rf4OonOS8=

--- a/roomserver/storage/postgres/storage.go
+++ b/roomserver/storage/postgres/storage.go
@@ -71,6 +71,9 @@ func (d *Database) StoreEvent(
 		}
 	}
 
+	// TODO: Here we should aim to have two different code paths for new rooms
+	// vs existing ones.
+
 	// Get the default room version. If the client doesn't supply a room_version
 	// then we will use our configured default to create the room.
 	// https://matrix.org/docs/spec/client_server/r0.6.0#post-matrix-client-r0-createroom
@@ -135,24 +138,26 @@ func (d *Database) StoreEvent(
 }
 
 func extractRoomVersionFromCreateEvent(event gomatrixserverlib.Event) (
-	roomVersion gomatrixserverlib.RoomVersion, err error,
+	gomatrixserverlib.RoomVersion, error,
 ) {
+	var err error
+	var roomVersion gomatrixserverlib.RoomVersion
 	// Look for m.room.create events.
 	if event.Type() != gomatrixserverlib.MRoomCreate {
-		return
+		return gomatrixserverlib.RoomVersion(""), nil
 	}
 	roomVersion = roomserverVersion.DefaultRoomVersion()
 	var createContent gomatrixserverlib.CreateContent
 	// The m.room.create event contains an optional "room_version" key in
 	// the event content, so we need to unmarshal that first.
 	if err = json.Unmarshal(event.Content(), &createContent); err != nil {
-		return
+		return gomatrixserverlib.RoomVersion(""), err
 	}
 	// A room version was specified in the event content?
 	if createContent.RoomVersion != nil {
 		roomVersion = *createContent.RoomVersion
 	}
-	return
+	return roomVersion, err
 }
 
 func (d *Database) assignRoomNID(

--- a/roomserver/storage/postgres/storage.go
+++ b/roomserver/storage/postgres/storage.go
@@ -18,6 +18,9 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
+
+	roomserverVersion "github.com/matrix-org/dendrite/roomserver/version"
 
 	// Import the postgres database driver.
 	_ "github.com/lib/pq"
@@ -68,8 +71,27 @@ func (d *Database) StoreEvent(
 		}
 	}
 
-	// TODO: Room version here
-	if roomNID, err = d.assignRoomNID(ctx, nil, event.RoomID(), "1"); err != nil {
+	// Get the default room version. If the client doesn't supply a room_version
+	// then we will use our configured default to create the room.
+	// https://matrix.org/docs/spec/client_server/r0.6.0#post-matrix-client-r0-createroom
+	// Note that the below logic depends on the m.room.create event being the
+	// first event that is persisted to the database when creating or joining a
+	// room.
+	roomVersion := roomserverVersion.DefaultRoomVersion()
+	// Look for m.room.create events.
+	if event.Type() == gomatrixserverlib.MRoomCreate {
+		var createContent gomatrixserverlib.CreateContent
+		// The m.room.create event contains an optional "room_version" key in
+		// the event content, so we need to unmarshal that first.
+		if err = json.Unmarshal(event.Content(), &createContent); err == nil {
+			if createContent.RoomVersion != nil {
+				// A room version was specified in the event content.
+				roomVersion = *createContent.RoomVersion
+			}
+		}
+	}
+
+	if roomNID, err = d.assignRoomNID(ctx, nil, event.RoomID(), roomVersion); err != nil {
 		return 0, types.StateAtEvent{}, err
 	}
 

--- a/roomserver/storage/sqlite3/storage.go
+++ b/roomserver/storage/sqlite3/storage.go
@@ -18,8 +18,11 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"net/url"
+
+	roomserverVersion "github.com/matrix-org/dendrite/roomserver/version"
 
 	"github.com/matrix-org/dendrite/common"
 	"github.com/matrix-org/dendrite/roomserver/api"
@@ -90,8 +93,27 @@ func (d *Database) StoreEvent(
 			}
 		}
 
-		// TODO: Room version here
-		if roomNID, err = d.assignRoomNID(ctx, txn, event.RoomID(), "1"); err != nil {
+		// Get the default room version. If the client doesn't supply a room_version
+		// then we will use our configured default to create the room.
+		// https://matrix.org/docs/spec/client_server/r0.6.0#post-matrix-client-r0-createroom
+		// Note that the below logic depends on the m.room.create event being the
+		// first event that is persisted to the database when creating or joining a
+		// room.
+		roomVersion := roomserverVersion.DefaultRoomVersion()
+		// Look for m.room.create events.
+		if event.Type() == gomatrixserverlib.MRoomCreate {
+			var createContent gomatrixserverlib.CreateContent
+			// The m.room.create event contains an optional "room_version" key in
+			// the event content, so we need to unmarshal that first.
+			if err = json.Unmarshal(event.Content(), &createContent); err == nil {
+				if createContent.RoomVersion != nil {
+					// A room version was specified in the event content.
+					roomVersion = *createContent.RoomVersion
+				}
+			}
+		}
+
+		if roomNID, err = d.assignRoomNID(ctx, txn, event.RoomID(), roomVersion); err != nil {
 			return err
 		}
 

--- a/roomserver/storage/sqlite3/storage.go
+++ b/roomserver/storage/sqlite3/storage.go
@@ -99,18 +99,9 @@ func (d *Database) StoreEvent(
 		// Note that the below logic depends on the m.room.create event being the
 		// first event that is persisted to the database when creating or joining a
 		// room.
-		roomVersion := roomserverVersion.DefaultRoomVersion()
-		// Look for m.room.create events.
-		if event.Type() == gomatrixserverlib.MRoomCreate {
-			var createContent gomatrixserverlib.CreateContent
-			// The m.room.create event contains an optional "room_version" key in
-			// the event content, so we need to unmarshal that first.
-			if err = json.Unmarshal(event.Content(), &createContent); err == nil {
-				if createContent.RoomVersion != nil {
-					// A room version was specified in the event content.
-					roomVersion = *createContent.RoomVersion
-				}
-			}
+		var roomVersion gomatrixserverlib.RoomVersion
+		if roomVersion, err = extractRoomVersionFromCreateEvent(event); err != nil {
+			return err
 		}
 
 		if roomNID, err = d.assignRoomNID(ctx, txn, event.RoomID(), roomVersion); err != nil {
@@ -170,6 +161,27 @@ func (d *Database) StoreEvent(
 			EventNID: eventNID,
 		},
 	}, nil
+}
+
+func extractRoomVersionFromCreateEvent(event gomatrixserverlib.Event) (
+	roomVersion gomatrixserverlib.RoomVersion, err error,
+) {
+	// Look for m.room.create events.
+	if event.Type() != gomatrixserverlib.MRoomCreate {
+		return
+	}
+	roomVersion = roomserverVersion.DefaultRoomVersion()
+	var createContent gomatrixserverlib.CreateContent
+	// The m.room.create event contains an optional "room_version" key in
+	// the event content, so we need to unmarshal that first.
+	if err = json.Unmarshal(event.Content(), &createContent); err != nil {
+		return
+	}
+	// A room version was specified in the event content?
+	if createContent.RoomVersion != nil {
+		roomVersion = *createContent.RoomVersion
+	}
+	return
 }
 
 func (d *Database) assignRoomNID(

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -134,8 +134,6 @@ Changing the actions of an unknown rule fails with 404
 Enabling an unknown default rule fails with 404
 Trying to get push rules with unknown rule_id fails with 404
 Events come down the correct room
-local user can join room with version 5
-User can invite local user to room with version 5
 # SyTest currently only implements the v1 endpoints for /send_join and /send_leave,
 # whereas Dendrite only supports the v2 endpoints for those, so let's ignore this
 # test for now.

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -104,12 +104,6 @@ Newly banned rooms appear in the leave section of incremental sync
 Newly banned rooms appear in the leave section of incremental sync
 local user can join room with version 1
 User can invite local user to room with version 1
-local user can join room with version 2
-User can invite local user to room with version 2
-local user can join room with version 3
-User can invite local user to room with version 3
-local user can join room with version 4
-User can invite local user to room with version 4
 Should reject keys claiming to belong to a different user
 Can add account data
 Can add account data to room
@@ -198,10 +192,6 @@ Local non-members don't see posted message events
 Remote room members also see posted message events
 Lazy loading parameters in the filter are strictly boolean
 remote user can join room with version 1
-remote user can join room with version 2
-remote user can join room with version 3
-remote user can join room with version 4
-remote user can join room with version 5
 Inbound federation can query room alias directory
 Outbound federation can query v2 /send_join
 Inbound federation can receive v2 /send_join


### PR DESCRIPTION
This PR does two things:

1. Adds the room version to the room create request in the Client API, and complains if the room version is not supported
1. Extracts the room version from the room create event when persisting the room to storage