### PR TITLE
maintenance: Fix matrix-org#896 use %w format verb to wrap errors

### DIFF
--- a/clientapi/routing/createroom.go
+++ b/clientapi/routing/createroom.go
@@ -381,7 +381,7 @@ func buildEvent(
 	eventID := fmt.Sprintf("$%s:%s", util.RandomString(16), cfg.Matrix.ServerName)
 	event, err := builder.Build(eventID, evTime, cfg.Matrix.ServerName, cfg.Matrix.KeyID, cfg.Matrix.PrivateKey)
 	if err != nil {
-		return nil, fmt.Errorf("cannot build event %s : Builder failed to build. %s", builder.Type, err)
+		return nil, fmt.Errorf("cannot build event %s : Builder failed to build. %w", builder.Type, err)
 	}
 	return &event, nil
 }

--- a/cmd/dendritejs/keyfetcher.go
+++ b/cmd/dendritejs/keyfetcher.go
@@ -53,15 +53,15 @@ func (f *libp2pKeyFetcher) FetchKeys(
 		peerIDStr := string(req.ServerName)
 		peerID, err := peer.Decode(peerIDStr)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to decode peer ID from server name '%s': %s", peerIDStr, err)
+			return nil, fmt.Errorf("Failed to decode peer ID from server name '%s': %w", peerIDStr, err)
 		}
 		pubKey, err := peerID.ExtractPublicKey()
 		if err != nil {
-			return nil, fmt.Errorf("Failed to extract public key from peer ID: %s", err)
+			return nil, fmt.Errorf("Failed to extract public key from peer ID: %w", err)
 		}
 		pubKeyBytes, err := pubKey.Raw()
 		if err != nil {
-			return nil, fmt.Errorf("Failed to extract raw bytes from public key: %s", err)
+			return nil, fmt.Errorf("Failed to extract raw bytes from public key: %w", err)
 		}
 		util.GetLogger(ctx).Info("libp2pKeyFetcher.FetchKeys: Using public key %v for server name %s", pubKeyBytes, req.ServerName)
 

--- a/common/consumers.go
+++ b/common/consumers.go
@@ -112,7 +112,7 @@ func (c *ContinualConsumer) consumePartition(pc sarama.PartitionConsumer) {
 		msgErr := c.ProcessMessage(message)
 		// Advance our position in the stream so that we will start at the right position after a restart.
 		if err := c.PartitionStore.SetPartitionOffset(context.TODO(), c.Topic, message.Partition, message.Offset); err != nil {
-			panic(fmt.Errorf("the ContinualConsumer failed to SetPartitionOffset: %s", err))
+			panic(fmt.Errorf("the ContinualConsumer failed to SetPartitionOffset: %w", err))
 		}
 		// Shutdown if we were told to do so.
 		if msgErr == ErrShutdown {

--- a/mediaapi/fileutils/fileutils.go
+++ b/mediaapi/fileutils/fileutils.go
@@ -49,7 +49,7 @@ func GetPathFromBase64Hash(base64Hash types.Base64Hash, absBasePath config.Path)
 		"file",
 	))
 	if err != nil {
-		return "", fmt.Errorf("Unable to construct filePath: %q", err)
+		return "", fmt.Errorf("Unable to construct filePath: %w", err)
 	}
 
 	// check if the absolute absBasePath is a prefix of the absolute filePath
@@ -73,7 +73,7 @@ func MoveFileWithHashCheck(tmpDir types.Path, mediaMetadata *types.MediaMetadata
 	duplicate := false
 	finalPath, err := GetPathFromBase64Hash(mediaMetadata.Base64Hash, absBasePath)
 	if err != nil {
-		return "", duplicate, fmt.Errorf("failed to get file path from metadata: %q", err)
+		return "", duplicate, fmt.Errorf("failed to get file path from metadata: %w", err)
 	}
 
 	var stat os.FileInfo
@@ -91,7 +91,7 @@ func MoveFileWithHashCheck(tmpDir types.Path, mediaMetadata *types.MediaMetadata
 		types.Path(finalPath),
 	)
 	if err != nil {
-		return "", duplicate, fmt.Errorf("failed to move file to final destination (%v): %q", finalPath, err)
+		return "", duplicate, fmt.Errorf("failed to move file to final destination (%v): %w", finalPath, err)
 	}
 	return types.Path(finalPath), duplicate, nil
 }
@@ -143,11 +143,11 @@ func moveFile(src types.Path, dst types.Path) error {
 
 	err := os.MkdirAll(dstDir, 0770)
 	if err != nil {
-		return fmt.Errorf("Failed to make directory: %q", err)
+		return fmt.Errorf("Failed to make directory: %w", err)
 	}
 	err = os.Rename(string(src), string(dst))
 	if err != nil {
-		return fmt.Errorf("Failed to move directory: %q", err)
+		return fmt.Errorf("Failed to move directory: %w", err)
 	}
 	return nil
 }
@@ -155,11 +155,11 @@ func moveFile(src types.Path, dst types.Path) error {
 func createTempFileWriter(absBasePath config.Path) (*bufio.Writer, *os.File, types.Path, error) {
 	tmpDir, err := createTempDir(absBasePath)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("Failed to create temp dir: %q", err)
+		return nil, nil, "", fmt.Errorf("Failed to create temp dir: %w", err)
 	}
 	writer, tmpFile, err := createFileWriter(tmpDir)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("Failed to create file writer: %q", err)
+		return nil, nil, "", fmt.Errorf("Failed to create file writer: %w", err)
 	}
 	return writer, tmpFile, tmpDir, nil
 }

--- a/mediaapi/fileutils/fileutils.go
+++ b/mediaapi/fileutils/fileutils.go
@@ -168,11 +168,11 @@ func createTempFileWriter(absBasePath config.Path) (*bufio.Writer, *os.File, typ
 func createTempDir(baseDirectory config.Path) (types.Path, error) {
 	baseTmpDir := filepath.Join(string(baseDirectory), "tmp")
 	if err := os.MkdirAll(baseTmpDir, 0770); err != nil {
-		return "", fmt.Errorf("Failed to create base temp dir: %v", err)
+		return "", fmt.Errorf("Failed to create base temp dir: %w", err)
 	}
 	tmpDir, err := ioutil.TempDir(baseTmpDir, "")
 	if err != nil {
-		return "", fmt.Errorf("Failed to create temp dir: %v", err)
+		return "", fmt.Errorf("Failed to create temp dir: %w", err)
 	}
 	return types.Path(tmpDir), nil
 }
@@ -184,7 +184,7 @@ func createFileWriter(directory types.Path) (*bufio.Writer, *os.File, error) {
 	filePath := filepath.Join(string(directory), "content")
 	file, err := os.Create(filePath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to create file: %v", err)
+		return nil, nil, fmt.Errorf("Failed to create file: %w", err)
 	}
 
 	return bufio.NewWriter(file), file, nil

--- a/syncapi/routing/messages.go
+++ b/syncapi/routing/messages.go
@@ -177,7 +177,7 @@ func (r *messagesReq) retrieveEvents() (
 		r.ctx, r.from, r.to, r.roomID, r.limit, r.backwardOrdering,
 	)
 	if err != nil {
-		err = fmt.Errorf("GetEventsInRange: %s", err)
+		err = fmt.Errorf("GetEventsInRange: %w", err)
 		return
 	}
 
@@ -228,14 +228,14 @@ func (r *messagesReq) retrieveEvents() (
 		r.ctx, events[0].EventID(),
 	)
 	if err != nil {
-		err = fmt.Errorf("EventPositionInTopology: for start event %s: %s", events[0].EventID(), err)
+		err = fmt.Errorf("EventPositionInTopology: for start event %s: %w", events[0].EventID(), err)
 		return
 	}
 	endPos, err := r.db.EventPositionInTopology(
 		r.ctx, events[len(events)-1].EventID(),
 	)
 	if err != nil {
-		err = fmt.Errorf("EventPositionInTopology: for end event %s: %s", events[len(events)-1].EventID(), err)
+		err = fmt.Errorf("EventPositionInTopology: for end event %s: %w", events[len(events)-1].EventID(), err)
 		return
 	}
 	// Generate pagination tokens to send to the client using the positions

--- a/syncapi/sync/notifier_test.go
+++ b/syncapi/sync/notifier_test.go
@@ -135,7 +135,7 @@ func TestNewEventAndJoinedToRoom(t *testing.T) {
 	go func() {
 		pos, err := waitForEvents(n, newTestSyncRequest(bob, syncPositionBefore))
 		if err != nil {
-			t.Errorf("TestNewEventAndJoinedToRoom error: %s", err)
+			t.Errorf("TestNewEventAndJoinedToRoom error: %w", err)
 		}
 		if pos != syncPositionAfter {
 			t.Errorf("TestNewEventAndJoinedToRoom want %v, got %v", syncPositionAfter, pos)
@@ -163,7 +163,7 @@ func TestNewInviteEventForUser(t *testing.T) {
 	go func() {
 		pos, err := waitForEvents(n, newTestSyncRequest(bob, syncPositionBefore))
 		if err != nil {
-			t.Errorf("TestNewInviteEventForUser error: %s", err)
+			t.Errorf("TestNewInviteEventForUser error: %w", err)
 		}
 		if pos != syncPositionAfter {
 			t.Errorf("TestNewInviteEventForUser want %v, got %v", syncPositionAfter, pos)
@@ -191,7 +191,7 @@ func TestEDUWakeup(t *testing.T) {
 	go func() {
 		pos, err := waitForEvents(n, newTestSyncRequest(bob, syncPositionAfter))
 		if err != nil {
-			t.Errorf("TestNewInviteEventForUser error: %s", err)
+			t.Errorf("TestNewInviteEventForUser error: %w", err)
 		}
 		if pos != syncPositionNewEDU {
 			t.Errorf("TestNewInviteEventForUser want %v, got %v", syncPositionNewEDU, pos)
@@ -219,7 +219,7 @@ func TestMultipleRequestWakeup(t *testing.T) {
 	poll := func() {
 		pos, err := waitForEvents(n, newTestSyncRequest(bob, syncPositionBefore))
 		if err != nil {
-			t.Errorf("TestMultipleRequestWakeup error: %s", err)
+			t.Errorf("TestMultipleRequestWakeup error: %w", err)
 		}
 		if pos != syncPositionAfter {
 			t.Errorf("TestMultipleRequestWakeup want %v, got %v", syncPositionAfter, pos)
@@ -259,7 +259,7 @@ func TestNewEventAndWasPreviouslyJoinedToRoom(t *testing.T) {
 	go func() {
 		pos, err := waitForEvents(n, newTestSyncRequest(bob, syncPositionBefore))
 		if err != nil {
-			t.Errorf("TestNewEventAndWasPreviouslyJoinedToRoom error: %s", err)
+			t.Errorf("TestNewEventAndWasPreviouslyJoinedToRoom error: %w", err)
 		}
 		if pos != syncPositionAfter {
 			t.Errorf("TestNewEventAndWasPreviouslyJoinedToRoom want %v, got %v", syncPositionAfter, pos)
@@ -278,7 +278,7 @@ func TestNewEventAndWasPreviouslyJoinedToRoom(t *testing.T) {
 	go func() {
 		pos, err := waitForEvents(n, newTestSyncRequest(alice, syncPositionAfter))
 		if err != nil {
-			t.Errorf("TestNewEventAndWasPreviouslyJoinedToRoom error: %s", err)
+			t.Errorf("TestNewEventAndWasPreviouslyJoinedToRoom error: %w", err)
 		}
 		if pos != syncPositionAfter2 {
 			t.Errorf("TestNewEventAndWasPreviouslyJoinedToRoom want %v, got %v", syncPositionAfter2, pos)


### PR DESCRIPTION
* In Go version 1.13 a new formatting verb introduced for fmt.Errorf
  %w https://blog.golang.org/go1.13-errors

* update %s to %w to wrap errors.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] I have added any new tests that need to pass to `testfile` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/CONTRIBUTING.md#sign-off)

Signed-off-by: Abhinav Krishna C K <me@abhy.me>