### PR TITLE
Implement QueryRoomVersionForRoom internal API

### DIFF
--- a/roomserver/api/query.go
+++ b/roomserver/api/query.go
@@ -251,8 +251,18 @@ type QueryRoomVersionCapabilitiesRequest struct{}
 
 // QueryRoomVersionCapabilitiesResponse is a response to QueryServersInRoomAtEventResponse
 type QueryRoomVersionCapabilitiesResponse struct {
-	DefaultRoomVersion    string            `json:"default"`
-	AvailableRoomVersions map[string]string `json:"available"`
+	DefaultRoomVersion    gomatrixserverlib.RoomVersion            `json:"default"`
+	AvailableRoomVersions map[gomatrixserverlib.RoomVersion]string `json:"available"`
+}
+
+// QueryRoomVersionForRoom asks for the room version for a given room.
+type QueryRoomVersionForRoomRequest struct {
+	RoomID string `json:"room_id"`
+}
+
+// QueryRoomVersionCapabilitiesResponse is a response to QueryServersInRoomAtEventResponse
+type QueryRoomVersionForRoomResponse struct {
+	RoomVersion gomatrixserverlib.RoomVersion `json:"room_version"`
 }
 
 // RoomserverQueryAPI is used to query information from the room server.
@@ -341,6 +351,13 @@ type RoomserverQueryAPI interface {
 		request *QueryRoomVersionCapabilitiesRequest,
 		response *QueryRoomVersionCapabilitiesResponse,
 	) error
+
+	// Asks for the room version for a given room.
+	QueryRoomVersionForRoom(
+		ctx context.Context,
+		request *QueryRoomVersionForRoomRequest,
+		response *QueryRoomVersionForRoomResponse,
+	) error
 }
 
 // RoomserverQueryLatestEventsAndStatePath is the HTTP path for the QueryLatestEventsAndState API.
@@ -378,6 +395,9 @@ const RoomserverQueryServersInRoomAtEventPath = "/api/roomserver/queryServersInR
 
 // RoomserverQueryRoomVersionCapabilitiesPath is the HTTP path for the QueryRoomVersionCapabilities API
 const RoomserverQueryRoomVersionCapabilitiesPath = "/api/roomserver/queryRoomVersionCapabilities"
+
+// RoomserverQueryRoomVersionCapabilitiesPath is the HTTP path for the QueryRoomVersionCapabilities API
+const RoomserverQueryRoomVersionForRoomPath = "/api/roomserver/queryRoomVersionForRoom"
 
 // NewRoomserverQueryAPIHTTP creates a RoomserverQueryAPI implemented by talking to a HTTP POST API.
 // If httpClient is nil then it uses the http.DefaultClient
@@ -536,7 +556,7 @@ func (h *httpRoomserverQueryAPI) QueryServersInRoomAtEvent(
 	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }
 
-// QueryServersInRoomAtEvent implements RoomServerQueryAPI
+// QueryRoomVersionCapabilities implements RoomServerQueryAPI
 func (h *httpRoomserverQueryAPI) QueryRoomVersionCapabilities(
 	ctx context.Context,
 	request *QueryRoomVersionCapabilitiesRequest,
@@ -546,5 +566,18 @@ func (h *httpRoomserverQueryAPI) QueryRoomVersionCapabilities(
 	defer span.Finish()
 
 	apiURL := h.roomserverURL + RoomserverQueryRoomVersionCapabilitiesPath
+	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+}
+
+// QueryRoomVersionForRoom implements RoomServerQueryAPI
+func (h *httpRoomserverQueryAPI) QueryRoomVersionForRoom(
+	ctx context.Context,
+	request *QueryRoomVersionForRoomRequest,
+	response *QueryRoomVersionForRoomResponse,
+) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "QueryRoomVersionForRoom")
+	defer span.Finish()
+
+	apiURL := h.roomserverURL + RoomserverQueryRoomVersionForRoomPath
 	return commonHTTP.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }

--- a/roomserver/query/query.go
+++ b/roomserver/query/query.go
@@ -811,11 +811,10 @@ func (r *RoomserverQueryAPI) QueryRoomVersionCapabilities(
 	response.DefaultRoomVersion = version.DefaultRoomVersion()
 	response.AvailableRoomVersions = make(map[gomatrixserverlib.RoomVersion]string)
 	for v, desc := range version.SupportedRoomVersions() {
-		sv := v
 		if desc.Stable {
-			response.AvailableRoomVersions[sv] = "stable"
+			response.AvailableRoomVersions[v] = "stable"
 		} else {
-			response.AvailableRoomVersions[sv] = "unstable"
+			response.AvailableRoomVersions[v] = "unstable"
 		}
 	}
 	return nil


### PR DESCRIPTION
This implements a `QueryRoomVersionForRoom` API, since there are a couple of places where we need to know the room version ahead of the room server:

1. The client API, when building a new event in response to a `/send` or similar
1. The federation API, when receiving events from a room over federation and performing auth checks etc

This also uses the `gomatrixserverlib.RoomVersion` type in `QueryRoomVersionCapabilities`.