### PR TITLE
Fix dendrite config file location in docker guide

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -11,10 +11,10 @@ and start working on dendrite.
 
 ### Configuration
 
-Copy the `dendrite-docker.yaml` file to the root of the project and rename it to
-`dendrite.yaml`. It already contains the defaults used in `docker-compose` for 
-networking so you will only have to change things like the `server_name` or to 
-toggle `naffka`.
+Create a directory named `cfg` in the root of the project. Copy the
+`dendrite-docker.yaml` file into that directory and rename it to `dendrite.yaml`.
+It already contains the defaults used in `docker-compose` for networking so you will
+only have to change things like the `server_name` or to toggle `naffka`.
 
 You can run the following `docker-compose` commands either from the top directory
 specifying the `docker-compose` file


### PR DESCRIPTION
The location for `dendrite.yaml` changed in [docker-compose.yml](https://github.com/matrix-org/dendrite/blob/f2030286de4838f26cffbb2fb3f48f850dc7335a/docker/docker-compose.yml#L18) but is forgotten in the guide.

Signed-off-by: Alex Chen <minecnly@gmail.com>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

- [ ] `N/A` ~I have added any new tests that need to pass to `testfile` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)~
- [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/CONTRIBUTING.md#sign-off)
