### PR TITLE
Move /room/{roomID}/state endpoints into client API (#606)

### DIFF
--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -149,6 +149,31 @@ func Setup(
 			return GetEvent(req, device, vars["roomID"], vars["eventID"], cfg, queryAPI, federation, keyRing)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
+
+	r0mux.Handle("/rooms/{roomID}/state", common.MakeAuthAPI("room_state", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		vars, err := common.URLDecodeMapValues(mux.Vars(req))
+		if err != nil {
+			return util.ErrorResponse(err)
+		}
+		return OnIncomingStateRequest(req.Context(), queryAPI, vars["roomID"])
+	})).Methods(http.MethodGet, http.MethodOptions)
+
+	r0mux.Handle("/rooms/{roomID}/state/{type}", common.MakeAuthAPI("room_state", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		vars, err := common.URLDecodeMapValues(mux.Vars(req))
+		if err != nil {
+			return util.ErrorResponse(err)
+		}
+		return OnIncomingStateTypeRequest(req.Context(), queryAPI, vars["roomID"], vars["type"], "")
+	})).Methods(http.MethodGet, http.MethodOptions)
+
+	r0mux.Handle("/rooms/{roomID}/state/{type}/{stateKey}", common.MakeAuthAPI("room_state", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+		vars, err := common.URLDecodeMapValues(mux.Vars(req))
+		if err != nil {
+			return util.ErrorResponse(err)
+		}
+		return OnIncomingStateTypeRequest(req.Context(), queryAPI, vars["roomID"], vars["type"], vars["stateKey"])
+	})).Methods(http.MethodGet, http.MethodOptions)
+
 	r0mux.Handle("/rooms/{roomID}/state/{eventType:[^/]+/?}",
 		common.MakeAuthAPI("send_message", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars, err := common.URLDecodeMapValues(mux.Vars(req))
@@ -164,6 +189,7 @@ func Setup(
 			return SendEvent(req, device, vars["roomID"], eventType, nil, &emptyString, cfg, queryAPI, producer, nil)
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
+
 	r0mux.Handle("/rooms/{roomID}/state/{eventType}/{stateKey}",
 		common.MakeAuthAPI("send_message", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars, err := common.URLDecodeMapValues(mux.Vars(req))

--- a/common/events.go
+++ b/common/events.go
@@ -73,6 +73,10 @@ func AddPrevEventsToEvent(
 		return fmt.Errorf("gomatrixserverlib.StateNeededForEventBuilder: %w", err)
 	}
 
+	if len(eventsNeeded.Tuples()) == 0 {
+		return errors.New("expecting state tuples for event builder, got none")
+	}
+
 	// Ask the roomserver for information about this room
 	queryReq := api.QueryLatestEventsAndStateRequest{
 		RoomID:       builder.RoomID,

--- a/federationapi/routing/threepid.go
+++ b/federationapi/routing/threepid.go
@@ -271,6 +271,10 @@ func buildMembershipEvent(
 		return nil, err
 	}
 
+	if len(eventsNeeded.Tuples()) == 0 {
+		return nil, errors.New("expecting state tuples for event builder, got none")
+	}
+
 	// Ask the roomserver for information about this room
 	queryReq := roomserverAPI.QueryLatestEventsAndStateRequest{
 		RoomID:       builder.RoomID,

--- a/roomserver/alias/alias.go
+++ b/roomserver/alias/alias.go
@@ -17,6 +17,7 @@ package alias
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"time"
 
@@ -217,6 +218,9 @@ func (r *RoomserverAliasAPI) sendUpdatedAliasesEvent(
 	eventsNeeded, err := gomatrixserverlib.StateNeededForEventBuilder(&builder)
 	if err != nil {
 		return err
+	}
+	if len(eventsNeeded.Tuples()) == 0 {
+		return errors.New("expecting state tuples for event builder, got none")
 	}
 	req := roomserverAPI.QueryLatestEventsAndStateRequest{
 		RoomID:       roomID,

--- a/roomserver/query/query.go
+++ b/roomserver/query/query.go
@@ -132,10 +132,18 @@ func (r *RoomserverQueryAPI) QueryLatestEventsAndState(
 		return err
 	}
 
-	// Look up the current state for the requested tuples.
-	stateEntries, err := roomState.LoadStateAtSnapshotForStringTuples(
-		ctx, currentStateSnapshotNID, request.StateToFetch,
-	)
+	var stateEntries []types.StateEntry
+	if len(request.StateToFetch) == 0 {
+		// Look up all room state.
+		stateEntries, err = roomState.LoadStateAtSnapshot(
+			ctx, currentStateSnapshotNID,
+		)
+	} else {
+		// Look up the current state for the requested tuples.
+		stateEntries, err = roomState.LoadStateAtSnapshotForStringTuples(
+			ctx, currentStateSnapshotNID, request.StateToFetch,
+		)
+	}
 	if err != nil {
 		return err
 	}

--- a/syncapi/routing/routing.go
+++ b/syncapi/routing/routing.go
@@ -56,30 +56,6 @@ func Setup(
 		return srp.OnIncomingSyncRequest(req, device)
 	})).Methods(http.MethodGet, http.MethodOptions)
 
-	r0mux.Handle("/rooms/{roomID}/state", common.MakeAuthAPI("room_state", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
-		vars, err := common.URLDecodeMapValues(mux.Vars(req))
-		if err != nil {
-			return util.ErrorResponse(err)
-		}
-		return OnIncomingStateRequest(req, syncDB, vars["roomID"])
-	})).Methods(http.MethodGet, http.MethodOptions)
-
-	r0mux.Handle("/rooms/{roomID}/state/{type}", common.MakeAuthAPI("room_state", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
-		vars, err := common.URLDecodeMapValues(mux.Vars(req))
-		if err != nil {
-			return util.ErrorResponse(err)
-		}
-		return OnIncomingStateTypeRequest(req, syncDB, vars["roomID"], vars["type"], "")
-	})).Methods(http.MethodGet, http.MethodOptions)
-
-	r0mux.Handle("/rooms/{roomID}/state/{type}/{stateKey}", common.MakeAuthAPI("room_state", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
-		vars, err := common.URLDecodeMapValues(mux.Vars(req))
-		if err != nil {
-			return util.ErrorResponse(err)
-		}
-		return OnIncomingStateTypeRequest(req, syncDB, vars["roomID"], vars["type"], vars["stateKey"])
-	})).Methods(http.MethodGet, http.MethodOptions)
-
 	r0mux.Handle("/rooms/{roomID}/messages", common.MakeAuthAPI("room_messages", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 		vars, err := common.URLDecodeMapValues(mux.Vars(req))
 		if err != nil {

--- a/sytest-blacklist
+++ b/sytest-blacklist
@@ -35,3 +35,7 @@ Inbound federation rejects invites which are not signed by the sender
 
 # Blacklisted because we don't support ignores yet
 Ignore invite in incremental sync
+
+# Blacklisted because this test calls /r0/events which we don't implement
+New room members see their own join event
+Existing members see new members' join events

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -245,3 +245,4 @@ Remote user can backfill in a room with version 4
 Outbound federation can send invites via v2 API
 User can invite local user to room with version 3
 User can invite local user to room with version 4
+A pair of servers can establish a join in a v2 room

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -55,8 +55,9 @@ Request to logout with invalid an access token is rejected
 Request to logout without an access token is rejected
 Room creation reports m.room.create to myself
 Room creation reports m.room.member to myself
-New room members see their own join event
-Existing members see new members' join events
+# Blacklisted because these tests call /r0/events which we don't implement
+# New room members see their own join event
+# Existing members see new members' join events
 setting 'm.room.power_levels' respects room powerlevel
 Unprivileged users can set m.room.topic if it only needs level 0
 Users cannot set ban powerlevel higher than their own


### PR DESCRIPTION
This moves the `/room/{roomID}/state` endpoints into the client API and uses the room server API to get the answers, rather than depending on the sync API database.

This also updates `QueryLatestEventsAndState` to return all state events if no specific state key tuples are requested, as opposed to before, where it returned none.

This closes #606 and blacklists a couple of tests due to matrix-org/sytest#852.