### PR TITLE
Tweaks to backfill

### DIFF
--- a/federationapi/routing/backfill.go
+++ b/federationapi/routing/backfill.go
@@ -93,7 +93,7 @@ func Backfill(
 	}
 
 	var eventJSONs []json.RawMessage
-	for _, e := range evs {
+	for _, e := range gomatrixserverlib.ReverseTopologicalOrdering(evs) {
 		eventJSONs = append(eventJSONs, e.JSON())
 	}
 

--- a/syncapi/storage/postgres/backward_extremities_table.go
+++ b/syncapi/storage/postgres/backward_extremities_table.go
@@ -60,7 +60,7 @@ const insertBackwardExtremitySQL = "" +
 	" ON CONFLICT DO NOTHING"
 
 const selectBackwardExtremitiesForRoomSQL = "" +
-	"SELECT event_id FROM syncapi_backward_extremities WHERE room_id = $1"
+	"SELECT DISTINCT event_id FROM syncapi_backward_extremities WHERE room_id = $1"
 
 const deleteBackwardExtremitySQL = "" +
 	"DELETE FROM syncapi_backward_extremities WHERE room_id = $1 AND prev_event_id = $2"

--- a/syncapi/storage/sqlite3/backward_extremities_table.go
+++ b/syncapi/storage/sqlite3/backward_extremities_table.go
@@ -60,7 +60,7 @@ const insertBackwardExtremitySQL = "" +
 	" ON CONFLICT (room_id, event_id, prev_event_id) DO NOTHING"
 
 const selectBackwardExtremitiesForRoomSQL = "" +
-	"SELECT event_id FROM syncapi_backward_extremities WHERE room_id = $1"
+	"SELECT DISTINCT event_id FROM syncapi_backward_extremities WHERE room_id = $1"
 
 const deleteBackwardExtremitySQL = "" +
 	"DELETE FROM syncapi_backward_extremities WHERE room_id = $1 AND prev_event_id = $2"


### PR DESCRIPTION
This PR makes a couple of small changes:

- Add `SELECT DISTINCT` to the queries for getting backward extremities, since otherwise `handleEmptyEventSlice` will often get the lots of duplicates for the join/membership event because it has multiple `prev_events` and then we end up dropping all of those duplicates into the query string for the HTTP request
- Sorting events in backfill response - apparently this is good practice