### PR TITLE
Loopback room events for invites

### DIFF
--- a/clientapi/routing/membership.go
+++ b/clientapi/routing/membership.go
@@ -127,18 +127,18 @@ func SendMembership(
 		returnData = struct {
 			RoomID string `json:"room_id"`
 		}{roomID}
+		fallthrough
 	default:
-	}
-
-	_, err = producer.SendEvents(
-		req.Context(),
-		[]gomatrixserverlib.HeaderedEvent{event.Headered(verRes.RoomVersion)},
-		cfg.Matrix.ServerName,
-		nil,
-	)
-	if err != nil {
-		util.GetLogger(req.Context()).WithError(err).Error("producer.SendEvents failed")
-		return jsonerror.InternalServerError()
+		_, err = producer.SendEvents(
+			req.Context(),
+			[]gomatrixserverlib.HeaderedEvent{event.Headered(verRes.RoomVersion)},
+			cfg.Matrix.ServerName,
+			nil,
+		)
+		if err != nil {
+			util.GetLogger(req.Context()).WithError(err).Error("producer.SendEvents failed")
+			return jsonerror.InternalServerError()
+		}
 	}
 
 	return util.JSONResponse{

--- a/roomserver/roomserver.go
+++ b/roomserver/roomserver.go
@@ -42,6 +42,7 @@ func SetupRoomServerComponent(
 
 	inputAPI := input.RoomserverInputAPI{
 		DB:                   roomserverDB,
+		Cfg:                  base.Cfg,
 		Producer:             base.KafkaProducer,
 		OutputRoomEventTopic: string(base.Cfg.Kafka.Topics.OutputRoomEvent),
 	}


### PR DESCRIPTION
In the previous invites PR, the client API needed to make two input calls to the roomserver for invites—one for the invite and one for the room event telling other room users about the invite. 

This PR updates the `processInviteEvent` function to return a loopback input room event and the roomserver will automatically take this and process it with the other room events afterward, so that the client API doesn't need to send two separate input events. 