### PR TITLE
Fix newlines between white/blacklist test names in buildkite annotations

### DIFF
--- a/show-expected-fail-tests.sh
+++ b/show-expected-fail-tests.sh
@@ -80,8 +80,8 @@ done <<< "${passed_but_expected_fail}"
 # TODO: Check that the same test doesn't appear twice in the whitelist|blacklist
 
 # Trim test output strings
-tests_to_add=$(echo -e $tests_to_add | xargs -d '\n')
-already_in_whitelist=$(echo -e $already_in_whitelist | xargs -d '\n')
+tests_to_add=$(echo -e $tests_to_add | xargs -d '\n\n')
+already_in_whitelist=$(echo -e $already_in_whitelist | xargs -d '\n\n')
 
 # Format output with markdown for buildkite annotation rendering purposes
 if [ -n "${tests_to_add}" ] && [ -n "${already_in_whitelist}" ]; then

--- a/show-expected-fail-tests.sh
+++ b/show-expected-fail-tests.sh
@@ -91,14 +91,14 @@ fi
 if [ -n "${tests_to_add}" ]; then
 	echo "**ERROR**: The following tests passed but are not present in \`$2\`. Please append them to the file:"
     echo "\`\`\`"
-        echo -e "${tests_to_add}"
+    echo -e "${tests_to_add}"
     echo "\`\`\`"
 fi
 
 if [ -n "${already_in_whitelist}" ]; then
 	echo "**WARN**: Tests in the whitelist still marked as **expected fail**:"
     echo "\`\`\`"
-        echo -e "${already_in_whitelist}"
+    echo -e "${already_in_whitelist}"
     echo "\`\`\`"
 fi
 

--- a/show-expected-fail-tests.sh
+++ b/show-expected-fail-tests.sh
@@ -80,8 +80,8 @@ done <<< "${passed_but_expected_fail}"
 # TODO: Check that the same test doesn't appear twice in the whitelist|blacklist
 
 # Trim test output strings
-tests_to_add=$(IFS=$'\n' echo "${tests_to_add[*]}")
-already_in_whitelist=$(IFS=$'\n' echo "${already_in_whitelist[*]}")
+tests_to_add=$(IFS=$'\n' echo "${tests_to_add[*]%%'\n'}")
+already_in_whitelist=$(IFS=$'\n' echo "${already_in_whitelist[*]%%'\n'}")
 
 # Format output with markdown for buildkite annotation rendering purposes
 if [ -n "${tests_to_add}" ] && [ -n "${already_in_whitelist}" ]; then
@@ -91,14 +91,14 @@ fi
 if [ -n "${tests_to_add}" ]; then
 	echo "**ERROR**: The following tests passed but are not present in \`$2\`. Please append them to the file:"
     echo "\`\`\`"
-	echo -e "${tests_to_add}"
+        echo -e "${tests_to_add}"
     echo "\`\`\`"
 fi
 
 if [ -n "${already_in_whitelist}" ]; then
 	echo "**WARN**: Tests in the whitelist still marked as **expected fail**:"
     echo "\`\`\`"
-	echo -e "${already_in_whitelist}"
+        echo -e "${already_in_whitelist}"
     echo "\`\`\`"
 fi
 

--- a/show-expected-fail-tests.sh
+++ b/show-expected-fail-tests.sh
@@ -80,8 +80,8 @@ done <<< "${passed_but_expected_fail}"
 # TODO: Check that the same test doesn't appear twice in the whitelist|blacklist
 
 # Trim test output strings
-tests_to_add=$(echo -e $tests_to_add | xargs -d '\n\n')
-already_in_whitelist=$(echo -e $already_in_whitelist | xargs -d '\n\n')
+tests_to_add=$(IFS=$'\n' echo "${tests_to_add[*]}")
+already_in_whitelist=$(IFS=$'\n' echo "${already_in_whitelist[*]}")
 
 # Format output with markdown for buildkite annotation rendering purposes
 if [ -n "${tests_to_add}" ] && [ -n "${already_in_whitelist}" ]; then

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -1,6 +1,24 @@
 GET /register yields a set of flows
 POST /register can create a user
 POST /register downcases capitals in usernames
+POST /register rejects registration of usernames with '!'
+POST /register rejects registration of usernames with '"'
+POST /register rejects registration of usernames with ':'
+POST /register rejects registration of usernames with '?'
+POST /register rejects registration of usernames with '\'
+POST /register rejects registration of usernames with '@'
+POST /register rejects registration of usernames with '['
+POST /register rejects registration of usernames with ']'
+POST /register rejects registration of usernames with '{'
+POST /register rejects registration of usernames with '|'
+POST /register rejects registration of usernames with '}'
+POST /register rejects registration of usernames with '£'
+POST /register rejects registration of usernames with 'é'
+POST /register rejects registration of usernames with '\n'
+POST /register rejects registration of usernames with '''
+GET /login yields a set of flows
+POST /login can log in as a user
+POST /login returns the same device_id as that in the request
 POST /login can log in as a user with just the local part of the id
 POST /login as non-existing user is rejected
 POST /login wrong password is rejected

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -1,24 +1,6 @@
 GET /register yields a set of flows
 POST /register can create a user
 POST /register downcases capitals in usernames
-POST /register rejects registration of usernames with '!'
-POST /register rejects registration of usernames with '"'
-POST /register rejects registration of usernames with ':'
-POST /register rejects registration of usernames with '?'
-POST /register rejects registration of usernames with '\'
-POST /register rejects registration of usernames with '@'
-POST /register rejects registration of usernames with '['
-POST /register rejects registration of usernames with ']'
-POST /register rejects registration of usernames with '{'
-POST /register rejects registration of usernames with '|'
-POST /register rejects registration of usernames with '}'
-POST /register rejects registration of usernames with '£'
-POST /register rejects registration of usernames with 'é'
-POST /register rejects registration of usernames with '\n'
-POST /register rejects registration of usernames with '''
-GET /login yields a set of flows
-POST /login can log in as a user
-POST /login returns the same device_id as that in the request
 POST /login can log in as a user with just the local part of the id
 POST /login as non-existing user is rejected
 POST /login wrong password is rejected


### PR DESCRIPTION
`xargs` sucks.

Fixes a bug in https://github.com/matrix-org/dendrite/pull/870

Adds a `\n` between each test entry. The `%%'\n'` bit removes the final newline from the end.