### PR TITLE
Roomserver perform leave

### DIFF
--- a/clientapi/routing/leaveroom.go
+++ b/clientapi/routing/leaveroom.go
@@ -1,0 +1,51 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"net/http"
+
+	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/util"
+)
+
+func LeaveRoomByID(
+	req *http.Request,
+	device *authtypes.Device,
+	rsAPI roomserverAPI.RoomserverInternalAPI,
+	roomID string,
+) util.JSONResponse {
+	// Prepare to ask the roomserver to perform the room join.
+	leaveReq := roomserverAPI.PerformLeaveRequest{
+		RoomID: roomID,
+		UserID: device.UserID,
+	}
+	leaveRes := roomserverAPI.PerformLeaveResponse{}
+
+	// Ask the roomserver to perform the leave.
+	if err := rsAPI.PerformLeave(req.Context(), &leaveReq, &leaveRes); err != nil {
+		return util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.Unknown(err.Error()),
+		}
+	}
+
+	return util.JSONResponse{
+		Code: http.StatusOK,
+		JSON: struct{}{},
+	}
+}

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -109,8 +109,18 @@ func Setup(
 			return GetJoinedRooms(req, device, accountDB)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
-
-	r0mux.Handle("/rooms/{roomID}/{membership:(?:join|kick|ban|unban|leave|invite)}",
+	r0mux.Handle("/rooms/{roomID}/leave",
+		common.MakeAuthAPI("membership", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+			vars, err := common.URLDecodeMapValues(mux.Vars(req))
+			if err != nil {
+				return util.ErrorResponse(err)
+			}
+			return LeaveRoomByID(
+				req, device, rsAPI, vars["roomID"],
+			)
+		}),
+	).Methods(http.MethodPost, http.MethodOptions)
+	r0mux.Handle("/rooms/{roomID}/{membership:(?:join|kick|ban|unban|invite)}",
 		common.MakeAuthAPI("membership", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
 			vars, err := common.URLDecodeMapValues(mux.Vars(req))
 			if err != nil {

--- a/federationapi/routing/leave.go
+++ b/federationapi/routing/leave.go
@@ -33,6 +33,15 @@ func MakeLeave(
 	rsAPI api.RoomserverInternalAPI,
 	roomID, userID string,
 ) util.JSONResponse {
+	verReq := api.QueryRoomVersionForRoomRequest{RoomID: roomID}
+	verRes := api.QueryRoomVersionForRoomResponse{}
+	if err := rsAPI.QueryRoomVersionForRoom(httpReq.Context(), &verReq, &verRes); err != nil {
+		return util.JSONResponse{
+			Code: http.StatusInternalServerError,
+			JSON: jsonerror.InternalServerError(),
+		}
+	}
+
 	_, domain, err := gomatrixserverlib.SplitID('@', userID)
 	if err != nil {
 		return util.JSONResponse{
@@ -87,7 +96,10 @@ func MakeLeave(
 
 	return util.JSONResponse{
 		Code: http.StatusOK,
-		JSON: map[string]interface{}{"event": builder},
+		JSON: map[string]interface{}{
+			"room_version": verRes.RoomVersion,
+			"event":        builder,
+		},
 	}
 }
 

--- a/federationsender/api/perform.go
+++ b/federationsender/api/perform.go
@@ -67,7 +67,9 @@ func (h *httpFederationSenderInternalAPI) PerformJoin(
 }
 
 type PerformLeaveRequest struct {
-	RoomID string `json:"room_id"`
+	RoomID      string            `json:"room_id"`
+	UserID      string            `json:"user_id"`
+	ServerNames types.ServerNames `json:"server_names"`
 }
 
 type PerformLeaveResponse struct {

--- a/federationsender/internal/perform.go
+++ b/federationsender/internal/perform.go
@@ -169,7 +169,8 @@ func (r *FederationSenderInternalAPI) PerformLeave(
 		)
 		if err != nil {
 			// TODO: Check if the user was not allowed to leave the room.
-			return err
+			logrus.WithError(err).Warnf("r.federation.MakeLeave failed")
+			continue
 		}
 
 		// Set all the fields to be what they should be, this should be a no-op

--- a/federationsender/internal/perform.go
+++ b/federationsender/internal/perform.go
@@ -193,11 +193,8 @@ func (r *FederationSenderInternalAPI) PerformLeave(
 
 		// Work out if we support the room version that has been supplied in
 		// the make_leave response.
-		if respMakeLeave.RoomVersion == "" {
-			respMakeLeave.RoomVersion = gomatrixserverlib.RoomVersionV1
-		}
 		if _, err = respMakeLeave.RoomVersion.EventFormat(); err != nil {
-			return fmt.Errorf("respMakeLeave.RoomVersion.EventFormat: %w", err)
+			return gomatrixserverlib.UnsupportedRoomVersionError{}
 		}
 
 		// Build the leave event.

--- a/federationsender/internal/perform.go
+++ b/federationsender/internal/perform.go
@@ -169,7 +169,7 @@ func (r *FederationSenderInternalAPI) PerformLeave(
 		)
 		if err != nil {
 			// TODO: Check if the user was not allowed to leave the room.
-			return fmt.Errorf("r.federation.MakeLeave: %w", err)
+			return err
 		}
 
 		// Set all the fields to be what they should be, this should be a no-op
@@ -225,7 +225,7 @@ func (r *FederationSenderInternalAPI) PerformLeave(
 
 	// If we reach here then we didn't complete a leave for some reason.
 	return fmt.Errorf(
-		"failed to leave user %q from room %q through %d server(s)",
-		request.UserID, request.RoomID, len(request.ServerNames),
+		"Failed to leave room %q through %d server(s)",
+		request.RoomID, len(request.ServerNames),
 	)
 }

--- a/federationsender/internal/perform.go
+++ b/federationsender/internal/perform.go
@@ -184,11 +184,13 @@ func (r *FederationSenderInternalAPI) PerformLeave(
 				"membership": "leave",
 			}
 			if err = respMakeLeave.LeaveEvent.SetContent(content); err != nil {
-				return fmt.Errorf("respMakeLeave.LeaveEvent.SetContent: %w", err)
+				logrus.WithError(err).Warnf("respMakeLeave.LeaveEvent.SetContent failed")
+				continue
 			}
 		}
 		if err = respMakeLeave.LeaveEvent.SetUnsigned(struct{}{}); err != nil {
-			return fmt.Errorf("respMakeLeave.LeaveEvent.SetUnsigned: %w", err)
+			logrus.WithError(err).Warnf("respMakeLeave.LeaveEvent.SetUnsigned failed")
+			continue
 		}
 
 		// Work out if we support the room version that has been supplied in
@@ -206,7 +208,8 @@ func (r *FederationSenderInternalAPI) PerformLeave(
 			respMakeLeave.RoomVersion,
 		)
 		if err != nil {
-			return fmt.Errorf("respMakeLeave.LeaveEvent.Build: %w", err)
+			logrus.WithError(err).Warnf("respMakeLeave.LeaveEvent.Build failed")
+			continue
 		}
 
 		// Try to perform a send_leave using the newly built event.

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/matrix-org/go-http-js-libp2p v0.0.0-20200318135427-31631a9ef51f
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20200325174927-327088cdef10
 	github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20200430104311-8d41c4d924ec
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20200504153202-7542702abea6
 	github.com/matrix-org/naffka v0.0.0-20200422140631-181f1ee7401f
 	github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7
 	github.com/mattn/go-sqlite3 v2.0.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -367,8 +367,8 @@ github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26 h1:Hr3zjRsq2bh
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20200124100636-0c2ec91d1df5 h1:kmRjpmFOenVpOaV/DRlo9p6z/IbOKlUC+hhKsAAh8Qg=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20200124100636-0c2ec91d1df5/go.mod h1:FsKa2pWE/bpQql9H7U4boOPXFoJX/QcqaZZ6ijLkaZI=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200430104311-8d41c4d924ec h1:9MvZSZzBKvCWqM5KXMGZ1PBDrSLcxs5zfc561UPgcYA=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200430104311-8d41c4d924ec/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200504153202-7542702abea6 h1:CnU+0kV1xzpvzEkFr1tX7c9BTWCTFOIlBPM1XD9I++c=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200504153202-7542702abea6/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
 github.com/matrix-org/naffka v0.0.0-20200127221512-0716baaabaf1 h1:osLoFdOy+ChQqVUn2PeTDETFftVkl4w9t/OW18g3lnk=
 github.com/matrix-org/naffka v0.0.0-20200127221512-0716baaabaf1/go.mod h1:cXoYQIENbdWIQHt1SyCo6Bl3C3raHwJ0wgVrXHSqf+A=
 github.com/matrix-org/naffka v0.0.0-20200422140631-181f1ee7401f h1:pRz4VTiRCO4zPlEMc3ESdUOcW4PXHH4Kj+YDz1XyE+Y=

--- a/roomserver/api/api.go
+++ b/roomserver/api/api.go
@@ -24,6 +24,12 @@ type RoomserverInternalAPI interface {
 		res *PerformJoinResponse,
 	) error
 
+	PerformLeave(
+		ctx context.Context,
+		req *PerformLeaveRequest,
+		res *PerformLeaveResponse,
+	) error
+
 	// Query the latest events and state for a room from the room server.
 	QueryLatestEventsAndState(
 		ctx context.Context,

--- a/roomserver/internal/api.go
+++ b/roomserver/internal/api.go
@@ -59,6 +59,19 @@ func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
+	servMux.Handle(api.RoomserverPerformLeavePath,
+		common.MakeInternalAPI("performLeave", func(req *http.Request) util.JSONResponse {
+			var request api.PerformLeaveRequest
+			var response api.PerformLeaveResponse
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.MessageResponse(http.StatusBadRequest, err.Error())
+			}
+			if err := r.PerformLeave(req.Context(), &request, &response); err != nil {
+				return util.ErrorResponse(err)
+			}
+			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
+		}),
+	)
 	servMux.Handle(
 		api.RoomserverQueryLatestEventsAndStatePath,
 		common.MakeInternalAPI("queryLatestEventsAndState", func(req *http.Request) util.JSONResponse {

--- a/roomserver/internal/perform_join.go
+++ b/roomserver/internal/perform_join.go
@@ -116,7 +116,7 @@ func (r *RoomserverInternalAPI) performJoinRoomByID(
 	if req.Content == nil {
 		req.Content = map[string]interface{}{}
 	}
-	req.Content["membership"] = "join"
+	req.Content["membership"] = gomatrixserverlib.Join
 	if err = eb.SetContent(req.Content); err != nil {
 		return fmt.Errorf("eb.SetContent: %w", err)
 	}
@@ -145,7 +145,7 @@ func (r *RoomserverInternalAPI) performJoinRoomByID(
 		for _, se := range buildRes.StateEvents {
 			if membership, merr := se.Membership(); merr == nil {
 				if se.StateKey() != nil && *se.StateKey() == *event.StateKey() {
-					alreadyJoined = (membership == "join")
+					alreadyJoined = (membership == gomatrixserverlib.Join)
 					break
 				}
 			}

--- a/roomserver/internal/perform_join.go
+++ b/roomserver/internal/perform_join.go
@@ -156,7 +156,7 @@ func (r *RoomserverInternalAPI) performJoinRoomByID(
 		if !alreadyJoined {
 			inputReq := api.InputRoomEventsRequest{
 				InputRoomEvents: []api.InputRoomEvent{
-					api.InputRoomEvent{
+					{
 						Kind:         api.KindNew,
 						Event:        event.Headered(buildRes.RoomVersion),
 						AuthEventIDs: event.AuthEventIDs(),

--- a/roomserver/internal/perform_leave.go
+++ b/roomserver/internal/perform_leave.go
@@ -1,0 +1,206 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/matrix-org/dendrite/common"
+	fsAPI "github.com/matrix-org/dendrite/federationsender/api"
+	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/gomatrixserverlib"
+)
+
+// WriteOutputEvents implements OutputRoomEventWriter
+func (r *RoomserverInternalAPI) PerformLeave(
+	ctx context.Context,
+	req *api.PerformLeaveRequest,
+	res *api.PerformLeaveResponse,
+) error {
+	_, domain, err := gomatrixserverlib.SplitID('@', req.UserID)
+	if err != nil {
+		return fmt.Errorf("Supplied user ID %q in incorrect format", req.UserID)
+	}
+	if domain != r.Cfg.Matrix.ServerName {
+		return fmt.Errorf("User %q does not belong to this homeserver", req.UserID)
+	}
+	if strings.HasPrefix(req.RoomID, "!") {
+		return r.performLeaveRoomByID(ctx, req, res)
+	}
+	return fmt.Errorf("Room ID %q is invalid", req.RoomID)
+}
+
+func (r *RoomserverInternalAPI) performLeaveRoomByID(
+	ctx context.Context,
+	req *api.PerformLeaveRequest,
+	res *api.PerformLeaveResponse, // nolint:unparam
+) error {
+	// If there's an invite outstanding for the room then respond to
+	// that.
+	senderUser, err := r.isInvitePending(ctx, req, res)
+	if err == nil {
+		fmt.Println("Responding to invite")
+		return r.performRejectInvite(ctx, req, res, senderUser)
+	} else {
+		fmt.Println("Not responding to invite:", err)
+	}
+
+	// First of all we want to find out if the room exists and if the
+	// user is actually in it.
+	latestReq := api.QueryLatestEventsAndStateRequest{
+		RoomID: req.RoomID,
+		StateToFetch: []gomatrixserverlib.StateKeyTuple{
+			{
+				EventType: gomatrixserverlib.MRoomMember,
+				StateKey:  req.UserID,
+			},
+		},
+	}
+	latestRes := api.QueryLatestEventsAndStateResponse{}
+	if err = r.QueryLatestEventsAndState(ctx, &latestReq, &latestRes); err != nil {
+		return err
+	}
+	if !latestRes.RoomExists {
+		return fmt.Errorf("room %q does not exist", req.RoomID)
+	}
+
+	// Now let's see if the user is in the room.
+	if len(latestRes.StateEvents) == 0 {
+		return fmt.Errorf("user %q is not a member of room %q", req.UserID, req.RoomID)
+	}
+	membership, err := latestRes.StateEvents[0].Membership()
+	if err != nil {
+		return fmt.Errorf("error getting membership: %w", err)
+	}
+	if membership != "join" {
+		// TODO: should be able to handle "invite" in this case too, if
+		// it's a case of kicking or banning or such
+		return fmt.Errorf("user %q is not joined to the room (membership is %q)", req.UserID, membership)
+	}
+
+	// Prepare the template for the leave event.
+	userID := req.UserID
+	eb := gomatrixserverlib.EventBuilder{
+		Type:     gomatrixserverlib.MRoomMember,
+		Sender:   userID,
+		StateKey: &userID,
+		RoomID:   req.RoomID,
+		Redacts:  "",
+	}
+	if err = eb.SetContent(map[string]interface{}{"membership": "leave"}); err != nil {
+		return fmt.Errorf("eb.SetContent: %w", err)
+	}
+	if err = eb.SetUnsigned(struct{}{}); err != nil {
+		return fmt.Errorf("eb.SetUnsigned: %w", err)
+	}
+
+	// We know that the user is in the room at this point so let's build
+	// a leave event.
+	// TODO: Check what happens if the room exists on the server
+	// but everyone has since left. I suspect it does the wrong thing.
+	buildRes := api.QueryLatestEventsAndStateResponse{}
+	event, err := common.BuildEvent(
+		ctx,        // the request context
+		&eb,        // the template join event
+		r.Cfg,      // the server configuration
+		time.Now(), // the event timestamp to use
+		r,          // the roomserver API to use
+		&buildRes,  // the query response
+	)
+	if err != nil {
+		return fmt.Errorf("common.BuildEvent: %w", err)
+	}
+
+	// Give our leave event to the roomserver input stream. The
+	// roomserver will process the membership change and notify
+	// downstream automatically.
+	inputReq := api.InputRoomEventsRequest{
+		InputRoomEvents: []api.InputRoomEvent{
+			{
+				Kind:         api.KindNew,
+				Event:        event.Headered(buildRes.RoomVersion),
+				AuthEventIDs: event.AuthEventIDs(),
+				SendAsServer: string(r.Cfg.Matrix.ServerName),
+			},
+		},
+	}
+	inputRes := api.InputRoomEventsResponse{}
+	if err = r.InputRoomEvents(ctx, &inputReq, &inputRes); err != nil {
+		return fmt.Errorf("r.InputRoomEvents: %w", err)
+	}
+
+	return nil
+}
+
+func (r *RoomserverInternalAPI) performRejectInvite(
+	ctx context.Context,
+	req *api.PerformLeaveRequest,
+	res *api.PerformLeaveResponse, // nolint:unparam
+	senderUser string,
+) error {
+	_, domain, err := gomatrixserverlib.SplitID('@', senderUser)
+	if err != nil {
+		return fmt.Errorf("user ID %q invalid: %w", senderUser, err)
+	}
+
+	// Ask the federation sender to perform a federated leave for us.
+	leaveReq := fsAPI.PerformLeaveRequest{
+		RoomID:      req.RoomID,
+		UserID:      req.UserID,
+		ServerNames: []gomatrixserverlib.ServerName{domain},
+	}
+	leaveRes := fsAPI.PerformLeaveResponse{}
+	if err := r.fsAPI.PerformLeave(ctx, &leaveReq, &leaveRes); err != nil {
+		return fmt.Errorf("fsAPI.PerformLeave: %w", err)
+	}
+
+	// If this succeeded then we can clean up the invite.
+	fmt.Println("REMOVE THE INVITE!")
+
+	return nil
+}
+
+func (r *RoomserverInternalAPI) isInvitePending(
+	ctx context.Context,
+	req *api.PerformLeaveRequest,
+	res *api.PerformLeaveResponse, // nolint:unparam
+) (string, error) {
+	// Look up the room NID for the supplied room ID.
+	roomNID, err := r.DB.RoomNID(ctx, req.RoomID)
+	if err != nil {
+		return "", fmt.Errorf("r.DB.RoomNID: %w", err)
+	}
+
+	// Look up the state key NID for the supplied user ID.
+	targetUserNIDs, err := r.DB.EventStateKeyNIDs(ctx, []string{req.UserID})
+	if err != nil {
+		return "", fmt.Errorf("r.DB.EventStateKeyNIDs: %w", err)
+	}
+	targetUserNID, targetUserFound := targetUserNIDs[req.UserID]
+	if !targetUserFound {
+		return "", fmt.Errorf("missing NID for user %q (%+v)", req.UserID, targetUserNIDs)
+	}
+
+	// Let's see if we have an event active for the user in the room. If
+	// we do then it will contain a server name that we can direct the
+	// send_leave to.
+	senderUserNIDs, err := r.DB.GetInvitesForUser(ctx, roomNID, targetUserNID)
+	if err != nil {
+		return "", fmt.Errorf("r.DB.GetInvitesForUser: %w", err)
+	}
+	fmt.Println("Sender user NIDs:", senderUserNIDs)
+
+	// Look up the user ID from the NID.
+	senderUsers, err := r.DB.EventStateKeys(ctx, senderUserNIDs)
+	if err != nil {
+		return "", fmt.Errorf("r.DB.EventStateKeys: %w", err)
+	}
+	fmt.Println("Sender users:", senderUsers)
+	senderUser, senderUserFound := senderUsers[senderUserNIDs[0]]
+	if !senderUserFound {
+		return "", fmt.Errorf("missing user for NID %d (%+v)", senderUserNIDs[0], senderUsers)
+	}
+
+	return senderUser, nil
+}

--- a/roomserver/internal/perform_leave.go
+++ b/roomserver/internal/perform_leave.go
@@ -155,9 +155,6 @@ func (r *RoomserverInternalAPI) performRejectInvite(
 		return fmt.Errorf("fsAPI.PerformLeave: %w", err)
 	}
 
-	// If this succeeded then we can clean up the invite.
-	fmt.Println("REMOVE THE INVITE!")
-
 	return nil
 }
 
@@ -189,14 +186,19 @@ func (r *RoomserverInternalAPI) isInvitePending(
 	if err != nil {
 		return "", fmt.Errorf("r.DB.GetInvitesForUser: %w", err)
 	}
-	fmt.Println("Sender user NIDs:", senderUserNIDs)
+	if len(senderUserNIDs) == 0 {
+		return "", fmt.Errorf("no senderUserNIDs")
+	}
 
 	// Look up the user ID from the NID.
 	senderUsers, err := r.DB.EventStateKeys(ctx, senderUserNIDs)
 	if err != nil {
 		return "", fmt.Errorf("r.DB.EventStateKeys: %w", err)
 	}
-	fmt.Println("Sender users:", senderUsers)
+	if len(senderUsers) == 0 {
+		return "", fmt.Errorf("no senderUsers")
+	}
+
 	senderUser, senderUserFound := senderUsers[senderUserNIDs[0]]
 	if !senderUserFound {
 		return "", fmt.Errorf("missing user for NID %d (%+v)", senderUserNIDs[0], senderUsers)

--- a/roomserver/internal/perform_leave.go
+++ b/roomserver/internal/perform_leave.go
@@ -70,7 +70,7 @@ func (r *RoomserverInternalAPI) performLeaveRoomByID(
 	if err != nil {
 		return fmt.Errorf("Error getting membership: %w", err)
 	}
-	if membership != "join" {
+	if membership != gomatrixserverlib.Join {
 		// TODO: should be able to handle "invite" in this case too, if
 		// it's a case of kicking or banning or such
 		return fmt.Errorf("User %q is not joined to the room (membership is %q)", req.UserID, membership)

--- a/roomserver/storage/sqlite3/event_state_keys_table.go
+++ b/roomserver/storage/sqlite3/event_state_keys_table.go
@@ -47,14 +47,14 @@ const selectEventStateKeyNIDSQL = `
 
 // Bulk lookup from string state key to numeric ID for that state key.
 // Takes an array of strings as the query parameter.
-const bulkSelectEventStateKeyNIDSQL = `
+const bulkSelectEventStateKeySQL = `
 	SELECT event_state_key, event_state_key_nid FROM roomserver_event_state_keys
 	  WHERE event_state_key IN ($1)
 `
 
 // Bulk lookup from numeric ID to string state key for that state key.
 // Takes an array of strings as the query parameter.
-const bulkSelectEventStateKeySQL = `
+const bulkSelectEventStateKeyNIDSQL = `
 	SELECT event_state_key, event_state_key_nid FROM roomserver_event_state_keys
 	  WHERE event_state_key_nid IN ($1)
 `
@@ -110,7 +110,7 @@ func (s *eventStateKeyStatements) bulkSelectEventStateKeyNID(
 	for k, v := range eventStateKeys {
 		iEventStateKeys[k] = v
 	}
-	selectOrig := strings.Replace(bulkSelectEventStateKeyNIDSQL, "($1)", common.QueryVariadic(len(eventStateKeys)), 1)
+	selectOrig := strings.Replace(bulkSelectEventStateKeySQL, "($1)", common.QueryVariadic(len(eventStateKeys)), 1)
 
 	rows, err := txn.QueryContext(ctx, selectOrig, iEventStateKeys...)
 	if err != nil {
@@ -136,7 +136,7 @@ func (s *eventStateKeyStatements) bulkSelectEventStateKey(
 	for k, v := range eventStateKeyNIDs {
 		iEventStateKeyNIDs[k] = v
 	}
-	selectOrig := strings.Replace(bulkSelectEventStateKeySQL, "($1)", common.QueryVariadic(len(eventStateKeyNIDs)), 1)
+	selectOrig := strings.Replace(bulkSelectEventStateKeyNIDSQL, "($1)", common.QueryVariadic(len(eventStateKeyNIDs)), 1)
 
 	rows, err := txn.QueryContext(ctx, selectOrig, iEventStateKeyNIDs...)
 	if err != nil {

--- a/roomserver/storage/sqlite3/event_state_keys_table.go
+++ b/roomserver/storage/sqlite3/event_state_keys_table.go
@@ -136,7 +136,7 @@ func (s *eventStateKeyStatements) bulkSelectEventStateKey(
 	for k, v := range eventStateKeyNIDs {
 		iEventStateKeyNIDs[k] = v
 	}
-	selectOrig := strings.Replace(bulkSelectEventStateKeyNIDSQL, "($1)", common.QueryVariadic(len(eventStateKeyNIDs)), 1)
+	selectOrig := strings.Replace(bulkSelectEventStateKeySQL, "($1)", common.QueryVariadic(len(eventStateKeyNIDs)), 1)
 
 	rows, err := txn.QueryContext(ctx, selectOrig, iEventStateKeyNIDs...)
 	if err != nil {


### PR DESCRIPTION
Moves the leave logic into the new perform workflow between the roomserver and the federationsender, and out of the client API.