### PR TITLE
Improve federation sender performance, implement backoff and blacklisting, fix up invites a bit

### DIFF
--- a/federationsender/consumers/roomserver.go
+++ b/federationsender/consumers/roomserver.go
@@ -211,7 +211,7 @@ func (s *OutputRoomEventConsumer) processInvite(oie api.OutputNewInviteEvent) er
 	// this for us in invite_room_state if it didn't already exist.
 	strippedState := []gomatrixserverlib.InviteV2StrippedState{}
 	if inviteRoomState := gjson.GetBytes(oie.Event.Unsigned(), "invite_room_state"); inviteRoomState.Exists() {
-		if err := json.Unmarshal([]byte(inviteRoomState.Raw), &strippedState); err != nil {
+		if err = json.Unmarshal([]byte(inviteRoomState.Raw), &strippedState); err != nil {
 			log.WithError(err).Warn("failed to extract invite_room_state from event unsigned")
 		}
 	}

--- a/federationsender/consumers/roomserver.go
+++ b/federationsender/consumers/roomserver.go
@@ -188,6 +188,25 @@ func (s *OutputRoomEventConsumer) processInvite(oie api.OutputNewInviteEvent) er
 		return nil
 	}
 
+	// Ignore invites that don't have state keys - they are invalid.
+	if oie.Event.StateKey() == nil {
+		return fmt.Errorf("event %q doesn't have state key", oie.Event.EventID())
+	}
+
+	// Don't try to handle events that are actually destined for us.
+	stateKey := *oie.Event.StateKey()
+	_, destination, err := gomatrixserverlib.SplitID('@', stateKey)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"event_id":  oie.Event.EventID(),
+			"state_key": stateKey,
+		}).Info("failed to split destination from state key")
+		return nil
+	}
+	if s.cfg.Matrix.ServerName == destination {
+		return nil
+	}
+
 	// Try to extract the room invite state. The roomserver will have stashed
 	// this for us in invite_room_state if it didn't already exist.
 	strippedState := []gomatrixserverlib.InviteV2StrippedState{}

--- a/federationsender/consumers/roomserver.go
+++ b/federationsender/consumers/roomserver.go
@@ -177,7 +177,7 @@ func (s *OutputRoomEventConsumer) processMessage(ore api.OutputNewRoomEvent) err
 
 	// Send the event.
 	return s.queues.SendEvent(
-		&ore.Event, gomatrixserverlib.ServerName(ore.SendAsServer), joinedHostsAtEvent,
+		ore.Event, gomatrixserverlib.ServerName(ore.SendAsServer), joinedHostsAtEvent,
 	)
 }
 
@@ -204,7 +204,7 @@ func (s *OutputRoomEventConsumer) processInvite(oie api.OutputNewInviteEvent) er
 	}
 
 	// Send the event.
-	return s.queues.SendInvite(&inviteReq)
+	return s.queues.SendInvite(inviteReq)
 }
 
 // joinedHostsAtEvent works out a list of matrix servers that were joined to

--- a/federationsender/consumers/roomserver.go
+++ b/federationsender/consumers/roomserver.go
@@ -177,7 +177,7 @@ func (s *OutputRoomEventConsumer) processMessage(ore api.OutputNewRoomEvent) err
 
 	// Send the event.
 	return s.queues.SendEvent(
-		ore.Event, gomatrixserverlib.ServerName(ore.SendAsServer), joinedHostsAtEvent,
+		&ore.Event, gomatrixserverlib.ServerName(ore.SendAsServer), joinedHostsAtEvent,
 	)
 }
 
@@ -204,7 +204,7 @@ func (s *OutputRoomEventConsumer) processInvite(oie api.OutputNewInviteEvent) er
 	}
 
 	// Send the event.
-	return s.queues.SendInvite(inviteReq)
+	return s.queues.SendInvite(&inviteReq)
 }
 
 // joinedHostsAtEvent works out a list of matrix servers that were joined to

--- a/federationsender/federationsender.go
+++ b/federationsender/federationsender.go
@@ -43,7 +43,9 @@ func SetupFederationSenderComponent(
 		logrus.WithError(err).Panic("failed to connect to federation sender db")
 	}
 
-	roomserverProducer := producers.NewRoomserverProducer(rsAPI, base.Cfg.Matrix.ServerName)
+	roomserverProducer := producers.NewRoomserverProducer(
+		rsAPI, base.Cfg.Matrix.ServerName, base.Cfg.Matrix.KeyID, base.Cfg.Matrix.PrivateKey,
+	)
 
 	statistics := &types.Statistics{}
 	queues := queue.NewOutgoingQueues(

--- a/federationsender/federationsender.go
+++ b/federationsender/federationsender.go
@@ -24,6 +24,7 @@ import (
 	"github.com/matrix-org/dendrite/federationsender/producers"
 	"github.com/matrix-org/dendrite/federationsender/queue"
 	"github.com/matrix-org/dendrite/federationsender/storage"
+	"github.com/matrix-org/dendrite/federationsender/types"
 	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/sirupsen/logrus"
@@ -44,7 +45,10 @@ func SetupFederationSenderComponent(
 
 	roomserverProducer := producers.NewRoomserverProducer(rsAPI, base.Cfg.Matrix.ServerName)
 
-	queues := queue.NewOutgoingQueues(base.Cfg.Matrix.ServerName, federation, roomserverProducer)
+	statistics := &types.Statistics{}
+	queues := queue.NewOutgoingQueues(
+		base.Cfg.Matrix.ServerName, federation, roomserverProducer, statistics,
+	)
 
 	rsConsumer := consumers.NewOutputRoomEventConsumer(
 		base.Cfg, base.KafkaConsumer, queues,
@@ -63,6 +67,7 @@ func SetupFederationSenderComponent(
 
 	queryAPI := internal.NewFederationSenderInternalAPI(
 		federationSenderDB, base.Cfg, roomserverProducer, federation, keyRing,
+		statistics,
 	)
 	queryAPI.SetupHTTP(http.DefaultServeMux)
 

--- a/federationsender/internal/api.go
+++ b/federationsender/internal/api.go
@@ -9,6 +9,7 @@ import (
 	"github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/dendrite/federationsender/producers"
 	"github.com/matrix-org/dendrite/federationsender/storage"
+	"github.com/matrix-org/dendrite/federationsender/types"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 )
@@ -18,6 +19,7 @@ type FederationSenderInternalAPI struct {
 	api.FederationSenderInternalAPI
 	db         storage.Database
 	cfg        *config.Dendrite
+	statistics *types.Statistics
 	producer   *producers.RoomserverProducer
 	federation *gomatrixserverlib.FederationClient
 	keyRing    *gomatrixserverlib.KeyRing
@@ -28,6 +30,7 @@ func NewFederationSenderInternalAPI(
 	producer *producers.RoomserverProducer,
 	federation *gomatrixserverlib.FederationClient,
 	keyRing *gomatrixserverlib.KeyRing,
+	statistics *types.Statistics,
 ) *FederationSenderInternalAPI {
 	return &FederationSenderInternalAPI{
 		db:         db,
@@ -35,6 +38,7 @@ func NewFederationSenderInternalAPI(
 		producer:   producer,
 		federation: federation,
 		keyRing:    keyRing,
+		statistics: statistics,
 	}
 }
 

--- a/federationsender/internal/perform.go
+++ b/federationsender/internal/perform.go
@@ -25,10 +25,12 @@ func (r *FederationSenderInternalAPI) PerformDirectoryLookup(
 		request.RoomAlias,
 	)
 	if err != nil {
+		r.statistics.ForServer(request.ServerName).Failure()
 		return err
 	}
 	response.RoomID = dir.RoomID
 	response.ServerNames = dir.Servers
+	r.statistics.ForServer(request.ServerName).Success()
 	return nil
 }
 
@@ -61,6 +63,7 @@ func (r *FederationSenderInternalAPI) PerformJoin(
 		)
 		if err != nil {
 			// TODO: Check if the user was not allowed to join the room.
+			r.statistics.ForServer(serverName).Failure()
 			return fmt.Errorf("r.federation.MakeJoin: %w", err)
 		}
 
@@ -112,6 +115,7 @@ func (r *FederationSenderInternalAPI) PerformJoin(
 		)
 		if err != nil {
 			logrus.WithError(err).Warnf("r.federation.SendJoin failed")
+			r.statistics.ForServer(serverName).Failure()
 			continue
 		}
 
@@ -137,6 +141,7 @@ func (r *FederationSenderInternalAPI) PerformJoin(
 		}
 
 		// We're all good.
+		r.statistics.ForServer(serverName).Success()
 		return nil
 	}
 
@@ -170,6 +175,7 @@ func (r *FederationSenderInternalAPI) PerformLeave(
 		if err != nil {
 			// TODO: Check if the user was not allowed to leave the room.
 			logrus.WithError(err).Warnf("r.federation.MakeLeave failed")
+			r.statistics.ForServer(serverName).Failure()
 			continue
 		}
 
@@ -221,9 +227,11 @@ func (r *FederationSenderInternalAPI) PerformLeave(
 		)
 		if err != nil {
 			logrus.WithError(err).Warnf("r.federation.SendLeave failed")
+			r.statistics.ForServer(serverName).Failure()
 			continue
 		}
 
+		r.statistics.ForServer(serverName).Success()
 		return nil
 	}
 

--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -124,9 +124,11 @@ func (oq *destinationQueue) sendEvent(ev *gomatrixserverlib.HeaderedEvent) {
 		// If the destination is blacklisted then drop the event.
 		return
 	}
+	fmt.Println("Queuing event", ev.EventID())
 	oq.runningMutex.Lock()
 	oq.pendingPDUs = append(oq.pendingPDUs, ev)
 	oq.runningMutex.Unlock()
+	fmt.Println("Queued event", ev.EventID())
 	oq.wake()
 }
 
@@ -204,8 +206,8 @@ func (oq *destinationQueue) backgroundSend() {
 			// the pending events and EDUs.
 			if transaction {
 				oq.runningMutex.Lock()
-				oq.pendingPDUs = oq.pendingPDUs[:0]
-				oq.pendingEDUs = oq.pendingEDUs[:0]
+				oq.pendingPDUs = oq.pendingPDUs[len(pendingPDUs):]
+				oq.pendingEDUs = oq.pendingEDUs[len(pendingEDUs):]
 				oq.runningMutex.Unlock()
 			}
 		}
@@ -224,7 +226,7 @@ func (oq *destinationQueue) backgroundSend() {
 			// the pending invites.
 			if invites {
 				oq.runningMutex.Lock()
-				oq.pendingInvites = oq.pendingInvites[:0]
+				oq.pendingInvites = oq.pendingInvites[len(pendingInvites):]
 				oq.runningMutex.Unlock()
 			}
 		}

--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -28,33 +29,91 @@ import (
 	"go.uber.org/atomic"
 )
 
+const (
+	// How many times should we tolerate consecutive failures before we
+	// just blacklist the host altogether? Bear in mind that the backoff
+	// is exponential, so the max time here to attempt is 2**failures.
+	FailuresUntilBlacklist = 16
+)
+
 // destinationQueue is a queue of events for a single destination.
 // It is responsible for sending the events to the destination and
 // ensures that only one request is in flight to a given destination
 // at a time.
 type destinationQueue struct {
-	rsProducer  *producers.RoomserverProducer
-	client      *gomatrixserverlib.FederationClient
-	origin      gomatrixserverlib.ServerName
-	destination gomatrixserverlib.ServerName
-	running     atomic.Bool
-	// The running mutex protects sentCounter, lastTransactionIDs and
-	// pendingEvents, pendingEDUs.
-	runningMutex       sync.Mutex
-	sentCounter        int
-	lastTransactionIDs []gomatrixserverlib.TransactionID
-	pendingEvents      []*gomatrixserverlib.HeaderedEvent
-	pendingEDUs        []*gomatrixserverlib.EDU
-	pendingInvites     []*gomatrixserverlib.InviteV2Request
+	rsProducer         *producers.RoomserverProducer        //
+	client             *gomatrixserverlib.FederationClient  //
+	origin             gomatrixserverlib.ServerName         //
+	destination        gomatrixserverlib.ServerName         //
+	running            atomic.Bool                          // is the queue worke running?
+	blacklisted        atomic.Bool                          // is the remote side dead?
+	backoffUntil       atomic.Value                         // time.Time
+	idleCounter        atomic.Uint32                        // how many ticks have we done nothing?
+	failCounter        atomic.Uint32                        // how many times have we failed?
+	sentCounter        atomic.Uint32                        // how many times have we succeeded?
+	runningMutex       sync.RWMutex                         // protects the below
+	lastTransactionIDs []gomatrixserverlib.TransactionID    // protected by runningMutex
+	pendingPDUs        []*gomatrixserverlib.HeaderedEvent   // protected by runningMutex
+	pendingEDUs        []*gomatrixserverlib.EDU             // protected by runningMutex
+	pendingInvites     []*gomatrixserverlib.InviteV2Request // protected by runningMutex
+}
+
+// Backoff marks a failure and works out when to back off until. It
+// returns true if the worker should give up altogether because of
+// too many consecutive failures.
+func (oq *destinationQueue) backoff() bool {
+	// Increase the fail counter.
+	failCounter := oq.failCounter.Load()
+	failCounter++
+	oq.failCounter.Store(failCounter)
+
+	// Check that we haven't failed more times than is acceptable.
+	if failCounter < FailuresUntilBlacklist {
+		// We're still under the threshold so work out the exponential
+		// backoff based on how many times we have failed already. The
+		// worker goroutine will wait until this time before processing
+		// anything from the queue.
+		backoffSeconds := math.Exp2(float64(failCounter))
+		oq.backoffUntil.Store(
+			time.Now().Add(time.Second * time.Duration(backoffSeconds)),
+		)
+		return false // Don't give up yet.
+	} else {
+		// We've exceeded the maximum amount of times we're willing
+		// to back off, which is probably in the region of hours by
+		// now. Just give up - clear the queues and reset the queue
+		// back to its default state.
+		oq.blacklisted.Store(true)
+		oq.runningMutex.Lock()
+		oq.pendingPDUs = nil
+		oq.pendingEDUs = nil
+		oq.pendingInvites = nil
+		oq.runningMutex.Unlock()
+		return true // Give up.
+	}
+}
+
+func (oq *destinationQueue) success() {
+	// Reset the idle and fail counters.
+	oq.idleCounter.Store(0)
+	oq.failCounter.Store(0)
+
+	// Increase the sent counter.
+	sentCounter := oq.failCounter.Load()
+	oq.sentCounter.Store(sentCounter + 1)
 }
 
 // Send event adds the event to the pending queue for the destination.
 // If the queue is empty then it starts a background goroutine to
 // start sending events to that destination.
 func (oq *destinationQueue) sendEvent(ev *gomatrixserverlib.HeaderedEvent) {
+	if oq.blacklisted.Load() {
+		// If the destination is blacklisted then drop the event.
+		return
+	}
 	oq.runningMutex.Lock()
-	defer oq.runningMutex.Unlock()
-	oq.pendingEvents = append(oq.pendingEvents, ev)
+	oq.pendingPDUs = append(oq.pendingPDUs, ev)
+	oq.runningMutex.Unlock()
 	if !oq.running.Load() {
 		go oq.backgroundSend()
 	}
@@ -64,9 +123,13 @@ func (oq *destinationQueue) sendEvent(ev *gomatrixserverlib.HeaderedEvent) {
 // If the queue is empty then it starts a background goroutine to
 // start sending events to that destination.
 func (oq *destinationQueue) sendEDU(e *gomatrixserverlib.EDU) {
+	if oq.blacklisted.Load() {
+		// If the destination is blacklisted then drop the event.
+		return
+	}
 	oq.runningMutex.Lock()
-	defer oq.runningMutex.Unlock()
 	oq.pendingEDUs = append(oq.pendingEDUs, e)
+	oq.runningMutex.Unlock()
 	if !oq.running.Load() {
 		go oq.backgroundSend()
 	}
@@ -76,9 +139,13 @@ func (oq *destinationQueue) sendEDU(e *gomatrixserverlib.EDU) {
 // destination. If the queue is empty then it starts a background
 // goroutine to start sending events to that destination.
 func (oq *destinationQueue) sendInvite(ev *gomatrixserverlib.InviteV2Request) {
+	if oq.blacklisted.Load() {
+		// If the destination is blacklisted then drop the event.
+		return
+	}
 	oq.runningMutex.Lock()
-	defer oq.runningMutex.Unlock()
 	oq.pendingInvites = append(oq.pendingInvites, ev)
+	oq.runningMutex.Unlock()
 	if !oq.running.Load() {
 		go oq.backgroundSend()
 	}
@@ -86,39 +153,104 @@ func (oq *destinationQueue) sendInvite(ev *gomatrixserverlib.InviteV2Request) {
 
 // backgroundSend is the worker goroutine for sending events.
 func (oq *destinationQueue) backgroundSend() {
+	// Mark the worker as running for its lifetime.
 	oq.running.Store(true)
 	defer oq.running.Store(false)
 
 	for {
-		transaction, invites := oq.nextTransaction(), oq.nextInvites()
-		if !transaction && !invites {
-			// If the queue is empty then stop processing for this destination.
-			// TODO: Remove this destination from the queue map.
-			return
+		// Wait for our backoff timer.
+		backoffUntil := time.Now()
+		if b, ok := oq.backoffUntil.Load().(time.Time); ok {
+			backoffUntil = b
+		}
+		if backoffUntil.After(time.Now()) {
+			<-time.After(time.Until(backoffUntil))
 		}
 
-		// TODO: handle retries.
-		// TODO: blacklist uncooperative servers.
+		// Retrieve any waiting things.
+		oq.runningMutex.RLock()
+		pendingPDUs, pendingEDUs := oq.pendingPDUs, oq.pendingEDUs
+		pendingInvites := oq.pendingInvites
+		idleCounter, sentCounter := oq.idleCounter.Load(), oq.sentCounter.Load()
+		oq.runningMutex.RUnlock()
+
+		// If we have pending PDUs or EDUs then construct a transaction.
+		if len(pendingPDUs) > 0 || len(pendingEDUs) > 0 {
+			// Try sending the next transaction and see what happens.
+			transaction, terr := oq.nextTransaction(pendingPDUs, pendingEDUs, sentCounter)
+			if terr != nil {
+				// We failed to send the transaction.
+				if giveUp := oq.backoff(); giveUp {
+					// It's been suggested that we should give up because
+					// the backoff has exceeded a maximum allowable value.
+					return
+				}
+				continue
+			}
+
+			// If we successfully sent the transaction then clear out
+			// the pending events and EDUs.
+			if transaction {
+				oq.success()
+				oq.runningMutex.Lock()
+				oq.pendingPDUs = oq.pendingPDUs[:0]
+				oq.pendingEDUs = oq.pendingEDUs[:0]
+				oq.runningMutex.Unlock()
+			}
+		}
+
+		// Try sending the next invite and see what happens.
+		if len(pendingInvites) > 0 {
+			invites, ierr := oq.nextInvites(pendingInvites)
+			if ierr != nil {
+				// We failed to send the transaction so increase the
+				// backoff and give it another go shortly.
+				oq.backoffUntil.Store(time.Until(backoffUntil) * 2)
+				continue
+			}
+
+			// If we successfully sent the invites then clear out
+			// the pending invites.
+			if invites {
+				oq.success()
+				oq.runningMutex.Lock()
+				oq.pendingInvites = oq.pendingInvites[:0]
+				oq.runningMutex.Unlock()
+			}
+		}
+
+		// At this point, if we did everything successfully,
+		// we can reset the backoff duration.
+		if idleCounter >= 5 {
+			// If this worker has been idle for a while then stop
+			// running it, otherwise the goroutine will just tick
+			// endlessly. It'll get automatically restarted when
+			// a new event needs to be sent.
+			return
+		} else {
+			// Otherwise, add to the ticker counter and ask the
+			// next iteration to wait for a second (to stop CPU
+			// spinning).
+			oq.idleCounter.Store(idleCounter + 1)
+			oq.backoffUntil.Store(time.Now().Add(time.Second))
+		}
 	}
 }
 
 // nextTransaction creates a new transaction from the pending event
 // queue and sends it. Returns true if a transaction was sent or
 // false otherwise.
-func (oq *destinationQueue) nextTransaction() bool {
-	oq.runningMutex.Lock()
-	defer oq.runningMutex.Unlock()
-
-	if len(oq.pendingEvents) == 0 && len(oq.pendingEDUs) == 0 {
-		return false
-	}
-
+func (oq *destinationQueue) nextTransaction(
+	pendingPDUs []*gomatrixserverlib.HeaderedEvent,
+	pendingEDUs []*gomatrixserverlib.EDU,
+	sentCounter uint32,
+) (bool, error) {
 	t := gomatrixserverlib.Transaction{
 		PDUs: []json.RawMessage{},
 		EDUs: []gomatrixserverlib.EDU{},
 	}
 	now := gomatrixserverlib.AsTimestamp(time.Now())
-	t.TransactionID = gomatrixserverlib.TransactionID(fmt.Sprintf("%d-%d", now, oq.sentCounter))
+	t.TransactionID = gomatrixserverlib.TransactionID(fmt.Sprintf("%d-%d", now, sentCounter))
 	t.Origin = oq.origin
 	t.Destination = oq.destination
 	t.OriginServerTS = now
@@ -129,19 +261,15 @@ func (oq *destinationQueue) nextTransaction() bool {
 
 	oq.lastTransactionIDs = []gomatrixserverlib.TransactionID{t.TransactionID}
 
-	for _, pdu := range oq.pendingEvents {
+	for _, pdu := range pendingPDUs {
 		// Append the JSON of the event, since this is a json.RawMessage type in the
 		// gomatrixserverlib.Transaction struct
 		t.PDUs = append(t.PDUs, (*pdu).JSON())
 	}
-	oq.pendingEvents = nil
-	oq.sentCounter += len(t.PDUs)
 
-	for _, edu := range oq.pendingEDUs {
+	for _, edu := range pendingEDUs {
 		t.EDUs = append(t.EDUs, *edu)
 	}
-	oq.pendingEDUs = nil
-	oq.sentCounter += len(t.EDUs)
 
 	util.GetLogger(context.TODO()).Infof("Sending transaction %q containing %d PDUs, %d EDUs", t.TransactionID, len(t.PDUs), len(t.EDUs))
 
@@ -151,22 +279,18 @@ func (oq *destinationQueue) nextTransaction() bool {
 			"destination": oq.destination,
 			log.ErrorKey:  err,
 		}).Info("problem sending transaction")
+		return false, err
 	}
 
-	return true
+	return true, nil
 }
 
 // nextInvite takes pending invite events from the queue and sends
 // them. Returns true if a transaction was sent or false otherwise.
-func (oq *destinationQueue) nextInvites() bool {
-	oq.runningMutex.Lock()
-	defer oq.runningMutex.Unlock()
-
-	if len(oq.pendingInvites) == 0 {
-		return false
-	}
-
-	for _, inviteReq := range oq.pendingInvites {
+func (oq *destinationQueue) nextInvites(
+	pendingInvites []*gomatrixserverlib.InviteV2Request,
+) (bool, error) {
+	for _, inviteReq := range pendingInvites {
 		ev, roomVersion := inviteReq.Event(), inviteReq.RoomVersion()
 
 		log.WithFields(log.Fields{
@@ -186,7 +310,7 @@ func (oq *destinationQueue) nextInvites() bool {
 				"state_key":   ev.StateKey(),
 				"destination": oq.destination,
 			}).WithError(err).Error("failed to send invite")
-			continue
+			return false, err
 		}
 
 		if _, err = oq.rsProducer.SendInviteResponse(
@@ -199,10 +323,9 @@ func (oq *destinationQueue) nextInvites() bool {
 				"state_key":   ev.StateKey(),
 				"destination": oq.destination,
 			}).WithError(err).Error("failed to return signed invite to roomserver")
+			return false, err
 		}
 	}
 
-	oq.pendingInvites = nil
-
-	return true
+	return true, nil
 }

--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -94,8 +94,11 @@ func (oq *destinationQueue) sendInvite(ev *gomatrixserverlib.InviteV2Request) {
 // backgroundSend is the worker goroutine for sending events.
 // nolint:gocyclo
 func (oq *destinationQueue) backgroundSend() {
-	// Mark the worker as running for its lifetime.
-	oq.running.Store(true)
+	// Check if a worker is already running, and if it isn't, then
+	// mark it as started.
+	if !oq.running.CAS(false, true) {
+		return
+	}
 	defer oq.running.Store(false)
 
 	for {

--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -50,7 +50,7 @@ func NewOutgoingQueues(
 
 // SendEvent sends an event to the destinations
 func (oqs *OutgoingQueues) SendEvent(
-	ev gomatrixserverlib.HeaderedEvent, origin gomatrixserverlib.ServerName,
+	ev *gomatrixserverlib.HeaderedEvent, origin gomatrixserverlib.ServerName,
 	destinations []gomatrixserverlib.ServerName,
 ) error {
 	if origin != oqs.origin {
@@ -84,7 +84,7 @@ func (oqs *OutgoingQueues) SendEvent(
 			oqs.queuesMutex.Unlock()
 		}
 
-		go oq.sendEvent(&ev)
+		go oq.sendEvent(ev)
 	}
 
 	return nil
@@ -92,7 +92,7 @@ func (oqs *OutgoingQueues) SendEvent(
 
 // SendEvent sends an event to the destinations
 func (oqs *OutgoingQueues) SendInvite(
-	inviteReq gomatrixserverlib.InviteV2Request,
+	inviteReq *gomatrixserverlib.InviteV2Request,
 ) error {
 	ev := inviteReq.Event()
 	stateKey := ev.StateKey()
@@ -131,7 +131,7 @@ func (oqs *OutgoingQueues) SendInvite(
 		oqs.queuesMutex.Unlock()
 	}
 
-	go oq.sendInvite(&inviteReq)
+	go oq.sendInvite(inviteReq)
 
 	return nil
 }

--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -86,7 +86,7 @@ func (oqs *OutgoingQueues) SendEvent(
 	}
 
 	// Remove our own server from the list of destinations.
-	destinations = filterDestinations(oqs.origin, destinations)
+	destinations = filterAndDedupeDests(oqs.origin, destinations)
 
 	log.WithFields(log.Fields{
 		"destinations": destinations, "event": ev.EventID(),
@@ -145,7 +145,7 @@ func (oqs *OutgoingQueues) SendEDU(
 	}
 
 	// Remove our own server from the list of destinations.
-	destinations = filterDestinations(oqs.origin, destinations)
+	destinations = filterAndDedupeDests(oqs.origin, destinations)
 
 	if len(destinations) > 0 {
 		log.WithFields(log.Fields{
@@ -160,9 +160,9 @@ func (oqs *OutgoingQueues) SendEDU(
 	return nil
 }
 
-// filterDestinations removes our own server from the list of destinations.
-// Otherwise we could end up trying to talk to ourselves.
-func filterDestinations(origin gomatrixserverlib.ServerName, destinations []gomatrixserverlib.ServerName) (
+// filterAndDedupeDests removes our own server from the list of destinations
+// and deduplicates any servers in the list that may appear more than once.
+func filterAndDedupeDests(origin gomatrixserverlib.ServerName, destinations []gomatrixserverlib.ServerName) (
 	result []gomatrixserverlib.ServerName,
 ) {
 	strs := make([]string, len(destinations))

--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -117,7 +117,8 @@ func (oqs *OutgoingQueues) SendInvite(
 	}
 
 	log.WithFields(log.Fields{
-		"event_id": ev.EventID(),
+		"event_id":    ev.EventID(),
+		"server_name": destination,
 	}).Info("Sending invite")
 
 	oqs.queuesMutex.RLock()

--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -89,7 +89,7 @@ func (oqs *OutgoingQueues) SendEvent(
 			oqs.queuesMutex.Unlock()
 		}
 
-		oq.sendEvent(ev)
+		go oq.sendEvent(ev)
 	}
 
 	return nil
@@ -138,7 +138,7 @@ func (oqs *OutgoingQueues) SendInvite(
 		oqs.queuesMutex.Unlock()
 	}
 
-	oq.sendInvite(inviteReq)
+	go oq.sendInvite(inviteReq)
 
 	return nil
 }
@@ -182,7 +182,7 @@ func (oqs *OutgoingQueues) SendEDU(
 			oqs.queuesMutex.Unlock()
 		}
 
-		oq.sendEDU(e)
+		go oq.sendEDU(e)
 	}
 
 	return nil

--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -50,7 +50,7 @@ func NewOutgoingQueues(
 
 // SendEvent sends an event to the destinations
 func (oqs *OutgoingQueues) SendEvent(
-	ev *gomatrixserverlib.HeaderedEvent, origin gomatrixserverlib.ServerName,
+	ev gomatrixserverlib.HeaderedEvent, origin gomatrixserverlib.ServerName,
 	destinations []gomatrixserverlib.ServerName,
 ) error {
 	if origin != oqs.origin {
@@ -84,7 +84,7 @@ func (oqs *OutgoingQueues) SendEvent(
 			oqs.queuesMutex.Unlock()
 		}
 
-		go oq.sendEvent(ev)
+		go oq.sendEvent(&ev)
 	}
 
 	return nil
@@ -92,7 +92,7 @@ func (oqs *OutgoingQueues) SendEvent(
 
 // SendEvent sends an event to the destinations
 func (oqs *OutgoingQueues) SendInvite(
-	inviteReq *gomatrixserverlib.InviteV2Request,
+	inviteReq gomatrixserverlib.InviteV2Request,
 ) error {
 	ev := inviteReq.Event()
 	stateKey := ev.StateKey()
@@ -131,7 +131,7 @@ func (oqs *OutgoingQueues) SendInvite(
 		oqs.queuesMutex.Unlock()
 	}
 
-	go oq.sendInvite(inviteReq)
+	go oq.sendInvite(&inviteReq)
 
 	return nil
 }

--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -88,7 +88,7 @@ func (oqs *OutgoingQueues) SendEvent(
 			oqs.queuesMutex.Unlock()
 		}
 
-		go oq.sendEvent(ev)
+		oq.sendEvent(ev)
 	}
 
 	return nil
@@ -137,7 +137,7 @@ func (oqs *OutgoingQueues) SendInvite(
 		oqs.queuesMutex.Unlock()
 	}
 
-	go oq.sendInvite(inviteReq)
+	oq.sendInvite(inviteReq)
 
 	return nil
 }
@@ -181,7 +181,7 @@ func (oqs *OutgoingQueues) SendEDU(
 			oqs.queuesMutex.Unlock()
 		}
 
-		go oq.sendEDU(e)
+		oq.sendEDU(e)
 	}
 
 	return nil

--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -21,6 +21,7 @@ import (
 	"github.com/matrix-org/dendrite/federationsender/producers"
 	"github.com/matrix-org/dendrite/federationsender/types"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/util"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -189,13 +190,18 @@ func (oqs *OutgoingQueues) SendEDU(
 
 // filterDestinations removes our own server from the list of destinations.
 // Otherwise we could end up trying to talk to ourselves.
-func filterDestinations(origin gomatrixserverlib.ServerName, destinations []gomatrixserverlib.ServerName) []gomatrixserverlib.ServerName {
-	var result []gomatrixserverlib.ServerName
-	for _, destination := range destinations {
-		if destination == origin {
+func filterDestinations(origin gomatrixserverlib.ServerName, destinations []gomatrixserverlib.ServerName) (
+	result []gomatrixserverlib.ServerName,
+) {
+	strs := make([]string, len(destinations))
+	for i, d := range destinations {
+		strs[i] = string(d)
+	}
+	for _, destination := range util.UniqueStrings(strs) {
+		if gomatrixserverlib.ServerName(destination) == origin {
 			continue
 		}
-		result = append(result, destination)
+		result = append(result, gomatrixserverlib.ServerName(destination))
 	}
 	return result
 }

--- a/federationsender/types/statistics.go
+++ b/federationsender/types/statistics.go
@@ -63,8 +63,7 @@ type ServerStatistics struct {
 // failure counters. If a host was blacklisted at this point then
 // we will unblacklist it.
 func (s *ServerStatistics) Success() {
-	sentCounter := s.failCounter.Load()
-	s.successCounter.Store(sentCounter + 1)
+	s.successCounter.Add(1)
 	s.failCounter.Store(0)
 	s.blacklisted.Store(false)
 }
@@ -75,9 +74,7 @@ func (s *ServerStatistics) Success() {
 // as blacklisted.
 func (s *ServerStatistics) Failure() bool {
 	// Increase the fail counter.
-	failCounter := s.failCounter.Load()
-	failCounter++
-	s.failCounter.Store(failCounter)
+	failCounter := s.failCounter.Add(1)
 
 	// Check that we haven't failed more times than is acceptable.
 	if failCounter >= FailuresUntilBlacklist {
@@ -100,8 +97,8 @@ func (s *ServerStatistics) Failure() bool {
 	return false
 }
 
-// WaitUntil returns both a bool stating whether to wait, and then
-// if true, a duration to wait for.
+// BackoffDuration returns both a bool stating whether to wait,
+// and then if true, a duration to wait for.
 func (s *ServerStatistics) BackoffDuration() (bool, time.Duration) {
 	backoff, until := false, time.Second
 	if b, ok := s.backoffUntil.Load().(time.Time); ok {

--- a/federationsender/types/statistics.go
+++ b/federationsender/types/statistics.go
@@ -1,0 +1,125 @@
+package types
+
+import (
+	"math"
+	"sync"
+	"time"
+
+	"github.com/matrix-org/gomatrixserverlib"
+	"go.uber.org/atomic"
+)
+
+const (
+	// How many times should we tolerate consecutive failures before we
+	// just blacklist the host altogether? Bear in mind that the backoff
+	// is exponential, so the max time here to attempt is 2**failures.
+	FailuresUntilBlacklist = 16 // 16 equates to roughly 18 hours.
+)
+
+// Statistics contains information about all of the remote federated
+// hosts that we have interacted with. It is basically a threadsafe
+// wrapper.
+type Statistics struct {
+	servers map[gomatrixserverlib.ServerName]*ServerStatistics
+	mutex   sync.RWMutex
+}
+
+// ForServer returns server statistics for the given server name. If it
+// does not exist, it will create empty statistics and return those.
+func (s *Statistics) ForServer(serverName gomatrixserverlib.ServerName) *ServerStatistics {
+	// If the map hasn't been initialised yet then do that.
+	if s.servers == nil {
+		s.mutex.Lock()
+		s.servers = make(map[gomatrixserverlib.ServerName]*ServerStatistics)
+		s.mutex.Unlock()
+	}
+	// Look up if we have statistics for this server already.
+	s.mutex.RLock()
+	server, found := s.servers[serverName]
+	s.mutex.RUnlock()
+	// If we don't, then make one.
+	if !found {
+		s.mutex.Lock()
+		server = &ServerStatistics{}
+		s.servers[serverName] = server
+		s.mutex.Unlock()
+	}
+	return server
+}
+
+// ServerStatistics contains information about our interactions with a
+// remote federated host, e.g. how many times we were successful, how
+// many times we failed etc. It also manages the backoff time and black-
+// listing a remote host if it remains uncooperative.
+type ServerStatistics struct {
+	blacklisted    atomic.Bool   // is the remote side dead?
+	backoffUntil   atomic.Value  // time.Time to wait until before sending requests
+	failCounter    atomic.Uint32 // how many times have we failed?
+	successCounter atomic.Uint32 // how many times have we succeeded?
+}
+
+// Success updates the server statistics with a new successful
+// attempt, which increases the sent counter and resets the idle and
+// failure counters. If a host was blacklisted at this point then
+// we will unblacklist it.
+func (s *ServerStatistics) Success() {
+	sentCounter := s.failCounter.Load()
+	s.successCounter.Store(sentCounter + 1)
+	s.failCounter.Store(0)
+	s.blacklisted.Store(false)
+}
+
+// Failure marks a failure and works out when to backoff until. It
+// returns true if the worker should give up altogether because of
+// too many consecutive failures. At this point the host is marked
+// as blacklisted.
+func (s *ServerStatistics) Failure() bool {
+	// Increase the fail counter.
+	failCounter := s.failCounter.Load()
+	failCounter++
+	s.failCounter.Store(failCounter)
+
+	// Check that we haven't failed more times than is acceptable.
+	if failCounter >= FailuresUntilBlacklist {
+		// We've exceeded the maximum amount of times we're willing
+		// to back off, which is probably in the region of hours by
+		// now. Mark the host as blacklisted and tell the caller to
+		// give up.
+		s.blacklisted.Store(true)
+		return true
+	}
+
+	// We're still under the threshold so work out the exponential
+	// backoff based on how many times we have failed already. The
+	// worker goroutine will wait until this time before processing
+	// anything from the queue.
+	backoffSeconds := time.Second * time.Duration(math.Exp2(float64(failCounter)))
+	s.backoffUntil.Store(
+		time.Now().Add(backoffSeconds),
+	)
+	return false
+}
+
+// WaitUntil returns both a bool stating whether to wait, and then
+// if true, a duration to wait for.
+func (s *ServerStatistics) BackoffDuration() (bool, time.Duration) {
+	backoff, until := false, time.Second
+	if b, ok := s.backoffUntil.Load().(time.Time); ok {
+		if b.After(time.Now()) {
+			backoff, until = true, time.Until(b)
+		}
+	}
+	return backoff, until
+}
+
+// Blacklisted returns true if the server is blacklisted and false
+// otherwise.
+func (s *ServerStatistics) Blacklisted() bool {
+	return s.blacklisted.Load()
+}
+
+// SuccessCount returns the number of successful requests. This is
+// usually useful in constructing transaction IDs.
+func (s *ServerStatistics) SuccessCount() uint32 {
+	return s.successCounter.Load()
+}

--- a/roomserver/internal/input.go
+++ b/roomserver/internal/input.go
@@ -54,27 +54,15 @@ func (r *RoomserverInternalAPI) InputRoomEvents(
 	ctx context.Context,
 	request *api.InputRoomEventsRequest,
 	response *api.InputRoomEventsResponse,
-) error {
+) (err error) {
 	// We lock as processRoomEvent can only be called once at a time
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 	for i := range request.InputInviteEvents {
-		if event, err := processInviteEvent(ctx, r.DB, r, request.InputInviteEvents[i]); err != nil {
+		if err = processInviteEvent(ctx, r.DB, r, request.InputInviteEvents[i]); err != nil {
 			return err
-		} else {
-			// If the room is one that we know about then append the invite
-			// event to the list of room events to process.
-			if nid, err := r.DB.RoomNIDExcludingStubs(ctx, event.RoomID()); err == nil && nid > 0 {
-				request.InputRoomEvents = append(request.InputRoomEvents, api.InputRoomEvent{
-					Kind:         api.KindNew,
-					Event:        *event,
-					AuthEventIDs: event.AuthEventIDs(),
-					SendAsServer: string(r.Cfg.Matrix.ServerName),
-				})
-			}
 		}
 	}
-	var err error
 	for i := range request.InputRoomEvents {
 		if response.EventID, err = processRoomEvent(ctx, r.DB, r, request.InputRoomEvents[i]); err != nil {
 			return err

--- a/roomserver/internal/input.go
+++ b/roomserver/internal/input.go
@@ -69,6 +69,7 @@ func (r *RoomserverInternalAPI) InputRoomEvents(
 					Kind:         api.KindNew,
 					Event:        *event,
 					AuthEventIDs: event.AuthEventIDs(),
+					SendAsServer: string(r.Cfg.Matrix.ServerName),
 				})
 			}
 		}

--- a/roomserver/internal/input.go
+++ b/roomserver/internal/input.go
@@ -18,7 +18,6 @@ package internal
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/Shopify/sarama"
 	"github.com/matrix-org/dendrite/roomserver/api"
@@ -68,7 +67,6 @@ func (r *RoomserverInternalAPI) InputRoomEvents(
 		// loopback room event containing the invite, for local invites.
 		// If it does, we should process it with the room events below.
 		if loopback != nil {
-			fmt.Println("LOOPING BACK", string(loopback.Event.JSON()))
 			request.InputRoomEvents = append(request.InputRoomEvents, *loopback)
 		}
 	}

--- a/roomserver/internal/input_events.go
+++ b/roomserver/internal/input_events.go
@@ -134,9 +134,9 @@ func processInviteEvent(
 	db storage.Database,
 	ow OutputRoomEventWriter,
 	input api.InputInviteEvent,
-) (returned *gomatrixserverlib.HeaderedEvent, err error) {
+) (err error) {
 	if input.Event.StateKey() == nil {
-		return nil, fmt.Errorf("invite must be a state event")
+		return fmt.Errorf("invite must be a state event")
 	}
 
 	roomID := input.Event.RoomID()
@@ -151,7 +151,7 @@ func processInviteEvent(
 
 	updater, err := db.MembershipUpdater(ctx, roomID, targetUserID, input.RoomVersion)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	succeeded := false
 	defer func() {
@@ -189,7 +189,7 @@ func processInviteEvent(
 		// For now we will implement option 2. Since in the abesence of a retry
 		// mechanism it will be equivalent to option 1, and we don't have a
 		// signalling mechanism to implement option 3.
-		return nil, nil
+		return nil
 	}
 
 	event := input.Event.Unwrap()
@@ -199,7 +199,7 @@ func processInviteEvent(
 		// most likely to be if the event came in over federation) then use
 		// that.
 		if err = event.SetUnsignedField("invite_room_state", input.InviteRoomState); err != nil {
-			return nil, err
+			return err
 		}
 	} else {
 		// There's no invite room state, so let's have a go at building it
@@ -208,22 +208,22 @@ func processInviteEvent(
 		// the invite room state, if we don't then we just fail quietly.
 		if irs, ierr := buildInviteStrippedState(ctx, db, input); ierr == nil {
 			if err = event.SetUnsignedField("invite_room_state", irs); err != nil {
-				return nil, err
+				return err
 			}
 		}
 	}
 
 	outputUpdates, err := updateToInviteMembership(updater, &event, nil, input.Event.RoomVersion)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if err = ow.WriteOutputEvents(roomID, outputUpdates); err != nil {
-		return nil, err
+		return err
 	}
 
 	succeeded = true
-	return &input.Event, nil
+	return nil
 }
 
 func buildInviteStrippedState(

--- a/roomserver/internal/input_events.go
+++ b/roomserver/internal/input_events.go
@@ -134,9 +134,9 @@ func processInviteEvent(
 	db storage.Database,
 	ow OutputRoomEventWriter,
 	input api.InputInviteEvent,
-) (err error) {
+) (returned *gomatrixserverlib.HeaderedEvent, err error) {
 	if input.Event.StateKey() == nil {
-		return fmt.Errorf("invite must be a state event")
+		return nil, fmt.Errorf("invite must be a state event")
 	}
 
 	roomID := input.Event.RoomID()
@@ -151,7 +151,7 @@ func processInviteEvent(
 
 	updater, err := db.MembershipUpdater(ctx, roomID, targetUserID, input.RoomVersion)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	succeeded := false
 	defer func() {
@@ -189,7 +189,7 @@ func processInviteEvent(
 		// For now we will implement option 2. Since in the abesence of a retry
 		// mechanism it will be equivalent to option 1, and we don't have a
 		// signalling mechanism to implement option 3.
-		return nil
+		return nil, nil
 	}
 
 	event := input.Event.Unwrap()
@@ -199,7 +199,7 @@ func processInviteEvent(
 		// most likely to be if the event came in over federation) then use
 		// that.
 		if err = event.SetUnsignedField("invite_room_state", input.InviteRoomState); err != nil {
-			return err
+			return nil, err
 		}
 	} else {
 		// There's no invite room state, so let's have a go at building it
@@ -208,22 +208,22 @@ func processInviteEvent(
 		// the invite room state, if we don't then we just fail quietly.
 		if irs, ierr := buildInviteStrippedState(ctx, db, input); ierr == nil {
 			if err = event.SetUnsignedField("invite_room_state", irs); err != nil {
-				return err
+				return nil, err
 			}
 		}
 	}
 
 	outputUpdates, err := updateToInviteMembership(updater, &event, nil, input.Event.RoomVersion)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if err = ow.WriteOutputEvents(roomID, outputUpdates); err != nil {
-		return err
+		return nil, err
 	}
 
 	succeeded = true
-	return nil
+	return &input.Event, nil
 }
 
 func buildInviteStrippedState(


### PR DESCRIPTION
This PR aims to dramatically improve the performance of the federation sender by improving the parallelism and reducing mutex contention in the federation sender.

It also implements exponential backoff for servers that return errors, and blacklisting for servers that continuously return errors.

It also fixes some stuff related to invites, because apparently that was upsetting CI.