### PR TITLE
Prefer /state_ids when missing state across federation

### DIFF
--- a/clientapi/producers/roomserver.go
+++ b/clientapi/producers/roomserver.go
@@ -54,7 +54,7 @@ func (c *RoomserverProducer) SendEvents(
 // SendEventWithState writes an event with KindNew to the roomserver input log
 // with the state at the event as KindOutlier before it.
 func (c *RoomserverProducer) SendEventWithState(
-	ctx context.Context, state gomatrixserverlib.RespState, event gomatrixserverlib.HeaderedEvent,
+	ctx context.Context, state *gomatrixserverlib.RespState, event gomatrixserverlib.HeaderedEvent,
 ) error {
 	outliers, err := state.Events()
 	if err != nil {

--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -306,6 +306,9 @@ func (t *txnReq) processEventWithMissingState(e gomatrixserverlib.Event, roomVer
 		// Fallback to /state
 		util.GetLogger(t.context).WithError(err).Warn("processEventWithMissingState failed to /state_ids, falling back to /state")
 		respState, err = t.lookupMissingStateViaState(e, roomVersion)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Check that the event is allowed by the state.
@@ -403,6 +406,11 @@ func (t *txnReq) lookupMissingStateViaStateIDs(e gomatrixserverlib.Event, roomVe
 			haveEventMap[event.EventID()] = &h
 		}
 	}
+	return t.createRespStateFromStateIDs(stateIDs, haveEventMap)
+}
+
+func (t *txnReq) createRespStateFromStateIDs(stateIDs gomatrixserverlib.RespStateIDs, haveEventMap map[string]*gomatrixserverlib.HeaderedEvent) (
+	*gomatrixserverlib.RespState, error) {
 	// create a RespState response using the response to /state_ids as a guide
 	respState := gomatrixserverlib.RespState{
 		AuthEvents:  make([]gomatrixserverlib.Event, len(stateIDs.AuthEventIDs)),

--- a/roomserver/api/query.go
+++ b/roomserver/api/query.go
@@ -29,7 +29,7 @@ type QueryLatestEventsAndStateRequest struct {
 	// The room ID to query the latest events for.
 	RoomID string `json:"room_id"`
 	// The state key tuples to fetch from the room current state.
-	// If this list is empty or nil then no state events are returned.
+	// If this list is empty or nil then *ALL* current state events are returned.
 	StateToFetch []gomatrixserverlib.StateKeyTuple `json:"state_to_fetch"`
 }
 


### PR DESCRIPTION
Rather than calling `/state` every time we are missing a `prev_event`, instead:
 - Get all the state we DO know about.
 - Call `/state_ids` on the new event.
 - Fill in all the event IDs we do know, and hit `/event` for each missing event.
 - Fake a `RespState` response and validate it.

If any of these steps fail, fallback to `/state`.