### PR TITLE
Don't run membership updater functions for leaves

### DIFF
--- a/roomserver/internal/input_membership.go
+++ b/roomserver/internal/input_membership.go
@@ -102,7 +102,7 @@ func updateMembership(
 	}
 	if oldMembership == newMembership || newMembership == gomatrixserverlib.Leave {
 		// If the membership is the same then nothing changed and we can return
-		// immediately, unless it's a Join update (e.g. profile update).
+		// immediately. Likewise if it's a leave - there's nothing more to do.
 		return updates, nil
 	}
 

--- a/roomserver/internal/input_membership.go
+++ b/roomserver/internal/input_membership.go
@@ -100,7 +100,7 @@ func updateMembership(
 			return nil, err
 		}
 	}
-	if oldMembership == newMembership && newMembership != gomatrixserverlib.Join {
+	if oldMembership == newMembership || newMembership == gomatrixserverlib.Leave {
 		// If the membership is the same then nothing changed and we can return
 		// immediately, unless it's a Join update (e.g. profile update).
 		return updates, nil


### PR DESCRIPTION
For leaves, the `add` variable is `nil` which causes the downstream functions to panic. This should therefore fix #1016.