### PR TITLE
Add PPROFLISTEN

### DIFF
--- a/cmd/dendrite-room-server/main.go
+++ b/cmd/dendrite-room-server/main.go
@@ -15,8 +15,6 @@
 package main
 
 import (
-	_ "net/http/pprof"
-
 	"github.com/matrix-org/dendrite/common/basecomponent"
 	"github.com/matrix-org/dendrite/common/keydb"
 	"github.com/matrix-org/dendrite/roomserver"

--- a/common/basecomponent/base.go
+++ b/common/basecomponent/base.go
@@ -42,6 +42,8 @@ import (
 	federationSenderAPI "github.com/matrix-org/dendrite/federationsender/api"
 	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/sirupsen/logrus"
+
+	_ "net/http/pprof"
 )
 
 // BaseDendrite is a base for creating new instances of dendrite. It parses
@@ -71,6 +73,7 @@ const HTTPClientTimeout = time.Second * 30
 func NewBaseDendrite(cfg *config.Dendrite, componentName string) *BaseDendrite {
 	common.SetupStdLogging()
 	common.SetupHookLogging(cfg.Logging, componentName)
+	common.SetupPprof()
 
 	closer, err := cfg.SetupTracing("Dendrite" + componentName)
 	if err != nil {

--- a/common/log.go
+++ b/common/log.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -77,6 +78,17 @@ func callerPrettyfier(f *runtime.Frame) (string, string) {
 	filename := fmt.Sprintf(" [%s:%d]", f.File, f.Line)
 
 	return funcname, filename
+}
+
+// SetupPprof starts a pprof listener. We use the DefaultServeMux here because it is
+// simplest, and it gives us the freedom to run pprof on a separate port.
+func SetupPprof() {
+	if hostPort := os.Getenv("PPROFLISTEN"); hostPort != "" {
+		logrus.Print("Starting pprof on", hostPort)
+		go func() {
+			logrus.WithError(http.ListenAndServe(hostPort, nil)).Print("Failed to setup pprof listener")
+		}()
+	}
 }
 
 // SetupStdLogging configures the logging format to standard output. Typically, it is called when the config is not yet loaded.

--- a/common/log.go
+++ b/common/log.go
@@ -84,7 +84,7 @@ func callerPrettyfier(f *runtime.Frame) (string, string) {
 // simplest, and it gives us the freedom to run pprof on a separate port.
 func SetupPprof() {
 	if hostPort := os.Getenv("PPROFLISTEN"); hostPort != "" {
-		logrus.Warn("Starting pprof on", hostPort)
+		logrus.Warn("Starting pprof on ", hostPort)
 		go func() {
 			logrus.WithError(http.ListenAndServe(hostPort, nil)).Error("Failed to setup pprof listener")
 		}()

--- a/common/log.go
+++ b/common/log.go
@@ -84,9 +84,9 @@ func callerPrettyfier(f *runtime.Frame) (string, string) {
 // simplest, and it gives us the freedom to run pprof on a separate port.
 func SetupPprof() {
 	if hostPort := os.Getenv("PPROFLISTEN"); hostPort != "" {
-		logrus.Print("Starting pprof on", hostPort)
+		logrus.Warn("Starting pprof on", hostPort)
 		go func() {
-			logrus.WithError(http.ListenAndServe(hostPort, nil)).Print("Failed to setup pprof listener")
+			logrus.WithError(http.ListenAndServe(hostPort, nil)).Error("Failed to setup pprof listener")
 		}()
 	}
 }


### PR DESCRIPTION
This adds a `PPROFLISTEN` env var to the base component so that we can easily enable pprof on a different port for any of the components and/or the monolith.