### PR TITLE
Enforce `mediaIDRegex` to be only valid `mediaIDCharacters`

### DIFF
--- a/mediaapi/routing/download.go
+++ b/mediaapi/routing/download.go
@@ -43,7 +43,7 @@ import (
 const mediaIDCharacters = "A-Za-z0-9_=-"
 
 // Note: unfortunately regex.MustCompile() cannot be assigned to a const
-var mediaIDRegex = regexp.MustCompile("[" + mediaIDCharacters + "]+")
+var mediaIDRegex = regexp.MustCompile("^[" + mediaIDCharacters + "]+$")
 
 // downloadRequest metadata included in or derivable from a download or thumbnail request
 // https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-media-r0-download-servername-mediaid


### PR DESCRIPTION
Enforce `mediaIDRegex` to be only valid `mediaIDCharacters`

Error messages indicate that:
> mediaId must be a non-empty string using only characters in `mediaIDCharacters`

However the regex used only required that some characters in the filename match
the restriction, not that the entire filename does. This commit ensures that
the filename must entirely fullfill the `mediaIDCharacters` restriction.

Signed-off-by: Sid Karunaratne <sid@karunaratne.net>


### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] I have added any new tests that need to pass to `testfile` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/CONTRIBUTING.md#sign-off)
