### PR TITLE
syncapi: Rename and split out tokens

### DIFF
--- a/syncapi/consumers/clientapi.go
+++ b/syncapi/consumers/clientapi.go
@@ -90,7 +90,7 @@ func (s *OutputClientDataConsumer) onMessage(msg *sarama.ConsumerMessage) error 
 		}).Panicf("could not save account data")
 	}
 
-	s.notifier.OnNewEvent(nil, "", []string{string(msg.Key)}, types.PaginationToken{PDUPosition: pduPos})
+	s.notifier.OnNewEvent(nil, "", []string{string(msg.Key)}, types.NewStreamToken(pduPos, 0))
 
 	return nil
 }

--- a/syncapi/consumers/eduserver.go
+++ b/syncapi/consumers/eduserver.go
@@ -65,9 +65,7 @@ func (s *OutputTypingEventConsumer) Start() error {
 	s.db.SetTypingTimeoutCallback(func(userID, roomID string, latestSyncPosition int64) {
 		s.notifier.OnNewEvent(
 			nil, roomID, nil,
-			types.PaginationToken{
-				EDUTypingPosition: types.StreamPosition(latestSyncPosition),
-			},
+			types.NewStreamToken(0, types.StreamPosition(latestSyncPosition)),
 		)
 	})
 
@@ -96,6 +94,6 @@ func (s *OutputTypingEventConsumer) onMessage(msg *sarama.ConsumerMessage) error
 		typingPos = s.db.RemoveTypingUser(typingEvent.UserID, typingEvent.RoomID)
 	}
 
-	s.notifier.OnNewEvent(nil, output.Event.RoomID, nil, types.PaginationToken{EDUTypingPosition: typingPos})
+	s.notifier.OnNewEvent(nil, output.Event.RoomID, nil, types.NewStreamToken(0, typingPos))
 	return nil
 }

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -146,7 +146,7 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 		}).Panicf("roomserver output log: write event failure")
 		return nil
 	}
-	s.notifier.OnNewEvent(&ev, "", nil, types.PaginationToken{PDUPosition: pduPos})
+	s.notifier.OnNewEvent(&ev, "", nil, types.NewStreamToken(pduPos, 0))
 
 	return nil
 }
@@ -164,7 +164,7 @@ func (s *OutputRoomEventConsumer) onNewInviteEvent(
 		}).Panicf("roomserver output log: write invite failure")
 		return nil
 	}
-	s.notifier.OnNewEvent(&msg.Event, "", nil, types.PaginationToken{PDUPosition: pduPos})
+	s.notifier.OnNewEvent(&msg.Event, "", nil, types.NewStreamToken(pduPos, 0))
 	return nil
 }
 

--- a/syncapi/routing/messages.go
+++ b/syncapi/routing/messages.go
@@ -38,8 +38,8 @@ type messagesReq struct {
 	federation       *gomatrixserverlib.FederationClient
 	cfg              *config.Dendrite
 	roomID           string
-	from             *types.PaginationToken
-	to               *types.PaginationToken
+	from             *types.TopologyToken
+	to               *types.TopologyToken
 	wasToProvided    bool
 	limit            int
 	backwardOrdering bool
@@ -66,7 +66,7 @@ func OnIncomingMessagesRequest(
 
 	// Extract parameters from the request's URL.
 	// Pagination tokens.
-	from, err := types.NewPaginationTokenFromString(req.URL.Query().Get("from"))
+	from, err := types.NewTopologyTokenFromString(req.URL.Query().Get("from"))
 	if err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
@@ -88,10 +88,10 @@ func OnIncomingMessagesRequest(
 
 	// Pagination tokens. To is optional, and its default value depends on the
 	// direction ("b" or "f").
-	var to *types.PaginationToken
+	var to types.TopologyToken
 	wasToProvided := true
 	if s := req.URL.Query().Get("to"); len(s) > 0 {
-		to, err = types.NewPaginationTokenFromString(s)
+		to, err = types.NewTopologyTokenFromString(s)
 		if err != nil {
 			return util.JSONResponse{
 				Code: http.StatusBadRequest,
@@ -139,8 +139,8 @@ func OnIncomingMessagesRequest(
 		federation:       federation,
 		cfg:              cfg,
 		roomID:           roomID,
-		from:             from,
-		to:               to,
+		from:             &from,
+		to:               &to,
 		wasToProvided:    wasToProvided,
 		limit:            limit,
 		backwardOrdering: backwardOrdering,
@@ -178,7 +178,7 @@ func OnIncomingMessagesRequest(
 // remote homeserver.
 func (r *messagesReq) retrieveEvents() (
 	clientEvents []gomatrixserverlib.ClientEvent, start,
-	end *types.PaginationToken, err error,
+	end types.TopologyToken, err error,
 ) {
 	// Retrieve the events from the local database.
 	streamEvents, err := r.db.GetEventsInRange(
@@ -206,7 +206,7 @@ func (r *messagesReq) retrieveEvents() (
 
 	// If we didn't get any event, we don't need to proceed any further.
 	if len(events) == 0 {
-		return []gomatrixserverlib.ClientEvent{}, r.from, r.to, nil
+		return []gomatrixserverlib.ClientEvent{}, *r.from, *r.to, nil
 	}
 
 	// Sort the events to ensure we send them in the right order.
@@ -246,12 +246,8 @@ func (r *messagesReq) retrieveEvents() (
 	}
 	// Generate pagination tokens to send to the client using the positions
 	// retrieved previously.
-	start = types.NewPaginationTokenFromTypeAndPosition(
-		types.PaginationTokenTypeTopology, startPos, startStreamPos,
-	)
-	end = types.NewPaginationTokenFromTypeAndPosition(
-		types.PaginationTokenTypeTopology, endPos, endStreamPos,
-	)
+	start = types.NewTopologyToken(startPos, startStreamPos)
+	end = types.NewTopologyToken(endPos, endStreamPos)
 
 	if r.backwardOrdering {
 		// A stream/topological position is a cursor located between two events.
@@ -259,14 +255,7 @@ func (r *messagesReq) retrieveEvents() (
 		// we consider a left to right chronological order), tokens need to refer
 		// to them by the event on their left, therefore we need to decrement the
 		// end position we send in the response if we're going backward.
-		end.PDUPosition--
-		end.EDUTypingPosition += 1000
-	}
-
-	// The lowest token value is 1, therefore we need to manually set it to that
-	// value if we're below it.
-	if end.PDUPosition < types.StreamPosition(1) {
-		end.PDUPosition = types.StreamPosition(1)
+		end.Decrement()
 	}
 
 	return clientEvents, start, end, err
@@ -317,11 +306,11 @@ func (r *messagesReq) handleNonEmptyEventsSlice(streamEvents []types.StreamEvent
 				// The condition in the SQL query is a strict "greater than" so
 				// we need to check against to-1.
 				streamPos := types.StreamPosition(streamEvents[len(streamEvents)-1].StreamPosition)
-				isSetLargeEnough = (r.to.PDUPosition-1 == streamPos)
+				isSetLargeEnough = (r.to.PDUPosition()-1 == streamPos)
 			}
 		} else {
 			streamPos := types.StreamPosition(streamEvents[0].StreamPosition)
-			isSetLargeEnough = (r.from.PDUPosition-1 == streamPos)
+			isSetLargeEnough = (r.from.PDUPosition()-1 == streamPos)
 		}
 	}
 
@@ -424,18 +413,17 @@ func (r *messagesReq) backfill(roomID string, fromEventIDs []string, limit int) 
 func setToDefault(
 	ctx context.Context, db storage.Database, backwardOrdering bool,
 	roomID string,
-) (to *types.PaginationToken, err error) {
+) (to types.TopologyToken, err error) {
 	if backwardOrdering {
 		// go 1 earlier than the first event so we correctly fetch the earliest event
-		to = types.NewPaginationTokenFromTypeAndPosition(types.PaginationTokenTypeTopology, 0, 0)
+		to = types.NewTopologyToken(0, 0)
 	} else {
-		var pos, stream types.StreamPosition
-		pos, stream, err = db.MaxTopologicalPosition(ctx, roomID)
+		var depth, stream types.StreamPosition
+		depth, stream, err = db.MaxTopologicalPosition(ctx, roomID)
 		if err != nil {
 			return
 		}
-
-		to = types.NewPaginationTokenFromTypeAndPosition(types.PaginationTokenTypeTopology, pos, stream)
+		to = types.NewTopologyToken(depth, stream)
 	}
 
 	return

--- a/syncapi/routing/messages.go
+++ b/syncapi/routing/messages.go
@@ -191,14 +191,10 @@ func (r *messagesReq) retrieveEvents() (
 	var streamEvents []types.StreamEvent
 	if r.fromStream != nil {
 		toStream := r.to.StreamToken()
-		util.GetLogger(r.ctx).Infof("quack fromStream positions %v", r.fromStream.Positions)
-		util.GetLogger(r.ctx).Infof("quack toStream positions %v", toStream.Positions)
 		streamEvents, err = r.db.GetEventsInStreamingRange(
 			r.ctx, r.fromStream, &toStream, r.roomID, r.limit, r.backwardOrdering,
 		)
 	} else {
-		util.GetLogger(r.ctx).Infof("quack from positions %v", r.from.Positions)
-		util.GetLogger(r.ctx).Infof("quack to positions %v", r.to.Positions)
 		streamEvents, err = r.db.GetEventsInTopologicalRange(
 			r.ctx, r.from, r.to, r.roomID, r.limit, r.backwardOrdering,
 		)

--- a/syncapi/storage/interface.go
+++ b/syncapi/storage/interface.go
@@ -50,13 +50,13 @@ type Database interface {
 	// Returns an error if there was an issue with the retrieval.
 	GetStateEventsForRoom(ctx context.Context, roomID string, stateFilterPart *gomatrixserverlib.StateFilter) (stateEvents []gomatrixserverlib.HeaderedEvent, err error)
 	// SyncPosition returns the latest positions for syncing.
-	SyncPosition(ctx context.Context) (types.PaginationToken, error)
+	SyncPosition(ctx context.Context) (types.StreamingToken, error)
 	// IncrementalSync returns all the data needed in order to create an incremental
 	// sync response for the given user. Events returned will include any client
 	// transaction IDs associated with the given device. These transaction IDs come
 	// from when the device sent the event via an API that included a transaction
 	// ID.
-	IncrementalSync(ctx context.Context, device authtypes.Device, fromPos, toPos types.PaginationToken, numRecentEventsPerRoom int, wantFullState bool) (*types.Response, error)
+	IncrementalSync(ctx context.Context, device authtypes.Device, fromPos, toPos types.StreamingToken, numRecentEventsPerRoom int, wantFullState bool) (*types.Response, error)
 	// CompleteSync returns a complete /sync API response for the given user.
 	CompleteSync(ctx context.Context, userID string, numRecentEventsPerRoom int) (*types.Response, error)
 	// GetAccountDataInRange returns all account data for a given user inserted or
@@ -88,9 +88,10 @@ type Database interface {
 	// RemoveTypingUser removes a typing user from the typing cache.
 	// Returns the newly calculated sync position for typing notifications.
 	RemoveTypingUser(userID, roomID string) types.StreamPosition
-	// GetEventsInRange retrieves all of the events on a given ordering using the
-	// given extremities and limit.
-	GetEventsInRange(ctx context.Context, from, to *types.PaginationToken, roomID string, limit int, backwardOrdering bool) (events []types.StreamEvent, err error)
+	// GetEventsInStreamingRange retrieves all of the events on a given ordering using the given extremities and limit.
+	GetEventsInStreamingRange(ctx context.Context, from, to *types.StreamingToken, roomID string, limit int, backwardOrdering bool) (events []types.StreamEvent, err error)
+	// GetEventsInTopologicalRange retrieves all of the events on a given ordering using the given extremities and limit.
+	GetEventsInTopologicalRange(ctx context.Context, from, to *types.TopologyToken, roomID string, limit int, backwardOrdering bool) (events []types.StreamEvent, err error)
 	// EventPositionInTopology returns the depth and stream position of the given event.
 	EventPositionInTopology(ctx context.Context, eventID string) (depth types.StreamPosition, stream types.StreamPosition, err error)
 	// EventsAtTopologicalPosition returns all of the events matching a given

--- a/syncapi/storage/postgres/syncserver.go
+++ b/syncapi/storage/postgres/syncserver.go
@@ -228,45 +228,47 @@ func (d *SyncServerDatasource) GetStateEventsForRoom(
 	return
 }
 
-func (d *SyncServerDatasource) GetEventsInRange(
+func (d *SyncServerDatasource) GetEventsInTopologicalRange(
 	ctx context.Context,
-	from, to *types.PaginationToken,
+	from, to *types.TopologyToken,
 	roomID string, limit int,
 	backwardOrdering bool,
 ) (events []types.StreamEvent, err error) {
-	// If the pagination token's type is types.PaginationTokenTypeTopology, the
-	// events must be retrieved from the rooms' topology table rather than the
-	// table contaning the syncapi server's whole stream of events.
-	if from.Type == types.PaginationTokenTypeTopology {
-		// Determine the backward and forward limit, i.e. the upper and lower
-		// limits to the selection in the room's topology, from the direction.
-		var backwardLimit, forwardLimit, forwardMicroLimit types.StreamPosition
-		if backwardOrdering {
-			// Backward ordering is antichronological (latest event to oldest
-			// one).
-			backwardLimit = to.PDUPosition
-			forwardLimit = from.PDUPosition
-			forwardMicroLimit = from.EDUTypingPosition
-		} else {
-			// Forward ordering is chronological (oldest event to latest one).
-			backwardLimit = from.PDUPosition
-			forwardLimit = to.PDUPosition
-		}
+	// Determine the backward and forward limit, i.e. the upper and lower
+	// limits to the selection in the room's topology, from the direction.
+	var backwardLimit, forwardLimit, forwardMicroLimit types.StreamPosition
+	if backwardOrdering {
+		// Backward ordering is antichronological (latest event to oldest
+		// one).
+		backwardLimit = to.Depth()
+		forwardLimit = from.Depth()
+		forwardMicroLimit = from.PDUPosition()
+	} else {
+		// Forward ordering is chronological (oldest event to latest one).
+		backwardLimit = from.Depth()
+		forwardLimit = to.Depth()
+	}
 
-		// Select the event IDs from the defined range.
-		var eIDs []string
-		eIDs, err = d.topology.selectEventIDsInRange(
-			ctx, roomID, backwardLimit, forwardLimit, forwardMicroLimit, limit, !backwardOrdering,
-		)
-		if err != nil {
-			return
-		}
-
-		// Retrieve the events' contents using their IDs.
-		events, err = d.events.selectEvents(ctx, nil, eIDs)
+	// Select the event IDs from the defined range.
+	var eIDs []string
+	eIDs, err = d.topology.selectEventIDsInRange(
+		ctx, roomID, backwardLimit, forwardLimit, forwardMicroLimit, limit, !backwardOrdering,
+	)
+	if err != nil {
 		return
 	}
 
+	// Retrieve the events' contents using their IDs.
+	events, err = d.events.selectEvents(ctx, nil, eIDs)
+	return
+}
+
+func (d *SyncServerDatasource) GetEventsInStreamingRange(
+	ctx context.Context,
+	from, to *types.StreamingToken,
+	roomID string, limit int,
+	backwardOrdering bool,
+) (events []types.StreamEvent, err error) {
 	// If the pagination token's type is types.PaginationTokenTypeStream, the
 	// events must be retrieved from the table contaning the syncapi server's
 	// whole stream of events.
@@ -274,14 +276,14 @@ func (d *SyncServerDatasource) GetEventsInRange(
 	if backwardOrdering {
 		// When using backward ordering, we want the most recent events first.
 		if events, err = d.events.selectRecentEvents(
-			ctx, nil, roomID, to.PDUPosition, from.PDUPosition, limit, false, false,
+			ctx, nil, roomID, to.PDUPosition(), from.PDUPosition(), limit, false, false,
 		); err != nil {
 			return
 		}
 	} else {
 		// When using forward ordering, we want the least recent events first.
 		if events, err = d.events.selectEarlyEvents(
-			ctx, nil, roomID, from.PDUPosition, to.PDUPosition, limit,
+			ctx, nil, roomID, from.PDUPosition(), to.PDUPosition(), limit,
 		); err != nil {
 			return
 		}
@@ -290,7 +292,7 @@ func (d *SyncServerDatasource) GetEventsInRange(
 	return
 }
 
-func (d *SyncServerDatasource) SyncPosition(ctx context.Context) (types.PaginationToken, error) {
+func (d *SyncServerDatasource) SyncPosition(ctx context.Context) (types.StreamingToken, error) {
 	return d.syncPositionTx(ctx, nil)
 }
 
@@ -353,7 +355,7 @@ func (d *SyncServerDatasource) syncStreamPositionTx(
 
 func (d *SyncServerDatasource) syncPositionTx(
 	ctx context.Context, txn *sql.Tx,
-) (sp types.PaginationToken, err error) {
+) (sp types.StreamingToken, err error) {
 
 	maxEventID, err := d.events.selectMaxEventID(ctx, txn)
 	if err != nil {
@@ -373,8 +375,7 @@ func (d *SyncServerDatasource) syncPositionTx(
 	if maxInviteID > maxEventID {
 		maxEventID = maxInviteID
 	}
-	sp.PDUPosition = types.StreamPosition(maxEventID)
-	sp.EDUTypingPosition = types.StreamPosition(d.eduCache.GetLatestSyncPosition())
+	sp = types.NewStreamToken(types.StreamPosition(maxEventID), types.StreamPosition(d.eduCache.GetLatestSyncPosition()))
 	return
 }
 
@@ -439,7 +440,7 @@ func (d *SyncServerDatasource) addPDUDeltaToResponse(
 // addTypingDeltaToResponse adds all typing notifications to a sync response
 // since the specified position.
 func (d *SyncServerDatasource) addTypingDeltaToResponse(
-	since types.PaginationToken,
+	since types.StreamingToken,
 	joinedRoomIDs []string,
 	res *types.Response,
 ) error {
@@ -448,7 +449,7 @@ func (d *SyncServerDatasource) addTypingDeltaToResponse(
 	var err error
 	for _, roomID := range joinedRoomIDs {
 		if typingUsers, updated := d.eduCache.GetTypingUsersIfUpdatedAfter(
-			roomID, int64(since.EDUTypingPosition),
+			roomID, int64(since.EDUPosition()),
 		); updated {
 			ev := gomatrixserverlib.ClientEvent{
 				Type: gomatrixserverlib.MTyping,
@@ -473,12 +474,12 @@ func (d *SyncServerDatasource) addTypingDeltaToResponse(
 // addEDUDeltaToResponse adds updates for EDUs of each type since fromPos if
 // the positions of that type are not equal in fromPos and toPos.
 func (d *SyncServerDatasource) addEDUDeltaToResponse(
-	fromPos, toPos types.PaginationToken,
+	fromPos, toPos types.StreamingToken,
 	joinedRoomIDs []string,
 	res *types.Response,
 ) (err error) {
 
-	if fromPos.EDUTypingPosition != toPos.EDUTypingPosition {
+	if fromPos.EDUPosition() != toPos.EDUPosition() {
 		err = d.addTypingDeltaToResponse(
 			fromPos, joinedRoomIDs, res,
 		)
@@ -490,7 +491,7 @@ func (d *SyncServerDatasource) addEDUDeltaToResponse(
 func (d *SyncServerDatasource) IncrementalSync(
 	ctx context.Context,
 	device authtypes.Device,
-	fromPos, toPos types.PaginationToken,
+	fromPos, toPos types.StreamingToken,
 	numRecentEventsPerRoom int,
 	wantFullState bool,
 ) (*types.Response, error) {
@@ -499,9 +500,9 @@ func (d *SyncServerDatasource) IncrementalSync(
 
 	var joinedRoomIDs []string
 	var err error
-	if fromPos.PDUPosition != toPos.PDUPosition || wantFullState {
+	if fromPos.PDUPosition() != toPos.PDUPosition() || wantFullState {
 		joinedRoomIDs, err = d.addPDUDeltaToResponse(
-			ctx, device, fromPos.PDUPosition, toPos.PDUPosition, numRecentEventsPerRoom, wantFullState, res,
+			ctx, device, fromPos.PDUPosition(), toPos.PDUPosition(), numRecentEventsPerRoom, wantFullState, res,
 		)
 	} else {
 		joinedRoomIDs, err = d.roomstate.selectRoomIDsWithMembership(
@@ -530,7 +531,7 @@ func (d *SyncServerDatasource) getResponseWithPDUsForCompleteSync(
 	numRecentEventsPerRoom int,
 ) (
 	res *types.Response,
-	toPos types.PaginationToken,
+	toPos types.StreamingToken,
 	joinedRoomIDs []string,
 	err error,
 ) {
@@ -577,7 +578,7 @@ func (d *SyncServerDatasource) getResponseWithPDUsForCompleteSync(
 		//       See: https://github.com/matrix-org/synapse/blob/v0.19.3/synapse/handlers/sync.py#L316
 		var recentStreamEvents []types.StreamEvent
 		recentStreamEvents, err = d.events.selectRecentEvents(
-			ctx, txn, roomID, types.StreamPosition(0), toPos.PDUPosition,
+			ctx, txn, roomID, types.StreamPosition(0), toPos.PDUPosition(),
 			numRecentEventsPerRoom, true, true,
 		)
 		if err != nil {
@@ -599,16 +600,15 @@ func (d *SyncServerDatasource) getResponseWithPDUsForCompleteSync(
 		recentEvents := d.StreamEventsToEvents(nil, recentStreamEvents)
 		stateEvents = removeDuplicates(stateEvents, recentEvents)
 		jr := types.NewJoinResponse()
-		jr.Timeline.PrevBatch = types.NewPaginationTokenFromTypeAndPosition(
-			types.PaginationTokenTypeTopology, backwardTopologyPos, backwardStreamPos,
-		).String()
+		prevBatch := types.NewTopologyToken(backwardTopologyPos, backwardStreamPos)
+		jr.Timeline.PrevBatch = prevBatch.String()
 		jr.Timeline.Events = gomatrixserverlib.HeaderedToClientEvents(recentEvents, gomatrixserverlib.FormatSync)
 		jr.Timeline.Limited = true
 		jr.State.Events = gomatrixserverlib.HeaderedToClientEvents(stateEvents, gomatrixserverlib.FormatSync)
 		res.Rooms.Join[roomID] = *jr
 	}
 
-	if err = d.addInvitesToResponse(ctx, txn, userID, 0, toPos.PDUPosition, res); err != nil {
+	if err = d.addInvitesToResponse(ctx, txn, userID, 0, toPos.PDUPosition(), res); err != nil {
 		return
 	}
 
@@ -628,7 +628,7 @@ func (d *SyncServerDatasource) CompleteSync(
 
 	// Use a zero value SyncPosition for fromPos so all EDU states are added.
 	err = d.addEDUDeltaToResponse(
-		types.PaginationToken{}, toPos, joinedRoomIDs, res,
+		types.NewStreamToken(0, 0), toPos, joinedRoomIDs, res,
 	)
 	if err != nil {
 		return nil, err
@@ -757,14 +757,15 @@ func (d *SyncServerDatasource) addRoomDeltaToResponse(
 	recentEvents := d.StreamEventsToEvents(device, recentStreamEvents)
 	delta.stateEvents = removeDuplicates(delta.stateEvents, recentEvents) // roll back
 	backwardTopologyPos, backwardStreamPos := d.getBackwardTopologyPos(ctx, recentStreamEvents)
+	prevBatch := types.NewTopologyToken(
+		backwardTopologyPos, backwardStreamPos,
+	)
 
 	switch delta.membership {
 	case gomatrixserverlib.Join:
 		jr := types.NewJoinResponse()
 
-		jr.Timeline.PrevBatch = types.NewPaginationTokenFromTypeAndPosition(
-			types.PaginationTokenTypeTopology, backwardTopologyPos, backwardStreamPos,
-		).String()
+		jr.Timeline.PrevBatch = prevBatch.String()
 		jr.Timeline.Events = gomatrixserverlib.HeaderedToClientEvents(recentEvents, gomatrixserverlib.FormatSync)
 		jr.Timeline.Limited = false // TODO: if len(events) >= numRecents + 1 and then set limited:true
 		jr.State.Events = gomatrixserverlib.HeaderedToClientEvents(delta.stateEvents, gomatrixserverlib.FormatSync)
@@ -775,9 +776,7 @@ func (d *SyncServerDatasource) addRoomDeltaToResponse(
 		// TODO: recentEvents may contain events that this user is not allowed to see because they are
 		//       no longer in the room.
 		lr := types.NewLeaveResponse()
-		lr.Timeline.PrevBatch = types.NewPaginationTokenFromTypeAndPosition(
-			types.PaginationTokenTypeTopology, backwardTopologyPos, backwardStreamPos,
-		).String()
+		lr.Timeline.PrevBatch = prevBatch.String()
 		lr.Timeline.Events = gomatrixserverlib.HeaderedToClientEvents(recentEvents, gomatrixserverlib.FormatSync)
 		lr.Timeline.Limited = false // TODO: if len(events) >= numRecents + 1 and then set limited:true
 		lr.State.Events = gomatrixserverlib.HeaderedToClientEvents(delta.stateEvents, gomatrixserverlib.FormatSync)

--- a/syncapi/sync/notifier_test.go
+++ b/syncapi/sync/notifier_test.go
@@ -33,7 +33,6 @@ var (
 	randomMessageEvent  gomatrixserverlib.HeaderedEvent
 	aliceInviteBobEvent gomatrixserverlib.HeaderedEvent
 	bobLeaveEvent       gomatrixserverlib.HeaderedEvent
-	baseSyncPos         = types.NewStreamToken(0, 0)
 	syncPositionVeryOld = types.NewStreamToken(5, 0)
 	syncPositionBefore  = types.NewStreamToken(11, 0)
 	syncPositionAfter   = types.NewStreamToken(12, 0)

--- a/syncapi/sync/notifier_test.go
+++ b/syncapi/sync/notifier_test.go
@@ -33,11 +33,12 @@ var (
 	randomMessageEvent  gomatrixserverlib.HeaderedEvent
 	aliceInviteBobEvent gomatrixserverlib.HeaderedEvent
 	bobLeaveEvent       gomatrixserverlib.HeaderedEvent
-	syncPositionVeryOld types.PaginationToken
-	syncPositionBefore  types.PaginationToken
-	syncPositionAfter   types.PaginationToken
-	syncPositionNewEDU  types.PaginationToken
-	syncPositionAfter2  types.PaginationToken
+	baseSyncPos         = types.NewStreamToken(0, 0)
+	syncPositionVeryOld = types.NewStreamToken(5, 0)
+	syncPositionBefore  = types.NewStreamToken(11, 0)
+	syncPositionAfter   = types.NewStreamToken(12, 0)
+	syncPositionNewEDU  = types.NewStreamToken(syncPositionAfter.PDUPosition(), 1)
+	syncPositionAfter2  = types.NewStreamToken(13, 0)
 )
 
 var (
@@ -47,26 +48,6 @@ var (
 )
 
 func init() {
-	baseSyncPos := types.PaginationToken{
-		PDUPosition:       0,
-		EDUTypingPosition: 0,
-	}
-
-	syncPositionVeryOld = baseSyncPos
-	syncPositionVeryOld.PDUPosition = 5
-
-	syncPositionBefore = baseSyncPos
-	syncPositionBefore.PDUPosition = 11
-
-	syncPositionAfter = baseSyncPos
-	syncPositionAfter.PDUPosition = 12
-
-	syncPositionNewEDU = syncPositionAfter
-	syncPositionNewEDU.EDUTypingPosition = 1
-
-	syncPositionAfter2 = baseSyncPos
-	syncPositionAfter2.PDUPosition = 13
-
 	var err error
 	err = json.Unmarshal([]byte(`{
 		"_room_version": "1",
@@ -118,6 +99,12 @@ func init() {
 	}
 }
 
+func mustEqualPositions(t *testing.T, got, want types.StreamingToken) {
+	if got.String() != want.String() {
+		t.Fatalf("mustEqualPositions got %s want %s", got.String(), want.String())
+	}
+}
+
 // Test that the current position is returned if a request is already behind.
 func TestImmediateNotification(t *testing.T) {
 	n := NewNotifier(syncPositionBefore)
@@ -125,9 +112,7 @@ func TestImmediateNotification(t *testing.T) {
 	if err != nil {
 		t.Fatalf("TestImmediateNotification error: %s", err)
 	}
-	if pos != syncPositionBefore {
-		t.Fatalf("TestImmediateNotification want %v, got %v", syncPositionBefore, pos)
-	}
+	mustEqualPositions(t, pos, syncPositionBefore)
 }
 
 // Test that new events to a joined room unblocks the request.
@@ -144,9 +129,7 @@ func TestNewEventAndJoinedToRoom(t *testing.T) {
 		if err != nil {
 			t.Errorf("TestNewEventAndJoinedToRoom error: %w", err)
 		}
-		if pos != syncPositionAfter {
-			t.Errorf("TestNewEventAndJoinedToRoom want %v, got %v", syncPositionAfter, pos)
-		}
+		mustEqualPositions(t, pos, syncPositionAfter)
 		wg.Done()
 	}()
 
@@ -172,9 +155,7 @@ func TestNewInviteEventForUser(t *testing.T) {
 		if err != nil {
 			t.Errorf("TestNewInviteEventForUser error: %w", err)
 		}
-		if pos != syncPositionAfter {
-			t.Errorf("TestNewInviteEventForUser want %v, got %v", syncPositionAfter, pos)
-		}
+		mustEqualPositions(t, pos, syncPositionAfter)
 		wg.Done()
 	}()
 
@@ -200,9 +181,7 @@ func TestEDUWakeup(t *testing.T) {
 		if err != nil {
 			t.Errorf("TestNewInviteEventForUser error: %w", err)
 		}
-		if pos != syncPositionNewEDU {
-			t.Errorf("TestNewInviteEventForUser want %v, got %v", syncPositionNewEDU, pos)
-		}
+		mustEqualPositions(t, pos, syncPositionNewEDU)
 		wg.Done()
 	}()
 
@@ -228,9 +207,7 @@ func TestMultipleRequestWakeup(t *testing.T) {
 		if err != nil {
 			t.Errorf("TestMultipleRequestWakeup error: %w", err)
 		}
-		if pos != syncPositionAfter {
-			t.Errorf("TestMultipleRequestWakeup want %v, got %v", syncPositionAfter, pos)
-		}
+		mustEqualPositions(t, pos, syncPositionAfter)
 		wg.Done()
 	}
 	go poll()
@@ -268,9 +245,7 @@ func TestNewEventAndWasPreviouslyJoinedToRoom(t *testing.T) {
 		if err != nil {
 			t.Errorf("TestNewEventAndWasPreviouslyJoinedToRoom error: %w", err)
 		}
-		if pos != syncPositionAfter {
-			t.Errorf("TestNewEventAndWasPreviouslyJoinedToRoom want %v, got %v", syncPositionAfter, pos)
-		}
+		mustEqualPositions(t, pos, syncPositionAfter)
 		leaveWG.Done()
 	}()
 	bobStream := lockedFetchUserStream(n, bob)
@@ -287,9 +262,7 @@ func TestNewEventAndWasPreviouslyJoinedToRoom(t *testing.T) {
 		if err != nil {
 			t.Errorf("TestNewEventAndWasPreviouslyJoinedToRoom error: %w", err)
 		}
-		if pos != syncPositionAfter2 {
-			t.Errorf("TestNewEventAndWasPreviouslyJoinedToRoom want %v, got %v", syncPositionAfter2, pos)
-		}
+		mustEqualPositions(t, pos, syncPositionAfter2)
 		aliceWG.Done()
 	}()
 
@@ -312,13 +285,13 @@ func TestNewEventAndWasPreviouslyJoinedToRoom(t *testing.T) {
 	time.Sleep(1 * time.Millisecond)
 }
 
-func waitForEvents(n *Notifier, req syncRequest) (types.PaginationToken, error) {
+func waitForEvents(n *Notifier, req syncRequest) (types.StreamingToken, error) {
 	listener := n.GetListener(req)
 	defer listener.Close()
 
 	select {
 	case <-time.After(5 * time.Second):
-		return types.PaginationToken{}, fmt.Errorf(
+		return types.StreamingToken{}, fmt.Errorf(
 			"waitForEvents timed out waiting for %s (pos=%v)", req.device.UserID, req.since,
 		)
 	case <-listener.GetNotifyChannel(*req.since):
@@ -344,7 +317,7 @@ func lockedFetchUserStream(n *Notifier, userID string) *UserStream {
 	return n.fetchUserStream(userID, true)
 }
 
-func newTestSyncRequest(userID string, since types.PaginationToken) syncRequest {
+func newTestSyncRequest(userID string, since types.StreamingToken) syncRequest {
 	return syncRequest{
 		device:        authtypes.Device{UserID: userID},
 		timeout:       1 * time.Minute,

--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -132,7 +132,7 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request, device *authtype
 	}
 }
 
-func (rp *RequestPool) currentSyncForUser(req syncRequest, latestPos types.PaginationToken) (res *types.Response, err error) {
+func (rp *RequestPool) currentSyncForUser(req syncRequest, latestPos types.StreamingToken) (res *types.Response, err error) {
 	// TODO: handle ignored users
 	if req.since == nil {
 		res, err = rp.db.CompleteSync(req.ctx, req.device.UserID, req.limit)
@@ -145,7 +145,7 @@ func (rp *RequestPool) currentSyncForUser(req syncRequest, latestPos types.Pagin
 	}
 
 	accountDataFilter := gomatrixserverlib.DefaultEventFilter() // TODO: use filter provided in req instead
-	res, err = rp.appendAccountData(res, req.device.UserID, req, latestPos.PDUPosition, &accountDataFilter)
+	res, err = rp.appendAccountData(res, req.device.UserID, req, latestPos.PDUPosition(), &accountDataFilter)
 	return
 }
 
@@ -187,7 +187,7 @@ func (rp *RequestPool) appendAccountData(
 	// Sync is not initial, get all account data since the latest sync
 	dataTypes, err := rp.db.GetAccountDataInRange(
 		req.ctx, userID,
-		types.StreamPosition(req.since.PDUPosition), types.StreamPosition(currentPos),
+		types.StreamPosition(req.since.PDUPosition()), types.StreamPosition(currentPos),
 		accountDataFilter,
 	)
 	if err != nil {

--- a/syncapi/sync/userstream.go
+++ b/syncapi/sync/userstream.go
@@ -34,7 +34,7 @@ type UserStream struct {
 	// Closed when there is an update.
 	signalChannel chan struct{}
 	// The last sync position that there may have been an update for the user
-	pos types.PaginationToken
+	pos types.StreamingToken
 	// The last time when we had some listeners waiting
 	timeOfLastChannel time.Time
 	// The number of listeners waiting
@@ -50,7 +50,7 @@ type UserStreamListener struct {
 }
 
 // NewUserStream creates a new user stream
-func NewUserStream(userID string, currPos types.PaginationToken) *UserStream {
+func NewUserStream(userID string, currPos types.StreamingToken) *UserStream {
 	return &UserStream{
 		UserID:            userID,
 		timeOfLastChannel: time.Now(),
@@ -83,7 +83,7 @@ func (s *UserStream) GetListener(ctx context.Context) UserStreamListener {
 }
 
 // Broadcast a new sync position for this user.
-func (s *UserStream) Broadcast(pos types.PaginationToken) {
+func (s *UserStream) Broadcast(pos types.StreamingToken) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
@@ -116,9 +116,9 @@ func (s *UserStream) TimeOfLastNonEmpty() time.Time {
 	return s.timeOfLastChannel
 }
 
-// GetStreamPosition returns last sync position which the UserStream was
+// GetSyncPosition returns last sync position which the UserStream was
 // notified about
-func (s *UserStreamListener) GetSyncPosition() types.PaginationToken {
+func (s *UserStreamListener) GetSyncPosition() types.StreamingToken {
 	s.userStream.lock.Lock()
 	defer s.userStream.lock.Unlock()
 
@@ -130,7 +130,7 @@ func (s *UserStreamListener) GetSyncPosition() types.PaginationToken {
 // sincePos specifies from which point we want to be notified about. If there
 // has already been an update after sincePos we'll return a closed channel
 // immediately.
-func (s *UserStreamListener) GetNotifyChannel(sincePos types.PaginationToken) <-chan struct{} {
+func (s *UserStreamListener) GetNotifyChannel(sincePos types.StreamingToken) <-chan struct{} {
 	s.userStream.lock.Lock()
 	defer s.userStream.lock.Unlock()
 

--- a/syncapi/types/types.go
+++ b/syncapi/types/types.go
@@ -107,6 +107,9 @@ func (t *TopologyToken) Depth() StreamPosition {
 func (t *TopologyToken) PDUPosition() StreamPosition {
 	return t.Positions[1]
 }
+func (t *TopologyToken) StreamToken() StreamingToken {
+	return NewStreamToken(t.PDUPosition(), 0)
+}
 func (t *TopologyToken) String() string {
 	return t.syncToken.String()
 }

--- a/syncapi/types/types.go
+++ b/syncapi/types/types.go
@@ -189,6 +189,10 @@ func NewTopologyTokenFromString(tok string) (token TopologyToken, err error) {
 		err = fmt.Errorf("token %s is not a topology token", tok)
 		return
 	}
+	if len(t.Positions) != 2 {
+		err = fmt.Errorf("token %s wrong number of values, got %d want 2", tok, len(t.Positions))
+		return
+	}
 	return TopologyToken{
 		syncToken: *t,
 	}, nil
@@ -210,6 +214,10 @@ func NewStreamTokenFromString(tok string) (token StreamingToken, err error) {
 	}
 	if t.Type != SyncTokenTypeStream {
 		err = fmt.Errorf("token %s is not a streaming token", tok)
+		return
+	}
+	if len(t.Positions) != 2 {
+		err = fmt.Errorf("token %s wrong number of values, got %d want 2", tok, len(t.Positions))
 		return
 	}
 	return StreamingToken{

--- a/syncapi/types/types_test.go
+++ b/syncapi/types/types_test.go
@@ -2,26 +2,11 @@ package types
 
 import "testing"
 
-func TestNewPaginationTokenFromString(t *testing.T) {
-	shouldPass := map[string]PaginationToken{
-		"2": PaginationToken{
-			Type:        PaginationTokenTypeStream,
-			PDUPosition: 2,
-		},
-		"s4": PaginationToken{
-			Type:        PaginationTokenTypeStream,
-			PDUPosition: 4,
-		},
-		"s3_1": PaginationToken{
-			Type:              PaginationTokenTypeStream,
-			PDUPosition:       3,
-			EDUTypingPosition: 1,
-		},
-		"t3_1_4": PaginationToken{
-			Type:              PaginationTokenTypeTopology,
-			PDUPosition:       3,
-			EDUTypingPosition: 1,
-		},
+func TestNewSyncTokenFromString(t *testing.T) {
+	shouldPass := map[string]syncToken{
+		"s4_0": NewStreamToken(4, 0).syncToken,
+		"s3_1": NewStreamToken(3, 1).syncToken,
+		"t3_1": NewTopologyToken(3, 1).syncToken,
 	}
 
 	shouldFail := []string{
@@ -32,20 +17,21 @@ func TestNewPaginationTokenFromString(t *testing.T) {
 		"b",
 		"b-1",
 		"-4",
+		"2",
 	}
 
 	for test, expected := range shouldPass {
-		result, err := NewPaginationTokenFromString(test)
+		result, err := newSyncTokenFromString(test)
 		if err != nil {
 			t.Error(err)
 		}
-		if *result != expected {
-			t.Errorf("expected %v but got %v", expected.String(), result.String())
+		if result.String() != expected.String() {
+			t.Errorf("%s expected %v but got %v", test, expected.String(), result.String())
 		}
 	}
 
 	for _, test := range shouldFail {
-		if _, err := NewPaginationTokenFromString(test); err == nil {
+		if _, err := newSyncTokenFromString(test); err == nil {
 			t.Errorf("input '%v' should have errored but didn't", test)
 		}
 	}


### PR DESCRIPTION
Previously we used the badly named `PaginationToken` which was
used for both `/sync` and `/messages` requests. This quickly
became confusing because named fields like `PDUPosition` meant
different things depending on the token type. Instead, we now have
two token types: `TopologyToken` and `StreamingToken`, both of
which have fields which make more sense for their specific situations.

Updated the codebase to use one or the other. `PaginationToken` still
lives on as `syncToken`, an unexported type which both tokens rely on.
This allows us to guarantee that the specific mappings of positions
to a string remain solely under the control of the `types` package.
This enables us to move high-level conceptual things like
"decrement this topological token" to function calls e.g
`TopologicalToken.Decrement()`.

This does not fix #1015 yet.