### PR TITLE
Send display name and avatar URL in join content

### DIFF
--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -100,7 +100,7 @@ func Setup(
 				return util.ErrorResponse(err)
 			}
 			return JoinRoomByIDOrAlias(
-				req, device, rsAPI, vars["roomIDOrAlias"],
+				req, device, rsAPI, accountDB, vars["roomIDOrAlias"],
 			)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)


### PR DESCRIPTION
This was removed in #1001 and not re-added. Display names and such will now show again properly when joining rooms.