### PR TITLE
Fix some cases where accepting invites over federation doesn't work

### DIFF
--- a/roomserver/internal/perform_join.go
+++ b/roomserver/internal/perform_join.go
@@ -129,7 +129,7 @@ func (r *RoomserverInternalAPI) performJoinRoomByID(
 	if err == nil && isInvitePending {
 		// Add the server of the person who invited us to the server list,
 		// as they should be a fairly good bet.
-		if _, inviterDomain, ierr := gomatrixserverlib.SplitID('!', inviteSender); ierr == nil {
+		if _, inviterDomain, ierr := gomatrixserverlib.SplitID('@', inviteSender); ierr == nil {
 			req.ServerNames = append(req.ServerNames, inviterDomain)
 		}
 


### PR DESCRIPTION
This should fix the problem whereby our join code *thinks* we know about a local room because we participated in it in the past, but we don't know about the new `invite` state because we are no longer in the room to find out about it. We will check the invites table to see if we should do a federated join.