### PR TITLE
Keyserver skeleton

### DIFF
--- a/cmd/dendrite-key-server/main.go
+++ b/cmd/dendrite-key-server/main.go
@@ -1,0 +1,34 @@
+// Copyright 2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/matrix-org/dendrite/common/basecomponent"
+	"github.com/matrix-org/dendrite/keyserver"
+)
+
+func main() {
+	cfg := basecomponent.ParseFlags()
+	base := basecomponent.NewBaseDendrite(cfg, "KeyServer")
+	defer base.Close() // nolint: errcheck
+
+	accountDB := base.CreateAccountsDB()
+	deviceDB := base.CreateDeviceDB()
+
+	keyserver.SetupKeyServerComponent(base, deviceDB, accountDB)
+
+	base.SetupAndServeHTTP(string(base.Cfg.Bind.KeyServer), string(base.Cfg.Listen.KeyServer))
+
+}

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/matrix-org/dendrite/eduserver/cache"
 	"github.com/matrix-org/dendrite/federationapi"
 	"github.com/matrix-org/dendrite/federationsender"
+	"github.com/matrix-org/dendrite/keyserver"
 	"github.com/matrix-org/dendrite/mediaapi"
 	"github.com/matrix-org/dendrite/publicroomsapi"
 	"github.com/matrix-org/dendrite/publicroomsapi/storage"
@@ -75,6 +76,9 @@ func main() {
 		base, deviceDB, accountDB,
 		federation, &keyRing, rsAPI,
 		eduInputAPI, asAPI, transactions.New(), fsAPI,
+	)
+	keyserver.SetupKeyServerComponent(
+		base, deviceDB, accountDB,
 	)
 	eduProducer := producers.NewEDUServerProducer(eduInputAPI)
 	federationapi.SetupFederationAPIComponent(base, accountDB, deviceDB, federation, &keyRing, rsAPI, asAPI, fsAPI, eduProducer)

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -229,6 +229,7 @@ type Dendrite struct {
 		FederationSender Address `yaml:"federation_sender"`
 		PublicRoomsAPI   Address `yaml:"public_rooms_api"`
 		EDUServer        Address `yaml:"edu_server"`
+		KeyServer        Address `yaml:"key_server"`
 	} `yaml:"bind"`
 
 	// The addresses for talking to other microservices.
@@ -242,6 +243,7 @@ type Dendrite struct {
 		FederationSender Address `yaml:"federation_sender"`
 		PublicRoomsAPI   Address `yaml:"public_rooms_api"`
 		EDUServer        Address `yaml:"edu_server"`
+		KeyServer        Address `yaml:"key_server"`
 	} `yaml:"listen"`
 
 	// The config for tracing the dendrite servers.

--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -136,8 +136,8 @@ listen:
     public_rooms_api: "localhost:7775"
     federation_sender: "localhost:7776"
     appservice_api: "localhost:7777"
-	edu_server: "localhost:7778"
-	key_server: "localhost:7779"
+    edu_server: "localhost:7778"
+    key_server: "localhost:7779"
 
 # The configuration for tracing the dendrite components.
 tracing:

--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -136,7 +136,8 @@ listen:
     public_rooms_api: "localhost:7775"
     federation_sender: "localhost:7776"
     appservice_api: "localhost:7777"
-    edu_server: "localhost:7778"
+	edu_server: "localhost:7778"
+	key_server: "localhost:7779"
 
 # The configuration for tracing the dendrite components.
 tracing:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -152,7 +152,17 @@ services:
     depends_on:
       - postgres
     networks:
-      - internal
+	  - internal
+	  
+  key_server:
+	container_name: dendrite_key_server
+	hostname: key_server
+	entrypoint: ["bash", "./docker/services/key-server.sh"]
+	build: ./
+	volumes:
+		- ..:/build
+	networks:
+		- internal
 
   postgres:
     container_name: dendrite_postgres

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -152,17 +152,17 @@ services:
     depends_on:
       - postgres
     networks:
-	  - internal
-	  
+      - internal
+      
   key_server:
-	container_name: dendrite_key_server
-	hostname: key_server
-	entrypoint: ["bash", "./docker/services/key-server.sh"]
-	build: ./
-	volumes:
-		- ..:/build
-	networks:
-		- internal
+    container_name: dendrite_key_server
+    hostname: key_server
+    entrypoint: ["bash", "./docker/services/key-server.sh"]
+    build: ./
+    volumes:
+        - ..:/build
+    networks:
+        - internal
 
   postgres:
     container_name: dendrite_postgres

--- a/docker/services/key-server.sh
+++ b/docker/services/key-server.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+bash ./docker/build.sh
+
+./bin/dendrite-key-server --config dendrite.yaml

--- a/keyserver/keyserver.go
+++ b/keyserver/keyserver.go
@@ -1,0 +1,32 @@
+// Copyright 2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keyserver
+
+import (
+	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
+	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
+	"github.com/matrix-org/dendrite/common/basecomponent"
+	"github.com/matrix-org/dendrite/keyserver/routing"
+)
+
+// SetupFederationSenderComponent sets up and registers HTTP handlers for the
+// FederationSender component.
+func SetupKeyServerComponent(
+	base *basecomponent.BaseDendrite,
+	deviceDB devices.Database,
+	accountsDB accounts.Database,
+) {
+	routing.Setup(base.APIMux, base.Cfg, accountsDB, deviceDB)
+}

--- a/keyserver/routing/keys.go
+++ b/keyserver/routing/keys.go
@@ -1,0 +1,33 @@
+// Copyright 2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"net/http"
+
+	"github.com/matrix-org/util"
+)
+
+func QueryKeys(
+	req *http.Request,
+) util.JSONResponse {
+	return util.JSONResponse{
+		Code: http.StatusOK,
+		JSON: map[string]interface{}{
+			"failures":    map[string]interface{}{},
+			"device_keys": map[string]interface{}{},
+		},
+	}
+}

--- a/keyserver/routing/routing.go
+++ b/keyserver/routing/routing.go
@@ -1,0 +1,56 @@
+// Copyright 2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/matrix-org/dendrite/clientapi/auth"
+	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
+	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
+	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
+	"github.com/matrix-org/dendrite/common"
+	"github.com/matrix-org/dendrite/common/config"
+	"github.com/matrix-org/util"
+)
+
+const pathPrefixR0 = "/_matrix/client/r0"
+
+// Setup registers HTTP handlers with the given ServeMux. It also supplies the given http.Client
+// to clients which need to make outbound HTTP requests.
+//
+// Due to Setup being used to call many other functions, a gocyclo nolint is
+// applied:
+// nolint: gocyclo
+func Setup(
+	apiMux *mux.Router, cfg *config.Dendrite,
+	accountDB accounts.Database,
+	deviceDB devices.Database,
+) {
+	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
+
+	authData := auth.Data{
+		AccountDB:   accountDB,
+		DeviceDB:    deviceDB,
+		AppServices: cfg.Derived.ApplicationServices,
+	}
+
+	r0mux.Handle("/keys/query",
+		common.MakeAuthAPI("queryKeys", authData, func(req *http.Request, device *authtypes.Device) util.JSONResponse {
+			return QueryKeys(req)
+		}),
+	).Methods(http.MethodPost, http.MethodOptions)
+}


### PR DESCRIPTION
This is the absolute minimum required to stop Riot being upset by 404s on `/keys/query`. It means we can create DMs again.