### PR TITLE
Prometheus metrics for LRU cache

### DIFF
--- a/common/caching/immutablecache.go
+++ b/common/caching/immutablecache.go
@@ -5,8 +5,8 @@ import (
 )
 
 const (
-	RoomVersionMaxCacheEntries = 128
-	ServerKeysMaxCacheEntries  = 128
+	RoomVersionMaxCacheEntries = 1024
+	ServerKeysMaxCacheEntries  = 1024
 )
 
 type ImmutableCache interface {

--- a/common/caching/immutablecache.go
+++ b/common/caching/immutablecache.go
@@ -1,6 +1,8 @@
 package caching
 
-import "github.com/matrix-org/gomatrixserverlib"
+import (
+	"github.com/matrix-org/gomatrixserverlib"
+)
 
 const (
 	RoomVersionMaxCacheEntries = 128


### PR DESCRIPTION
This adds a couple of Prometheus metrics for the LRU caches for room versions and server key responses.

This also increases the cache size for each to 1024 (from 128). The room version cache only grows with the number of rooms used, but the server key cache grows very quickly above the 128 when in rooms like Matrix HQ.

I don't know if 1024 is necessarily an optimal number, but a rough calculation suggests it shouldn't use much more than 500kb for server keys and significantly less for room versions, and since we are really evicting only the least-used keys, it should still help a lot with the most frequently used cases.