### PR TITLE
Return user_id and stream_id in federated devices query

### DIFF
--- a/federationapi/routing/devices.go
+++ b/federationapi/routing/devices.go
@@ -23,7 +23,9 @@ import (
 )
 
 type userDevicesResponse struct {
-	Devices []authtypes.Device `json:"devices"`
+	UserID   string             `json:"user_id"`
+	StreamID int                `json:"stream_id"`
+	Devices  []authtypes.Device `json:"devices"`
 }
 
 // GetUserDevices for the given user id
@@ -48,6 +50,12 @@ func GetUserDevices(
 
 	return util.JSONResponse{
 		Code: 200,
-		JSON: userDevicesResponse{devs},
+		// TODO: we should return an incrementing stream ID each time the device
+		// list changes for delta changes to be recognised
+		JSON: userDevicesResponse{
+			UserID:   userID,
+			StreamID: 0,
+			Devices:  devs,
+		},
 	}
 }


### PR DESCRIPTION
This adds `user_id` and `stream_id` keys into the response for a federated device request. These are required by the spec: https://matrix.org/docs/spec/server_server/r0.1.3#get-matrix-federation-v1-user-devices-userid