### PR TITLE
Set canonical alias on room creation

### DIFF
--- a/common/eventcontent.go
+++ b/common/eventcontent.go
@@ -36,6 +36,11 @@ type HistoryVisibilityContent struct {
 	HistoryVisibility string `json:"history_visibility"`
 }
 
+// CanonicalAlias is the event content for https://matrix.org/docs/spec/client_server/r0.6.0#m-room-canonical-alias
+type CanonicalAlias struct {
+	Alias string `json:"alias"`
+}
+
 // InitialPowerLevelsContent returns the initial values for m.room.power_levels on room creation
 // if they have not been specified.
 // http://matrix.org/docs/spec/client_server/r0.2.0.html#m-room-power-levels


### PR DESCRIPTION
So it shows up in Riot.

It turns out I was the one who set the order up in the comment, and I'd rather do ACLs first before vanity stuff like canonical alias.