### PR TITLE
Add -api flag to monolith

### DIFF
--- a/appservice/appservice.go
+++ b/appservice/appservice.go
@@ -82,7 +82,9 @@ func SetupAppServiceAPIComponent(
 		Cfg: base.Cfg,
 	}
 
-	appserviceQueryAPI.SetupHTTP(http.DefaultServeMux)
+	if base.EnableHTTPAPIs {
+		appserviceQueryAPI.SetupHTTP(http.DefaultServeMux)
+	}
 
 	consumer := consumers.NewOutputRoomEventConsumer(
 		base.Cfg, base.KafkaConsumer, accountsDB, appserviceDB,

--- a/cmd/dendrite-appservice-server/main.go
+++ b/cmd/dendrite-appservice-server/main.go
@@ -22,7 +22,7 @@ import (
 
 func main() {
 	cfg := basecomponent.ParseFlags()
-	base := basecomponent.NewBaseDendrite(cfg, "AppServiceAPI")
+	base := basecomponent.NewBaseDendrite(cfg, "AppServiceAPI", true)
 
 	defer base.Close() // nolint: errcheck
 	accountDB := base.CreateAccountsDB()

--- a/cmd/dendrite-client-api-server/main.go
+++ b/cmd/dendrite-client-api-server/main.go
@@ -26,7 +26,7 @@ import (
 func main() {
 	cfg := basecomponent.ParseFlags()
 
-	base := basecomponent.NewBaseDendrite(cfg, "ClientAPI")
+	base := basecomponent.NewBaseDendrite(cfg, "ClientAPI", true)
 	defer base.Close() // nolint: errcheck
 
 	accountDB := base.CreateAccountsDB()

--- a/cmd/dendrite-demo-libp2p/p2pdendrite.go
+++ b/cmd/dendrite-demo-libp2p/p2pdendrite.go
@@ -54,7 +54,7 @@ type P2PDendrite struct {
 // The componentName is used for logging purposes, and should be a friendly name
 // of the component running, e.g. SyncAPI.
 func NewP2PDendrite(cfg *config.Dendrite, componentName string) *P2PDendrite {
-	baseDendrite := basecomponent.NewBaseDendrite(cfg, componentName)
+	baseDendrite := basecomponent.NewBaseDendrite(cfg, componentName, false)
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/cmd/dendrite-edu-server/main.go
+++ b/cmd/dendrite-edu-server/main.go
@@ -23,7 +23,7 @@ import (
 
 func main() {
 	cfg := basecomponent.ParseFlags()
-	base := basecomponent.NewBaseDendrite(cfg, "EDUServerAPI")
+	base := basecomponent.NewBaseDendrite(cfg, "EDUServerAPI", true)
 	defer func() {
 		if err := base.Close(); err != nil {
 			logrus.WithError(err).Warn("BaseDendrite close failed")

--- a/cmd/dendrite-federation-api-server/main.go
+++ b/cmd/dendrite-federation-api-server/main.go
@@ -25,7 +25,7 @@ import (
 
 func main() {
 	cfg := basecomponent.ParseFlags()
-	base := basecomponent.NewBaseDendrite(cfg, "FederationAPI")
+	base := basecomponent.NewBaseDendrite(cfg, "FederationAPI", true)
 	defer base.Close() // nolint: errcheck
 
 	accountDB := base.CreateAccountsDB()

--- a/cmd/dendrite-federation-sender-server/main.go
+++ b/cmd/dendrite-federation-sender-server/main.go
@@ -22,7 +22,7 @@ import (
 
 func main() {
 	cfg := basecomponent.ParseFlags()
-	base := basecomponent.NewBaseDendrite(cfg, "FederationSender")
+	base := basecomponent.NewBaseDendrite(cfg, "FederationSender", true)
 	defer base.Close() // nolint: errcheck
 
 	federation := base.CreateFederationClient()

--- a/cmd/dendrite-key-server/main.go
+++ b/cmd/dendrite-key-server/main.go
@@ -21,7 +21,7 @@ import (
 
 func main() {
 	cfg := basecomponent.ParseFlags()
-	base := basecomponent.NewBaseDendrite(cfg, "KeyServer")
+	base := basecomponent.NewBaseDendrite(cfg, "KeyServer", true)
 	defer base.Close() // nolint: errcheck
 
 	accountDB := base.CreateAccountsDB()

--- a/cmd/dendrite-media-api-server/main.go
+++ b/cmd/dendrite-media-api-server/main.go
@@ -21,7 +21,7 @@ import (
 
 func main() {
 	cfg := basecomponent.ParseFlags()
-	base := basecomponent.NewBaseDendrite(cfg, "MediaAPI")
+	base := basecomponent.NewBaseDendrite(cfg, "MediaAPI", true)
 	defer base.Close() // nolint: errcheck
 
 	deviceDB := base.CreateDeviceDB()

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -45,7 +45,7 @@ var (
 	httpsBindAddr  = flag.String("https-bind-address", ":8448", "The HTTPS listening port for the server")
 	certFile       = flag.String("tls-cert", "", "The PEM formatted X509 certificate to use for TLS")
 	keyFile        = flag.String("tls-key", "", "The PEM private key to use for TLS")
-	enableHTTPAPIs = flag.Bool("enable-http-apis", false, "Expose internal HTTP APIs in monolith mode")
+	enableHTTPAPIs = flag.Bool("api", false, "Expose internal HTTP APIs in monolith mode")
 )
 
 func main() {

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -41,15 +41,16 @@ import (
 )
 
 var (
-	httpBindAddr  = flag.String("http-bind-address", ":8008", "The HTTP listening port for the server")
-	httpsBindAddr = flag.String("https-bind-address", ":8448", "The HTTPS listening port for the server")
-	certFile      = flag.String("tls-cert", "", "The PEM formatted X509 certificate to use for TLS")
-	keyFile       = flag.String("tls-key", "", "The PEM private key to use for TLS")
+	httpBindAddr   = flag.String("http-bind-address", ":8008", "The HTTP listening port for the server")
+	httpsBindAddr  = flag.String("https-bind-address", ":8448", "The HTTPS listening port for the server")
+	certFile       = flag.String("tls-cert", "", "The PEM formatted X509 certificate to use for TLS")
+	keyFile        = flag.String("tls-key", "", "The PEM private key to use for TLS")
+	enableHTTPAPIs = flag.Bool("enable-http-apis", false, "Expose internal HTTP APIs in monolith mode")
 )
 
 func main() {
 	cfg := basecomponent.ParseMonolithFlags()
-	base := basecomponent.NewBaseDendrite(cfg, "Monolith")
+	base := basecomponent.NewBaseDendrite(cfg, "Monolith", *enableHTTPAPIs)
 	defer base.Close() // nolint: errcheck
 
 	accountDB := base.CreateAccountsDB()

--- a/cmd/dendrite-public-rooms-api-server/main.go
+++ b/cmd/dendrite-public-rooms-api-server/main.go
@@ -23,7 +23,7 @@ import (
 
 func main() {
 	cfg := basecomponent.ParseFlags()
-	base := basecomponent.NewBaseDendrite(cfg, "PublicRoomsAPI")
+	base := basecomponent.NewBaseDendrite(cfg, "PublicRoomsAPI", true)
 	defer base.Close() // nolint: errcheck
 
 	deviceDB := base.CreateDeviceDB()

--- a/cmd/dendrite-room-server/main.go
+++ b/cmd/dendrite-room-server/main.go
@@ -22,7 +22,7 @@ import (
 
 func main() {
 	cfg := basecomponent.ParseFlags()
-	base := basecomponent.NewBaseDendrite(cfg, "RoomServerAPI")
+	base := basecomponent.NewBaseDendrite(cfg, "RoomServerAPI", true)
 	defer base.Close() // nolint: errcheck
 	keyDB := base.CreateKeyDB()
 	federation := base.CreateFederationClient()

--- a/cmd/dendrite-sync-api-server/main.go
+++ b/cmd/dendrite-sync-api-server/main.go
@@ -21,7 +21,7 @@ import (
 
 func main() {
 	cfg := basecomponent.ParseFlags()
-	base := basecomponent.NewBaseDendrite(cfg, "SyncAPI")
+	base := basecomponent.NewBaseDendrite(cfg, "SyncAPI", true)
 	defer base.Close() // nolint: errcheck
 
 	deviceDB := base.CreateDeviceDB()

--- a/cmd/dendritejs/main.go
+++ b/cmd/dendritejs/main.go
@@ -108,7 +108,7 @@ func main() {
 	if err := cfg.Derive(); err != nil {
 		logrus.Fatalf("Failed to derive values from config: %s", err)
 	}
-	base := basecomponent.NewBaseDendrite(cfg, "Monolith")
+	base := basecomponent.NewBaseDendrite(cfg, "Monolith", false)
 	defer base.Close() // nolint: errcheck
 
 	accountDB := base.CreateAccountsDB()

--- a/common/basecomponent/base.go
+++ b/common/basecomponent/base.go
@@ -53,12 +53,12 @@ import (
 // should only be used during start up.
 // Must be closed when shutting down.
 type BaseDendrite struct {
-	componentName  string
-	enableHTTPAPIs bool
-	tracerCloser   io.Closer
+	componentName string
+	tracerCloser  io.Closer
 
 	// APIMux should be used to register new public matrix api endpoints
 	APIMux         *mux.Router
+	EnableHTTPAPIs bool
 	httpClient     *http.Client
 	Cfg            *config.Dendrite
 	ImmutableCache caching.ImmutableCache
@@ -97,7 +97,7 @@ func NewBaseDendrite(cfg *config.Dendrite, componentName string, enableHTTPAPIs 
 
 	return &BaseDendrite{
 		componentName:  componentName,
-		enableHTTPAPIs: enableHTTPAPIs,
+		EnableHTTPAPIs: enableHTTPAPIs,
 		tracerCloser:   closer,
 		Cfg:            cfg,
 		ImmutableCache: cache,

--- a/common/basecomponent/base.go
+++ b/common/basecomponent/base.go
@@ -53,8 +53,9 @@ import (
 // should only be used during start up.
 // Must be closed when shutting down.
 type BaseDendrite struct {
-	componentName string
-	tracerCloser  io.Closer
+	componentName  string
+	enableHTTPAPIs bool
+	tracerCloser   io.Closer
 
 	// APIMux should be used to register new public matrix api endpoints
 	APIMux         *mux.Router
@@ -71,7 +72,7 @@ const HTTPClientTimeout = time.Second * 30
 // NewBaseDendrite creates a new instance to be used by a component.
 // The componentName is used for logging purposes, and should be a friendly name
 // of the compontent running, e.g. "SyncAPI"
-func NewBaseDendrite(cfg *config.Dendrite, componentName string) *BaseDendrite {
+func NewBaseDendrite(cfg *config.Dendrite, componentName string, enableHTTPAPIs bool) *BaseDendrite {
 	common.SetupStdLogging()
 	common.SetupHookLogging(cfg.Logging, componentName)
 	common.SetupPprof()
@@ -96,6 +97,7 @@ func NewBaseDendrite(cfg *config.Dendrite, componentName string) *BaseDendrite {
 
 	return &BaseDendrite{
 		componentName:  componentName,
+		enableHTTPAPIs: enableHTTPAPIs,
 		tracerCloser:   closer,
 		Cfg:            cfg,
 		ImmutableCache: cache,

--- a/eduserver/eduserver.go
+++ b/eduserver/eduserver.go
@@ -35,6 +35,9 @@ func SetupEDUServerComponent(
 		OutputTypingEventTopic: string(base.Cfg.Kafka.Topics.OutputTypingEvent),
 	}
 
-	inputAPI.SetupHTTP(http.DefaultServeMux)
+	if base.EnableHTTPAPIs {
+		inputAPI.SetupHTTP(http.DefaultServeMux)
+	}
+
 	return inputAPI
 }

--- a/federationsender/federationsender.go
+++ b/federationsender/federationsender.go
@@ -71,7 +71,10 @@ func SetupFederationSenderComponent(
 		federationSenderDB, base.Cfg, roomserverProducer, federation, keyRing,
 		statistics,
 	)
-	queryAPI.SetupHTTP(http.DefaultServeMux)
+
+	if base.EnableHTTPAPIs {
+		queryAPI.SetupHTTP(http.DefaultServeMux)
+	}
 
 	return queryAPI
 }

--- a/roomserver/roomserver.go
+++ b/roomserver/roomserver.go
@@ -51,7 +51,9 @@ func SetupRoomServerComponent(
 		KeyRing:              keyRing,
 	}
 
-	internalAPI.SetupHTTP(http.DefaultServeMux)
+	if base.EnableHTTPAPIs {
+		internalAPI.SetupHTTP(http.DefaultServeMux)
+	}
 
 	return &internalAPI
 }


### PR DESCRIPTION
This adds an `-api` command line flag to the monolith server for controlling whether or not to expose internal HTTP APIs, given that they are not otherwise used in monolith mode.

For all polylith components, the API defaults to enabled for obvious reasons.