### PR TITLE
Tweaks to latest events updater

### DIFF
--- a/roomserver/internal/input_latest_events.go
+++ b/roomserver/internal/input_latest_events.go
@@ -345,12 +345,7 @@ func (u *latestEventsUpdater) makeOutputNewRoomEvent() (*api.OutputEvent, error)
 	for _, entry := range u.stateBeforeEventAdds {
 		ore.StateBeforeAddsEventIDs = append(ore.StateBeforeAddsEventIDs, eventIDMap[entry.EventNID])
 	}
-	// If we are overwriting the latest events and state then we don't
-	// want to send out any changes that happened as a result to servers
-	// over federation.
-	if !u.stateAtEvent.Overwrite {
-		ore.SendAsServer = u.sendAsServer
-	}
+	ore.SendAsServer = u.sendAsServer
 
 	return &api.OutputEvent{
 		Type:         api.OutputTypeNewRoomEvent,

--- a/roomserver/internal/input_latest_events.go
+++ b/roomserver/internal/input_latest_events.go
@@ -69,10 +69,17 @@ func updateLatestEvents(
 	}()
 
 	u := latestEventsUpdater{
-		ctx: ctx, db: db, updater: updater, ow: ow, roomNID: roomNID,
-		stateAtEvent: stateAtEvent, event: event, sendAsServer: sendAsServer,
+		ctx:           ctx,
+		db:            db,
+		updater:       updater,
+		ow:            ow,
+		roomNID:       roomNID,
+		stateAtEvent:  stateAtEvent,
+		event:         event,
+		sendAsServer:  sendAsServer,
 		transactionID: transactionID,
 	}
+
 	if err = u.doUpdateLatestEvents(); err != nil {
 		return err
 	}
@@ -119,34 +126,51 @@ func (u *latestEventsUpdater) doUpdateLatestEvents() error {
 	u.lastEventIDSent = u.updater.LastEventIDSent()
 	u.oldStateNID = u.updater.CurrentStateSnapshotNID()
 
+	// If the event has already been written to the output log then we
+	// don't need to do anything, as we've handled it already.
 	hasBeenSent, err := u.updater.HasEventBeenSent(u.stateAtEvent.EventNID)
 	if err != nil {
 		return err
 	} else if hasBeenSent {
-		// Already sent this event so we can stop processing
 		return nil
 	}
 
+	// Update the roomserver_previous_events table with references. This
+	// is effectively tracking the structure of the DAG.
 	if err = u.updater.StorePreviousEvents(u.stateAtEvent.EventNID, prevEvents); err != nil {
 		return err
 	}
 
+	// Get the event reference for our new event. This will be used when
+	// determining if the event is referenced by an existing event.
 	eventReference := u.event.EventReference()
-	// Check if this event is already referenced by another event in the room.
+
+	// Check if our new event is already referenced by an existing event
+	// in the room. If it is then it isn't a latest event.
 	alreadyReferenced, err := u.updater.IsReferenced(eventReference)
 	if err != nil {
 		return err
 	}
 
-	u.latest = calculateLatest(oldLatest, alreadyReferenced, prevEvents, types.StateAtEventAndReference{
-		EventReference: eventReference,
-		StateAtEvent:   u.stateAtEvent,
-	})
+	// Work out what the latest events are.
+	u.latest = calculateLatest(
+		oldLatest,
+		alreadyReferenced,
+		prevEvents,
+		types.StateAtEventAndReference{
+			EventReference: eventReference,
+			StateAtEvent:   u.stateAtEvent,
+		},
+	)
 
+	// Now that we know what the latest events are, it's time to get the
+	// latest state.
 	if err = u.latestState(); err != nil {
 		return err
 	}
 
+	// If we need to generate any output events then here's where we do it.
+	// TODO: Move this!
 	updates, err := updateMemberships(u.ctx, u.db, u.updater, u.removed, u.added)
 	if err != nil {
 		return err
@@ -181,10 +205,15 @@ func (u *latestEventsUpdater) latestState() error {
 	var err error
 	roomState := state.NewStateResolution(u.db)
 
+	// Get a list of the current latest events.
 	latestStateAtEvents := make([]types.StateAtEvent, len(u.latest))
 	for i := range u.latest {
 		latestStateAtEvents[i] = u.latest[i].StateAtEvent
 	}
+
+	// Takes the NIDs of the latest events and creates a state snapshot
+	// of the state after the events. The snapshot state will be resolved
+	// using the correct state resolution algorithm for the room.
 	u.newStateNID, err = roomState.CalculateAndStoreStateAfterEvents(
 		u.ctx, u.roomNID, latestStateAtEvents,
 	)
@@ -192,6 +221,17 @@ func (u *latestEventsUpdater) latestState() error {
 		return err
 	}
 
+	// If we are overwriting the state then we don't need to do anything
+	// further here.
+	if u.stateAtEvent.Overwrite {
+		return nil
+	}
+
+	// Now that we have a new state snapshot based on the latest events,
+	// we can compare that new snapshot to the previous one and see what
+	// has changed. This gives us one list of removed state events and
+	// another list of added ones. Replacing a value for a state-key tuple
+	// will result one removed (the old event) and one added (the new event).
 	u.removed, u.added, err = roomState.DifferenceBetweeenStateSnapshots(
 		u.ctx, u.oldStateNID, u.newStateNID,
 	)
@@ -199,6 +239,8 @@ func (u *latestEventsUpdater) latestState() error {
 		return err
 	}
 
+	// Also work out the state before the event removes and the event
+	// adds.
 	u.stateBeforeEventRemoves, u.stateBeforeEventAdds, err = roomState.DifferenceBetweeenStateSnapshots(
 		u.ctx, u.newStateNID, u.stateAtEvent.BeforeStateSnapshotNID,
 	)
@@ -292,7 +334,12 @@ func (u *latestEventsUpdater) makeOutputNewRoomEvent() (*api.OutputEvent, error)
 	for _, entry := range u.stateBeforeEventAdds {
 		ore.StateBeforeAddsEventIDs = append(ore.StateBeforeAddsEventIDs, eventIDMap[entry.EventNID])
 	}
-	ore.SendAsServer = u.sendAsServer
+	// If we are overwriting the latest events and state then we don't
+	// want to send out any changes that happened as a result to servers
+	// over federation.
+	if !u.stateAtEvent.Overwrite {
+		ore.SendAsServer = u.sendAsServer
+	}
 
 	return &api.OutputEvent{
 		Type:         api.OutputTypeNewRoomEvent,

--- a/roomserver/internal/input_membership.go
+++ b/roomserver/internal/input_membership.go
@@ -16,7 +16,6 @@ package internal
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/matrix-org/dendrite/roomserver/api"
@@ -108,10 +107,10 @@ func updateMembership(
 	}
 
 	if add == nil {
-		// This shouldn't happen. Returning an error here is better than panicking
-		// in the membership updater functions later on.
-		// TODO: Why does this happen to begin with?
-		return updates, errors.New("add should not be nil")
+		// This can happen when we have rejoined a room and suddenly we have a
+		// divergence between the former state and the new one. We don't want to
+		// act on removals and apparently there are no adds, so stop here.
+		return updates, nil
 	}
 
 	mu, err := updater.MembershipUpdater(targetUserNID)

--- a/roomserver/types/types.go
+++ b/roomserver/types/types.go
@@ -75,6 +75,10 @@ func (a StateEntry) LessThan(b StateEntry) bool {
 
 // StateAtEvent is the state before and after a matrix event.
 type StateAtEvent struct {
+	// Should this state overwrite the latest events and memberships of the room?
+	// This might be necessary when rejoining a federated room after a period of
+	// absence, as our state and latest events will be out of date.
+	Overwrite bool
 	// The state before the event.
 	BeforeStateSnapshotNID StateSnapshotNID
 	// The state entry for the event itself, allows us to calculate the state after the event.


### PR DESCRIPTION
This PR, aside from adding a whole bunch of comments, foundationally makes three subtle changes:

**Adds an `Overwrite` field to `types.StateAtEntry`**

When the roomserver input API receives a `KindNew` event that `HasState` then we:
  1. Set `Overwrite` to `true`
  2. Create a state snapshot based solely on the outliers specified in `StateEventIDs`
  3. We then set the state of the new event to the snapshot created in the previous step

**If `Overwrite` is set, then the latest events updater starts with an empty set of latest events**

This is effectively equivalent to discarding any previously-known forward extremities and updating the room so that it has exactly one new forward extremity: the new input event.

Note that we *don't* reset `oldStateNID` - this is deliberate, because we still secretly want to know the difference between the last state snapshot and our current one so that we can fast-forward changes.

That way we are still working strictly on a delta and we don't repeat any output events to other components that have been sent in the past.

**If `Overwrite` is set, then strip `ServerName` from the output event**

The other components still need these events to update their own internal state after working out the difference between our last-known state and the new state, but this makes sure that we don't send anything out over federation when fast-forwarding. They probably happened in the past.

Still to do, possibly in a separate PR:
- Make sure that we don't overwrite unnecessarily if we are already in the room
- Make sure that we correctly resolve the state between the `/send_join` response and the current room state if we are already in the room