### PR TITLE
Make "Outbound federation can backfill events" pass sytest

### DIFF
--- a/syncapi/routing/messages.go
+++ b/syncapi/routing/messages.go
@@ -412,7 +412,14 @@ func (r *messagesReq) backfill(roomID string, fromEventIDs []string, limit int) 
 		}
 	}
 
-	return res.Events, nil
+	// we may have got more than the requested limit so resize now
+	events := res.Events
+	if len(events) > limit {
+		// last `limit` events
+		events = events[len(events)-limit:]
+	}
+
+	return events, nil
 }
 
 // setToDefault returns the default value for the "to" query parameter of a

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -279,3 +279,4 @@ Inbound federation can return missing events for invite visibility
 Inbound federation can get public room list
 An event which redacts itself should be ignored
 A pair of events which redact each other should be ignored
+Outbound federation can backfill events


### PR DESCRIPTION
- Use a backfill limit of 100 regardless of what was asked.
- Special case the create event for `StateIDsBeforeEvent`
- Trim to the limit in `syncapi`
