### PR TITLE
sytest: Add remaining backfill tests

### DIFF
--- a/federationapi/routing/backfill.go
+++ b/federationapi/routing/backfill.go
@@ -102,7 +102,7 @@ func Backfill(
 		}
 	}
 
-	var eventJSONs []json.RawMessage
+	eventJSONs := []json.RawMessage{}
 	for _, e := range gomatrixserverlib.ReverseTopologicalOrdering(
 		evs,
 		gomatrixserverlib.TopologicalOrderByPrevEvents,

--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -59,6 +59,7 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request, device *authtype
 		"userID":  userID,
 		"since":   syncReq.since,
 		"timeout": syncReq.timeout,
+		"limit":   syncReq.limit,
 	})
 
 	currPos := rp.notifier.CurrentPosition()

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -281,3 +281,5 @@ An event which redacts itself should be ignored
 A pair of events which redact each other should be ignored
 Outbound federation can backfill events
 Inbound federation can backfill events
+Backfill checks the events requested belong to the room
+Backfilled events whose prev_events are in a different room do not allow cross-room back-pagination


### PR DESCRIPTION
One failed because of `null` instead of `[]` in HTTP responses.

One failed because we hadn't implemented in-line filter limits!
