### PR TITLE
Separate muxes for public and internal APIs

### DIFF
--- a/appservice/appservice.go
+++ b/appservice/appservice.go
@@ -101,7 +101,7 @@ func SetupAppServiceAPIComponent(
 
 	// Set up HTTP Endpoints
 	routing.Setup(
-		base.APIMux, base.Cfg, rsAPI,
+		base.PublicAPIMux, base.Cfg, rsAPI,
 		accountsDB, federation, transactionsCache,
 	)
 

--- a/appservice/routing/routing.go
+++ b/appservice/routing/routing.go
@@ -27,7 +27,7 @@ import (
 	"github.com/matrix-org/util"
 )
 
-const pathPrefixApp = "/_matrix/app/v1"
+const pathPrefixApp = "/app/v1"
 
 // Setup registers HTTP handlers with the given ServeMux. It also supplies the given http.Client
 // to clients which need to make outbound HTTP requests.

--- a/clientapi/clientapi.go
+++ b/clientapi/clientapi.go
@@ -65,7 +65,7 @@ func SetupClientAPIComponent(
 	}
 
 	routing.Setup(
-		base.APIMux, base.Cfg, roomserverProducer, rsAPI, asAPI,
+		base.PublicAPIMux, base.Cfg, roomserverProducer, rsAPI, asAPI,
 		accountsDB, deviceDB, federation, *keyRing, userUpdateProducer,
 		syncProducer, eduProducer, transactionsCache, fsAPI,
 	)

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -36,9 +36,9 @@ import (
 	"github.com/matrix-org/util"
 )
 
-const pathPrefixV1 = "/_matrix/client/api/v1"
-const pathPrefixR0 = "/_matrix/client/r0"
-const pathPrefixUnstable = "/_matrix/client/unstable"
+const pathPrefixV1 = "/client/api/v1"
+const pathPrefixR0 = "/client/r0"
+const pathPrefixUnstable = "/client/unstable"
 
 // Setup registers HTTP handlers with the given ServeMux. It also supplies the given http.Client
 // to clients which need to make outbound HTTP requests.
@@ -47,7 +47,7 @@ const pathPrefixUnstable = "/_matrix/client/unstable"
 // applied:
 // nolint: gocyclo
 func Setup(
-	apiMux *mux.Router, cfg *config.Dendrite,
+	publicAPIMux *mux.Router, cfg *config.Dendrite,
 	producer *producers.RoomserverProducer,
 	rsAPI roomserverAPI.RoomserverInternalAPI,
 	asAPI appserviceAPI.AppServiceQueryAPI,
@@ -62,7 +62,7 @@ func Setup(
 	federationSender federationSenderAPI.FederationSenderInternalAPI,
 ) {
 
-	apiMux.Handle("/_matrix/client/versions",
+	publicAPIMux.Handle("/client/versions",
 		internal.MakeExternalAPI("versions", func(req *http.Request) util.JSONResponse {
 			return util.JSONResponse{
 				Code: http.StatusOK,
@@ -78,9 +78,9 @@ func Setup(
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
-	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
-	v1mux := apiMux.PathPrefix(pathPrefixV1).Subrouter()
-	unstableMux := apiMux.PathPrefix(pathPrefixUnstable).Subrouter()
+	r0mux := publicAPIMux.PathPrefix(pathPrefixR0).Subrouter()
+	v1mux := publicAPIMux.PathPrefix(pathPrefixV1).Subrouter()
+	unstableMux := publicAPIMux.PathPrefix(pathPrefixUnstable).Subrouter()
 
 	authData := auth.Data{
 		AccountDB:   accountDB,

--- a/cmd/client-api-proxy/main.go
+++ b/cmd/client-api-proxy/main.go
@@ -75,7 +75,6 @@ func makeProxy(targetURL string) (*httputil.ReverseProxy, error) {
 			// Pratically this means that any distinction between '%2F' and '/'
 			// in the URL will be lost by the time it reaches the target.
 			path := req.URL.Path
-			path = "api" + path
 			log.WithFields(log.Fields{
 				"path":   path,
 				"url":    targetURL,

--- a/cmd/dendrite-demo-libp2p/main.go
+++ b/cmd/dendrite-demo-libp2p/main.go
@@ -178,13 +178,10 @@ func main() {
 	publicroomsapi.SetupPublicRoomsAPIComponent(&base.Base, deviceDB, publicRoomsDB, rsAPI, federation, nil) // Check this later
 	syncapi.SetupSyncAPIComponent(&base.Base, deviceDB, accountDB, rsAPI, federation, &cfg)
 
-	httpHandler := internal.WrapHandlerInCORS(base.Base.PublicAPIMux)
-
 	// Set up the API endpoints we handle. /metrics is for prometheus, and is
 	// not wrapped by CORS, while everything else is
 	http.Handle("/metrics", promhttp.Handler())
-	http.Handle("/_matrix", httpHandler)
-	http.Handle("/_matrix", httpHandler)
+	http.Handle("/_matrix", internal.WrapHandlerInCORS(base.Base.PublicAPIMux))
 	if base.Base.EnableHTTPAPIs {
 		http.Handle("/api/", base.Base.InternalAPIMux)
 	}

--- a/cmd/dendrite-demo-libp2p/main.go
+++ b/cmd/dendrite-demo-libp2p/main.go
@@ -178,12 +178,16 @@ func main() {
 	publicroomsapi.SetupPublicRoomsAPIComponent(&base.Base, deviceDB, publicRoomsDB, rsAPI, federation, nil) // Check this later
 	syncapi.SetupSyncAPIComponent(&base.Base, deviceDB, accountDB, rsAPI, federation, &cfg)
 
-	httpHandler := internal.WrapHandlerInCORS(base.Base.APIMux)
+	httpHandler := internal.WrapHandlerInCORS(base.Base.PublicAPIMux)
 
 	// Set up the API endpoints we handle. /metrics is for prometheus, and is
 	// not wrapped by CORS, while everything else is
 	http.Handle("/metrics", promhttp.Handler())
-	http.Handle("/", httpHandler)
+	http.Handle("/_matrix", httpHandler)
+	http.Handle("/_matrix", httpHandler)
+	if base.Base.EnableHTTPAPIs {
+		http.Handle("/api/", base.Base.InternalAPIMux)
+	}
 
 	// Expose the matrix APIs directly rather than putting them under a /api path.
 	go func() {

--- a/cmd/dendrite-demo-libp2p/main.go
+++ b/cmd/dendrite-demo-libp2p/main.go
@@ -47,7 +47,6 @@ import (
 
 	"github.com/matrix-org/dendrite/eduserver/cache"
 
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 )
 
@@ -178,13 +177,13 @@ func main() {
 	publicroomsapi.SetupPublicRoomsAPIComponent(&base.Base, deviceDB, publicRoomsDB, rsAPI, federation, nil) // Check this later
 	syncapi.SetupSyncAPIComponent(&base.Base, deviceDB, accountDB, rsAPI, federation, &cfg)
 
-	// Set up the API endpoints we handle. /metrics is for prometheus, and is
-	// not wrapped by CORS, while everything else is
-	http.Handle("/metrics", promhttp.Handler())
-	http.Handle("/_matrix", internal.WrapHandlerInCORS(base.Base.PublicAPIMux))
-	if base.Base.EnableHTTPAPIs {
-		http.Handle("/api/", base.Base.InternalAPIMux)
-	}
+	internal.SetupHTTPAPI(
+		http.DefaultServeMux,
+		base.Base.PublicAPIMux,
+		base.Base.InternalAPIMux,
+		&cfg,
+		base.Base.EnableHTTPAPIs,
+	)
 
 	// Expose the matrix APIs directly rather than putting them under a /api path.
 	go func() {

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -91,14 +91,17 @@ func main() {
 	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB, publicRoomsDB, rsAPI, federation, nil)
 	syncapi.SetupSyncAPIComponent(base, deviceDB, accountDB, rsAPI, federation, cfg)
 
-	httpHandler := internal.WrapHandlerInCORS(base.APIMux)
+	httpHandler := internal.WrapHandlerInCORS(base.PublicAPIMux)
 
 	// Set up the API endpoints we handle. /metrics is for prometheus, and is
 	// not wrapped by CORS, while everything else is
 	if cfg.Metrics.Enabled {
 		http.Handle("/metrics", internal.WrapHandlerInBasicAuth(promhttp.Handler(), cfg.Metrics.BasicAuth))
 	}
-	http.Handle("/", httpHandler)
+	http.Handle("/_matrix", httpHandler)
+	if base.EnableHTTPAPIs {
+		http.Handle("/api/", base.InternalAPIMux)
+	}
 
 	// Expose the matrix APIs directly rather than putting them under a /api path.
 	go func() {

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -91,14 +91,12 @@ func main() {
 	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB, publicRoomsDB, rsAPI, federation, nil)
 	syncapi.SetupSyncAPIComponent(base, deviceDB, accountDB, rsAPI, federation, cfg)
 
-	httpHandler := internal.WrapHandlerInCORS(base.PublicAPIMux)
-
 	// Set up the API endpoints we handle. /metrics is for prometheus, and is
 	// not wrapped by CORS, while everything else is
 	if cfg.Metrics.Enabled {
 		http.Handle("/metrics", internal.WrapHandlerInBasicAuth(promhttp.Handler(), cfg.Metrics.BasicAuth))
 	}
-	http.Handle("/_matrix", httpHandler)
+	http.Handle("/_matrix", internal.WrapHandlerInCORS(base.PublicAPIMux))
 	if base.EnableHTTPAPIs {
 		http.Handle("/api/", base.InternalAPIMux)
 	}

--- a/cmd/dendritejs/main.go
+++ b/cmd/dendritejs/main.go
@@ -227,8 +227,7 @@ func main() {
 	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB, publicRoomsDB, rsAPI, federation, p2pPublicRoomProvider)
 	syncapi.SetupSyncAPIComponent(base, deviceDB, accountDB, rsAPI, federation, cfg)
 
-	httpHandler := internal.WrapHandlerInCORS(base.PublicAPIMux)
-	http.Handle("/_matrix", httpHandler)
+	http.Handle("/_matrix", internal.WrapHandlerInCORS(base.PublicAPIMux))
 	if base.EnableHTTPAPIs {
 		http.Handle("/api/", base.InternalAPIMux)
 	}

--- a/cmd/dendritejs/main.go
+++ b/cmd/dendritejs/main.go
@@ -227,9 +227,11 @@ func main() {
 	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB, publicRoomsDB, rsAPI, federation, p2pPublicRoomProvider)
 	syncapi.SetupSyncAPIComponent(base, deviceDB, accountDB, rsAPI, federation, cfg)
 
-	httpHandler := internal.WrapHandlerInCORS(base.APIMux)
-
-	http.Handle("/", httpHandler)
+	httpHandler := internal.WrapHandlerInCORS(base.PublicAPIMux)
+	http.Handle("/_matrix", httpHandler)
+	if base.EnableHTTPAPIs {
+		http.Handle("/api/", base.InternalAPIMux)
+	}
 
 	// Expose the matrix APIs via libp2p-js - for federation traffic
 	if node != nil {

--- a/cmd/dendritejs/main.go
+++ b/cmd/dendritejs/main.go
@@ -227,10 +227,13 @@ func main() {
 	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB, publicRoomsDB, rsAPI, federation, p2pPublicRoomProvider)
 	syncapi.SetupSyncAPIComponent(base, deviceDB, accountDB, rsAPI, federation, cfg)
 
-	http.Handle("/_matrix", internal.WrapHandlerInCORS(base.PublicAPIMux))
-	if base.EnableHTTPAPIs {
-		http.Handle("/api/", base.InternalAPIMux)
-	}
+	internal.SetupHTTPAPI(
+		http.DefaultServeMux,
+		base.PublicAPIMux,
+		base.InternalAPIMux,
+		cfg,
+		base.EnableHTTPAPIs,
+	)
 
 	// Expose the matrix APIs via libp2p-js - for federation traffic
 	if node != nil {

--- a/cmd/federation-api-proxy/main.go
+++ b/cmd/federation-api-proxy/main.go
@@ -73,7 +73,6 @@ func makeProxy(targetURL string) (*httputil.ReverseProxy, error) {
 			// Pratically this means that any distinction between '%2F' and '/'
 			// in the URL will be lost by the time it reaches the target.
 			path := req.URL.Path
-			path = "api" + path
 			log.WithFields(log.Fields{
 				"path":   path,
 				"url":    targetURL,

--- a/federationapi/federationapi.go
+++ b/federationapi/federationapi.go
@@ -44,7 +44,7 @@ func SetupFederationAPIComponent(
 	roomserverProducer := producers.NewRoomserverProducer(rsAPI)
 
 	routing.Setup(
-		base.APIMux, base.Cfg, rsAPI, asAPI, roomserverProducer,
+		base.PublicAPIMux, base.Cfg, rsAPI, asAPI, roomserverProducer,
 		eduProducer, federationSenderAPI, *keyRing,
 		federation, accountsDB, deviceDB,
 	)

--- a/federationapi/routing/routing.go
+++ b/federationapi/routing/routing.go
@@ -31,9 +31,9 @@ import (
 )
 
 const (
-	pathPrefixV2Keys       = "/_matrix/key/v2"
-	pathPrefixV1Federation = "/_matrix/federation/v1"
-	pathPrefixV2Federation = "/_matrix/federation/v2"
+	pathPrefixV2Keys       = "/key/v2"
+	pathPrefixV1Federation = "/federation/v1"
+	pathPrefixV2Federation = "/federation/v2"
 )
 
 // Setup registers HTTP handlers with the given ServeMux.
@@ -42,7 +42,7 @@ const (
 // applied:
 // nolint: gocyclo
 func Setup(
-	apiMux *mux.Router,
+	publicAPIMux *mux.Router,
 	cfg *config.Dendrite,
 	rsAPI roomserverAPI.RoomserverInternalAPI,
 	asAPI appserviceAPI.AppServiceQueryAPI,
@@ -54,9 +54,9 @@ func Setup(
 	accountDB accounts.Database,
 	deviceDB devices.Database,
 ) {
-	v2keysmux := apiMux.PathPrefix(pathPrefixV2Keys).Subrouter()
-	v1fedmux := apiMux.PathPrefix(pathPrefixV1Federation).Subrouter()
-	v2fedmux := apiMux.PathPrefix(pathPrefixV2Federation).Subrouter()
+	v2keysmux := publicAPIMux.PathPrefix(pathPrefixV2Keys).Subrouter()
+	v1fedmux := publicAPIMux.PathPrefix(pathPrefixV1Federation).Subrouter()
+	v2fedmux := publicAPIMux.PathPrefix(pathPrefixV2Federation).Subrouter()
 
 	localKeys := internal.MakeExternalAPI("localkeys", func(req *http.Request) util.JSONResponse {
 		return LocalKeys(cfg)

--- a/federationsender/federationsender.go
+++ b/federationsender/federationsender.go
@@ -15,8 +15,6 @@
 package federationsender
 
 import (
-	"net/http"
-
 	"github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/dendrite/federationsender/consumers"
 	"github.com/matrix-org/dendrite/federationsender/internal"
@@ -72,9 +70,7 @@ func SetupFederationSenderComponent(
 		statistics,
 	)
 
-	if base.EnableHTTPAPIs {
-		queryAPI.SetupHTTP(http.DefaultServeMux)
-	}
+	queryAPI.SetupHTTP(base.InternalAPIMux)
 
 	return queryAPI
 }

--- a/federationsender/internal/api.go
+++ b/federationsender/internal/api.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/dendrite/federationsender/producers"
 	"github.com/matrix-org/dendrite/federationsender/storage"
@@ -43,8 +44,8 @@ func NewFederationSenderInternalAPI(
 }
 
 // SetupHTTP adds the FederationSenderInternalAPI handlers to the http.ServeMux.
-func (f *FederationSenderInternalAPI) SetupHTTP(servMux *http.ServeMux) {
-	servMux.Handle(
+func (f *FederationSenderInternalAPI) SetupHTTP(internalAPIMux *mux.Router) {
+	internalAPIMux.Handle(
 		api.FederationSenderQueryJoinedHostsInRoomPath,
 		internal.MakeInternalAPI("QueryJoinedHostsInRoom", func(req *http.Request) util.JSONResponse {
 			var request api.QueryJoinedHostsInRoomRequest
@@ -58,7 +59,7 @@ func (f *FederationSenderInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(
+	internalAPIMux.Handle(
 		api.FederationSenderQueryJoinedHostServerNamesInRoomPath,
 		internal.MakeInternalAPI("QueryJoinedHostServerNamesInRoom", func(req *http.Request) util.JSONResponse {
 			var request api.QueryJoinedHostServerNamesInRoomRequest
@@ -72,7 +73,7 @@ func (f *FederationSenderInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(api.FederationSenderPerformJoinRequestPath,
+	internalAPIMux.Handle(api.FederationSenderPerformJoinRequestPath,
 		internal.MakeInternalAPI("PerformJoinRequest", func(req *http.Request) util.JSONResponse {
 			var request api.PerformJoinRequest
 			var response api.PerformJoinResponse
@@ -85,7 +86,7 @@ func (f *FederationSenderInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(api.FederationSenderPerformLeaveRequestPath,
+	internalAPIMux.Handle(api.FederationSenderPerformLeaveRequestPath,
 		internal.MakeInternalAPI("PerformLeaveRequest", func(req *http.Request) util.JSONResponse {
 			var request api.PerformLeaveRequest
 			var response api.PerformLeaveResponse

--- a/internal/basecomponent/base.go
+++ b/internal/basecomponent/base.go
@@ -225,7 +225,7 @@ func (b *BaseDendrite) SetupAndServeHTTP(bindaddr string, listenaddr string) {
 
 	internal.SetupHTTPAPI(
 		http.DefaultServeMux,
-		internal.WrapHandlerInCORS(b.PublicAPIMux),
+		b.PublicAPIMux,
 		b.InternalAPIMux,
 		b.Cfg,
 		b.EnableHTTPAPIs,

--- a/internal/basecomponent/base.go
+++ b/internal/basecomponent/base.go
@@ -96,14 +96,15 @@ func NewBaseDendrite(cfg *config.Dendrite, componentName string, enableHTTPAPIs 
 		logrus.WithError(err).Warnf("Failed to create cache")
 	}
 
+	httpmux := mux.NewRouter()
 	return &BaseDendrite{
 		componentName:  componentName,
 		EnableHTTPAPIs: enableHTTPAPIs,
 		tracerCloser:   closer,
 		Cfg:            cfg,
 		ImmutableCache: cache,
-		PublicAPIMux:   mux.NewRouter().UseEncodedPath(),
-		InternalAPIMux: mux.NewRouter().UseEncodedPath(),
+		PublicAPIMux:   httpmux.PathPrefix(internal.HTTPPublicPathPrefix).Subrouter().UseEncodedPath(),
+		InternalAPIMux: httpmux.PathPrefix(internal.HTTPInternalPathPrefix).Subrouter().UseEncodedPath(),
 		httpClient:     &http.Client{Timeout: HTTPClientTimeout},
 		KafkaConsumer:  kafkaConsumer,
 		KafkaProducer:  kafkaProducer,

--- a/internal/httpapi.go
+++ b/internal/httpapi.go
@@ -189,7 +189,7 @@ func SetupHTTPAPI(servMux *http.ServeMux, publicApiMux http.Handler, internalApi
 		servMux.Handle("/metrics", WrapHandlerInBasicAuth(promhttp.Handler(), cfg.Metrics.BasicAuth))
 	}
 	if enableHTTPAPIs {
-		servMux.Handle("/api/", internalApiMux)
+		servMux.Handle("/api", internalApiMux)
 	}
 	servMux.Handle("/_matrix", WrapHandlerInCORS(publicApiMux))
 }

--- a/internal/httpapi.go
+++ b/internal/httpapi.go
@@ -184,11 +184,14 @@ func MakeFedAPI(
 
 // SetupHTTPAPI registers an HTTP API mux under /api and sets up a metrics
 // listener.
-func SetupHTTPAPI(servMux *http.ServeMux, apiMux http.Handler, cfg *config.Dendrite) {
+func SetupHTTPAPI(servMux *http.ServeMux, publicApiMux http.Handler, internalApiMux http.Handler, cfg *config.Dendrite, enableHTTPAPIs bool) {
 	if cfg.Metrics.Enabled {
 		servMux.Handle("/metrics", WrapHandlerInBasicAuth(promhttp.Handler(), cfg.Metrics.BasicAuth))
 	}
-	servMux.Handle("/api/", http.StripPrefix("/api", apiMux))
+	if enableHTTPAPIs {
+		servMux.Handle("/api/", internalApiMux)
+	}
+	servMux.Handle("/_matrix", publicApiMux)
 }
 
 // WrapHandlerInBasicAuth adds basic auth to a handler. Only used for /metrics

--- a/internal/httpapi.go
+++ b/internal/httpapi.go
@@ -191,7 +191,7 @@ func SetupHTTPAPI(servMux *http.ServeMux, publicApiMux http.Handler, internalApi
 	if enableHTTPAPIs {
 		servMux.Handle("/api/", internalApiMux)
 	}
-	servMux.Handle("/_matrix", publicApiMux)
+	servMux.Handle("/_matrix", WrapHandlerInCORS(publicApiMux))
 }
 
 // WrapHandlerInBasicAuth adds basic auth to a handler. Only used for /metrics

--- a/keyserver/keyserver.go
+++ b/keyserver/keyserver.go
@@ -28,5 +28,5 @@ func SetupKeyServerComponent(
 	deviceDB devices.Database,
 	accountsDB accounts.Database,
 ) {
-	routing.Setup(base.APIMux, base.Cfg, accountsDB, deviceDB)
+	routing.Setup(base.PublicAPIMux, base.Cfg, accountsDB, deviceDB)
 }

--- a/keyserver/routing/routing.go
+++ b/keyserver/routing/routing.go
@@ -27,7 +27,7 @@ import (
 	"github.com/matrix-org/util"
 )
 
-const pathPrefixR0 = "/_matrix/client/r0"
+const pathPrefixR0 = "/client/r0"
 
 // Setup registers HTTP handlers with the given ServeMux. It also supplies the given http.Client
 // to clients which need to make outbound HTTP requests.
@@ -36,11 +36,11 @@ const pathPrefixR0 = "/_matrix/client/r0"
 // applied:
 // nolint: gocyclo
 func Setup(
-	apiMux *mux.Router, cfg *config.Dendrite,
+	publicAPIMux *mux.Router, cfg *config.Dendrite,
 	accountDB accounts.Database,
 	deviceDB devices.Database,
 ) {
-	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
+	r0mux := publicAPIMux.PathPrefix(pathPrefixR0).Subrouter()
 
 	authData := auth.Data{
 		AccountDB:   accountDB,

--- a/mediaapi/mediaapi.go
+++ b/mediaapi/mediaapi.go
@@ -35,6 +35,6 @@ func SetupMediaAPIComponent(
 	}
 
 	routing.Setup(
-		base.APIMux, base.Cfg, mediaDB, deviceDB, gomatrixserverlib.NewClient(),
+		base.PublicAPIMux, base.Cfg, mediaDB, deviceDB, gomatrixserverlib.NewClient(),
 	)
 }

--- a/mediaapi/routing/routing.go
+++ b/mediaapi/routing/routing.go
@@ -33,7 +33,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-const pathPrefixR0 = "/_matrix/media/r0"
+const pathPrefixR0 = "/media/r0"
 
 // Setup registers the media API HTTP handlers
 //
@@ -41,13 +41,13 @@ const pathPrefixR0 = "/_matrix/media/r0"
 // applied:
 // nolint: gocyclo
 func Setup(
-	apiMux *mux.Router,
+	publicAPIMux *mux.Router,
 	cfg *config.Dendrite,
 	db storage.Database,
 	deviceDB devices.Database,
 	client *gomatrixserverlib.Client,
 ) {
-	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
+	r0mux := publicAPIMux.PathPrefix(pathPrefixR0).Subrouter()
 
 	activeThumbnailGeneration := &types.ActiveThumbnailGeneration{
 		PathToResult: map[string]*types.ThumbnailGenerationResult{},

--- a/publicroomsapi/publicroomsapi.go
+++ b/publicroomsapi/publicroomsapi.go
@@ -43,5 +43,5 @@ func SetupPublicRoomsAPIComponent(
 		logrus.WithError(err).Panic("failed to start public rooms server consumer")
 	}
 
-	routing.Setup(base.APIMux, deviceDB, publicRoomsDB, rsAPI, fedClient, extRoomsProvider)
+	routing.Setup(base.PublicAPIMux, deviceDB, publicRoomsDB, rsAPI, fedClient, extRoomsProvider)
 }

--- a/publicroomsapi/routing/routing.go
+++ b/publicroomsapi/routing/routing.go
@@ -31,7 +31,7 @@ import (
 	"github.com/matrix-org/util"
 )
 
-const pathPrefixR0 = "/_matrix/client/r0"
+const pathPrefixR0 = "/client/r0"
 
 // Setup configures the given mux with publicroomsapi server listeners
 //
@@ -39,10 +39,10 @@ const pathPrefixR0 = "/_matrix/client/r0"
 // applied:
 // nolint: gocyclo
 func Setup(
-	apiMux *mux.Router, deviceDB devices.Database, publicRoomsDB storage.Database, rsAPI api.RoomserverInternalAPI,
+	publicAPIMux *mux.Router, deviceDB devices.Database, publicRoomsDB storage.Database, rsAPI api.RoomserverInternalAPI,
 	fedClient *gomatrixserverlib.FederationClient, extRoomsProvider types.ExternalPublicRoomsProvider,
 ) {
-	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
+	r0mux := publicAPIMux.PathPrefix(pathPrefixR0).Subrouter()
 
 	authData := auth.Data{
 		AccountDB:   nil,
@@ -79,7 +79,7 @@ func Setup(
 	).Methods(http.MethodGet, http.MethodPost, http.MethodOptions)
 
 	// Federation - TODO: should this live here or in federation API? It's sure easier if it's here so here it is.
-	apiMux.Handle("/_matrix/federation/v1/publicRooms",
+	publicAPIMux.Handle("/federation/v1/publicRooms",
 		internal.MakeExternalAPI("federation_public_rooms", func(req *http.Request) util.JSONResponse {
 			return directory.GetPostPublicRooms(req, publicRoomsDB)
 		}),

--- a/roomserver/api/alias.go
+++ b/roomserver/api/alias.go
@@ -85,19 +85,19 @@ type RemoveRoomAliasRequest struct {
 type RemoveRoomAliasResponse struct{}
 
 // RoomserverSetRoomAliasPath is the HTTP path for the SetRoomAlias API.
-const RoomserverSetRoomAliasPath = "/api/roomserver/setRoomAlias"
+const RoomserverSetRoomAliasPath = "/roomserver/setRoomAlias"
 
 // RoomserverGetRoomIDForAliasPath is the HTTP path for the GetRoomIDForAlias API.
-const RoomserverGetRoomIDForAliasPath = "/api/roomserver/GetRoomIDForAlias"
+const RoomserverGetRoomIDForAliasPath = "/roomserver/GetRoomIDForAlias"
 
 // RoomserverGetAliasesForRoomIDPath is the HTTP path for the GetAliasesForRoomID API.
-const RoomserverGetAliasesForRoomIDPath = "/api/roomserver/GetAliasesForRoomID"
+const RoomserverGetAliasesForRoomIDPath = "/roomserver/GetAliasesForRoomID"
 
 // RoomserverGetCreatorIDForAliasPath is the HTTP path for the GetCreatorIDForAlias API.
-const RoomserverGetCreatorIDForAliasPath = "/api/roomserver/GetCreatorIDForAlias"
+const RoomserverGetCreatorIDForAliasPath = "/roomserver/GetCreatorIDForAlias"
 
 // RoomserverRemoveRoomAliasPath is the HTTP path for the RemoveRoomAlias API.
-const RoomserverRemoveRoomAliasPath = "/api/roomserver/removeRoomAlias"
+const RoomserverRemoveRoomAliasPath = "/roomserver/removeRoomAlias"
 
 // SetRoomAlias implements RoomserverAliasAPI
 func (h *httpRoomserverInternalAPI) SetRoomAlias(

--- a/roomserver/api/input.go
+++ b/roomserver/api/input.go
@@ -103,7 +103,7 @@ type InputRoomEventsResponse struct {
 }
 
 // RoomserverInputRoomEventsPath is the HTTP path for the InputRoomEvents API.
-const RoomserverInputRoomEventsPath = "/api/roomserver/inputRoomEvents"
+const RoomserverInputRoomEventsPath = "/roomserver/inputRoomEvents"
 
 // InputRoomEvents implements RoomserverInputAPI
 func (h *httpRoomserverInternalAPI) InputRoomEvents(

--- a/roomserver/api/perform.go
+++ b/roomserver/api/perform.go
@@ -10,10 +10,10 @@ import (
 
 const (
 	// RoomserverPerformJoinPath is the HTTP path for the PerformJoin API.
-	RoomserverPerformJoinPath = "/api/roomserver/performJoin"
+	RoomserverPerformJoinPath = "/roomserver/performJoin"
 
 	// RoomserverPerformLeavePath is the HTTP path for the PerformLeave API.
-	RoomserverPerformLeavePath = "/api/roomserver/performLeave"
+	RoomserverPerformLeavePath = "/roomserver/performLeave"
 )
 
 type PerformJoinRequest struct {

--- a/roomserver/api/query.go
+++ b/roomserver/api/query.go
@@ -273,40 +273,40 @@ type QueryRoomVersionForRoomResponse struct {
 }
 
 // RoomserverQueryLatestEventsAndStatePath is the HTTP path for the QueryLatestEventsAndState API.
-const RoomserverQueryLatestEventsAndStatePath = "/api/roomserver/queryLatestEventsAndState"
+const RoomserverQueryLatestEventsAndStatePath = "/roomserver/queryLatestEventsAndState"
 
 // RoomserverQueryStateAfterEventsPath is the HTTP path for the QueryStateAfterEvents API.
-const RoomserverQueryStateAfterEventsPath = "/api/roomserver/queryStateAfterEvents"
+const RoomserverQueryStateAfterEventsPath = "/roomserver/queryStateAfterEvents"
 
 // RoomserverQueryEventsByIDPath is the HTTP path for the QueryEventsByID API.
-const RoomserverQueryEventsByIDPath = "/api/roomserver/queryEventsByID"
+const RoomserverQueryEventsByIDPath = "/roomserver/queryEventsByID"
 
 // RoomserverQueryMembershipForUserPath is the HTTP path for the QueryMembershipForUser API.
-const RoomserverQueryMembershipForUserPath = "/api/roomserver/queryMembershipForUser"
+const RoomserverQueryMembershipForUserPath = "/roomserver/queryMembershipForUser"
 
 // RoomserverQueryMembershipsForRoomPath is the HTTP path for the QueryMembershipsForRoom API
-const RoomserverQueryMembershipsForRoomPath = "/api/roomserver/queryMembershipsForRoom"
+const RoomserverQueryMembershipsForRoomPath = "/roomserver/queryMembershipsForRoom"
 
 // RoomserverQueryInvitesForUserPath is the HTTP path for the QueryInvitesForUser API
-const RoomserverQueryInvitesForUserPath = "/api/roomserver/queryInvitesForUser"
+const RoomserverQueryInvitesForUserPath = "/roomserver/queryInvitesForUser"
 
 // RoomserverQueryServerAllowedToSeeEventPath is the HTTP path for the QueryServerAllowedToSeeEvent API
-const RoomserverQueryServerAllowedToSeeEventPath = "/api/roomserver/queryServerAllowedToSeeEvent"
+const RoomserverQueryServerAllowedToSeeEventPath = "/roomserver/queryServerAllowedToSeeEvent"
 
 // RoomserverQueryMissingEventsPath is the HTTP path for the QueryMissingEvents API
-const RoomserverQueryMissingEventsPath = "/api/roomserver/queryMissingEvents"
+const RoomserverQueryMissingEventsPath = "/roomserver/queryMissingEvents"
 
 // RoomserverQueryStateAndAuthChainPath is the HTTP path for the QueryStateAndAuthChain API
-const RoomserverQueryStateAndAuthChainPath = "/api/roomserver/queryStateAndAuthChain"
+const RoomserverQueryStateAndAuthChainPath = "/roomserver/queryStateAndAuthChain"
 
 // RoomserverQueryBackfillPath is the HTTP path for the QueryBackfillPath API
-const RoomserverQueryBackfillPath = "/api/roomserver/queryBackfill"
+const RoomserverQueryBackfillPath = "/roomserver/queryBackfill"
 
 // RoomserverQueryRoomVersionCapabilitiesPath is the HTTP path for the QueryRoomVersionCapabilities API
-const RoomserverQueryRoomVersionCapabilitiesPath = "/api/roomserver/queryRoomVersionCapabilities"
+const RoomserverQueryRoomVersionCapabilitiesPath = "/roomserver/queryRoomVersionCapabilities"
 
 // RoomserverQueryRoomVersionForRoomPath is the HTTP path for the QueryRoomVersionForRoom API
-const RoomserverQueryRoomVersionForRoomPath = "/api/roomserver/queryRoomVersionForRoom"
+const RoomserverQueryRoomVersionForRoomPath = "/roomserver/queryRoomVersionForRoom"
 
 // QueryLatestEventsAndState implements RoomserverQueryAPI
 func (h *httpRoomserverInternalAPI) QueryLatestEventsAndState(

--- a/roomserver/internal/api.go
+++ b/roomserver/internal/api.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/Shopify/sarama"
+	"github.com/gorilla/mux"
 	fsAPI "github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/caching"
@@ -32,8 +33,8 @@ type RoomserverInternalAPI struct {
 
 // SetupHTTP adds the RoomserverInternalAPI handlers to the http.ServeMux.
 // nolint: gocyclo
-func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
-	servMux.Handle(api.RoomserverInputRoomEventsPath,
+func (r *RoomserverInternalAPI) SetupHTTP(internalAPIMux *mux.Router) {
+	internalAPIMux.Handle(api.RoomserverInputRoomEventsPath,
 		internal.MakeInternalAPI("inputRoomEvents", func(req *http.Request) util.JSONResponse {
 			var request api.InputRoomEventsRequest
 			var response api.InputRoomEventsResponse
@@ -46,7 +47,7 @@ func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(api.RoomserverPerformJoinPath,
+	internalAPIMux.Handle(api.RoomserverPerformJoinPath,
 		internal.MakeInternalAPI("performJoin", func(req *http.Request) util.JSONResponse {
 			var request api.PerformJoinRequest
 			var response api.PerformJoinResponse
@@ -59,7 +60,7 @@ func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(api.RoomserverPerformLeavePath,
+	internalAPIMux.Handle(api.RoomserverPerformLeavePath,
 		internal.MakeInternalAPI("performLeave", func(req *http.Request) util.JSONResponse {
 			var request api.PerformLeaveRequest
 			var response api.PerformLeaveResponse
@@ -72,7 +73,7 @@ func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(
+	internalAPIMux.Handle(
 		api.RoomserverQueryLatestEventsAndStatePath,
 		internal.MakeInternalAPI("queryLatestEventsAndState", func(req *http.Request) util.JSONResponse {
 			var request api.QueryLatestEventsAndStateRequest
@@ -86,7 +87,7 @@ func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(
+	internalAPIMux.Handle(
 		api.RoomserverQueryStateAfterEventsPath,
 		internal.MakeInternalAPI("queryStateAfterEvents", func(req *http.Request) util.JSONResponse {
 			var request api.QueryStateAfterEventsRequest
@@ -100,7 +101,7 @@ func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(
+	internalAPIMux.Handle(
 		api.RoomserverQueryEventsByIDPath,
 		internal.MakeInternalAPI("queryEventsByID", func(req *http.Request) util.JSONResponse {
 			var request api.QueryEventsByIDRequest
@@ -114,7 +115,7 @@ func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(
+	internalAPIMux.Handle(
 		api.RoomserverQueryMembershipForUserPath,
 		internal.MakeInternalAPI("QueryMembershipForUser", func(req *http.Request) util.JSONResponse {
 			var request api.QueryMembershipForUserRequest
@@ -128,7 +129,7 @@ func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(
+	internalAPIMux.Handle(
 		api.RoomserverQueryMembershipsForRoomPath,
 		internal.MakeInternalAPI("queryMembershipsForRoom", func(req *http.Request) util.JSONResponse {
 			var request api.QueryMembershipsForRoomRequest
@@ -142,7 +143,7 @@ func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(
+	internalAPIMux.Handle(
 		api.RoomserverQueryInvitesForUserPath,
 		internal.MakeInternalAPI("queryInvitesForUser", func(req *http.Request) util.JSONResponse {
 			var request api.QueryInvitesForUserRequest
@@ -156,7 +157,7 @@ func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(
+	internalAPIMux.Handle(
 		api.RoomserverQueryServerAllowedToSeeEventPath,
 		internal.MakeInternalAPI("queryServerAllowedToSeeEvent", func(req *http.Request) util.JSONResponse {
 			var request api.QueryServerAllowedToSeeEventRequest
@@ -170,7 +171,7 @@ func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(
+	internalAPIMux.Handle(
 		api.RoomserverQueryMissingEventsPath,
 		internal.MakeInternalAPI("queryMissingEvents", func(req *http.Request) util.JSONResponse {
 			var request api.QueryMissingEventsRequest
@@ -184,7 +185,7 @@ func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(
+	internalAPIMux.Handle(
 		api.RoomserverQueryStateAndAuthChainPath,
 		internal.MakeInternalAPI("queryStateAndAuthChain", func(req *http.Request) util.JSONResponse {
 			var request api.QueryStateAndAuthChainRequest
@@ -198,7 +199,7 @@ func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(
+	internalAPIMux.Handle(
 		api.RoomserverQueryBackfillPath,
 		internal.MakeInternalAPI("QueryBackfill", func(req *http.Request) util.JSONResponse {
 			var request api.QueryBackfillRequest
@@ -212,7 +213,7 @@ func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(
+	internalAPIMux.Handle(
 		api.RoomserverQueryRoomVersionCapabilitiesPath,
 		internal.MakeInternalAPI("QueryRoomVersionCapabilities", func(req *http.Request) util.JSONResponse {
 			var request api.QueryRoomVersionCapabilitiesRequest
@@ -226,7 +227,7 @@ func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(
+	internalAPIMux.Handle(
 		api.RoomserverQueryRoomVersionForRoomPath,
 		internal.MakeInternalAPI("QueryRoomVersionForRoom", func(req *http.Request) util.JSONResponse {
 			var request api.QueryRoomVersionForRoomRequest
@@ -240,7 +241,7 @@ func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(
+	internalAPIMux.Handle(
 		api.RoomserverSetRoomAliasPath,
 		internal.MakeInternalAPI("setRoomAlias", func(req *http.Request) util.JSONResponse {
 			var request api.SetRoomAliasRequest
@@ -254,7 +255,7 @@ func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(
+	internalAPIMux.Handle(
 		api.RoomserverGetRoomIDForAliasPath,
 		internal.MakeInternalAPI("GetRoomIDForAlias", func(req *http.Request) util.JSONResponse {
 			var request api.GetRoomIDForAliasRequest
@@ -268,7 +269,7 @@ func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(
+	internalAPIMux.Handle(
 		api.RoomserverGetCreatorIDForAliasPath,
 		internal.MakeInternalAPI("GetCreatorIDForAlias", func(req *http.Request) util.JSONResponse {
 			var request api.GetCreatorIDForAliasRequest
@@ -282,7 +283,7 @@ func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(
+	internalAPIMux.Handle(
 		api.RoomserverGetAliasesForRoomIDPath,
 		internal.MakeInternalAPI("getAliasesForRoomID", func(req *http.Request) util.JSONResponse {
 			var request api.GetAliasesForRoomIDRequest
@@ -296,7 +297,7 @@ func (r *RoomserverInternalAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(
+	internalAPIMux.Handle(
 		api.RoomserverRemoveRoomAliasPath,
 		internal.MakeInternalAPI("removeRoomAlias", func(req *http.Request) util.JSONResponse {
 			var request api.RemoveRoomAliasRequest

--- a/roomserver/roomserver.go
+++ b/roomserver/roomserver.go
@@ -15,8 +15,6 @@
 package roomserver
 
 import (
-	"net/http"
-
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
 
@@ -51,9 +49,7 @@ func SetupRoomServerComponent(
 		KeyRing:              keyRing,
 	}
 
-	if base.EnableHTTPAPIs {
-		internalAPI.SetupHTTP(http.DefaultServeMux)
-	}
+	internalAPI.SetupHTTP(base.InternalAPIMux)
 
 	return &internalAPI
 }

--- a/syncapi/routing/routing.go
+++ b/syncapi/routing/routing.go
@@ -30,7 +30,7 @@ import (
 	"github.com/matrix-org/util"
 )
 
-const pathPrefixR0 = "/_matrix/client/r0"
+const pathPrefixR0 = "/client/r0"
 
 // Setup configures the given mux with sync-server listeners
 //
@@ -38,12 +38,12 @@ const pathPrefixR0 = "/_matrix/client/r0"
 // applied:
 // nolint: gocyclo
 func Setup(
-	apiMux *mux.Router, srp *sync.RequestPool, syncDB storage.Database,
+	publicAPIMux *mux.Router, srp *sync.RequestPool, syncDB storage.Database,
 	deviceDB devices.Database, federation *gomatrixserverlib.FederationClient,
 	rsAPI api.RoomserverInternalAPI,
 	cfg *config.Dendrite,
 ) {
-	r0mux := apiMux.PathPrefix(pathPrefixR0).Subrouter()
+	r0mux := publicAPIMux.PathPrefix(pathPrefixR0).Subrouter()
 
 	authData := auth.Data{
 		AccountDB:   nil,

--- a/syncapi/syncapi.go
+++ b/syncapi/syncapi.go
@@ -81,5 +81,5 @@ func SetupSyncAPIComponent(
 		logrus.WithError(err).Panicf("failed to start typing server consumer")
 	}
 
-	routing.Setup(base.APIMux, requestPool, syncDB, deviceDB, federation, rsAPI, cfg)
+	routing.Setup(base.PublicAPIMux, requestPool, syncDB, deviceDB, federation, rsAPI, cfg)
 }


### PR DESCRIPTION
This separates the HTTP routing into `PublicAPIMux` (which maps to `/_matrix`) and `InternalAPIMux` (which maps to `/api`).