### PR TITLE
Miscellaneous fixes

### DIFF
--- a/appservice/appservice.go
+++ b/appservice/appservice.go
@@ -82,9 +82,7 @@ func SetupAppServiceAPIComponent(
 		Cfg: base.Cfg,
 	}
 
-	if base.EnableHTTPAPIs {
-		appserviceQueryAPI.SetupHTTP(http.DefaultServeMux)
-	}
+	appserviceQueryAPI.SetupHTTP(base.InternalAPIMux)
 
 	consumer := consumers.NewOutputRoomEventConsumer(
 		base.Cfg, base.KafkaConsumer, accountsDB, appserviceDB,

--- a/appservice/query/query.go
+++ b/appservice/query/query.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/appservice/api"
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/config"
@@ -182,8 +183,8 @@ func makeHTTPClient() *http.Client {
 
 // SetupHTTP adds the AppServiceQueryPAI handlers to the http.ServeMux. This
 // handles and muxes incoming api requests the to internal AppServiceQueryAPI.
-func (a *AppServiceQueryAPI) SetupHTTP(servMux *http.ServeMux) {
-	servMux.Handle(
+func (a *AppServiceQueryAPI) SetupHTTP(internalAPIMux *mux.Router) {
+	internalAPIMux.Handle(
 		api.AppServiceRoomAliasExistsPath,
 		internal.MakeInternalAPI("appserviceRoomAliasExists", func(req *http.Request) util.JSONResponse {
 			var request api.RoomAliasExistsRequest
@@ -197,7 +198,7 @@ func (a *AppServiceQueryAPI) SetupHTTP(servMux *http.ServeMux) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	servMux.Handle(
+	internalAPIMux.Handle(
 		api.AppServiceUserIDExistsPath,
 		internal.MakeInternalAPI("appserviceUserIDExists", func(req *http.Request) util.JSONResponse {
 			var request api.UserIDExistsRequest

--- a/clientapi/auth/storage/devices/sqlite3/devices_table.go
+++ b/clientapi/auth/storage/devices/sqlite3/devices_table.go
@@ -208,9 +208,8 @@ func (s *devicesStatements) selectDeviceByID(
 	ctx context.Context, localpart, deviceID string,
 ) (*authtypes.Device, error) {
 	var dev authtypes.Device
-	var created sql.NullInt64
 	stmt := s.selectDeviceByIDStmt
-	err := stmt.QueryRowContext(ctx, localpart, deviceID).Scan(&created)
+	err := stmt.QueryRowContext(ctx, localpart, deviceID).Scan(&dev.DisplayName)
 	if err == nil {
 		dev.ID = deviceID
 		dev.UserID = userutil.MakeUserID(localpart, s.serverName)
@@ -231,9 +230,16 @@ func (s *devicesStatements) selectDevicesByLocalpart(
 
 	for rows.Next() {
 		var dev authtypes.Device
-		err = rows.Scan(&dev.ID, &dev.DisplayName)
+		var id, displayname sql.NullString
+		err = rows.Scan(&id, &displayname)
 		if err != nil {
 			return devices, err
+		}
+		if id.Valid {
+			dev.ID = id.String
+		}
+		if displayname.Valid {
+			dev.DisplayName = displayname.String
 		}
 		dev.UserID = userutil.MakeUserID(localpart, s.serverName)
 		devices = append(devices, dev)

--- a/clientapi/routing/joinroom.go
+++ b/clientapi/routing/joinroom.go
@@ -75,6 +75,6 @@ func JoinRoomByIDOrAlias(
 		// TODO: Put the response struct somewhere internal.
 		JSON: struct {
 			RoomID string `json:"room_id"`
-		}{joinReq.RoomIDOrAlias},
+		}{joinRes.RoomID},
 	}
 }

--- a/eduserver/eduserver.go
+++ b/eduserver/eduserver.go
@@ -13,8 +13,6 @@
 package eduserver
 
 import (
-	"net/http"
-
 	"github.com/matrix-org/dendrite/eduserver/api"
 	"github.com/matrix-org/dendrite/eduserver/cache"
 	"github.com/matrix-org/dendrite/eduserver/input"
@@ -35,9 +33,7 @@ func SetupEDUServerComponent(
 		OutputTypingEventTopic: string(base.Cfg.Kafka.Topics.OutputTypingEvent),
 	}
 
-	if base.EnableHTTPAPIs {
-		inputAPI.SetupHTTP(http.DefaultServeMux)
-	}
+	inputAPI.SetupHTTP(base.InternalAPIMux)
 
 	return inputAPI
 }

--- a/eduserver/input/input.go
+++ b/eduserver/input/input.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
+	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/eduserver/api"
 	"github.com/matrix-org/dendrite/eduserver/cache"
 	"github.com/matrix-org/dendrite/internal"
@@ -90,8 +91,8 @@ func (t *EDUServerInputAPI) sendEvent(ite *api.InputTypingEvent) error {
 }
 
 // SetupHTTP adds the EDUServerInputAPI handlers to the http.ServeMux.
-func (t *EDUServerInputAPI) SetupHTTP(servMux *http.ServeMux) {
-	servMux.Handle(api.EDUServerInputTypingEventPath,
+func (t *EDUServerInputAPI) SetupHTTP(internalAPIMux *mux.Router) {
+	internalAPIMux.Handle(api.EDUServerInputTypingEventPath,
 		internal.MakeInternalAPI("inputTypingEvents", func(req *http.Request) util.JSONResponse {
 			var request api.InputTypingEventRequest
 			var response api.InputTypingEventResponse

--- a/federationsender/internal/api.go
+++ b/federationsender/internal/api.go
@@ -99,4 +99,17 @@ func (f *FederationSenderInternalAPI) SetupHTTP(internalAPIMux *mux.Router) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
+	internalAPIMux.Handle(api.FederationSenderPerformDirectoryLookupRequestPath,
+		internal.MakeInternalAPI("PerformDirectoryLookupRequest", func(req *http.Request) util.JSONResponse {
+			var request api.PerformDirectoryLookupRequest
+			var response api.PerformDirectoryLookupResponse
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.MessageResponse(http.StatusBadRequest, err.Error())
+			}
+			if err := f.PerformDirectoryLookup(req.Context(), &request, &response); err != nil {
+				return util.ErrorResponse(err)
+			}
+			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
+		}),
+	)
 }

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -60,9 +60,9 @@ func PostJSON(
 			Message string `json:"message"`
 		}
 		if msgerr := json.NewDecoder(res.Body).Decode(&errorBody); msgerr == nil {
-			return fmt.Errorf("api: %d from %s: %s", res.StatusCode, apiURL, errorBody.Message)
+			return fmt.Errorf("Internal API: %d from %s: %s", res.StatusCode, apiURL, errorBody.Message)
 		}
-		return fmt.Errorf("api: %d from %s", res.StatusCode, apiURL)
+		return fmt.Errorf("Internal API: %d from %s", res.StatusCode, apiURL)
 	}
 	return json.NewDecoder(res.Body).Decode(response)
 }

--- a/roomserver/api/perform.go
+++ b/roomserver/api/perform.go
@@ -24,6 +24,7 @@ type PerformJoinRequest struct {
 }
 
 type PerformJoinResponse struct {
+	RoomID string `json:"room_id"`
 }
 
 func (h *httpRoomserverInternalAPI) PerformJoin(

--- a/roomserver/internal/perform_join.go
+++ b/roomserver/internal/perform_join.go
@@ -90,6 +90,12 @@ func (r *RoomserverInternalAPI) performJoinRoomByID(
 	req *api.PerformJoinRequest,
 	res *api.PerformJoinResponse, // nolint:unparam
 ) error {
+	// By this point, if req.RoomIDOrAlias contained an alias, then
+	// it will have been overwritten with a room ID by performJoinRoomByAlias.
+	// We should now include this in the response so that the CS API can
+	// return the right room ID.
+	res.RoomID = req.RoomIDOrAlias
+
 	// Get the domain part of the room ID.
 	_, domain, err := gomatrixserverlib.SplitID('!', req.RoomIDOrAlias)
 	if err != nil {

--- a/roomserver/internal/perform_join.go
+++ b/roomserver/internal/perform_join.go
@@ -121,10 +121,11 @@ func (r *RoomserverInternalAPI) performJoinRoomByID(
 		return fmt.Errorf("eb.SetContent: %w", err)
 	}
 
-	// First work out if this is in response to an existing invite.
-	// If it is then we avoid the situation where we might think we
-	// know about a room in the following section but don't know the
-	// latest state as all of our users have left.
+	// First work out if this is in response to an existing invite
+	// from a federated server. If it is then we avoid the situation
+	// where we might think we know about a room in the following
+	// section but don't know the latest state as all of our users
+	// have left.
 	isInvitePending, inviteSender, err := r.isInvitePending(ctx, req.RoomIDOrAlias, req.UserID)
 	if err == nil && isInvitePending {
 		// Check if there's an invite pending.
@@ -134,7 +135,7 @@ func (r *RoomserverInternalAPI) performJoinRoomByID(
 		}
 
 		// Check that the domain isn't ours. If it's local then we don't
-		// need to do anythig as our own copy of the room state will be
+		// need to do anything as our own copy of the room state will be
 		// up-to-date.
 		if inviterDomain != r.Cfg.Matrix.ServerName {
 			// Add the server of the person who invited us to the server list,

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -288,3 +288,4 @@ New room members see their own join event
 Existing members see new members' join events
 Inbound federation can receive events
 Inbound federation can receive redacted events
+Can logout current device

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -289,4 +289,3 @@ Existing members see new members' join events
 Inbound federation can receive events
 Inbound federation can receive redacted events
 Can logout current device
-Guest users can accept invites to private rooms over federation

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -289,3 +289,4 @@ Existing members see new members' join events
 Inbound federation can receive events
 Inbound federation can receive redacted events
 Can logout current device
+Guest users can accept invites to private rooms over federation


### PR DESCRIPTION
This PR contains four minor fixes:

- Return the correct room ID from `PerformJoin`, instead of incorrectly returning the alias (this happened only in HTTP API mode because we can't overwrite the request there)
- Fix some bugs in the devices storage code which resulted in SQL errors (and apparently this fixes a test too)
- Check the domain part before defaulting to federated joins in response to invites
- Implement missing `PerformDirectoryLookupRequest` implementation on the API mux
- Fix the setup of the appservice and EDU server HTTP APIs