### PR TITLE
roomserver: start refactoring storage layer

### DIFF
--- a/roomserver/storage/postgres/event_types_table.go
+++ b/roomserver/storage/postgres/event_types_table.go
@@ -22,6 +22,7 @@ import (
 	"github.com/matrix-org/dendrite/internal"
 
 	"github.com/lib/pq"
+	"github.com/matrix-org/dendrite/roomserver/storage/tables"
 	"github.com/matrix-org/dendrite/roomserver/types"
 )
 
@@ -98,36 +99,37 @@ type eventTypeStatements struct {
 	bulkSelectEventTypeNIDStmt *sql.Stmt
 }
 
-func (s *eventTypeStatements) prepare(db *sql.DB) (err error) {
-	_, err = db.Exec(eventTypesSchema)
+func NewPostgresEventTypesTable(db *sql.DB) (tables.EventTypes, error) {
+	s := &eventTypeStatements{}
+	_, err := db.Exec(eventTypesSchema)
 	if err != nil {
-		return
+		return nil, err
 	}
 
-	return statementList{
+	return s, statementList{
 		{&s.insertEventTypeNIDStmt, insertEventTypeNIDSQL},
 		{&s.selectEventTypeNIDStmt, selectEventTypeNIDSQL},
 		{&s.bulkSelectEventTypeNIDStmt, bulkSelectEventTypeNIDSQL},
 	}.prepare(db)
 }
 
-func (s *eventTypeStatements) insertEventTypeNID(
-	ctx context.Context, eventType string,
+func (s *eventTypeStatements) InsertEventTypeNID(
+	ctx context.Context, txn *sql.Tx, eventType string,
 ) (types.EventTypeNID, error) {
 	var eventTypeNID int64
-	err := s.insertEventTypeNIDStmt.QueryRowContext(ctx, eventType).Scan(&eventTypeNID)
+	err := txn.Stmt(s.insertEventTypeNIDStmt).QueryRowContext(ctx, eventType).Scan(&eventTypeNID)
 	return types.EventTypeNID(eventTypeNID), err
 }
 
-func (s *eventTypeStatements) selectEventTypeNID(
-	ctx context.Context, eventType string,
+func (s *eventTypeStatements) SelectEventTypeNID(
+	ctx context.Context, txn *sql.Tx, eventType string,
 ) (types.EventTypeNID, error) {
 	var eventTypeNID int64
-	err := s.selectEventTypeNIDStmt.QueryRowContext(ctx, eventType).Scan(&eventTypeNID)
+	err := txn.Stmt(s.selectEventTypeNIDStmt).QueryRowContext(ctx, eventType).Scan(&eventTypeNID)
 	return types.EventTypeNID(eventTypeNID), err
 }
 
-func (s *eventTypeStatements) bulkSelectEventTypeNID(
+func (s *eventTypeStatements) BulkSelectEventTypeNID(
 	ctx context.Context, eventTypes []string,
 ) (map[string]types.EventTypeNID, error) {
 	rows, err := s.bulkSelectEventTypeNIDStmt.QueryContext(ctx, pq.StringArray(eventTypes))

--- a/roomserver/storage/postgres/sql.go
+++ b/roomserver/storage/postgres/sql.go
@@ -39,7 +39,6 @@ func (s *statements) prepare(db *sql.DB) error {
 
 	for _, prepare := range []func(db *sql.DB) error{
 		s.eventTypeStatements.prepare,
-		s.eventStateKeyStatements.prepare,
 		s.roomStatements.prepare,
 		s.eventStatements.prepare,
 		s.eventJSONStatements.prepare,

--- a/roomserver/storage/postgres/sql.go
+++ b/roomserver/storage/postgres/sql.go
@@ -38,7 +38,6 @@ func (s *statements) prepare(db *sql.DB) error {
 	var err error
 
 	for _, prepare := range []func(db *sql.DB) error{
-		s.eventTypeStatements.prepare,
 		s.roomStatements.prepare,
 		s.eventStatements.prepare,
 		s.eventJSONStatements.prepare,

--- a/roomserver/storage/postgres/storage.go
+++ b/roomserver/storage/postgres/storage.go
@@ -26,14 +26,18 @@ import (
 	// Import the postgres database driver.
 	_ "github.com/lib/pq"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/storage/shared"
+	"github.com/matrix-org/dendrite/roomserver/storage/tables"
 	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
 // A Database is used to store room events and stream offsets.
 type Database struct {
-	statements statements
-	db         *sql.DB
+	shared.Database
+	statements     statements
+	eventStateKeys tables.EventStateKeys
+	db             *sql.DB
 }
 
 // Open a postgres database.
@@ -45,6 +49,13 @@ func Open(dataSourceName string, dbProperties internal.DbProperties) (*Database,
 	}
 	if err = d.statements.prepare(d.db); err != nil {
 		return nil, err
+	}
+	d.eventStateKeys, err = NewPostgresEventStateKeysTable(d.db)
+	if err != nil {
+		return nil, err
+	}
+	d.Database = shared.Database{
+		EventStateKeysTable: d.eventStateKeys,
 	}
 	return &d, nil
 }
@@ -198,13 +209,13 @@ func (d *Database) assignStateKeyNID(
 	ctx context.Context, txn *sql.Tx, eventStateKey string,
 ) (types.EventStateKeyNID, error) {
 	// Check if we already have a numeric ID in the database.
-	eventStateKeyNID, err := d.statements.selectEventStateKeyNID(ctx, txn, eventStateKey)
+	eventStateKeyNID, err := d.eventStateKeys.SelectEventStateKeyNID(ctx, txn, eventStateKey)
 	if err == sql.ErrNoRows {
 		// We don't have a numeric ID so insert one into the database.
-		eventStateKeyNID, err = d.statements.insertEventStateKeyNID(ctx, txn, eventStateKey)
+		eventStateKeyNID, err = d.eventStateKeys.InsertEventStateKeyNID(ctx, txn, eventStateKey)
 		if err == sql.ErrNoRows {
 			// We raced with another insert so run the select again.
-			eventStateKeyNID, err = d.statements.selectEventStateKeyNID(ctx, txn, eventStateKey)
+			eventStateKeyNID, err = d.eventStateKeys.SelectEventStateKeyNID(ctx, txn, eventStateKey)
 		}
 	}
 	return eventStateKeyNID, err
@@ -222,20 +233,6 @@ func (d *Database) EventTypeNIDs(
 	ctx context.Context, eventTypes []string,
 ) (map[string]types.EventTypeNID, error) {
 	return d.statements.bulkSelectEventTypeNID(ctx, eventTypes)
-}
-
-// EventStateKeyNIDs implements state.RoomStateDatabase
-func (d *Database) EventStateKeyNIDs(
-	ctx context.Context, eventStateKeys []string,
-) (map[string]types.EventStateKeyNID, error) {
-	return d.statements.bulkSelectEventStateKeyNID(ctx, eventStateKeys)
-}
-
-// EventStateKeys implements query.RoomserverQueryAPIDatabase
-func (d *Database) EventStateKeys(
-	ctx context.Context, eventStateKeyNIDs []types.EventStateKeyNID,
-) (map[types.EventStateKeyNID]string, error) {
-	return d.statements.bulkSelectEventStateKey(ctx, eventStateKeyNIDs)
 }
 
 // EventNIDs implements query.RoomserverQueryAPIDatabase

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -8,7 +8,15 @@ import (
 )
 
 type Database struct {
+	EventTypesTable     tables.EventTypes
 	EventStateKeysTable tables.EventStateKeys
+}
+
+// EventTypeNIDs implements state.RoomStateDatabase
+func (d *Database) EventTypeNIDs(
+	ctx context.Context, eventTypes []string,
+) (map[string]types.EventTypeNID, error) {
+	return d.EventTypesTable.BulkSelectEventTypeNID(ctx, eventTypes)
 }
 
 // EventStateKeys implements query.RoomserverQueryAPIDatabase

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -1,0 +1,26 @@
+package shared
+
+import (
+	"context"
+
+	"github.com/matrix-org/dendrite/roomserver/storage/tables"
+	"github.com/matrix-org/dendrite/roomserver/types"
+)
+
+type Database struct {
+	EventStateKeysTable tables.EventStateKeys
+}
+
+// EventStateKeys implements query.RoomserverQueryAPIDatabase
+func (d *Database) EventStateKeys(
+	ctx context.Context, eventStateKeyNIDs []types.EventStateKeyNID,
+) (map[types.EventStateKeyNID]string, error) {
+	return d.EventStateKeysTable.BulkSelectEventStateKey(ctx, eventStateKeyNIDs)
+}
+
+// EventStateKeyNIDs implements state.RoomStateDatabase
+func (d *Database) EventStateKeyNIDs(
+	ctx context.Context, eventStateKeys []string,
+) (map[string]types.EventStateKeyNID, error) {
+	return d.EventStateKeysTable.BulkSelectEventStateKeyNID(ctx, eventStateKeys)
+}

--- a/roomserver/storage/sqlite3/event_types_table.go
+++ b/roomserver/storage/sqlite3/event_types_table.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/matrix-org/dendrite/internal"
+	"github.com/matrix-org/dendrite/roomserver/storage/tables"
 	"github.com/matrix-org/dendrite/roomserver/types"
 )
 
@@ -81,14 +82,15 @@ type eventTypeStatements struct {
 	bulkSelectEventTypeNIDStmt   *sql.Stmt
 }
 
-func (s *eventTypeStatements) prepare(db *sql.DB) (err error) {
+func NewSqliteEventTypesTable(db *sql.DB) (tables.EventTypes, error) {
+	s := &eventTypeStatements{}
 	s.db = db
-	_, err = db.Exec(eventTypesSchema)
+	_, err := db.Exec(eventTypesSchema)
 	if err != nil {
-		return
+		return nil, err
 	}
 
-	return statementList{
+	return s, statementList{
 		{&s.insertEventTypeNIDStmt, insertEventTypeNIDSQL},
 		{&s.insertEventTypeNIDResultStmt, insertEventTypeNIDResultSQL},
 		{&s.selectEventTypeNIDStmt, selectEventTypeNIDSQL},
@@ -96,7 +98,7 @@ func (s *eventTypeStatements) prepare(db *sql.DB) (err error) {
 	}.prepare(db)
 }
 
-func (s *eventTypeStatements) insertEventTypeNID(
+func (s *eventTypeStatements) InsertEventTypeNID(
 	ctx context.Context, tx *sql.Tx, eventType string,
 ) (types.EventTypeNID, error) {
 	var eventTypeNID int64
@@ -109,7 +111,7 @@ func (s *eventTypeStatements) insertEventTypeNID(
 	return types.EventTypeNID(eventTypeNID), err
 }
 
-func (s *eventTypeStatements) selectEventTypeNID(
+func (s *eventTypeStatements) SelectEventTypeNID(
 	ctx context.Context, tx *sql.Tx, eventType string,
 ) (types.EventTypeNID, error) {
 	var eventTypeNID int64
@@ -118,8 +120,8 @@ func (s *eventTypeStatements) selectEventTypeNID(
 	return types.EventTypeNID(eventTypeNID), err
 }
 
-func (s *eventTypeStatements) bulkSelectEventTypeNID(
-	ctx context.Context, tx *sql.Tx, eventTypes []string,
+func (s *eventTypeStatements) BulkSelectEventTypeNID(
+	ctx context.Context, eventTypes []string,
 ) (map[string]types.EventTypeNID, error) {
 	///////////////
 	iEventTypes := make([]interface{}, len(eventTypes))
@@ -133,8 +135,7 @@ func (s *eventTypeStatements) bulkSelectEventTypeNID(
 	}
 	///////////////
 
-	selectStmt := internal.TxStmt(tx, selectPrep)
-	rows, err := selectStmt.QueryContext(ctx, iEventTypes...)
+	rows, err := selectPrep.QueryContext(ctx, iEventTypes...)
 	if err != nil {
 		return nil, err
 	}

--- a/roomserver/storage/sqlite3/sql.go
+++ b/roomserver/storage/sqlite3/sql.go
@@ -39,7 +39,6 @@ func (s *statements) prepare(db *sql.DB) error {
 
 	for _, prepare := range []func(db *sql.DB) error{
 		s.eventTypeStatements.prepare,
-		s.eventStateKeyStatements.prepare,
 		s.roomStatements.prepare,
 		s.eventStatements.prepare,
 		s.eventJSONStatements.prepare,

--- a/roomserver/storage/sqlite3/sql.go
+++ b/roomserver/storage/sqlite3/sql.go
@@ -38,7 +38,6 @@ func (s *statements) prepare(db *sql.DB) error {
 	var err error
 
 	for _, prepare := range []func(db *sql.DB) error{
-		s.eventTypeStatements.prepare,
 		s.roomStatements.prepare,
 		s.eventStatements.prepare,
 		s.eventJSONStatements.prepare,

--- a/roomserver/storage/sqlite3/storage.go
+++ b/roomserver/storage/sqlite3/storage.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/storage/shared"
+	"github.com/matrix-org/dendrite/roomserver/storage/tables"
 	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib"
 	_ "github.com/mattn/go-sqlite3"
@@ -33,8 +35,10 @@ import (
 
 // A Database is used to store room events and stream offsets.
 type Database struct {
-	statements statements
-	db         *sql.DB
+	shared.Database
+	statements     statements
+	eventStateKeys tables.EventStateKeys
+	db             *sql.DB
 }
 
 // Open a sqlite database.
@@ -66,7 +70,11 @@ func Open(dataSourceName string) (*Database, error) {
 	if err = d.statements.prepare(d.db); err != nil {
 		return nil, err
 	}
-	return &d, nil
+	d.eventStateKeys, err = NewSqliteEventStateKeysTable(d.db)
+	d.Database = shared.Database{
+		EventStateKeysTable: d.eventStateKeys,
+	}
+	return &d, err
 }
 
 // StoreEvent implements input.EventDatabase
@@ -226,13 +234,13 @@ func (d *Database) assignStateKeyNID(
 	ctx context.Context, txn *sql.Tx, eventStateKey string,
 ) (eventStateKeyNID types.EventStateKeyNID, err error) {
 	// Check if we already have a numeric ID in the database.
-	eventStateKeyNID, err = d.statements.selectEventStateKeyNID(ctx, txn, eventStateKey)
+	eventStateKeyNID, err = d.eventStateKeys.SelectEventStateKeyNID(ctx, txn, eventStateKey)
 	if err == sql.ErrNoRows {
 		// We don't have a numeric ID so insert one into the database.
-		eventStateKeyNID, err = d.statements.insertEventStateKeyNID(ctx, txn, eventStateKey)
+		eventStateKeyNID, err = d.eventStateKeys.InsertEventStateKeyNID(ctx, txn, eventStateKey)
 		if err == sql.ErrNoRows {
 			// We raced with another insert so run the select again.
-			eventStateKeyNID, err = d.statements.selectEventStateKeyNID(ctx, txn, eventStateKey)
+			eventStateKeyNID, err = d.eventStateKeys.SelectEventStateKeyNID(ctx, txn, eventStateKey)
 		}
 	}
 	return
@@ -255,28 +263,6 @@ func (d *Database) EventTypeNIDs(
 ) (etnids map[string]types.EventTypeNID, err error) {
 	err = internal.WithTransaction(d.db, func(txn *sql.Tx) error {
 		etnids, err = d.statements.bulkSelectEventTypeNID(ctx, txn, eventTypes)
-		return err
-	})
-	return
-}
-
-// EventStateKeyNIDs implements state.RoomStateDatabase
-func (d *Database) EventStateKeyNIDs(
-	ctx context.Context, eventStateKeys []string,
-) (esknids map[string]types.EventStateKeyNID, err error) {
-	err = internal.WithTransaction(d.db, func(txn *sql.Tx) error {
-		esknids, err = d.statements.bulkSelectEventStateKeyNID(ctx, txn, eventStateKeys)
-		return err
-	})
-	return
-}
-
-// EventStateKeys implements query.RoomserverQueryAPIDatabase
-func (d *Database) EventStateKeys(
-	ctx context.Context, eventStateKeyNIDs []types.EventStateKeyNID,
-) (out map[types.EventStateKeyNID]string, err error) {
-	err = internal.WithTransaction(d.db, func(txn *sql.Tx) error {
-		out, err = d.statements.bulkSelectEventStateKey(ctx, txn, eventStateKeyNIDs)
 		return err
 	})
 	return

--- a/roomserver/storage/tables/interface.go
+++ b/roomserver/storage/tables/interface.go
@@ -1,0 +1,15 @@
+package tables
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/matrix-org/dendrite/roomserver/types"
+)
+
+type EventStateKeys interface {
+	InsertEventStateKeyNID(ctx context.Context, txn *sql.Tx, eventStateKey string) (types.EventStateKeyNID, error)
+	SelectEventStateKeyNID(ctx context.Context, txn *sql.Tx, eventStateKey string) (types.EventStateKeyNID, error)
+	BulkSelectEventStateKeyNID(ctx context.Context, eventStateKeys []string) (map[string]types.EventStateKeyNID, error)
+	BulkSelectEventStateKey(ctx context.Context, eventStateKeyNIDs []types.EventStateKeyNID) (map[types.EventStateKeyNID]string, error)
+}

--- a/roomserver/storage/tables/interface.go
+++ b/roomserver/storage/tables/interface.go
@@ -7,6 +7,12 @@ import (
 	"github.com/matrix-org/dendrite/roomserver/types"
 )
 
+type EventTypes interface {
+	InsertEventTypeNID(ctx context.Context, tx *sql.Tx, eventType string) (types.EventTypeNID, error)
+	SelectEventTypeNID(ctx context.Context, tx *sql.Tx, eventType string) (types.EventTypeNID, error)
+	BulkSelectEventTypeNID(ctx context.Context, eventTypes []string) (map[string]types.EventTypeNID, error)
+}
+
 type EventStateKeys interface {
 	InsertEventStateKeyNID(ctx context.Context, txn *sql.Tx, eventStateKey string) (types.EventStateKeyNID, error)
 	SelectEventStateKeyNID(ctx context.Context, txn *sql.Tx, eventStateKey string) (types.EventStateKeyNID, error)


### PR DESCRIPTION
Convert event_types and event_state_keys tables to use the shared format we use for syncapi.