### PR TITLE
Convert transactions/rooms table to share more code

### DIFF
--- a/roomserver/storage/postgres/events_table.go
+++ b/roomserver/storage/postgres/events_table.go
@@ -426,10 +426,9 @@ func (s *eventStatements) SelectMaxEventDepth(ctx context.Context, txn *sql.Tx, 
 }
 
 func (s *eventStatements) SelectRoomNIDForEventNID(
-	ctx context.Context, txn *sql.Tx, eventNID types.EventNID,
+	ctx context.Context, eventNID types.EventNID,
 ) (roomNID types.RoomNID, err error) {
-	selectStmt := internal.TxStmt(txn, s.selectRoomNIDForEventNIDStmt)
-	err = selectStmt.QueryRowContext(ctx, int64(eventNID)).Scan(&roomNID)
+	err = s.selectRoomNIDForEventNIDStmt.QueryRowContext(ctx, int64(eventNID)).Scan(&roomNID)
 	return
 }
 

--- a/roomserver/storage/postgres/rooms_table.go
+++ b/roomserver/storage/postgres/rooms_table.go
@@ -186,11 +186,10 @@ func (s *roomStatements) SelectRoomVersionForRoomID(
 }
 
 func (s *roomStatements) SelectRoomVersionForRoomNID(
-	ctx context.Context, txn *sql.Tx, roomNID types.RoomNID,
+	ctx context.Context, roomNID types.RoomNID,
 ) (gomatrixserverlib.RoomVersion, error) {
 	var roomVersion gomatrixserverlib.RoomVersion
-	stmt := internal.TxStmt(txn, s.selectRoomVersionForRoomNIDStmt)
-	err := stmt.QueryRowContext(ctx, roomNID).Scan(&roomVersion)
+	err := s.selectRoomVersionForRoomNIDStmt.QueryRowContext(ctx, roomNID).Scan(&roomVersion)
 	if err == sql.ErrNoRows {
 		return roomVersion, errors.New("room not found")
 	}

--- a/roomserver/storage/postgres/sql.go
+++ b/roomserver/storage/postgres/sql.go
@@ -38,7 +38,6 @@ func (s *statements) prepare(db *sql.DB) error {
 	var err error
 
 	for _, prepare := range []func(db *sql.DB) error{
-		s.roomStatements.prepare,
 		s.stateSnapshotStatements.prepare,
 		s.stateBlockStatements.prepare,
 		s.previousEventStatements.prepare,

--- a/roomserver/storage/postgres/sql.go
+++ b/roomserver/storage/postgres/sql.go
@@ -44,7 +44,6 @@ func (s *statements) prepare(db *sql.DB) error {
 		s.roomAliasesStatements.prepare,
 		s.inviteStatements.prepare,
 		s.membershipStatements.prepare,
-		s.transactionStatements.prepare,
 	} {
 		if err = prepare(db); err != nil {
 			return err

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -17,6 +17,7 @@ type Database struct {
 	EventTypesTable     tables.EventTypes
 	EventStateKeysTable tables.EventStateKeys
 	RoomsTable          tables.Rooms
+	TransactionsTable   tables.Transactions
 }
 
 // EventTypeNIDs implements state.RoomStateDatabase
@@ -146,4 +147,16 @@ func (d *Database) GetRoomVersionForRoomNID(
 	return d.RoomsTable.SelectRoomVersionForRoomNID(
 		ctx, nil, roomNID,
 	)
+}
+
+// GetTransactionEventID implements input.EventDatabase
+func (d *Database) GetTransactionEventID(
+	ctx context.Context, transactionID string,
+	sessionID int64, userID string,
+) (string, error) {
+	eventID, err := d.TransactionsTable.SelectTransactionEventID(ctx, transactionID, sessionID, userID)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return eventID, err
 }

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -3,8 +3,10 @@ package shared
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 
 	"github.com/matrix-org/dendrite/internal"
+	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/roomserver/storage/tables"
 	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -84,6 +86,21 @@ func (d *Database) EventIDs(
 	return d.EventsTable.BulkSelectEventID(ctx, eventNIDs)
 }
 
+// EventsFromIDs implements query.RoomserverQueryAPIEventDB
+func (d *Database) EventsFromIDs(ctx context.Context, eventIDs []string) ([]types.Event, error) {
+	nidMap, err := d.EventNIDs(ctx, eventIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	var nids []types.EventNID
+	for _, nid := range nidMap {
+		nids = append(nids, nid)
+	}
+
+	return d.Events(ctx, nids)
+}
+
 // RoomNID implements query.RoomserverQueryAPIDB
 func (d *Database) RoomNID(ctx context.Context, roomID string) (types.RoomNID, error) {
 	roomNID, err := d.RoomsTable.SelectRoomNID(ctx, nil, roomID)
@@ -145,8 +162,40 @@ func (d *Database) GetRoomVersionForRoomNID(
 	ctx context.Context, roomNID types.RoomNID,
 ) (gomatrixserverlib.RoomVersion, error) {
 	return d.RoomsTable.SelectRoomVersionForRoomNID(
-		ctx, nil, roomNID,
+		ctx, roomNID,
 	)
+}
+
+// Events implements input.EventDatabase
+func (d *Database) Events(
+	ctx context.Context, eventNIDs []types.EventNID,
+) ([]types.Event, error) {
+	eventJSONs, err := d.EventJSONTable.BulkSelectEventJSON(ctx, eventNIDs)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]types.Event, len(eventJSONs))
+	for i, eventJSON := range eventJSONs {
+		var roomNID types.RoomNID
+		var roomVersion gomatrixserverlib.RoomVersion
+		result := &results[i]
+		result.EventNID = eventJSON.EventNID
+		roomNID, err = d.EventsTable.SelectRoomNIDForEventNID(ctx, eventJSON.EventNID)
+		if err != nil {
+			return nil, err
+		}
+		roomVersion, err = d.RoomsTable.SelectRoomVersionForRoomNID(ctx, roomNID)
+		if err != nil {
+			return nil, err
+		}
+		result.Event, err = gomatrixserverlib.NewEventFromTrustedJSON(
+			eventJSON.EventJSON, false, roomVersion,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return results, nil
 }
 
 // GetTransactionEventID implements input.EventDatabase
@@ -159,4 +208,173 @@ func (d *Database) GetTransactionEventID(
 		return "", nil
 	}
 	return eventID, err
+}
+
+// StoreEvent implements input.EventDatabase
+func (d *Database) StoreEvent(
+	ctx context.Context, event gomatrixserverlib.Event,
+	txnAndSessionID *api.TransactionID, authEventNIDs []types.EventNID,
+) (types.RoomNID, types.StateAtEvent, error) {
+	var (
+		roomNID          types.RoomNID
+		eventTypeNID     types.EventTypeNID
+		eventStateKeyNID types.EventStateKeyNID
+		eventNID         types.EventNID
+		stateNID         types.StateSnapshotNID
+		err              error
+	)
+
+	err = internal.WithTransaction(d.DB, func(txn *sql.Tx) error {
+		if txnAndSessionID != nil {
+			if err = d.TransactionsTable.InsertTransaction(
+				ctx, txn, txnAndSessionID.TransactionID,
+				txnAndSessionID.SessionID, event.Sender(), event.EventID(),
+			); err != nil {
+				return err
+			}
+		}
+
+		// TODO: Here we should aim to have two different code paths for new rooms
+		// vs existing ones.
+
+		// Get the default room version. If the client doesn't supply a room_version
+		// then we will use our configured default to create the room.
+		// https://matrix.org/docs/spec/client_server/r0.6.0#post-matrix-client-r0-createroom
+		// Note that the below logic depends on the m.room.create event being the
+		// first event that is persisted to the database when creating or joining a
+		// room.
+		var roomVersion gomatrixserverlib.RoomVersion
+		if roomVersion, err = extractRoomVersionFromCreateEvent(event); err != nil {
+			return err
+		}
+
+		if roomNID, err = d.assignRoomNID(ctx, txn, event.RoomID(), roomVersion); err != nil {
+			return err
+		}
+
+		if eventTypeNID, err = d.assignEventTypeNID(ctx, txn, event.Type()); err != nil {
+			return err
+		}
+
+		eventStateKey := event.StateKey()
+		// Assigned a numeric ID for the state_key if there is one present.
+		// Otherwise set the numeric ID for the state_key to 0.
+		if eventStateKey != nil {
+			if eventStateKeyNID, err = d.assignStateKeyNID(ctx, txn, *eventStateKey); err != nil {
+				return err
+			}
+		}
+
+		if eventNID, stateNID, err = d.EventsTable.InsertEvent(
+			ctx,
+			txn,
+			roomNID,
+			eventTypeNID,
+			eventStateKeyNID,
+			event.EventID(),
+			event.EventReference().EventSHA256,
+			authEventNIDs,
+			event.Depth(),
+		); err != nil {
+			if err == sql.ErrNoRows {
+				// We've already inserted the event so select the numeric event ID
+				eventNID, stateNID, err = d.EventsTable.SelectEvent(ctx, txn, event.EventID())
+			}
+			if err != nil {
+				return err
+			}
+		}
+
+		if err = d.EventJSONTable.InsertEventJSON(ctx, txn, eventNID, event.JSON()); err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		return 0, types.StateAtEvent{}, err
+	}
+
+	return roomNID, types.StateAtEvent{
+		BeforeStateSnapshotNID: stateNID,
+		StateEntry: types.StateEntry{
+			StateKeyTuple: types.StateKeyTuple{
+				EventTypeNID:     eventTypeNID,
+				EventStateKeyNID: eventStateKeyNID,
+			},
+			EventNID: eventNID,
+		},
+	}, nil
+}
+
+func (d *Database) assignRoomNID(
+	ctx context.Context, txn *sql.Tx,
+	roomID string, roomVersion gomatrixserverlib.RoomVersion,
+) (types.RoomNID, error) {
+	// Check if we already have a numeric ID in the database.
+	roomNID, err := d.RoomsTable.SelectRoomNID(ctx, txn, roomID)
+	if err == sql.ErrNoRows {
+		// We don't have a numeric ID so insert one into the database.
+		roomNID, err = d.RoomsTable.InsertRoomNID(ctx, txn, roomID, roomVersion)
+		if err == sql.ErrNoRows {
+			// We raced with another insert so run the select again.
+			roomNID, err = d.RoomsTable.SelectRoomNID(ctx, txn, roomID)
+		}
+	}
+	return roomNID, err
+}
+
+func (d *Database) assignEventTypeNID(
+	ctx context.Context, txn *sql.Tx, eventType string,
+) (eventTypeNID types.EventTypeNID, err error) {
+	// Check if we already have a numeric ID in the database.
+	eventTypeNID, err = d.EventTypesTable.SelectEventTypeNID(ctx, txn, eventType)
+	if err == sql.ErrNoRows {
+		// We don't have a numeric ID so insert one into the database.
+		eventTypeNID, err = d.EventTypesTable.InsertEventTypeNID(ctx, txn, eventType)
+		if err == sql.ErrNoRows {
+			// We raced with another insert so run the select again.
+			eventTypeNID, err = d.EventTypesTable.SelectEventTypeNID(ctx, txn, eventType)
+		}
+	}
+	return
+}
+
+func (d *Database) assignStateKeyNID(
+	ctx context.Context, txn *sql.Tx, eventStateKey string,
+) (types.EventStateKeyNID, error) {
+	// Check if we already have a numeric ID in the database.
+	eventStateKeyNID, err := d.EventStateKeysTable.SelectEventStateKeyNID(ctx, txn, eventStateKey)
+	if err == sql.ErrNoRows {
+		// We don't have a numeric ID so insert one into the database.
+		eventStateKeyNID, err = d.EventStateKeysTable.InsertEventStateKeyNID(ctx, txn, eventStateKey)
+		if err == sql.ErrNoRows {
+			// We raced with another insert so run the select again.
+			eventStateKeyNID, err = d.EventStateKeysTable.SelectEventStateKeyNID(ctx, txn, eventStateKey)
+		}
+	}
+	return eventStateKeyNID, err
+}
+
+func extractRoomVersionFromCreateEvent(event gomatrixserverlib.Event) (
+	gomatrixserverlib.RoomVersion, error,
+) {
+	var err error
+	var roomVersion gomatrixserverlib.RoomVersion
+	// Look for m.room.create events.
+	if event.Type() != gomatrixserverlib.MRoomCreate {
+		return gomatrixserverlib.RoomVersion(""), nil
+	}
+	roomVersion = gomatrixserverlib.RoomVersionV1
+	var createContent gomatrixserverlib.CreateContent
+	// The m.room.create event contains an optional "room_version" key in
+	// the event content, so we need to unmarshal that first.
+	if err = json.Unmarshal(event.Content(), &createContent); err != nil {
+		return gomatrixserverlib.RoomVersion(""), err
+	}
+	// A room version was specified in the event content?
+	if createContent.RoomVersion != nil {
+		roomVersion = gomatrixserverlib.RoomVersion(*createContent.RoomVersion)
+	}
+	return roomVersion, err
 }

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -2,16 +2,21 @@ package shared
 
 import (
 	"context"
+	"database/sql"
 
+	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/roomserver/storage/tables"
 	"github.com/matrix-org/dendrite/roomserver/types"
+	"github.com/matrix-org/gomatrixserverlib"
 )
 
 type Database struct {
+	DB                  *sql.DB
 	EventsTable         tables.Events
 	EventJSONTable      tables.EventJSON
 	EventTypesTable     tables.EventTypes
 	EventStateKeysTable tables.EventStateKeys
+	RoomsTable          tables.Rooms
 }
 
 // EventTypeNIDs implements state.RoomStateDatabase
@@ -76,4 +81,69 @@ func (d *Database) EventIDs(
 	ctx context.Context, eventNIDs []types.EventNID,
 ) (map[types.EventNID]string, error) {
 	return d.EventsTable.BulkSelectEventID(ctx, eventNIDs)
+}
+
+// RoomNID implements query.RoomserverQueryAPIDB
+func (d *Database) RoomNID(ctx context.Context, roomID string) (types.RoomNID, error) {
+	roomNID, err := d.RoomsTable.SelectRoomNID(ctx, nil, roomID)
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	return roomNID, err
+}
+
+// RoomNIDExcludingStubs implements query.RoomserverQueryAPIDB
+func (d *Database) RoomNIDExcludingStubs(ctx context.Context, roomID string) (roomNID types.RoomNID, err error) {
+	roomNID, err = d.RoomNID(ctx, roomID)
+	if err != nil {
+		return
+	}
+	latestEvents, _, err := d.RoomsTable.SelectLatestEventNIDs(ctx, nil, roomNID)
+	if err != nil {
+		return
+	}
+	if len(latestEvents) == 0 {
+		roomNID = 0
+		return
+	}
+	return
+}
+
+// LatestEventIDs implements query.RoomserverQueryAPIDatabase
+func (d *Database) LatestEventIDs(
+	ctx context.Context, roomNID types.RoomNID,
+) (references []gomatrixserverlib.EventReference, currentStateSnapshotNID types.StateSnapshotNID, depth int64, err error) {
+	err = internal.WithTransaction(d.DB, func(txn *sql.Tx) error {
+		var eventNIDs []types.EventNID
+		eventNIDs, currentStateSnapshotNID, err = d.RoomsTable.SelectLatestEventNIDs(ctx, txn, roomNID)
+		if err != nil {
+			return err
+		}
+		references, err = d.EventsTable.BulkSelectEventReference(ctx, txn, eventNIDs)
+		if err != nil {
+			return err
+		}
+		depth, err = d.EventsTable.SelectMaxEventDepth(ctx, txn, eventNIDs)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	return
+}
+
+func (d *Database) GetRoomVersionForRoom(
+	ctx context.Context, roomID string,
+) (gomatrixserverlib.RoomVersion, error) {
+	return d.RoomsTable.SelectRoomVersionForRoomID(
+		ctx, nil, roomID,
+	)
+}
+
+func (d *Database) GetRoomVersionForRoomNID(
+	ctx context.Context, roomNID types.RoomNID,
+) (gomatrixserverlib.RoomVersion, error) {
+	return d.RoomsTable.SelectRoomVersionForRoomNID(
+		ctx, nil, roomNID,
+	)
 }

--- a/roomserver/storage/sqlite3/events_table.go
+++ b/roomserver/storage/sqlite3/events_table.go
@@ -469,10 +469,9 @@ func (s *eventStatements) SelectMaxEventDepth(ctx context.Context, txn *sql.Tx, 
 }
 
 func (s *eventStatements) SelectRoomNIDForEventNID(
-	ctx context.Context, txn *sql.Tx, eventNID types.EventNID,
+	ctx context.Context, eventNID types.EventNID,
 ) (roomNID types.RoomNID, err error) {
-	selectStmt := internal.TxStmt(txn, s.selectRoomNIDForEventNIDStmt)
-	err = selectStmt.QueryRowContext(ctx, int64(eventNID)).Scan(&roomNID)
+	err = s.selectRoomNIDForEventNIDStmt.QueryRowContext(ctx, int64(eventNID)).Scan(&roomNID)
 	return
 }
 

--- a/roomserver/storage/sqlite3/rooms_table.go
+++ b/roomserver/storage/sqlite3/rooms_table.go
@@ -178,11 +178,10 @@ func (s *roomStatements) SelectRoomVersionForRoomID(
 }
 
 func (s *roomStatements) SelectRoomVersionForRoomNID(
-	ctx context.Context, txn *sql.Tx, roomNID types.RoomNID,
+	ctx context.Context, roomNID types.RoomNID,
 ) (gomatrixserverlib.RoomVersion, error) {
 	var roomVersion gomatrixserverlib.RoomVersion
-	stmt := internal.TxStmt(txn, s.selectRoomVersionForRoomNIDStmt)
-	err := stmt.QueryRowContext(ctx, roomNID).Scan(&roomVersion)
+	err := s.selectRoomVersionForRoomNIDStmt.QueryRowContext(ctx, roomNID).Scan(&roomVersion)
 	if err == sql.ErrNoRows {
 		return roomVersion, errors.New("room not found")
 	}

--- a/roomserver/storage/sqlite3/sql.go
+++ b/roomserver/storage/sqlite3/sql.go
@@ -38,7 +38,6 @@ func (s *statements) prepare(db *sql.DB) error {
 	var err error
 
 	for _, prepare := range []func(db *sql.DB) error{
-		s.roomStatements.prepare,
 		s.stateSnapshotStatements.prepare,
 		s.stateBlockStatements.prepare,
 		s.previousEventStatements.prepare,

--- a/roomserver/storage/sqlite3/sql.go
+++ b/roomserver/storage/sqlite3/sql.go
@@ -44,7 +44,6 @@ func (s *statements) prepare(db *sql.DB) error {
 		s.roomAliasesStatements.prepare,
 		s.inviteStatements.prepare,
 		s.membershipStatements.prepare,
-		s.transactionStatements.prepare,
 	} {
 		if err = prepare(db); err != nil {
 			return err

--- a/roomserver/storage/sqlite3/storage.go
+++ b/roomserver/storage/sqlite3/storage.go
@@ -98,6 +98,7 @@ func Open(dataSourceName string) (*Database, error) {
 		return nil, err
 	}
 	d.Database = shared.Database{
+		DB:                  d.db,
 		EventsTable:         d.events,
 		EventTypesTable:     d.eventTypes,
 		EventStateKeysTable: d.eventStateKeys,

--- a/roomserver/storage/sqlite3/transactions_table.go
+++ b/roomserver/storage/sqlite3/transactions_table.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 
 	"github.com/matrix-org/dendrite/internal"
+	"github.com/matrix-org/dendrite/roomserver/storage/tables"
 )
 
 const transactionsSchema = `
@@ -46,19 +47,20 @@ type transactionStatements struct {
 	selectTransactionEventIDStmt *sql.Stmt
 }
 
-func (s *transactionStatements) prepare(db *sql.DB) (err error) {
-	_, err = db.Exec(transactionsSchema)
+func NewSqliteTransactionsTable(db *sql.DB) (tables.Transactions, error) {
+	s := &transactionStatements{}
+	_, err := db.Exec(transactionsSchema)
 	if err != nil {
-		return
+		return nil, err
 	}
 
-	return statementList{
+	return s, statementList{
 		{&s.insertTransactionStmt, insertTransactionSQL},
 		{&s.selectTransactionEventIDStmt, selectTransactionEventIDSQL},
 	}.prepare(db)
 }
 
-func (s *transactionStatements) insertTransaction(
+func (s *transactionStatements) InsertTransaction(
 	ctx context.Context, txn *sql.Tx,
 	transactionID string,
 	sessionID int64,
@@ -72,14 +74,13 @@ func (s *transactionStatements) insertTransaction(
 	return
 }
 
-func (s *transactionStatements) selectTransactionEventID(
-	ctx context.Context, txn *sql.Tx,
+func (s *transactionStatements) SelectTransactionEventID(
+	ctx context.Context,
 	transactionID string,
 	sessionID int64,
 	userID string,
 ) (eventID string, err error) {
-	stmt := internal.TxStmt(txn, s.selectTransactionEventIDStmt)
-	err = stmt.QueryRowContext(
+	err = s.selectTransactionEventIDStmt.QueryRowContext(
 		ctx, transactionID, sessionID, userID,
 	).Scan(&eventID)
 	return

--- a/roomserver/storage/tables/interface.go
+++ b/roomserver/storage/tables/interface.go
@@ -65,3 +65,8 @@ type Rooms interface {
 	SelectRoomVersionForRoomID(ctx context.Context, txn *sql.Tx, roomID string) (gomatrixserverlib.RoomVersion, error)
 	SelectRoomVersionForRoomNID(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID) (gomatrixserverlib.RoomVersion, error)
 }
+
+type Transactions interface {
+	InsertTransaction(ctx context.Context, txn *sql.Tx, transactionID string, sessionID int64, userID string, eventID string) error
+	SelectTransactionEventID(ctx context.Context, transactionID string, sessionID int64, userID string) (eventID string, err error)
+}

--- a/roomserver/storage/tables/interface.go
+++ b/roomserver/storage/tables/interface.go
@@ -55,3 +55,13 @@ type Events interface {
 	SelectMaxEventDepth(ctx context.Context, txn *sql.Tx, eventNIDs []types.EventNID) (int64, error)
 	SelectRoomNIDForEventNID(ctx context.Context, txn *sql.Tx, eventNID types.EventNID) (roomNID types.RoomNID, err error)
 }
+
+type Rooms interface {
+	InsertRoomNID(ctx context.Context, txn *sql.Tx, roomID string, roomVersion gomatrixserverlib.RoomVersion) (types.RoomNID, error)
+	SelectRoomNID(ctx context.Context, txn *sql.Tx, roomID string) (types.RoomNID, error)
+	SelectLatestEventNIDs(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID) ([]types.EventNID, types.StateSnapshotNID, error)
+	SelectLatestEventsNIDsForUpdate(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID) ([]types.EventNID, types.EventNID, types.StateSnapshotNID, error)
+	UpdateLatestEventNIDs(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, eventNIDs []types.EventNID, lastEventSentNID types.EventNID, stateSnapshotNID types.StateSnapshotNID) error
+	SelectRoomVersionForRoomID(ctx context.Context, txn *sql.Tx, roomID string) (gomatrixserverlib.RoomVersion, error)
+	SelectRoomVersionForRoomNID(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID) (gomatrixserverlib.RoomVersion, error)
+}

--- a/roomserver/storage/tables/interface.go
+++ b/roomserver/storage/tables/interface.go
@@ -53,7 +53,7 @@ type Events interface {
 	// If an event ID is not in the database then it is omitted from the map.
 	BulkSelectEventNID(ctx context.Context, eventIDs []string) (map[string]types.EventNID, error)
 	SelectMaxEventDepth(ctx context.Context, txn *sql.Tx, eventNIDs []types.EventNID) (int64, error)
-	SelectRoomNIDForEventNID(ctx context.Context, txn *sql.Tx, eventNID types.EventNID) (roomNID types.RoomNID, err error)
+	SelectRoomNIDForEventNID(ctx context.Context, eventNID types.EventNID) (roomNID types.RoomNID, err error)
 }
 
 type Rooms interface {
@@ -63,7 +63,7 @@ type Rooms interface {
 	SelectLatestEventsNIDsForUpdate(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID) ([]types.EventNID, types.EventNID, types.StateSnapshotNID, error)
 	UpdateLatestEventNIDs(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, eventNIDs []types.EventNID, lastEventSentNID types.EventNID, stateSnapshotNID types.StateSnapshotNID) error
 	SelectRoomVersionForRoomID(ctx context.Context, txn *sql.Tx, roomID string) (gomatrixserverlib.RoomVersion, error)
-	SelectRoomVersionForRoomNID(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID) (gomatrixserverlib.RoomVersion, error)
+	SelectRoomVersionForRoomNID(ctx context.Context, roomNID types.RoomNID) (gomatrixserverlib.RoomVersion, error)
 }
 
 type Transactions interface {


### PR DESCRIPTION
Starting to see dividends with `+400/-600`!

Again, I've tweaked what accepts or doesn't accept transactions based on how they are being used.

At this point, all the event storage bits are now done by `shared.Database` - so things like `StoreEvent` and `Events`, which assigns NIDs and writes the JSON.

One bizarre thing I've noticed is that in several places the pq implementation will insert/select/insert the NIDs so it doesn't need to acquire a txn (presumably for "speed"), which using a `shared.Database` doesn't really allow for (the table impl is free to not use the txn but we will always start one). Personally, I think we should always be using a txn, and profile it if we think it becomes a bottleneck (where then caching the NID in-memory will be the superior choice..). But whatever, I'll change that in another PR.