### PR TITLE
Return 500 when processing a transaction fails fatally

### DIFF
--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -76,6 +76,7 @@ func Send(
 	resp, err := t.processTransaction()
 	if err != nil {
 		util.GetLogger(httpReq.Context()).WithError(err).Error("t.processTransaction failed")
+		return util.ErrorResponse(err)
 	}
 
 	// https://matrix.org/docs/spec/server_server/r0.1.3#put-matrix-federation-v1-send-txnid
@@ -117,7 +118,7 @@ type txnFederationClient interface {
 func (t *txnReq) processTransaction() (*gomatrixserverlib.RespSend, error) {
 	results := make(map[string]gomatrixserverlib.PDUResult)
 
-	var pdus []gomatrixserverlib.HeaderedEvent
+	pdus := []gomatrixserverlib.HeaderedEvent{}
 	for _, pdu := range t.PDUs {
 		var header struct {
 			RoomID string `json:"room_id"`


### PR DESCRIPTION
Return a 500 if the `/send` transaction fails fatally, e.g. the database is dead or something.

Beforehand we were returning a 200 anyway and apparently this was [causing some upset for Synapse](https://sentry.matrix.org/sentry/synapse-matrixorg/issues/107452/events/latest/).