### PR TITLE
Hopefully fix get_missing_events

### DIFF
--- a/federationapi/routing/missingevents.go
+++ b/federationapi/routing/missingevents.go
@@ -60,9 +60,14 @@ func GetMissingEvents(
 	}
 
 	eventsResponse.Events = filterEvents(eventsResponse.Events, gme.MinDepth, roomID)
+
+	resp := gomatrixserverlib.RespMissingEvents{
+		Events: gomatrixserverlib.UnwrapEventHeaders(eventsResponse.Events),
+	}
+
 	return util.JSONResponse{
 		Code: http.StatusOK,
-		JSON: eventsResponse,
+		JSON: resp,
 	}
 }
 


### PR DESCRIPTION
We were returning `HeaderedEvent`s in response to `/get_missing_events` which would likely cause gomatrixserverlib to fail the signature checks on the other end and redact the event.