### PR TITLE
fedsender: de-duplicate without sorting server names

### DIFF
--- a/federationsender/api/perform.go
+++ b/federationsender/api/perform.go
@@ -44,8 +44,9 @@ func (h *httpFederationSenderInternalAPI) PerformDirectoryLookup(
 }
 
 type PerformJoinRequest struct {
-	RoomID      string                 `json:"room_id"`
-	UserID      string                 `json:"user_id"`
+	RoomID string `json:"room_id"`
+	UserID string `json:"user_id"`
+	// The sorted list of servers to try. Servers will be tried sequentially, after de-duplication.
 	ServerNames types.ServerNames      `json:"server_names"`
 	Content     map[string]interface{} `json:"content"`
 }

--- a/federationsender/internal/perform.go
+++ b/federationsender/internal/perform.go
@@ -46,8 +46,19 @@ func (r *FederationSenderInternalAPI) PerformJoin(
 		supportedVersions = append(supportedVersions, version)
 	}
 
-	// Deduplicate the server names we were provided.
-	util.SortAndUnique(request.ServerNames)
+	// Deduplicate the server names we were provided but keep the ordering
+	// as this encodes useful information about which servers are most likely
+	// to respond.
+	seenSet := make(map[gomatrixserverlib.ServerName]bool)
+	var uniqueList []gomatrixserverlib.ServerName
+	for _, srv := range request.ServerNames {
+		if seenSet[srv] {
+			continue
+		}
+		seenSet[srv] = true
+		uniqueList = append(uniqueList, srv)
+	}
+	request.ServerNames = uniqueList
 
 	// Try each server that we were provided until we land on one that
 	// successfully completes the make-join send-join dance.


### PR DESCRIPTION
This should significantly improve room join times for p2p as it means we will try the peer ID of the room alias first, which we know is up (as it responded to the directory lookup request). In some cases, it will mean we can join rooms we previously couldn't as libp2p seems to black hole connections after a while.