### PR TITLE
Delegate responsibility for marking room versions as supported/stable to gomatrixserverlib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/matrix-org/go-http-js-libp2p v0.0.0-20200518170932-783164aeeda4
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20200522092705-bc8506ccbcf3
 	github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20200602095934-0117edafc57a
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20200602125825-24ff01093eca
 	github.com/matrix-org/naffka v0.0.0-20200422140631-181f1ee7401f
 	github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7
 	github.com/mattn/go-sqlite3 v2.0.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -356,8 +356,8 @@ github.com/matrix-org/go-sqlite3-js v0.0.0-20200522092705-bc8506ccbcf3 h1:Yb+Wlf
 github.com/matrix-org/go-sqlite3-js v0.0.0-20200522092705-bc8506ccbcf3/go.mod h1:e+cg2q7C7yE5QnAXgzo512tgFh1RbQLC0+jozuegKgo=
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26 h1:Hr3zjRsq2bhrnp3Ky1qgx/fzCtCALOoGYylh2tpS9K4=
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200602095934-0117edafc57a h1:TX8oRfmzq84CFTcEuk1uvDPzV+jA9SlRSEj8MU/W3o0=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200602095934-0117edafc57a/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200602125825-24ff01093eca h1:s/dJePRDKjD1fGeoTnEYFqPmp1v7fC6GTd6iFwCKxw8=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200602125825-24ff01093eca/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
 github.com/matrix-org/naffka v0.0.0-20200422140631-181f1ee7401f h1:pRz4VTiRCO4zPlEMc3ESdUOcW4PXHH4Kj+YDz1XyE+Y=
 github.com/matrix-org/naffka v0.0.0-20200422140631-181f1ee7401f/go.mod h1:y0oDTjZDv5SM9a2rp3bl+CU+bvTRINQsdb7YlDql5Go=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7 h1:ntrLa/8xVzeSs8vHFHK25k0C+NV74sYMJnNSg5NoSRo=

--- a/roomserver/version/version.go
+++ b/roomserver/version/version.go
@@ -20,42 +20,6 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
-// RoomVersionDescription contains information about a room version,
-// namely whether it is marked as supported or stable in this server
-// version.
-// A version is supported if the server has some support for rooms
-// that are this version. A version is marked as stable or unstable
-// in order to hint whether the version should be used to clients
-// calling the /capabilities endpoint.
-// https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-capabilities
-type RoomVersionDescription struct {
-	Supported bool
-	Stable    bool
-}
-
-var roomVersions = map[gomatrixserverlib.RoomVersion]RoomVersionDescription{
-	gomatrixserverlib.RoomVersionV1: RoomVersionDescription{
-		Supported: true,
-		Stable:    true,
-	},
-	gomatrixserverlib.RoomVersionV2: RoomVersionDescription{
-		Supported: true,
-		Stable:    true,
-	},
-	gomatrixserverlib.RoomVersionV3: RoomVersionDescription{
-		Supported: true,
-		Stable:    true,
-	},
-	gomatrixserverlib.RoomVersionV4: RoomVersionDescription{
-		Supported: true,
-		Stable:    true,
-	},
-	gomatrixserverlib.RoomVersionV5: RoomVersionDescription{
-		Supported: true,
-		Stable:    true,
-	},
-}
-
 // DefaultRoomVersion contains the room version that will, by
 // default, be used to create new rooms on this server.
 func DefaultRoomVersion() gomatrixserverlib.RoomVersion {
@@ -64,43 +28,37 @@ func DefaultRoomVersion() gomatrixserverlib.RoomVersion {
 
 // RoomVersions returns a map of all known room versions to this
 // server.
-func RoomVersions() map[gomatrixserverlib.RoomVersion]RoomVersionDescription {
-	return roomVersions
+func RoomVersions() map[gomatrixserverlib.RoomVersion]gomatrixserverlib.RoomVersionDescription {
+	return gomatrixserverlib.RoomVersions()
 }
 
 // SupportedRoomVersions returns a map of descriptions for room
 // versions that are supported by this homeserver.
-func SupportedRoomVersions() map[gomatrixserverlib.RoomVersion]RoomVersionDescription {
-	versions := make(map[gomatrixserverlib.RoomVersion]RoomVersionDescription)
-	for id, version := range RoomVersions() {
-		if version.Supported {
-			versions[id] = version
-		}
-	}
-	return versions
+func SupportedRoomVersions() map[gomatrixserverlib.RoomVersion]gomatrixserverlib.RoomVersionDescription {
+	return gomatrixserverlib.SupportedRoomVersions()
 }
 
 // RoomVersion returns information about a specific room version.
 // An UnknownVersionError is returned if the version is not known
 // to the server.
-func RoomVersion(version gomatrixserverlib.RoomVersion) (RoomVersionDescription, error) {
-	if version, ok := roomVersions[version]; ok {
+func RoomVersion(version gomatrixserverlib.RoomVersion) (gomatrixserverlib.RoomVersionDescription, error) {
+	if version, ok := gomatrixserverlib.RoomVersions()[version]; ok {
 		return version, nil
 	}
-	return RoomVersionDescription{}, UnknownVersionError{version}
+	return gomatrixserverlib.RoomVersionDescription{}, UnknownVersionError{version}
 }
 
 // SupportedRoomVersion returns information about a specific room
 // version. An UnknownVersionError is returned if the version is not
 // known to the server, or an UnsupportedVersionError is returned if
 // the version is known but specifically marked as unsupported.
-func SupportedRoomVersion(version gomatrixserverlib.RoomVersion) (RoomVersionDescription, error) {
+func SupportedRoomVersion(version gomatrixserverlib.RoomVersion) (gomatrixserverlib.RoomVersionDescription, error) {
 	result, err := RoomVersion(version)
 	if err != nil {
-		return RoomVersionDescription{}, err
+		return gomatrixserverlib.RoomVersionDescription{}, err
 	}
 	if !result.Supported {
-		return RoomVersionDescription{}, UnsupportedVersionError{version}
+		return gomatrixserverlib.RoomVersionDescription{}, UnsupportedVersionError{version}
 	}
 	return result, nil
 }


### PR DESCRIPTION
Continuation of matrix-org/gomatrixserverlib#200. Since room version logic is pretty much exclusively in gomatrixserverlib, it makes sense that gomatrixserverlib also controls which versions are supported/stable.