### PR TITLE
Don't reset counters before successful outgoing federation request

### DIFF
--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -59,7 +59,6 @@ func (oq *destinationQueue) retry() {
 	// and then skip ahead a lot which feels non-ideal but equally we can't persist thousands of events
 	// in-memory to maybe-send it one day. Ideally we would just shove these pending events in a database
 	// so we can send a lot of events.
-	oq.statistics.Success()
 	// if we were backing off, swap to not backing off and interrupt the select.
 	// We need to use an atomic bool here to prevent multiple calls to retry() blocking on the channel
 	// as it is unbuffered.


### PR DESCRIPTION
When we receive an incoming federation request, we currently reset the counters and then interrupt the backoff/restart the queue.

This PR changes the behaviour so that we interrupt the backoff/restart the queue but we *don't* reset the counters. The idea is that:

- if the remote server still isn't behaving normally, we won't unnecessarily try to hammer it with requests again;
- if the remote server is behaving normally, then our federation request that happens as a result of interrupting the federation counter will reset the counters for us.