### PR TITLE
General cleanup when making components

### DIFF
--- a/cmd/dendrite-appservice-server/main.go
+++ b/cmd/dendrite-appservice-server/main.go
@@ -21,7 +21,7 @@ import (
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags()
+	cfg := basecomponent.ParseFlags(false)
 	base := basecomponent.NewBaseDendrite(cfg, "AppServiceAPI", true)
 
 	defer base.Close() // nolint: errcheck

--- a/cmd/dendrite-client-api-server/main.go
+++ b/cmd/dendrite-client-api-server/main.go
@@ -16,8 +16,6 @@ package main
 
 import (
 	"github.com/matrix-org/dendrite/clientapi"
-	"github.com/matrix-org/dendrite/eduserver"
-	"github.com/matrix-org/dendrite/eduserver/cache"
 	"github.com/matrix-org/dendrite/internal/basecomponent"
 	"github.com/matrix-org/dendrite/internal/transactions"
 )
@@ -38,8 +36,7 @@ func main() {
 	asQuery := base.AppserviceHTTPClient()
 	rsAPI := base.RoomserverHTTPClient()
 	fsAPI := base.FederationSenderHTTPClient()
-	rsAPI.SetFederationSenderAPI(fsAPI)
-	eduInputAPI := eduserver.SetupEDUServerComponent(base, cache.New(), deviceDB)
+	eduInputAPI := base.EDUServerClient()
 
 	clientapi.SetupClientAPIComponent(
 		base, deviceDB, accountDB, federation, keyRing,

--- a/cmd/dendrite-client-api-server/main.go
+++ b/cmd/dendrite-client-api-server/main.go
@@ -23,7 +23,7 @@ import (
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags()
+	cfg := basecomponent.ParseFlags(false)
 
 	base := basecomponent.NewBaseDendrite(cfg, "ClientAPI", true)
 	defer base.Close() // nolint: errcheck

--- a/cmd/dendrite-edu-server/main.go
+++ b/cmd/dendrite-edu-server/main.go
@@ -22,7 +22,7 @@ import (
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags()
+	cfg := basecomponent.ParseFlags(false)
 	base := basecomponent.NewBaseDendrite(cfg, "EDUServerAPI", true)
 	defer func() {
 		if err := base.Close(); err != nil {

--- a/cmd/dendrite-federation-api-server/main.go
+++ b/cmd/dendrite-federation-api-server/main.go
@@ -16,8 +16,6 @@ package main
 
 import (
 	"github.com/matrix-org/dendrite/clientapi/producers"
-	"github.com/matrix-org/dendrite/eduserver"
-	"github.com/matrix-org/dendrite/eduserver/cache"
 	"github.com/matrix-org/dendrite/federationapi"
 	"github.com/matrix-org/dendrite/internal/basecomponent"
 )
@@ -30,17 +28,13 @@ func main() {
 	accountDB := base.CreateAccountsDB()
 	deviceDB := base.CreateDeviceDB()
 	federation := base.CreateFederationClient()
-
 	serverKeyAPI := base.ServerKeyAPIClient()
 	keyRing := serverKeyAPI.KeyRing()
-
 	fsAPI := base.FederationSenderHTTPClient()
-
 	rsAPI := base.RoomserverHTTPClient()
 	asAPI := base.AppserviceHTTPClient()
-	rsAPI.SetFederationSenderAPI(fsAPI)
-	eduInputAPI := eduserver.SetupEDUServerComponent(base, cache.New(), deviceDB)
-	eduProducer := producers.NewEDUServerProducer(eduInputAPI)
+	// TODO: this isn't a producer
+	eduProducer := producers.NewEDUServerProducer(base.EDUServerClient())
 
 	federationapi.SetupFederationAPIComponent(
 		base, accountDB, deviceDB, federation, keyRing,

--- a/cmd/dendrite-federation-api-server/main.go
+++ b/cmd/dendrite-federation-api-server/main.go
@@ -23,7 +23,7 @@ import (
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags()
+	cfg := basecomponent.ParseFlags(false)
 	base := basecomponent.NewBaseDendrite(cfg, "FederationAPI", true)
 	defer base.Close() // nolint: errcheck
 

--- a/cmd/dendrite-federation-sender-server/main.go
+++ b/cmd/dendrite-federation-sender-server/main.go
@@ -30,10 +30,9 @@ func main() {
 	keyRing := serverKeyAPI.KeyRing()
 
 	rsAPI := base.RoomserverHTTPClient()
-	fsAPI := federationsender.SetupFederationSenderComponent(
+	federationsender.SetupFederationSenderComponent(
 		base, federation, rsAPI, keyRing,
 	)
-	rsAPI.SetFederationSenderAPI(fsAPI)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.FederationSender), string(base.Cfg.Listen.FederationSender))
 

--- a/cmd/dendrite-federation-sender-server/main.go
+++ b/cmd/dendrite-federation-sender-server/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags()
+	cfg := basecomponent.ParseFlags(false)
 	base := basecomponent.NewBaseDendrite(cfg, "FederationSender", true)
 	defer base.Close() // nolint: errcheck
 

--- a/cmd/dendrite-key-server/main.go
+++ b/cmd/dendrite-key-server/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags()
+	cfg := basecomponent.ParseFlags(false)
 	base := basecomponent.NewBaseDendrite(cfg, "KeyServer", true)
 	defer base.Close() // nolint: errcheck
 

--- a/cmd/dendrite-media-api-server/main.go
+++ b/cmd/dendrite-media-api-server/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags()
+	cfg := basecomponent.ParseFlags(false)
 	base := basecomponent.NewBaseDendrite(cfg, "MediaAPI", true)
 	defer base.Close() // nolint: errcheck
 

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -49,7 +49,7 @@ var (
 )
 
 func main() {
-	cfg := basecomponent.ParseMonolithFlags()
+	cfg := basecomponent.ParseFlags(true)
 	if *enableHTTPAPIs {
 		// If the HTTP APIs are enabled then we need to update the Listen
 		// statements in the configuration so that we know where to find

--- a/cmd/dendrite-public-rooms-api-server/main.go
+++ b/cmd/dendrite-public-rooms-api-server/main.go
@@ -22,7 +22,7 @@ import (
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags()
+	cfg := basecomponent.ParseFlags(false)
 	base := basecomponent.NewBaseDendrite(cfg, "PublicRoomsAPI", true)
 	defer base.Close() // nolint: errcheck
 

--- a/cmd/dendrite-public-rooms-api-server/main.go
+++ b/cmd/dendrite-public-rooms-api-server/main.go
@@ -28,9 +28,7 @@ func main() {
 
 	deviceDB := base.CreateDeviceDB()
 
-	fsAPI := base.FederationSenderHTTPClient()
 	rsAPI := base.RoomserverHTTPClient()
-	rsAPI.SetFederationSenderAPI(fsAPI)
 
 	publicRoomsDB, err := storage.NewPublicRoomsServerDatabase(string(base.Cfg.Database.PublicRoomsAPI), base.Cfg.DbProperties(), cfg.Matrix.ServerName)
 	if err != nil {

--- a/cmd/dendrite-room-server/main.go
+++ b/cmd/dendrite-room-server/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags()
+	cfg := basecomponent.ParseFlags(false)
 	base := basecomponent.NewBaseDendrite(cfg, "RoomServerAPI", true)
 	defer base.Close() // nolint: errcheck
 	federation := base.CreateFederationClient()

--- a/cmd/dendrite-server-key-api-server/main.go
+++ b/cmd/dendrite-server-key-api-server/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags()
+	cfg := basecomponent.ParseFlags(false)
 	base := basecomponent.NewBaseDendrite(cfg, "ServerKeyAPI", true)
 	defer base.Close() // nolint: errcheck
 

--- a/cmd/dendrite-sync-api-server/main.go
+++ b/cmd/dendrite-sync-api-server/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags()
+	cfg := basecomponent.ParseFlags(false)
 	base := basecomponent.NewBaseDendrite(cfg, "SyncAPI", true)
 	defer base.Close() // nolint: errcheck
 

--- a/internal/basecomponent/flags.go
+++ b/internal/basecomponent/flags.go
@@ -25,33 +25,14 @@ import (
 var configPath = flag.String("config", "dendrite.yaml", "The path to the config file. For more information, see the config file in this repository.")
 
 // ParseFlags parses the commandline flags and uses them to create a config.
-// If running as a monolith use `ParseMonolithFlags` instead.
-func ParseFlags() *config.Dendrite {
+func ParseFlags(monolith bool) *config.Dendrite {
 	flag.Parse()
 
 	if *configPath == "" {
 		logrus.Fatal("--config must be supplied")
 	}
 
-	cfg, err := config.Load(*configPath)
-
-	if err != nil {
-		logrus.Fatalf("Invalid config file: %s", err)
-	}
-
-	return cfg
-}
-
-// ParseMonolithFlags parses the commandline flags and uses them to create a
-// config. Should only be used if running a monolith. See `ParseFlags`.
-func ParseMonolithFlags() *config.Dendrite {
-	flag.Parse()
-
-	if *configPath == "" {
-		logrus.Fatal("--config must be supplied")
-	}
-
-	cfg, err := config.LoadMonolithic(*configPath)
+	cfg, err := config.Load(*configPath, monolith)
 
 	if err != nil {
 		logrus.Fatalf("Invalid config file: %s", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -370,11 +370,9 @@ type LogrusHook struct {
 // It implements the error interface.
 type configErrors []string
 
-// Load a yaml config file for a server run as multiple processes.
+// Load a yaml config file for a server run as multiple processes or as a monolith.
 // Checks the config to ensure that it is valid.
-// The checks are different if the server is run as a monolithic process instead
-// of being split into multiple components
-func Load(configPath string) (*Dendrite, error) {
+func Load(configPath string, monolith bool) (*Dendrite, error) {
 	configData, err := ioutil.ReadFile(configPath)
 	if err != nil {
 		return nil, err
@@ -385,27 +383,7 @@ func Load(configPath string) (*Dendrite, error) {
 	}
 	// Pass the current working directory and ioutil.ReadFile so that they can
 	// be mocked in the tests
-	monolithic := false
-	return loadConfig(basePath, configData, ioutil.ReadFile, monolithic)
-}
-
-// LoadMonolithic loads a yaml config file for a server run as a single monolith.
-// Checks the config to ensure that it is valid.
-// The checks are different if the server is run as a monolithic process instead
-// of being split into multiple components
-func LoadMonolithic(configPath string) (*Dendrite, error) {
-	configData, err := ioutil.ReadFile(configPath)
-	if err != nil {
-		return nil, err
-	}
-	basePath, err := filepath.Abs(".")
-	if err != nil {
-		return nil, err
-	}
-	// Pass the current working directory and ioutil.ReadFile so that they can
-	// be mocked in the tests
-	monolithic := true
-	return loadConfig(basePath, configData, ioutil.ReadFile, monolithic)
+	return loadConfig(basePath, configData, ioutil.ReadFile, monolith)
 }
 
 func loadConfig(

--- a/roomserver/inthttp/client.go
+++ b/roomserver/inthttp/client.go
@@ -45,7 +45,6 @@ const (
 type httpRoomserverInternalAPI struct {
 	roomserverURL  string
 	httpClient     *http.Client
-	fsAPI          fsInputAPI.FederationSenderInternalAPI
 	immutableCache caching.ImmutableCache
 }
 
@@ -66,11 +65,8 @@ func NewRoomserverClient(
 	}, nil
 }
 
-// SetFederationSenderInputAPI passes in a federation sender input API reference
-// so that we can avoid the chicken-and-egg problem of both the roomserver input API
-// and the federation sender input API being interdependent.
+// SetFederationSenderInputAPI no-ops in HTTP client mode as there is no chicken/egg scenario
 func (h *httpRoomserverInternalAPI) SetFederationSenderAPI(fsAPI fsInputAPI.FederationSenderInternalAPI) {
-	h.fsAPI = fsAPI
 }
 
 // SetRoomAlias implements RoomserverAliasAPI


### PR DESCRIPTION
- Remove ParseMonolith stuff and just have a boolean on Parse
- Remove places where we needlessly make components
- Remove places where we needlessly set the fed sender on the room server client
- Remove places where we inadvertently made more EDU servers