### PR TITLE
WIP base refactor

### DIFF
--- a/cmd/dendrite-appservice-server/main.go
+++ b/cmd/dendrite-appservice-server/main.go
@@ -16,24 +16,16 @@ package main
 
 import (
 	"github.com/matrix-org/dendrite/appservice"
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/setup"
 	"github.com/matrix-org/dendrite/internal/transactions"
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags(false)
-	base := basecomponent.NewBaseDendrite(cfg, "AppServiceAPI", true)
-
+	cfg := setup.ParseFlags(false)
+	base := setup.NewBase(cfg, "AppServiceAPI", true)
 	defer base.Close() // nolint: errcheck
-	accountDB := base.CreateAccountsDB()
-	deviceDB := base.CreateDeviceDB()
-	federation := base.CreateFederationClient()
-	rsAPI := base.RoomserverHTTPClient()
-	cache := transactions.New()
 
-	appservice.SetupAppServiceAPIComponent(
-		base, accountDB, deviceDB, federation, rsAPI, cache,
-	)
+	appservice.SetupAppServiceAPIComponent(base, transactions.New())
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.AppServiceAPI), string(base.Cfg.Listen.AppServiceAPI))
 

--- a/cmd/dendrite-client-api-server/main.go
+++ b/cmd/dendrite-client-api-server/main.go
@@ -16,32 +16,16 @@ package main
 
 import (
 	"github.com/matrix-org/dendrite/clientapi"
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/setup"
 	"github.com/matrix-org/dendrite/internal/transactions"
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags(false)
+	cfg := setup.ParseFlags(false)
 
-	base := basecomponent.NewBaseDendrite(cfg, "ClientAPI", true)
+	base := setup.NewBase(cfg, "ClientAPI", true)
 	defer base.Close() // nolint: errcheck
-
-	accountDB := base.CreateAccountsDB()
-	deviceDB := base.CreateDeviceDB()
-	federation := base.CreateFederationClient()
-
-	serverKeyAPI := base.ServerKeyAPIClient()
-	keyRing := serverKeyAPI.KeyRing()
-
-	asQuery := base.AppserviceHTTPClient()
-	rsAPI := base.RoomserverHTTPClient()
-	fsAPI := base.FederationSenderHTTPClient()
-	eduInputAPI := base.EDUServerClient()
-
-	clientapi.SetupClientAPIComponent(
-		base, deviceDB, accountDB, federation, keyRing,
-		rsAPI, eduInputAPI, asQuery, transactions.New(), fsAPI,
-	)
+	clientapi.SetupClientAPIComponent(base, transactions.New())
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.ClientAPI), string(base.Cfg.Listen.ClientAPI))
 

--- a/cmd/dendrite-demo-libp2p/p2pdendrite.go
+++ b/cmd/dendrite-demo-libp2p/p2pdendrite.go
@@ -22,7 +22,7 @@ import (
 
 	pstore "github.com/libp2p/go-libp2p-core/peerstore"
 	record "github.com/libp2p/go-libp2p-record"
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/setup"
 
 	"github.com/libp2p/go-libp2p"
 	circuit "github.com/libp2p/go-libp2p-circuit"
@@ -37,9 +37,9 @@ import (
 	"github.com/matrix-org/dendrite/internal/config"
 )
 
-// P2PDendrite is a Peer-to-Peer variant of BaseDendrite.
+// P2PDendrite is a Peer-to-Peer variant of Base.
 type P2PDendrite struct {
-	Base basecomponent.BaseDendrite
+	Base setup.Base
 
 	// Store our libp2p object so that we can make outgoing connections from it
 	// later
@@ -54,7 +54,7 @@ type P2PDendrite struct {
 // The componentName is used for logging purposes, and should be a friendly name
 // of the component running, e.g. SyncAPI.
 func NewP2PDendrite(cfg *config.Dendrite, componentName string) *P2PDendrite {
-	baseDendrite := basecomponent.NewBaseDendrite(cfg, componentName, false)
+	baseDendrite := setup.NewBase(cfg, componentName, false)
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/cmd/dendrite-edu-server/main.go
+++ b/cmd/dendrite-edu-server/main.go
@@ -17,21 +17,20 @@ import (
 
 	"github.com/matrix-org/dendrite/eduserver"
 	"github.com/matrix-org/dendrite/eduserver/cache"
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/setup"
 	"github.com/sirupsen/logrus"
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags(false)
-	base := basecomponent.NewBaseDendrite(cfg, "EDUServerAPI", true)
+	cfg := setup.ParseFlags(false)
+	base := setup.NewBase(cfg, "EDUServerAPI", true)
 	defer func() {
 		if err := base.Close(); err != nil {
-			logrus.WithError(err).Warn("BaseDendrite close failed")
+			logrus.WithError(err).Warn("Base close failed")
 		}
 	}()
-	deviceDB := base.CreateDeviceDB()
 
-	eduserver.SetupEDUServerComponent(base, cache.New(), deviceDB)
+	eduserver.SetupEDUServerComponent(base, cache.New())
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.EDUServer), string(base.Cfg.Listen.EDUServer))
 

--- a/cmd/dendrite-federation-api-server/main.go
+++ b/cmd/dendrite-federation-api-server/main.go
@@ -17,30 +17,17 @@ package main
 import (
 	"github.com/matrix-org/dendrite/clientapi/producers"
 	"github.com/matrix-org/dendrite/federationapi"
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/setup"
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags(false)
-	base := basecomponent.NewBaseDendrite(cfg, "FederationAPI", true)
+	cfg := setup.ParseFlags(false)
+	base := setup.NewBase(cfg, "FederationAPI", true)
 	defer base.Close() // nolint: errcheck
-
-	accountDB := base.CreateAccountsDB()
-	deviceDB := base.CreateDeviceDB()
-	federation := base.CreateFederationClient()
-	serverKeyAPI := base.ServerKeyAPIClient()
-	keyRing := serverKeyAPI.KeyRing()
-	fsAPI := base.FederationSenderHTTPClient()
-	rsAPI := base.RoomserverHTTPClient()
-	asAPI := base.AppserviceHTTPClient()
 	// TODO: this isn't a producer
-	eduProducer := producers.NewEDUServerProducer(base.EDUServerClient())
+	eduProducer := producers.NewEDUServerProducer(base.EDUServer())
 
-	federationapi.SetupFederationAPIComponent(
-		base, accountDB, deviceDB, federation, keyRing,
-		rsAPI, asAPI, fsAPI, eduProducer,
-	)
-
+	federationapi.SetupFederationAPIComponent(base, eduProducer)
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.FederationAPI), string(base.Cfg.Listen.FederationAPI))
 
 }

--- a/cmd/dendrite-federation-sender-server/main.go
+++ b/cmd/dendrite-federation-sender-server/main.go
@@ -16,23 +16,14 @@ package main
 
 import (
 	"github.com/matrix-org/dendrite/federationsender"
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/setup"
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags(false)
-	base := basecomponent.NewBaseDendrite(cfg, "FederationSender", true)
+	cfg := setup.ParseFlags(false)
+	base := setup.NewBase(cfg, "FederationSender", true)
 	defer base.Close() // nolint: errcheck
-
-	federation := base.CreateFederationClient()
-
-	serverKeyAPI := base.ServerKeyAPIClient()
-	keyRing := serverKeyAPI.KeyRing()
-
-	rsAPI := base.RoomserverHTTPClient()
-	federationsender.SetupFederationSenderComponent(
-		base, federation, rsAPI, keyRing,
-	)
+	federationsender.SetupFederationSenderComponent(base)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.FederationSender), string(base.Cfg.Listen.FederationSender))
 

--- a/cmd/dendrite-key-server/main.go
+++ b/cmd/dendrite-key-server/main.go
@@ -15,19 +15,15 @@
 package main
 
 import (
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/setup"
 	"github.com/matrix-org/dendrite/keyserver"
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags(false)
-	base := basecomponent.NewBaseDendrite(cfg, "KeyServer", true)
+	cfg := setup.ParseFlags(false)
+	base := setup.NewBase(cfg, "KeyServer", true)
 	defer base.Close() // nolint: errcheck
-
-	accountDB := base.CreateAccountsDB()
-	deviceDB := base.CreateDeviceDB()
-
-	keyserver.SetupKeyServerComponent(base, deviceDB, accountDB)
+	keyserver.SetupKeyServerComponent(base)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.KeyServer), string(base.Cfg.Listen.KeyServer))
 

--- a/cmd/dendrite-media-api-server/main.go
+++ b/cmd/dendrite-media-api-server/main.go
@@ -15,18 +15,15 @@
 package main
 
 import (
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/setup"
 	"github.com/matrix-org/dendrite/mediaapi"
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags(false)
-	base := basecomponent.NewBaseDendrite(cfg, "MediaAPI", true)
+	cfg := setup.ParseFlags(false)
+	base := setup.NewBase(cfg, "MediaAPI", true)
 	defer base.Close() // nolint: errcheck
-
-	deviceDB := base.CreateDeviceDB()
-
-	mediaapi.SetupMediaAPIComponent(base, deviceDB)
+	mediaapi.SetupMediaAPIComponent(base)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.MediaAPI), string(base.Cfg.Listen.MediaAPI))
 

--- a/cmd/dendrite-public-rooms-api-server/main.go
+++ b/cmd/dendrite-public-rooms-api-server/main.go
@@ -15,26 +15,15 @@
 package main
 
 import (
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/setup"
 	"github.com/matrix-org/dendrite/publicroomsapi"
-	"github.com/matrix-org/dendrite/publicroomsapi/storage"
-	"github.com/sirupsen/logrus"
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags(false)
-	base := basecomponent.NewBaseDendrite(cfg, "PublicRoomsAPI", true)
+	cfg := setup.ParseFlags(false)
+	base := setup.NewBase(cfg, "PublicRoomsAPI", true)
 	defer base.Close() // nolint: errcheck
-
-	deviceDB := base.CreateDeviceDB()
-
-	rsAPI := base.RoomserverHTTPClient()
-
-	publicRoomsDB, err := storage.NewPublicRoomsServerDatabase(string(base.Cfg.Database.PublicRoomsAPI), base.Cfg.DbProperties(), cfg.Matrix.ServerName)
-	if err != nil {
-		logrus.WithError(err).Panicf("failed to connect to public rooms db")
-	}
-	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB, publicRoomsDB, rsAPI, nil, nil)
+	publicroomsapi.SetupPublicRoomsAPIComponent(base, nil)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.PublicRoomsAPI), string(base.Cfg.Listen.PublicRoomsAPI))
 

--- a/cmd/dendrite-room-server/main.go
+++ b/cmd/dendrite-room-server/main.go
@@ -15,22 +15,16 @@
 package main
 
 import (
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/setup"
 	"github.com/matrix-org/dendrite/roomserver"
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags(false)
-	base := basecomponent.NewBaseDendrite(cfg, "RoomServerAPI", true)
+	cfg := setup.ParseFlags(false)
+	base := setup.NewBase(cfg, "RoomServerAPI", true)
 	defer base.Close() // nolint: errcheck
-	federation := base.CreateFederationClient()
-
-	serverKeyAPI := base.ServerKeyAPIClient()
-	keyRing := serverKeyAPI.KeyRing()
-
-	fsAPI := base.FederationSenderHTTPClient()
-	rsAPI := roomserver.SetupRoomServerComponent(base, keyRing, federation)
-	rsAPI.SetFederationSenderAPI(fsAPI)
+	rsAPI := roomserver.SetupRoomServerComponent(base)
+	rsAPI.SetFederationSenderAPI(base.FederationSender())
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.RoomServer), string(base.Cfg.Listen.RoomServer))
 

--- a/cmd/dendrite-server-key-api-server/main.go
+++ b/cmd/dendrite-server-key-api-server/main.go
@@ -15,18 +15,16 @@
 package main
 
 import (
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/setup"
 	"github.com/matrix-org/dendrite/serverkeyapi"
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags(false)
-	base := basecomponent.NewBaseDendrite(cfg, "ServerKeyAPI", true)
+	cfg := setup.ParseFlags(false)
+	base := setup.NewBase(cfg, "ServerKeyAPI", true)
 	defer base.Close() // nolint: errcheck
 
-	federation := base.CreateFederationClient()
-
-	serverkeyapi.SetupServerKeyAPIComponent(base, federation)
+	serverkeyapi.SetupServerKeyAPIComponent(base)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.ServerKeyAPI), string(base.Cfg.Listen.ServerKeyAPI))
 }

--- a/cmd/dendrite-sync-api-server/main.go
+++ b/cmd/dendrite-sync-api-server/main.go
@@ -15,22 +15,16 @@
 package main
 
 import (
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/setup"
 	"github.com/matrix-org/dendrite/syncapi"
 )
 
 func main() {
-	cfg := basecomponent.ParseFlags(false)
-	base := basecomponent.NewBaseDendrite(cfg, "SyncAPI", true)
+	cfg := setup.ParseFlags(false)
+	base := setup.NewBase(cfg, "SyncAPI", true)
 	defer base.Close() // nolint: errcheck
 
-	deviceDB := base.CreateDeviceDB()
-	accountDB := base.CreateAccountsDB()
-	federation := base.CreateFederationClient()
-
-	rsAPI := base.RoomserverHTTPClient()
-
-	syncapi.SetupSyncAPIComponent(base, deviceDB, accountDB, rsAPI, federation, cfg)
+	syncapi.SetupSyncAPIComponent(base)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.SyncAPI), string(base.Cfg.Listen.SyncAPI))
 

--- a/cmd/dendritejs/keyfetcher.go
+++ b/cmd/dendritejs/keyfetcher.go
@@ -84,3 +84,27 @@ func (f *libp2pKeyFetcher) FetcherName() string {
 func (f *libp2pKeyFetcher) StoreKeys(ctx context.Context, results map[gomatrixserverlib.PublicKeyLookupRequest]gomatrixserverlib.PublicKeyLookupResult) error {
 	return nil
 }
+
+type libp2pServerKeyAPI struct {
+	keyRing *gomatrixserverlib.KeyRing
+}
+
+func (a *libp2pServerKeyAPI) KeyRing() *gomatrixserverlib.KeyRing {
+	return a.keyRing
+}
+
+func (a *libp2pServerKeyAPI) InputPublicKeys(
+	ctx context.Context,
+	request *InputPublicKeysRequest,
+	response *InputPublicKeysResponse,
+) error {
+	return nil
+}
+
+func (a *libp2pServerKeyAPI) QueryPublicKeys(
+	ctx context.Context,
+	request *QueryPublicKeysRequest,
+	response *QueryPublicKeysResponse,
+) error {
+	return nil
+}

--- a/eduserver/eduserver.go
+++ b/eduserver/eduserver.go
@@ -17,12 +17,11 @@
 package eduserver
 
 import (
-	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
 	"github.com/matrix-org/dendrite/eduserver/api"
 	"github.com/matrix-org/dendrite/eduserver/cache"
 	"github.com/matrix-org/dendrite/eduserver/input"
 	"github.com/matrix-org/dendrite/eduserver/inthttp"
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/setup"
 )
 
 // SetupEDUServerComponent sets up and registers HTTP handlers for the
@@ -30,13 +29,12 @@ import (
 // allowing other components running in the same process to hit the query the
 // APIs directly instead of having to use HTTP.
 func SetupEDUServerComponent(
-	base *basecomponent.BaseDendrite,
+	base *setup.Base,
 	eduCache *cache.EDUCache,
-	deviceDB devices.Database,
 ) api.EDUServerInputAPI {
 	inputAPI := &input.EDUServerInputAPI{
 		Cache:                        eduCache,
-		DeviceDB:                     deviceDB,
+		DeviceDB:                     base.DeviceDB,
 		Producer:                     base.KafkaProducer,
 		OutputTypingEventTopic:       string(base.Cfg.Kafka.Topics.OutputTypingEvent),
 		OutputSendToDeviceEventTopic: string(base.Cfg.Kafka.Topics.OutputSendToDeviceEvent),

--- a/federationapi/federationapi.go
+++ b/federationapi/federationapi.go
@@ -15,37 +15,24 @@
 package federationapi
 
 import (
-	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"
-	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
-	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
-	federationSenderAPI "github.com/matrix-org/dendrite/federationsender/api"
-	"github.com/matrix-org/dendrite/internal/basecomponent"
-	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/internal/setup"
 
 	// TODO: Are we really wanting to pull in the producer from clientapi
 	"github.com/matrix-org/dendrite/clientapi/producers"
 	"github.com/matrix-org/dendrite/federationapi/routing"
-	"github.com/matrix-org/gomatrixserverlib"
 )
 
 // SetupFederationAPIComponent sets up and registers HTTP handlers for the
 // FederationAPI component.
 func SetupFederationAPIComponent(
-	base *basecomponent.BaseDendrite,
-	accountsDB accounts.Database,
-	deviceDB devices.Database,
-	federation *gomatrixserverlib.FederationClient,
-	keyRing *gomatrixserverlib.KeyRing,
-	rsAPI roomserverAPI.RoomserverInternalAPI,
-	asAPI appserviceAPI.AppServiceQueryAPI,
-	federationSenderAPI federationSenderAPI.FederationSenderInternalAPI,
+	base *setup.Base,
 	eduProducer *producers.EDUServerProducer,
 ) {
-	roomserverProducer := producers.NewRoomserverProducer(rsAPI)
+	roomserverProducer := producers.NewRoomserverProducer(base.RoomserverAPI())
 
 	routing.Setup(
-		base.PublicAPIMux, base.Cfg, rsAPI, asAPI, roomserverProducer,
-		eduProducer, federationSenderAPI, *keyRing,
-		federation, accountsDB, deviceDB,
+		base.PublicAPIMux, base.Cfg, base.RoomserverAPI(), base.AppserviceAPI(), roomserverProducer,
+		eduProducer, base.FederationSender(), *base.ServerKeyAPI().KeyRing(),
+		base.FederationClient, base.AccountDB, base.DeviceDB,
 	)
 }

--- a/internal/setup/flags.go
+++ b/internal/setup/flags.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package basecomponent
+package setup
 
 import (
 	"flag"

--- a/keyserver/keyserver.go
+++ b/keyserver/keyserver.go
@@ -15,18 +15,12 @@
 package keyserver
 
 import (
-	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
-	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/setup"
 	"github.com/matrix-org/dendrite/keyserver/routing"
 )
 
 // SetupFederationSenderComponent sets up and registers HTTP handlers for the
 // FederationSender component.
-func SetupKeyServerComponent(
-	base *basecomponent.BaseDendrite,
-	deviceDB devices.Database,
-	accountsDB accounts.Database,
-) {
-	routing.Setup(base.PublicAPIMux, base.Cfg, accountsDB, deviceDB)
+func SetupKeyServerComponent(base *setup.Base) {
+	routing.Setup(base.PublicAPIMux, base.Cfg, base.AccountDB, base.DeviceDB)
 }

--- a/mediaapi/mediaapi.go
+++ b/mediaapi/mediaapi.go
@@ -15,8 +15,7 @@
 package mediaapi
 
 import (
-	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/setup"
 	"github.com/matrix-org/dendrite/mediaapi/routing"
 	"github.com/matrix-org/dendrite/mediaapi/storage"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -25,16 +24,13 @@ import (
 
 // SetupMediaAPIComponent sets up and registers HTTP handlers for the MediaAPI
 // component.
-func SetupMediaAPIComponent(
-	base *basecomponent.BaseDendrite,
-	deviceDB devices.Database,
-) {
+func SetupMediaAPIComponent(base *setup.Base) {
 	mediaDB, err := storage.Open(string(base.Cfg.Database.MediaAPI), base.Cfg.DbProperties())
 	if err != nil {
 		logrus.WithError(err).Panicf("failed to connect to media db")
 	}
 
 	routing.Setup(
-		base.PublicAPIMux, base.Cfg, mediaDB, deviceDB, gomatrixserverlib.NewClient(),
+		base.PublicAPIMux, base.Cfg, mediaDB, base.DeviceDB, gomatrixserverlib.NewClient(),
 	)
 }

--- a/publicroomsapi/storage/storage_wasm.go
+++ b/publicroomsapi/storage/storage_wasm.go
@@ -18,12 +18,13 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/publicroomsapi/storage/sqlite3"
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
 // NewPublicRoomsServerDatabase opens a database connection.
-func NewPublicRoomsServerDatabase(dataSourceName string, localServerName gomatrixserverlib.ServerName) (Database, error) {
+func NewPublicRoomsServerDatabase(dataSourceName string, dbProperties internal.DbProperties, localServerName gomatrixserverlib.ServerName) (Database, error) {
 	uri, err := url.Parse(dataSourceName)
 	if err != nil {
 		return nil, err

--- a/roomserver/roomserver.go
+++ b/roomserver/roomserver.go
@@ -17,9 +17,8 @@ package roomserver
 import (
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/roomserver/inthttp"
-	"github.com/matrix-org/gomatrixserverlib"
 
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/setup"
 	"github.com/matrix-org/dendrite/roomserver/internal"
 	"github.com/matrix-org/dendrite/roomserver/storage"
 	"github.com/sirupsen/logrus"
@@ -30,9 +29,7 @@ import (
 // allowing other components running in the same process to hit the query the
 // APIs directly instead of having to use HTTP.
 func SetupRoomServerComponent(
-	base *basecomponent.BaseDendrite,
-	keyRing gomatrixserverlib.JSONVerifier,
-	fedClient *gomatrixserverlib.FederationClient,
+	base *setup.Base,
 ) api.RoomserverInternalAPI {
 	roomserverDB, err := storage.Open(string(base.Cfg.Database.RoomServer), base.Cfg.DbProperties())
 	if err != nil {
@@ -46,8 +43,8 @@ func SetupRoomServerComponent(
 		OutputRoomEventTopic: string(base.Cfg.Kafka.Topics.OutputRoomEvent),
 		ImmutableCache:       base.ImmutableCache,
 		ServerName:           base.Cfg.Matrix.ServerName,
-		FedClient:            fedClient,
-		KeyRing:              keyRing,
+		FedClient:            base.FederationClient,
+		KeyRing:              base.ServerKeyAPI().KeyRing(),
 	}
 
 	inthttp.AddRoutes(internalAPI, base.InternalAPIMux)

--- a/serverkeyapi/serverkeyapi.go
+++ b/serverkeyapi/serverkeyapi.go
@@ -4,7 +4,7 @@ import (
 	"crypto/ed25519"
 	"encoding/base64"
 
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/setup"
 	"github.com/matrix-org/dendrite/serverkeyapi/api"
 	"github.com/matrix-org/dendrite/serverkeyapi/internal"
 	"github.com/matrix-org/dendrite/serverkeyapi/inthttp"
@@ -14,10 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func SetupServerKeyAPIComponent(
-	base *basecomponent.BaseDendrite,
-	fedClient *gomatrixserverlib.FederationClient,
-) api.ServerKeyInternalAPI {
+func SetupServerKeyAPIComponent(base *setup.Base) api.ServerKeyInternalAPI {
 	innerDB, err := storage.NewDatabase(
 		string(base.Cfg.Database.ServerKey),
 		base.Cfg.DbProperties(),
@@ -35,11 +32,11 @@ func SetupServerKeyAPIComponent(
 	}
 
 	internalAPI := internal.ServerKeyAPI{
-		FedClient: fedClient,
+		FedClient: base.FederationClient,
 		OurKeyRing: gomatrixserverlib.KeyRing{
 			KeyFetchers: []gomatrixserverlib.KeyFetcher{
 				&gomatrixserverlib.DirectKeyFetcher{
-					Client: fedClient.Client,
+					Client: base.FederationClient.Client,
 				},
 			},
 			KeyDatabase: serverKeyDB,
@@ -51,7 +48,7 @@ func SetupServerKeyAPIComponent(
 		perspective := &gomatrixserverlib.PerspectiveKeyFetcher{
 			PerspectiveServerName: ps.ServerName,
 			PerspectiveServerKeys: map[gomatrixserverlib.KeyID]ed25519.PublicKey{},
-			Client:                fedClient.Client,
+			Client:                base.FederationClient.Client,
 		}
 
 		for _, key := range ps.Keys {


### PR DESCRIPTION
This PR:
 - Renames `basecomponent.BaseDendrite` to `setup.Base`
 - Automatically creates account/device DBs and the federation client on instantiation.
 - Automatically sets up internal HTTP clients if `useHTTPAPIs == true`.
 - Exposes the clients/dbs as public fields.
 - Makes all `SetupFooComponent` primarily just take a `setup.Base`, and pull out the fields which they need to use.

This means most polylith components are now reduced to:
```go
func main() {
	cfg := setup.ParseFlags(false)
	base := setup.NewBase(cfg, "FederationSender", true)
	defer base.Close() // nolint: errcheck
	federationsender.SetupFederationSenderComponent(base)
	base.SetupAndServeHTTP(string(base.Cfg.Bind.FederationSender), string(base.Cfg.Listen.FederationSender))
}
```

The monolith doesn't need HTTP clients if `-api` is not provided, so in those circumstances there are now `SetFoo(fooAPI)` functions which replace the public fields. Accessing `Foo()` when it is unset causes a panic early.

There's a few problems that I still need to work on:
 - `dendrite-demo-libp2p` replaces the public rooms DB which is no longer possible.
 - `dendritejs` now needs to implement `ServerKeyAPI` so it can pull out the key ring. Given no one seems to actually want the server key API itself I wonder how useful this struct actually is (they all immediately call `KeyRing()`).
 - We've lost the ability to identify dependencies at compile time, making the ordering in the monolith code very important. I need to think about how to better structure this.