### PR TITLE
Split out SetupFooComponent

### DIFF
--- a/clientapi/clientapi.go
+++ b/clientapi/clientapi.go
@@ -15,6 +15,7 @@
 package clientapi
 
 import (
+	"github.com/gorilla/mux"
 	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
@@ -30,9 +31,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// SetupClientAPIComponent sets up and registers HTTP handlers for the ClientAPI
-// component.
-func SetupClientAPIComponent(
+// AddPublicRoutes sets up and registers HTTP handlers for the ClientAPI component.
+func AddPublicRoutes(
+	router *mux.Router,
 	base *basecomponent.BaseDendrite,
 	deviceDB devices.Database,
 	accountsDB accounts.Database,
@@ -65,7 +66,7 @@ func SetupClientAPIComponent(
 	}
 
 	routing.Setup(
-		base.PublicAPIMux, base.Cfg, roomserverProducer, rsAPI, asAPI,
+		router, base.Cfg, roomserverProducer, rsAPI, asAPI,
 		accountsDB, deviceDB, federation, *keyRing, userUpdateProducer,
 		syncProducer, eduProducer, transactionsCache, fsAPI,
 	)

--- a/cmd/dendrite-appservice-server/main.go
+++ b/cmd/dendrite-appservice-server/main.go
@@ -31,9 +31,9 @@ func main() {
 	rsAPI := base.RoomserverHTTPClient()
 	cache := transactions.New()
 
-	appservice.SetupAppServiceAPIComponent(
-		base, accountDB, deviceDB, federation, rsAPI, cache,
-	)
+	intAPI := appservice.NewInternalAPI(base, accountDB, deviceDB, rsAPI)
+	appservice.AddInternalRoutes(base.InternalAPIMux, intAPI)
+	appservice.AddPublicRoutes(base.PublicAPIMux, base.Cfg, rsAPI, accountDB, federation, cache)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.AppServiceAPI), string(base.Cfg.Listen.AppServiceAPI))
 

--- a/cmd/dendrite-client-api-server/main.go
+++ b/cmd/dendrite-client-api-server/main.go
@@ -38,8 +38,8 @@ func main() {
 	fsAPI := base.FederationSenderHTTPClient()
 	eduInputAPI := base.EDUServerClient()
 
-	clientapi.SetupClientAPIComponent(
-		base, deviceDB, accountDB, federation, keyRing,
+	clientapi.AddPublicRoutes(
+		base.PublicAPIMux, base, deviceDB, accountDB, federation, keyRing,
 		rsAPI, eduInputAPI, asQuery, transactions.New(), fsAPI,
 	)
 

--- a/cmd/dendrite-demo-libp2p/main.go
+++ b/cmd/dendrite-demo-libp2p/main.go
@@ -136,15 +136,15 @@ func main() {
 	deviceDB := base.Base.CreateDeviceDB()
 	federation := createFederationClient(base)
 
-	serverKeyAPI := serverkeyapi.SetupServerKeyAPIComponent(
-		&base.Base, federation,
+	serverKeyAPI := serverkeyapi.NewInternalAPI(
+		base.Base.Cfg, federation, base.Base.Caches,
 	)
 	keyRing := serverKeyAPI.KeyRing()
 	createKeyDB(
 		base, serverKeyAPI,
 	)
 
-	rsAPI := roomserver.SetupRoomServerComponent(
+	rsAPI := roomserver.NewInternalAPI(
 		&base.Base, keyRing, federation,
 	)
 	eduInputAPI := eduserver.NewInternalAPI(
@@ -169,8 +169,8 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Panicf("failed to connect to public rooms db")
 	}
-	publicroomsapi.SetupPublicRoomsAPIComponent(&base.Base, deviceDB, publicRoomsDB, rsAPI, federation, nil) // Check this later
-	syncapi.SetupSyncAPIComponent(&base.Base, deviceDB, accountDB, rsAPI, federation, &cfg)
+	publicroomsapi.AddPublicRoutes(base.Base.PublicAPIMux, &base.Base, deviceDB, publicRoomsDB, rsAPI, federation, nil) // Check this later
+	syncapi.AddPublicRoutes(base.Base.PublicAPIMux, &base.Base, deviceDB, accountDB, rsAPI, federation, &cfg)
 
 	internal.SetupHTTPAPI(
 		http.DefaultServeMux,

--- a/cmd/dendrite-demo-libp2p/main.go
+++ b/cmd/dendrite-demo-libp2p/main.go
@@ -150,21 +150,20 @@ func main() {
 	eduInputAPI := eduserver.NewInternalAPI(
 		&base.Base, cache.New(), deviceDB,
 	)
-	asAPI := appservice.SetupAppServiceAPIComponent(
-		&base.Base, accountDB, deviceDB, federation, rsAPI, transactions.New(),
-	)
+	asAPI := appservice.NewInternalAPI(&base.Base, accountDB, deviceDB, rsAPI)
+	appservice.AddPublicRoutes(base.Base.PublicAPIMux, &cfg, rsAPI, accountDB, federation, transactions.New())
 	fsAPI := federationsender.SetupFederationSenderComponent(
 		&base.Base, federation, rsAPI, keyRing,
 	)
 	rsAPI.SetFederationSenderAPI(fsAPI)
 
-	clientapi.SetupClientAPIComponent(
-		&base.Base, deviceDB, accountDB,
+	clientapi.AddPublicRoutes(
+		base.Base.PublicAPIMux, &base.Base, deviceDB, accountDB,
 		federation, keyRing, rsAPI,
 		eduInputAPI, asAPI, transactions.New(), fsAPI,
 	)
 	eduProducer := producers.NewEDUServerProducer(eduInputAPI)
-	federationapi.AddRoutes(&base.Base, accountDB, deviceDB, federation, keyRing, rsAPI, asAPI, fsAPI, eduProducer)
+	federationapi.AddPublicRoutes(&base.Base, accountDB, deviceDB, federation, keyRing, rsAPI, asAPI, fsAPI, eduProducer)
 	mediaapi.SetupMediaAPIComponent(&base.Base, deviceDB)
 	publicRoomsDB, err := storage.NewPublicRoomsServerDatabaseWithPubSub(string(base.Base.Cfg.Database.PublicRoomsAPI), base.LibP2PPubsub, cfg.Matrix.ServerName)
 	if err != nil {

--- a/cmd/dendrite-demo-libp2p/main.go
+++ b/cmd/dendrite-demo-libp2p/main.go
@@ -147,7 +147,7 @@ func main() {
 	rsAPI := roomserver.SetupRoomServerComponent(
 		&base.Base, keyRing, federation,
 	)
-	eduInputAPI := eduserver.SetupEDUServerComponent(
+	eduInputAPI := eduserver.NewInternalAPI(
 		&base.Base, cache.New(), deviceDB,
 	)
 	asAPI := appservice.SetupAppServiceAPIComponent(
@@ -164,7 +164,7 @@ func main() {
 		eduInputAPI, asAPI, transactions.New(), fsAPI,
 	)
 	eduProducer := producers.NewEDUServerProducer(eduInputAPI)
-	federationapi.SetupFederationAPIComponent(&base.Base, accountDB, deviceDB, federation, keyRing, rsAPI, asAPI, fsAPI, eduProducer)
+	federationapi.AddRoutes(&base.Base, accountDB, deviceDB, federation, keyRing, rsAPI, asAPI, fsAPI, eduProducer)
 	mediaapi.SetupMediaAPIComponent(&base.Base, deviceDB)
 	publicRoomsDB, err := storage.NewPublicRoomsServerDatabaseWithPubSub(string(base.Base.Cfg.Database.PublicRoomsAPI), base.LibP2PPubsub, cfg.Matrix.ServerName)
 	if err != nil {

--- a/cmd/dendrite-demo-libp2p/main.go
+++ b/cmd/dendrite-demo-libp2p/main.go
@@ -152,7 +152,7 @@ func main() {
 	)
 	asAPI := appservice.NewInternalAPI(&base.Base, accountDB, deviceDB, rsAPI)
 	appservice.AddPublicRoutes(base.Base.PublicAPIMux, &cfg, rsAPI, accountDB, federation, transactions.New())
-	fsAPI := federationsender.SetupFederationSenderComponent(
+	fsAPI := federationsender.NewInternalAPI(
 		&base.Base, federation, rsAPI, keyRing,
 	)
 	rsAPI.SetFederationSenderAPI(fsAPI)
@@ -163,8 +163,8 @@ func main() {
 		eduInputAPI, asAPI, transactions.New(), fsAPI,
 	)
 	eduProducer := producers.NewEDUServerProducer(eduInputAPI)
-	federationapi.AddPublicRoutes(&base.Base, accountDB, deviceDB, federation, keyRing, rsAPI, asAPI, fsAPI, eduProducer)
-	mediaapi.SetupMediaAPIComponent(&base.Base, deviceDB)
+	federationapi.AddPublicRoutes(base.Base.PublicAPIMux, base.Base.Cfg, accountDB, deviceDB, federation, keyRing, rsAPI, asAPI, fsAPI, eduProducer)
+	mediaapi.AddPublicRoutes(base.Base.PublicAPIMux, base.Base.Cfg, deviceDB)
 	publicRoomsDB, err := storage.NewPublicRoomsServerDatabaseWithPubSub(string(base.Base.Cfg.Database.PublicRoomsAPI), base.LibP2PPubsub, cfg.Matrix.ServerName)
 	if err != nil {
 		logrus.WithError(err).Panicf("failed to connect to public rooms db")

--- a/cmd/dendrite-edu-server/main.go
+++ b/cmd/dendrite-edu-server/main.go
@@ -31,7 +31,8 @@ func main() {
 	}()
 	deviceDB := base.CreateDeviceDB()
 
-	eduserver.SetupEDUServerComponent(base, cache.New(), deviceDB)
+	intAPI := eduserver.NewInternalAPI(base, cache.New(), deviceDB)
+	eduserver.AddRoutes(base.InternalAPIMux, intAPI)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.EDUServer), string(base.Cfg.Listen.EDUServer))
 

--- a/cmd/dendrite-edu-server/main.go
+++ b/cmd/dendrite-edu-server/main.go
@@ -32,7 +32,7 @@ func main() {
 	deviceDB := base.CreateDeviceDB()
 
 	intAPI := eduserver.NewInternalAPI(base, cache.New(), deviceDB)
-	eduserver.AddRoutes(base.InternalAPIMux, intAPI)
+	eduserver.AddInternalRoutes(base.InternalAPIMux, intAPI)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.EDUServer), string(base.Cfg.Listen.EDUServer))
 

--- a/cmd/dendrite-federation-api-server/main.go
+++ b/cmd/dendrite-federation-api-server/main.go
@@ -36,7 +36,7 @@ func main() {
 	// TODO: this isn't a producer
 	eduProducer := producers.NewEDUServerProducer(base.EDUServerClient())
 
-	federationapi.AddRoutes(
+	federationapi.AddPublicRoutes(
 		base, accountDB, deviceDB, federation, keyRing,
 		rsAPI, asAPI, fsAPI, eduProducer,
 	)

--- a/cmd/dendrite-federation-api-server/main.go
+++ b/cmd/dendrite-federation-api-server/main.go
@@ -37,7 +37,7 @@ func main() {
 	eduProducer := producers.NewEDUServerProducer(base.EDUServerClient())
 
 	federationapi.AddPublicRoutes(
-		base, accountDB, deviceDB, federation, keyRing,
+		base.PublicAPIMux, base.Cfg, accountDB, deviceDB, federation, keyRing,
 		rsAPI, asAPI, fsAPI, eduProducer,
 	)
 

--- a/cmd/dendrite-federation-api-server/main.go
+++ b/cmd/dendrite-federation-api-server/main.go
@@ -36,7 +36,7 @@ func main() {
 	// TODO: this isn't a producer
 	eduProducer := producers.NewEDUServerProducer(base.EDUServerClient())
 
-	federationapi.SetupFederationAPIComponent(
+	federationapi.AddRoutes(
 		base, accountDB, deviceDB, federation, keyRing,
 		rsAPI, asAPI, fsAPI, eduProducer,
 	)

--- a/cmd/dendrite-federation-sender-server/main.go
+++ b/cmd/dendrite-federation-sender-server/main.go
@@ -30,9 +30,10 @@ func main() {
 	keyRing := serverKeyAPI.KeyRing()
 
 	rsAPI := base.RoomserverHTTPClient()
-	federationsender.SetupFederationSenderComponent(
+	fsAPI := federationsender.NewInternalAPI(
 		base, federation, rsAPI, keyRing,
 	)
+	federationsender.AddInternalRoutes(base.InternalAPIMux, fsAPI)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.FederationSender), string(base.Cfg.Listen.FederationSender))
 

--- a/cmd/dendrite-key-server/main.go
+++ b/cmd/dendrite-key-server/main.go
@@ -27,7 +27,7 @@ func main() {
 	accountDB := base.CreateAccountsDB()
 	deviceDB := base.CreateDeviceDB()
 
-	keyserver.SetupKeyServerComponent(base, deviceDB, accountDB)
+	keyserver.AddPublicRoutes(base.PublicAPIMux, base.Cfg, deviceDB, accountDB)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.KeyServer), string(base.Cfg.Listen.KeyServer))
 

--- a/cmd/dendrite-media-api-server/main.go
+++ b/cmd/dendrite-media-api-server/main.go
@@ -26,7 +26,7 @@ func main() {
 
 	deviceDB := base.CreateDeviceDB()
 
-	mediaapi.SetupMediaAPIComponent(base, deviceDB)
+	mediaapi.AddPublicRoutes(base.PublicAPIMux, base.Cfg, deviceDB)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.MediaAPI), string(base.Cfg.Listen.MediaAPI))
 

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -101,10 +101,11 @@ func main() {
 		asAPI = base.AppserviceHTTPClient()
 	}
 
-	fsAPI := federationsender.SetupFederationSenderComponent(
+	fsAPI := federationsender.NewInternalAPI(
 		base, federation, rsAPI, keyRing,
 	)
 	if base.UseHTTPAPIs {
+		federationsender.AddInternalRoutes(base.InternalAPIMux, fsAPI)
 		fsAPI = base.FederationSenderHTTPClient()
 	}
 	rsComponent.SetFederationSenderAPI(fsAPI)
@@ -115,12 +116,12 @@ func main() {
 		eduInputAPI, asAPI, transactions.New(), fsAPI,
 	)
 
-	keyserver.SetupKeyServerComponent(
-		base, deviceDB, accountDB,
+	keyserver.AddPublicRoutes(
+		base.PublicAPIMux, base.Cfg, deviceDB, accountDB,
 	)
 	eduProducer := producers.NewEDUServerProducer(eduInputAPI)
-	federationapi.AddPublicRoutes(base, accountDB, deviceDB, federation, keyRing, rsAPI, asAPI, fsAPI, eduProducer)
-	mediaapi.SetupMediaAPIComponent(base, deviceDB)
+	federationapi.AddPublicRoutes(base.PublicAPIMux, base.Cfg, accountDB, deviceDB, federation, keyRing, rsAPI, asAPI, fsAPI, eduProducer)
+	mediaapi.AddPublicRoutes(base.PublicAPIMux, base.Cfg, deviceDB)
 	publicRoomsDB, err := storage.NewPublicRoomsServerDatabase(string(base.Cfg.Database.PublicRoomsAPI), base.Cfg.DbProperties(), cfg.Matrix.ServerName)
 	if err != nil {
 		logrus.WithError(err).Panicf("failed to connect to public rooms db")

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -86,10 +86,11 @@ func main() {
 		rsAPI = base.RoomserverHTTPClient()
 	}
 
-	eduInputAPI := eduserver.SetupEDUServerComponent(
+	eduInputAPI := eduserver.NewInternalAPI(
 		base, cache.New(), deviceDB,
 	)
 	if base.UseHTTPAPIs {
+		eduserver.AddRoutes(base.InternalAPIMux, eduInputAPI)
 		eduInputAPI = base.EDUServerClient()
 	}
 
@@ -118,7 +119,7 @@ func main() {
 		base, deviceDB, accountDB,
 	)
 	eduProducer := producers.NewEDUServerProducer(eduInputAPI)
-	federationapi.SetupFederationAPIComponent(base, accountDB, deviceDB, federation, keyRing, rsAPI, asAPI, fsAPI, eduProducer)
+	federationapi.AddRoutes(base, accountDB, deviceDB, federation, keyRing, rsAPI, asAPI, fsAPI, eduProducer)
 	mediaapi.SetupMediaAPIComponent(base, deviceDB)
 	publicRoomsDB, err := storage.NewPublicRoomsServerDatabase(string(base.Cfg.Database.PublicRoomsAPI), base.Cfg.DbProperties(), cfg.Matrix.ServerName)
 	if err != nil {

--- a/cmd/dendrite-public-rooms-api-server/main.go
+++ b/cmd/dendrite-public-rooms-api-server/main.go
@@ -34,7 +34,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Panicf("failed to connect to public rooms db")
 	}
-	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB, publicRoomsDB, rsAPI, nil, nil)
+	publicroomsapi.AddPublicRoutes(base.PublicAPIMux, base, deviceDB, publicRoomsDB, rsAPI, nil, nil)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.PublicRoomsAPI), string(base.Cfg.Listen.PublicRoomsAPI))
 

--- a/cmd/dendrite-room-server/main.go
+++ b/cmd/dendrite-room-server/main.go
@@ -31,7 +31,7 @@ func main() {
 	fsAPI := base.FederationSenderHTTPClient()
 	rsAPI := roomserver.NewInternalAPI(base, keyRing, federation)
 	rsAPI.SetFederationSenderAPI(fsAPI)
-	roomserver.AddInternalRoutes(base.PublicAPIMux, rsAPI)
+	roomserver.AddInternalRoutes(base.InternalAPIMux, rsAPI)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.RoomServer), string(base.Cfg.Listen.RoomServer))
 

--- a/cmd/dendrite-room-server/main.go
+++ b/cmd/dendrite-room-server/main.go
@@ -29,8 +29,9 @@ func main() {
 	keyRing := serverKeyAPI.KeyRing()
 
 	fsAPI := base.FederationSenderHTTPClient()
-	rsAPI := roomserver.SetupRoomServerComponent(base, keyRing, federation)
+	rsAPI := roomserver.NewInternalAPI(base, keyRing, federation)
 	rsAPI.SetFederationSenderAPI(fsAPI)
+	roomserver.AddInternalRoutes(base.PublicAPIMux, rsAPI)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.RoomServer), string(base.Cfg.Listen.RoomServer))
 

--- a/cmd/dendrite-server-key-api-server/main.go
+++ b/cmd/dendrite-server-key-api-server/main.go
@@ -26,7 +26,8 @@ func main() {
 
 	federation := base.CreateFederationClient()
 
-	serverkeyapi.SetupServerKeyAPIComponent(base, federation)
+	intAPI := serverkeyapi.NewInternalAPI(base.Cfg, federation, base.Caches)
+	serverkeyapi.AddInternalRoutes(base.InternalAPIMux, intAPI, base.Caches)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.ServerKeyAPI), string(base.Cfg.Listen.ServerKeyAPI))
 }

--- a/cmd/dendrite-sync-api-server/main.go
+++ b/cmd/dendrite-sync-api-server/main.go
@@ -30,7 +30,7 @@ func main() {
 
 	rsAPI := base.RoomserverHTTPClient()
 
-	syncapi.SetupSyncAPIComponent(base, deviceDB, accountDB, rsAPI, federation, cfg)
+	syncapi.AddPublicRoutes(base.PublicAPIMux, base, deviceDB, accountDB, rsAPI, federation, cfg)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.SyncAPI), string(base.Cfg.Listen.SyncAPI))
 

--- a/cmd/dendritejs/main.go
+++ b/cmd/dendritejs/main.go
@@ -207,7 +207,7 @@ func main() {
 	}
 
 	rsAPI := roomserver.SetupRoomServerComponent(base, keyRing, federation)
-	eduInputAPI := eduserver.SetupEDUServerComponent(base, cache.New(), deviceDB)
+	eduInputAPI := eduserver.NewInternalAPI(base, cache.New(), deviceDB)
 	asQuery := appservice.SetupAppServiceAPIComponent(
 		base, accountDB, deviceDB, federation, rsAPI, transactions.New(),
 	)
@@ -221,7 +221,7 @@ func main() {
 		eduInputAPI, asQuery, transactions.New(), fedSenderAPI,
 	)
 	eduProducer := producers.NewEDUServerProducer(eduInputAPI)
-	federationapi.SetupFederationAPIComponent(base, accountDB, deviceDB, federation, &keyRing, rsAPI, asQuery, fedSenderAPI, eduProducer)
+	federationapi.AddRoutes(base, accountDB, deviceDB, federation, &keyRing, rsAPI, asQuery, fedSenderAPI, eduProducer)
 	mediaapi.SetupMediaAPIComponent(base, deviceDB)
 	publicRoomsDB, err := storage.NewPublicRoomsServerDatabase(string(base.Cfg.Database.PublicRoomsAPI), cfg.Matrix.ServerName)
 	if err != nil {

--- a/cmd/dendritejs/main.go
+++ b/cmd/dendritejs/main.go
@@ -206,7 +206,7 @@ func main() {
 		KeyDatabase: fetcher,
 	}
 
-	rsAPI := roomserver.SetupRoomServerComponent(base, keyRing, federation)
+	rsAPI := roomserver.NewInternalAPI(base, keyRing, federation)
 	eduInputAPI := eduserver.NewInternalAPI(base, cache.New(), deviceDB)
 	asQuery := appservice.NewInternalAPI(
 		base, accountDB, deviceDB, rsAPI,
@@ -227,8 +227,8 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Panicf("failed to connect to public rooms db")
 	}
-	publicroomsapi.SetupPublicRoomsAPIComponent(base, deviceDB, publicRoomsDB, rsAPI, federation, p2pPublicRoomProvider)
-	syncapi.SetupSyncAPIComponent(base, deviceDB, accountDB, rsAPI, federation, cfg)
+	publicroomsapi.AddPublicRoutes(base.PublicAPIMux, base, deviceDB, publicRoomsDB, rsAPI, federation, p2pPublicRoomProvider)
+	syncapi.AddPublicRoutes(base.PublicAPIMux, base, deviceDB, accountDB, rsAPI, federation, cfg)
 
 	internal.SetupHTTPAPI(
 		http.DefaultServeMux,

--- a/cmd/dendritejs/main.go
+++ b/cmd/dendritejs/main.go
@@ -208,20 +208,20 @@ func main() {
 
 	rsAPI := roomserver.SetupRoomServerComponent(base, keyRing, federation)
 	eduInputAPI := eduserver.NewInternalAPI(base, cache.New(), deviceDB)
-	asQuery := appservice.SetupAppServiceAPIComponent(
-		base, accountDB, deviceDB, federation, rsAPI, transactions.New(),
+	asQuery := appservice.NewInternalAPI(
+		base, accountDB, deviceDB, rsAPI,
 	)
 	fedSenderAPI := federationsender.SetupFederationSenderComponent(base, federation, rsAPI, &keyRing)
 	rsAPI.SetFederationSenderAPI(fedSenderAPI)
 	p2pPublicRoomProvider := NewLibP2PPublicRoomsProvider(node, fedSenderAPI)
 
-	clientapi.SetupClientAPIComponent(
-		base, deviceDB, accountDB,
+	clientapi.AddPublicRoutes(
+		base.PublicAPIMux, base, deviceDB, accountDB,
 		federation, &keyRing, rsAPI,
 		eduInputAPI, asQuery, transactions.New(), fedSenderAPI,
 	)
 	eduProducer := producers.NewEDUServerProducer(eduInputAPI)
-	federationapi.AddRoutes(base, accountDB, deviceDB, federation, &keyRing, rsAPI, asQuery, fedSenderAPI, eduProducer)
+	federationapi.AddPublicRoutes(base, accountDB, deviceDB, federation, &keyRing, rsAPI, asQuery, fedSenderAPI, eduProducer)
 	mediaapi.SetupMediaAPIComponent(base, deviceDB)
 	publicRoomsDB, err := storage.NewPublicRoomsServerDatabase(string(base.Cfg.Database.PublicRoomsAPI), cfg.Matrix.ServerName)
 	if err != nil {

--- a/cmd/dendritejs/main.go
+++ b/cmd/dendritejs/main.go
@@ -211,7 +211,7 @@ func main() {
 	asQuery := appservice.NewInternalAPI(
 		base, accountDB, deviceDB, rsAPI,
 	)
-	fedSenderAPI := federationsender.SetupFederationSenderComponent(base, federation, rsAPI, &keyRing)
+	fedSenderAPI := federationsender.NewInternalAPI(base, federation, rsAPI, &keyRing)
 	rsAPI.SetFederationSenderAPI(fedSenderAPI)
 	p2pPublicRoomProvider := NewLibP2PPublicRoomsProvider(node, fedSenderAPI)
 
@@ -221,8 +221,8 @@ func main() {
 		eduInputAPI, asQuery, transactions.New(), fedSenderAPI,
 	)
 	eduProducer := producers.NewEDUServerProducer(eduInputAPI)
-	federationapi.AddPublicRoutes(base, accountDB, deviceDB, federation, &keyRing, rsAPI, asQuery, fedSenderAPI, eduProducer)
-	mediaapi.SetupMediaAPIComponent(base, deviceDB)
+	federationapi.AddPublicRoutes(base.PublicAPIMux, base.Cfg, accountDB, deviceDB, federation, &keyRing, rsAPI, asQuery, fedSenderAPI, eduProducer)
+	mediaapi.AddPublicRoutes(base.PublicAPIMux, base.Cfg, deviceDB)
 	publicRoomsDB, err := storage.NewPublicRoomsServerDatabase(string(base.Cfg.Database.PublicRoomsAPI), cfg.Matrix.ServerName)
 	if err != nil {
 		logrus.WithError(err).Panicf("failed to connect to public rooms db")

--- a/eduserver/eduserver.go
+++ b/eduserver/eduserver.go
@@ -26,9 +26,9 @@ import (
 	"github.com/matrix-org/dendrite/internal/basecomponent"
 )
 
-// AddRoutes registers HTTP handlers for the internal API. Invokes functions
+// AddInternalRoutes registers HTTP handlers for the internal API. Invokes functions
 // on the given input API.
-func AddRoutes(internalMux *mux.Router, inputAPI api.EDUServerInputAPI) {
+func AddInternalRoutes(internalMux *mux.Router, inputAPI api.EDUServerInputAPI) {
 	inthttp.AddRoutes(inputAPI, internalMux)
 }
 

--- a/eduserver/eduserver.go
+++ b/eduserver/eduserver.go
@@ -17,6 +17,7 @@
 package eduserver
 
 import (
+	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
 	"github.com/matrix-org/dendrite/eduserver/api"
 	"github.com/matrix-org/dendrite/eduserver/cache"
@@ -25,16 +26,20 @@ import (
 	"github.com/matrix-org/dendrite/internal/basecomponent"
 )
 
-// SetupEDUServerComponent sets up and registers HTTP handlers for the
-// EDUServer component. Returns instances of the various roomserver APIs,
-// allowing other components running in the same process to hit the query the
-// APIs directly instead of having to use HTTP.
-func SetupEDUServerComponent(
+// AddRoutes registers HTTP handlers for the internal API. Invokes functions
+// on the given input API.
+func AddRoutes(internalMux *mux.Router, inputAPI api.EDUServerInputAPI) {
+	inthttp.AddRoutes(inputAPI, internalMux)
+}
+
+// NewInternalAPI returns a concerete implementation of the internal API. Callers
+// can call functions directly on the returned API or via an HTTP interface using AddRoutes.
+func NewInternalAPI(
 	base *basecomponent.BaseDendrite,
 	eduCache *cache.EDUCache,
 	deviceDB devices.Database,
 ) api.EDUServerInputAPI {
-	inputAPI := &input.EDUServerInputAPI{
+	return &input.EDUServerInputAPI{
 		Cache:                        eduCache,
 		DeviceDB:                     deviceDB,
 		Producer:                     base.KafkaProducer,
@@ -42,8 +47,4 @@ func SetupEDUServerComponent(
 		OutputSendToDeviceEventTopic: string(base.Cfg.Kafka.Topics.OutputSendToDeviceEvent),
 		ServerName:                   base.Cfg.Matrix.ServerName,
 	}
-
-	inthttp.AddRoutes(inputAPI, base.InternalAPIMux)
-
-	return inputAPI
 }

--- a/eduserver/eduserver.go
+++ b/eduserver/eduserver.go
@@ -33,7 +33,7 @@ func AddInternalRoutes(internalMux *mux.Router, inputAPI api.EDUServerInputAPI) 
 }
 
 // NewInternalAPI returns a concerete implementation of the internal API. Callers
-// can call functions directly on the returned API or via an HTTP interface using AddRoutes.
+// can call functions directly on the returned API or via an HTTP interface using AddInternalRoutes.
 func NewInternalAPI(
 	base *basecomponent.BaseDendrite,
 	eduCache *cache.EDUCache,

--- a/federationapi/federationapi.go
+++ b/federationapi/federationapi.go
@@ -28,9 +28,8 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
-// SetupFederationAPIComponent sets up and registers HTTP handlers for the
-// FederationAPI component.
-func SetupFederationAPIComponent(
+// AddRoutes sets up and registers HTTP handlers on the base API muxes for the FederationAPI component.
+func AddRoutes(
 	base *basecomponent.BaseDendrite,
 	accountsDB accounts.Database,
 	deviceDB devices.Database,

--- a/federationapi/federationapi.go
+++ b/federationapi/federationapi.go
@@ -28,8 +28,8 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
-// AddRoutes sets up and registers HTTP handlers on the base API muxes for the FederationAPI component.
-func AddRoutes(
+// AddPublicRoutes sets up and registers HTTP handlers on the base API muxes for the FederationAPI component.
+func AddPublicRoutes(
 	base *basecomponent.BaseDendrite,
 	accountsDB accounts.Database,
 	deviceDB devices.Database,

--- a/federationapi/federationapi.go
+++ b/federationapi/federationapi.go
@@ -15,11 +15,12 @@
 package federationapi
 
 import (
+	"github.com/gorilla/mux"
 	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
 	federationSenderAPI "github.com/matrix-org/dendrite/federationsender/api"
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/config"
 	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
 
 	// TODO: Are we really wanting to pull in the producer from clientapi
@@ -30,7 +31,8 @@ import (
 
 // AddPublicRoutes sets up and registers HTTP handlers on the base API muxes for the FederationAPI component.
 func AddPublicRoutes(
-	base *basecomponent.BaseDendrite,
+	router *mux.Router,
+	cfg *config.Dendrite,
 	accountsDB accounts.Database,
 	deviceDB devices.Database,
 	federation *gomatrixserverlib.FederationClient,
@@ -43,7 +45,7 @@ func AddPublicRoutes(
 	roomserverProducer := producers.NewRoomserverProducer(rsAPI)
 
 	routing.Setup(
-		base.PublicAPIMux, base.Cfg, rsAPI, asAPI, roomserverProducer,
+		router, cfg, rsAPI, asAPI, roomserverProducer,
 		eduProducer, federationSenderAPI, *keyRing,
 		federation, accountsDB, deviceDB,
 	)

--- a/federationsender/federationsender.go
+++ b/federationsender/federationsender.go
@@ -15,6 +15,7 @@
 package federationsender
 
 import (
+	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/dendrite/federationsender/consumers"
 	"github.com/matrix-org/dendrite/federationsender/internal"
@@ -29,9 +30,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// SetupFederationSenderComponent sets up and registers HTTP handlers for the
-// FederationSender component.
-func SetupFederationSenderComponent(
+// AddInternalRoutes registers HTTP handlers for the internal API. Invokes functions
+// on the given input API.
+func AddInternalRoutes(router *mux.Router, intAPI api.FederationSenderInternalAPI) {
+	inthttp.AddRoutes(intAPI, router)
+}
+
+// NewInternalAPI returns a concerete implementation of the internal API. Callers
+// can call functions directly on the returned API or via an HTTP interface using AddInternalRoutes.
+func NewInternalAPI(
 	base *basecomponent.BaseDendrite,
 	federation *gomatrixserverlib.FederationClient,
 	rsAPI roomserverAPI.RoomserverInternalAPI,
@@ -66,8 +73,5 @@ func SetupFederationSenderComponent(
 		logrus.WithError(err).Panic("failed to start typing server consumer")
 	}
 
-	queryAPI := internal.NewFederationSenderInternalAPI(federationSenderDB, base.Cfg, roomserverProducer, federation, keyRing, statistics, queues)
-	inthttp.AddRoutes(queryAPI, base.InternalAPIMux)
-
-	return queryAPI
+	return internal.NewFederationSenderInternalAPI(federationSenderDB, base.Cfg, roomserverProducer, federation, keyRing, statistics, queues)
 }

--- a/keyserver/keyserver.go
+++ b/keyserver/keyserver.go
@@ -15,18 +15,18 @@
 package keyserver
 
 import (
+	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/config"
 	"github.com/matrix-org/dendrite/keyserver/routing"
 )
 
-// SetupFederationSenderComponent sets up and registers HTTP handlers for the
-// FederationSender component.
-func SetupKeyServerComponent(
-	base *basecomponent.BaseDendrite,
+// AddPublicRoutes registers HTTP handlers for CS API calls
+func AddPublicRoutes(
+	router *mux.Router, cfg *config.Dendrite,
 	deviceDB devices.Database,
 	accountsDB accounts.Database,
 ) {
-	routing.Setup(base.PublicAPIMux, base.Cfg, accountsDB, deviceDB)
+	routing.Setup(router, cfg, accountsDB, deviceDB)
 }

--- a/mediaapi/mediaapi.go
+++ b/mediaapi/mediaapi.go
@@ -15,26 +15,26 @@
 package mediaapi
 
 import (
+	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/config"
 	"github.com/matrix-org/dendrite/mediaapi/routing"
 	"github.com/matrix-org/dendrite/mediaapi/storage"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/sirupsen/logrus"
 )
 
-// SetupMediaAPIComponent sets up and registers HTTP handlers for the MediaAPI
-// component.
-func SetupMediaAPIComponent(
-	base *basecomponent.BaseDendrite,
+// AddPublicRoutes sets up and registers HTTP handlers for the MediaAPI component.
+func AddPublicRoutes(
+	router *mux.Router, cfg *config.Dendrite,
 	deviceDB devices.Database,
 ) {
-	mediaDB, err := storage.Open(string(base.Cfg.Database.MediaAPI), base.Cfg.DbProperties())
+	mediaDB, err := storage.Open(string(cfg.Database.MediaAPI), cfg.DbProperties())
 	if err != nil {
 		logrus.WithError(err).Panicf("failed to connect to media db")
 	}
 
 	routing.Setup(
-		base.PublicAPIMux, base.Cfg, mediaDB, deviceDB, gomatrixserverlib.NewClient(),
+		router, cfg, mediaDB, deviceDB, gomatrixserverlib.NewClient(),
 	)
 }

--- a/publicroomsapi/publicroomsapi.go
+++ b/publicroomsapi/publicroomsapi.go
@@ -15,6 +15,7 @@
 package publicroomsapi
 
 import (
+	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
 	"github.com/matrix-org/dendrite/internal/basecomponent"
 	"github.com/matrix-org/dendrite/publicroomsapi/consumers"
@@ -26,9 +27,10 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// SetupPublicRoomsAPIComponent sets up and registers HTTP handlers for the PublicRoomsAPI
+// AddPublicRoutes sets up and registers HTTP handlers for the PublicRoomsAPI
 // component.
-func SetupPublicRoomsAPIComponent(
+func AddPublicRoutes(
+	router *mux.Router,
 	base *basecomponent.BaseDendrite,
 	deviceDB devices.Database,
 	publicRoomsDB storage.Database,
@@ -43,5 +45,5 @@ func SetupPublicRoomsAPIComponent(
 		logrus.WithError(err).Panic("failed to start public rooms server consumer")
 	}
 
-	routing.Setup(base.PublicAPIMux, deviceDB, publicRoomsDB, rsAPI, fedClient, extRoomsProvider)
+	routing.Setup(router, deviceDB, publicRoomsDB, rsAPI, fedClient, extRoomsProvider)
 }

--- a/syncapi/syncapi.go
+++ b/syncapi/syncapi.go
@@ -17,6 +17,7 @@ package syncapi
 import (
 	"context"
 
+	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
@@ -32,9 +33,10 @@ import (
 	"github.com/matrix-org/dendrite/syncapi/sync"
 )
 
-// SetupSyncAPIComponent sets up and registers HTTP handlers for the SyncAPI
+// AddPublicRoutes sets up and registers HTTP handlers for the SyncAPI
 // component.
-func SetupSyncAPIComponent(
+func AddPublicRoutes(
+	router *mux.Router,
 	base *basecomponent.BaseDendrite,
 	deviceDB devices.Database,
 	accountsDB accounts.Database,
@@ -88,5 +90,5 @@ func SetupSyncAPIComponent(
 		logrus.WithError(err).Panicf("failed to start send-to-device consumer")
 	}
 
-	routing.Setup(base.PublicAPIMux, requestPool, syncDB, deviceDB, federation, rsAPI, cfg)
+	routing.Setup(router, requestPool, syncDB, deviceDB, federation, rsAPI, cfg)
 }


### PR DESCRIPTION
It did far too much before which made it confusing to understand. There's now a maximum of three functions:
 - `NewInternalAPI` : Returns the concrete impl of the internal API. In pure monolith mode this is all you need to call.
 - `AddPublicRoutes` : Adds CS/SS API HTTP routes
 - `AddInternalRoutes` : Adds internal HTTP routes, only for polylith or when `-api` is given.

The net result is a far more readable:
```go
	fsAPI := federationsender.NewInternalAPI(
		base, federation, rsAPI, keyRing,
	)
	if base.UseHTTPAPIs {
		federationsender.AddInternalRoutes(base.InternalAPIMux, fsAPI)
		fsAPI = base.FederationSenderHTTPClient()
	}
```