### PR TITLE
Factor out how monolith routes get added

### DIFF
--- a/cmd/dendrite-client-api-server/main.go
+++ b/cmd/dendrite-client-api-server/main.go
@@ -39,7 +39,7 @@ func main() {
 	eduInputAPI := base.EDUServerClient()
 
 	clientapi.AddPublicRoutes(
-		base.PublicAPIMux, base, deviceDB, accountDB, federation, keyRing,
+		base.PublicAPIMux, base.Cfg, base.KafkaConsumer, base.KafkaProducer, deviceDB, accountDB, federation, keyRing,
 		rsAPI, eduInputAPI, asQuery, transactions.New(), fsAPI,
 	)
 

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -19,23 +19,17 @@ import (
 	"net/http"
 
 	"github.com/matrix-org/dendrite/appservice"
-	"github.com/matrix-org/dendrite/clientapi"
 	"github.com/matrix-org/dendrite/clientapi/producers"
 	"github.com/matrix-org/dendrite/eduserver"
 	"github.com/matrix-org/dendrite/eduserver/cache"
-	"github.com/matrix-org/dendrite/federationapi"
 	"github.com/matrix-org/dendrite/federationsender"
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/basecomponent"
 	"github.com/matrix-org/dendrite/internal/config"
-	"github.com/matrix-org/dendrite/internal/transactions"
-	"github.com/matrix-org/dendrite/keyserver"
-	"github.com/matrix-org/dendrite/mediaapi"
-	"github.com/matrix-org/dendrite/publicroomsapi"
+	"github.com/matrix-org/dendrite/internal/setup"
 	"github.com/matrix-org/dendrite/publicroomsapi/storage"
 	"github.com/matrix-org/dendrite/roomserver"
 	"github.com/matrix-org/dendrite/serverkeyapi"
-	"github.com/matrix-org/dendrite/syncapi"
 
 	"github.com/sirupsen/logrus"
 )
@@ -97,7 +91,6 @@ func main() {
 	}
 
 	asAPI := appservice.NewInternalAPI(base, accountDB, deviceDB, rsAPI)
-	appservice.AddPublicRoutes(base.PublicAPIMux, cfg, rsAPI, accountDB, federation, transactions.New())
 	if base.UseHTTPAPIs {
 		appservice.AddInternalRoutes(base.InternalAPIMux, asAPI)
 		asAPI = base.AppserviceHTTPClient()
@@ -112,24 +105,31 @@ func main() {
 	}
 	rsComponent.SetFederationSenderAPI(fsAPI)
 
-	clientapi.AddPublicRoutes(
-		base.PublicAPIMux, base, deviceDB, accountDB,
-		federation, keyRing, rsAPI,
-		eduInputAPI, asAPI, transactions.New(), fsAPI,
-	)
-
-	keyserver.AddPublicRoutes(
-		base.PublicAPIMux, base.Cfg, deviceDB, accountDB,
-	)
 	eduProducer := producers.NewEDUServerProducer(eduInputAPI)
-	federationapi.AddPublicRoutes(base.PublicAPIMux, base.Cfg, accountDB, deviceDB, federation, keyRing, rsAPI, asAPI, fsAPI, eduProducer)
-	mediaapi.AddPublicRoutes(base.PublicAPIMux, base.Cfg, deviceDB)
 	publicRoomsDB, err := storage.NewPublicRoomsServerDatabase(string(base.Cfg.Database.PublicRoomsAPI), base.Cfg.DbProperties(), cfg.Matrix.ServerName)
 	if err != nil {
 		logrus.WithError(err).Panicf("failed to connect to public rooms db")
 	}
-	publicroomsapi.AddPublicRoutes(base.PublicAPIMux, base, deviceDB, publicRoomsDB, rsAPI, federation, nil)
-	syncapi.AddPublicRoutes(base.PublicAPIMux, base, deviceDB, accountDB, rsAPI, federation, cfg)
+
+	monolith := setup.Monolith{
+		Config:        base.Cfg,
+		AccountDB:     accountDB,
+		DeviceDB:      deviceDB,
+		FedClient:     federation,
+		KeyRing:       keyRing,
+		KafkaConsumer: base.KafkaConsumer,
+		KafkaProducer: base.KafkaProducer,
+
+		AppserviceAPI:       asAPI,
+		EDUInternalAPI:      eduInputAPI,
+		EDUProducer:         eduProducer,
+		FederationSenderAPI: fsAPI,
+		RoomserverAPI:       rsAPI,
+		ServerKeyAPI:        serverKeyAPI,
+
+		PublicRoomsDB: publicRoomsDB,
+	}
+	monolith.AddAllPublicRoutes(base.PublicAPIMux)
 
 	internal.SetupHTTPAPI(
 		http.DefaultServeMux,

--- a/cmd/dendrite-public-rooms-api-server/main.go
+++ b/cmd/dendrite-public-rooms-api-server/main.go
@@ -34,7 +34,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Panicf("failed to connect to public rooms db")
 	}
-	publicroomsapi.AddPublicRoutes(base.PublicAPIMux, base, deviceDB, publicRoomsDB, rsAPI, nil, nil)
+	publicroomsapi.AddPublicRoutes(base.PublicAPIMux, base.Cfg, base.KafkaConsumer, deviceDB, publicRoomsDB, rsAPI, nil, nil)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.PublicRoomsAPI), string(base.Cfg.Listen.PublicRoomsAPI))
 

--- a/cmd/dendrite-sync-api-server/main.go
+++ b/cmd/dendrite-sync-api-server/main.go
@@ -30,7 +30,7 @@ func main() {
 
 	rsAPI := base.RoomserverHTTPClient()
 
-	syncapi.AddPublicRoutes(base.PublicAPIMux, base, deviceDB, accountDB, rsAPI, federation, cfg)
+	syncapi.AddPublicRoutes(base.PublicAPIMux, base.KafkaConsumer, deviceDB, accountDB, rsAPI, federation, cfg)
 
 	base.SetupAndServeHTTP(string(base.Cfg.Bind.SyncAPI), string(base.Cfg.Listen.SyncAPI))
 

--- a/internal/setup/monolith.go
+++ b/internal/setup/monolith.go
@@ -1,0 +1,78 @@
+package setup
+
+import (
+	"github.com/Shopify/sarama"
+	"github.com/gorilla/mux"
+	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"
+	"github.com/matrix-org/dendrite/clientapi"
+	"github.com/matrix-org/dendrite/clientapi/auth/storage/accounts"
+	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
+	"github.com/matrix-org/dendrite/clientapi/producers"
+	eduServerAPI "github.com/matrix-org/dendrite/eduserver/api"
+	"github.com/matrix-org/dendrite/federationapi"
+	federationSenderAPI "github.com/matrix-org/dendrite/federationsender/api"
+	"github.com/matrix-org/dendrite/internal/config"
+	"github.com/matrix-org/dendrite/internal/transactions"
+	"github.com/matrix-org/dendrite/keyserver"
+	"github.com/matrix-org/dendrite/mediaapi"
+	"github.com/matrix-org/dendrite/publicroomsapi"
+	"github.com/matrix-org/dendrite/publicroomsapi/storage"
+	"github.com/matrix-org/dendrite/publicroomsapi/types"
+	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
+	serverKeyAPI "github.com/matrix-org/dendrite/serverkeyapi/api"
+	"github.com/matrix-org/dendrite/syncapi"
+	"github.com/matrix-org/gomatrixserverlib"
+)
+
+// Monolith represents an instantiation of all dependencies required to build
+// all components of Dendrite, for use in monolith mode.
+type Monolith struct {
+	Config        *config.Dendrite
+	DeviceDB      devices.Database
+	AccountDB     accounts.Database
+	KeyRing       *gomatrixserverlib.KeyRing
+	FedClient     *gomatrixserverlib.FederationClient
+	KafkaConsumer sarama.Consumer
+	KafkaProducer sarama.SyncProducer
+
+	AppserviceAPI       appserviceAPI.AppServiceQueryAPI
+	EDUInternalAPI      eduServerAPI.EDUServerInputAPI
+	FederationSenderAPI federationSenderAPI.FederationSenderInternalAPI
+	RoomserverAPI       roomserverAPI.RoomserverInternalAPI
+	ServerKeyAPI        serverKeyAPI.ServerKeyInternalAPI
+
+	// TODO: remove, this isn't even a producer
+	EDUProducer *producers.EDUServerProducer
+	// TODO: can we remove this? It's weird that we are required the database
+	// yet every other component can do that on its own. libp2p-demo uses a custom
+	// database though annoyingly.
+	PublicRoomsDB storage.Database
+
+	// Optional
+	ExtPublicRoomsProvider types.ExternalPublicRoomsProvider
+}
+
+// AddAllPublicRoutes attaches all public paths to the given router
+func (m *Monolith) AddAllPublicRoutes(publicMux *mux.Router) {
+	clientapi.AddPublicRoutes(
+		publicMux, m.Config, m.KafkaConsumer, m.KafkaProducer, m.DeviceDB, m.AccountDB,
+		m.FedClient, m.KeyRing, m.RoomserverAPI,
+		m.EDUInternalAPI, m.AppserviceAPI, transactions.New(),
+		m.FederationSenderAPI,
+	)
+
+	keyserver.AddPublicRoutes(publicMux, m.Config, m.DeviceDB, m.AccountDB)
+	federationapi.AddPublicRoutes(
+		publicMux, m.Config, m.AccountDB, m.DeviceDB, m.FedClient,
+		m.KeyRing, m.RoomserverAPI, m.AppserviceAPI, m.FederationSenderAPI,
+		m.EDUProducer,
+	)
+	mediaapi.AddPublicRoutes(publicMux, m.Config, m.DeviceDB)
+	publicroomsapi.AddPublicRoutes(
+		publicMux, m.Config, m.KafkaConsumer, m.DeviceDB, m.PublicRoomsDB, m.RoomserverAPI, m.FedClient,
+		m.ExtPublicRoomsProvider,
+	)
+	syncapi.AddPublicRoutes(
+		publicMux, m.KafkaConsumer, m.DeviceDB, m.AccountDB, m.RoomserverAPI, m.FedClient, m.Config,
+	)
+}

--- a/publicroomsapi/publicroomsapi.go
+++ b/publicroomsapi/publicroomsapi.go
@@ -15,9 +15,10 @@
 package publicroomsapi
 
 import (
+	"github.com/Shopify/sarama"
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/clientapi/auth/storage/devices"
-	"github.com/matrix-org/dendrite/internal/basecomponent"
+	"github.com/matrix-org/dendrite/internal/config"
 	"github.com/matrix-org/dendrite/publicroomsapi/consumers"
 	"github.com/matrix-org/dendrite/publicroomsapi/routing"
 	"github.com/matrix-org/dendrite/publicroomsapi/storage"
@@ -31,7 +32,8 @@ import (
 // component.
 func AddPublicRoutes(
 	router *mux.Router,
-	base *basecomponent.BaseDendrite,
+	cfg *config.Dendrite,
+	consumer sarama.Consumer,
 	deviceDB devices.Database,
 	publicRoomsDB storage.Database,
 	rsAPI roomserverAPI.RoomserverInternalAPI,
@@ -39,7 +41,7 @@ func AddPublicRoutes(
 	extRoomsProvider types.ExternalPublicRoomsProvider,
 ) {
 	rsConsumer := consumers.NewOutputRoomEventConsumer(
-		base.Cfg, base.KafkaConsumer, publicRoomsDB, rsAPI,
+		cfg, consumer, publicRoomsDB, rsAPI,
 	)
 	if err := rsConsumer.Start(); err != nil {
 		logrus.WithError(err).Panic("failed to start public rooms server consumer")


### PR DESCRIPTION
Previously we had 3 monoliths:
 - dendrite-monolith-server
 - dendrite-demo-libp2p
 - dendritejs

which all had their own way of setting up public routes. Factor this
out into a new `setup.Monolith` struct which gets all dependencies
set as fields. This is different to `basecomponent.Base` which
doesn't provide any way to set configured deps (e.g public rooms db)

Part of a larger process to clean up how we initialise Dendrite.
