### PR TITLE
More key tweaks

### DIFF
--- a/internal/caching/caches.go
+++ b/internal/caching/caches.go
@@ -12,4 +12,5 @@ type Caches struct {
 type Cache interface {
 	Get(key string) (value interface{}, ok bool)
 	Set(key string, value interface{})
+	Unset(key string)
 }

--- a/internal/caching/impl_inmemorylru.go
+++ b/internal/caching/impl_inmemorylru.go
@@ -68,6 +68,13 @@ func (c *InMemoryLRUCachePartition) Set(key string, value interface{}) {
 	c.lru.Add(key, value)
 }
 
+func (c *InMemoryLRUCachePartition) Unset(key string) {
+	if !c.mutable {
+		panic(fmt.Sprintf("invalid use of immutable cache tries to unset value of %q", key))
+	}
+	c.lru.Remove(key)
+}
+
 func (c *InMemoryLRUCachePartition) Get(key string) (value interface{}, ok bool) {
 	return c.lru.Get(key)
 }

--- a/serverkeyapi/inthttp/client.go
+++ b/serverkeyapi/inthttp/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"time"
 
 	"github.com/matrix-org/dendrite/internal/caching"
 	internalHTTP "github.com/matrix-org/dendrite/internal/http"
@@ -50,7 +49,7 @@ func (s *httpServerKeyInternalAPI) KeyRing() *gomatrixserverlib.KeyRing {
 	// the other end of the API.
 	return &gomatrixserverlib.KeyRing{
 		KeyDatabase: s,
-		KeyFetchers: []gomatrixserverlib.KeyFetcher{s},
+		KeyFetchers: []gomatrixserverlib.KeyFetcher{},
 	}
 }
 
@@ -90,12 +89,8 @@ func (s *httpServerKeyInternalAPI) FetchKeys(
 	response := api.QueryPublicKeysResponse{
 		Results: make(map[gomatrixserverlib.PublicKeyLookupRequest]gomatrixserverlib.PublicKeyLookupResult),
 	}
-	now := gomatrixserverlib.AsTimestamp(time.Now())
 	for req, ts := range requests {
 		if res, ok := s.cache.GetServerKey(req); ok {
-			if now > res.ValidUntilTS && res.ExpiredTS == gomatrixserverlib.PublicKeyNotExpired {
-				continue
-			}
 			result[req] = res
 			continue
 		}

--- a/serverkeyapi/inthttp/server.go
+++ b/serverkeyapi/inthttp/server.go
@@ -8,7 +8,6 @@ import (
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/caching"
 	"github.com/matrix-org/dendrite/serverkeyapi/api"
-	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 )
 
@@ -35,12 +34,7 @@ func AddRoutes(s api.ServerKeyInternalAPI, internalAPIMux *mux.Router, cache cac
 			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
-			store := make(map[gomatrixserverlib.PublicKeyLookupRequest]gomatrixserverlib.PublicKeyLookupResult)
-			for req, res := range request.Keys {
-				store[req] = res
-				cache.StoreServerKey(req, res)
-			}
-			if err := s.StoreKeys(req.Context(), store); err != nil {
+			if err := s.StoreKeys(req.Context(), request.Keys); err != nil {
 				return util.ErrorResponse(err)
 			}
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}


### PR DESCRIPTION
This makes, yet again, more tweaks to the key fetching behaviour:

- The `ServerKeys` cache will no longer return a result that isn't valid now (and will actively evict such cache entries if it finds them)
- The `ServerKeyAPI` and `httpServerKeyInternalAPI` keyrings no longer returns itself as a `KeyFetcher` (as everything they do is already covered by the fact they return themselves as the `KeyDatabase`)
- Use `gomatrixserverlib.WasValidAt` for consistency
- Adds a missing validity check in `ServerKeyAPI`
- Removes one or two redundant checks from other places where a validity check has already been done