### PR TITLE
Add trace logging to RoomserverInternalAPI

### DIFF
--- a/clientapi/producers/syncapi.go
+++ b/clientapi/producers/syncapi.go
@@ -17,9 +17,9 @@ package producers
 import (
 	"encoding/json"
 
-	"github.com/matrix-org/dendrite/internal"
-
 	"github.com/Shopify/sarama"
+	"github.com/matrix-org/dendrite/internal"
+	log "github.com/sirupsen/logrus"
 )
 
 // SyncAPIProducer produces events for the sync API server to consume
@@ -44,6 +44,11 @@ func (p *SyncAPIProducer) SendData(userID string, roomID string, dataType string
 	m.Topic = string(p.Topic)
 	m.Key = sarama.StringEncoder(userID)
 	m.Value = sarama.ByteEncoder(value)
+	log.WithFields(log.Fields{
+		"user_id":   userID,
+		"room_id":   roomID,
+		"data_type": dataType,
+	}).Infof("Producing to topic '%s'", p.Topic)
 
 	_, _, err = p.Producer.SendMessage(&m)
 	return err

--- a/eduserver/input/input.go
+++ b/eduserver/input/input.go
@@ -97,6 +97,11 @@ func (t *EDUServerInputAPI) sendTypingEvent(ite *api.InputTypingEvent) error {
 	if err != nil {
 		return err
 	}
+	logrus.WithFields(logrus.Fields{
+		"room_id": ite.RoomID,
+		"user_id": ite.UserID,
+		"typing":  ite.Typing,
+	}).Infof("Producing to topic '%s'", t.OutputTypingEventTopic)
 
 	m := &sarama.ProducerMessage{
 		Topic: string(t.OutputTypingEventTopic),
@@ -132,18 +137,17 @@ func (t *EDUServerInputAPI) sendToDeviceEvent(ise *api.InputSendToDeviceEvent) e
 		devices = append(devices, ise.DeviceID)
 	}
 
+	logrus.WithFields(logrus.Fields{
+		"user_id":     ise.UserID,
+		"num_devices": len(devices),
+		"type":        ise.Type,
+	}).Infof("Producing to topic '%s'", t.OutputSendToDeviceEventTopic)
 	for _, device := range devices {
 		ote := &api.OutputSendToDeviceEvent{
 			UserID:            ise.UserID,
 			DeviceID:          device,
 			SendToDeviceEvent: ise.SendToDeviceEvent,
 		}
-
-		logrus.WithFields(logrus.Fields{
-			"user_id":    ise.UserID,
-			"device_id":  ise.DeviceID,
-			"event_type": ise.Type,
-		}).Info("handling send-to-device message")
 
 		eventJSON, err := json.Marshal(ote)
 		if err != nil {

--- a/federationsender/consumers/roomserver.go
+++ b/federationsender/consumers/roomserver.go
@@ -86,11 +86,6 @@ func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	switch output.Type {
 	case api.OutputTypeNewRoomEvent:
 		ev := &output.NewRoomEvent.Event
-		log.WithFields(log.Fields{
-			"event_id":       ev.EventID(),
-			"room_id":        ev.RoomID(),
-			"send_as_server": output.NewRoomEvent.SendAsServer,
-		}).Info("received room event from roomserver")
 
 		if err := s.processMessage(*output.NewRoomEvent); err != nil {
 			// panic rather than continue with an inconsistent database

--- a/roomserver/api/api_trace.go
+++ b/roomserver/api/api_trace.go
@@ -1,0 +1,218 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	fsAPI "github.com/matrix-org/dendrite/federationsender/api"
+	"github.com/matrix-org/util"
+)
+
+// RoomserverInternalAPITrace wraps a RoomserverInternalAPI and logs the
+// complete request/response/error
+type RoomserverInternalAPITrace struct {
+	Impl RoomserverInternalAPI
+}
+
+func (t *RoomserverInternalAPITrace) SetFederationSenderAPI(fsAPI fsAPI.FederationSenderInternalAPI) {
+	t.Impl.SetFederationSenderAPI(fsAPI)
+}
+
+func (t *RoomserverInternalAPITrace) InputRoomEvents(
+	ctx context.Context,
+	req *InputRoomEventsRequest,
+	res *InputRoomEventsResponse,
+) error {
+	err := t.Impl.InputRoomEvents(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("InputRoomEvents req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
+func (t *RoomserverInternalAPITrace) PerformJoin(
+	ctx context.Context,
+	req *PerformJoinRequest,
+	res *PerformJoinResponse,
+) error {
+	err := t.Impl.PerformJoin(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("PerformJoin req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
+func (t *RoomserverInternalAPITrace) PerformLeave(
+	ctx context.Context,
+	req *PerformLeaveRequest,
+	res *PerformLeaveResponse,
+) error {
+	err := t.Impl.PerformLeave(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("PerformLeave req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
+func (t *RoomserverInternalAPITrace) QueryLatestEventsAndState(
+	ctx context.Context,
+	req *QueryLatestEventsAndStateRequest,
+	res *QueryLatestEventsAndStateResponse,
+) error {
+	err := t.Impl.QueryLatestEventsAndState(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("QueryLatestEventsAndState req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
+func (t *RoomserverInternalAPITrace) QueryStateAfterEvents(
+	ctx context.Context,
+	req *QueryStateAfterEventsRequest,
+	res *QueryStateAfterEventsResponse,
+) error {
+	err := t.Impl.QueryStateAfterEvents(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("QueryStateAfterEvents req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
+func (t *RoomserverInternalAPITrace) QueryEventsByID(
+	ctx context.Context,
+	req *QueryEventsByIDRequest,
+	res *QueryEventsByIDResponse,
+) error {
+	err := t.Impl.QueryEventsByID(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("QueryEventsByID req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
+func (t *RoomserverInternalAPITrace) QueryMembershipForUser(
+	ctx context.Context,
+	req *QueryMembershipForUserRequest,
+	res *QueryMembershipForUserResponse,
+) error {
+	err := t.Impl.QueryMembershipForUser(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("QueryMembershipForUser req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
+func (t *RoomserverInternalAPITrace) QueryMembershipsForRoom(
+	ctx context.Context,
+	req *QueryMembershipsForRoomRequest,
+	res *QueryMembershipsForRoomResponse,
+) error {
+	err := t.Impl.QueryMembershipsForRoom(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("QueryMembershipsForRoom req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
+func (t *RoomserverInternalAPITrace) QueryServerAllowedToSeeEvent(
+	ctx context.Context,
+	req *QueryServerAllowedToSeeEventRequest,
+	res *QueryServerAllowedToSeeEventResponse,
+) error {
+	err := t.Impl.QueryServerAllowedToSeeEvent(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("QueryServerAllowedToSeeEvent req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
+func (t *RoomserverInternalAPITrace) QueryMissingEvents(
+	ctx context.Context,
+	req *QueryMissingEventsRequest,
+	res *QueryMissingEventsResponse,
+) error {
+	err := t.Impl.QueryMissingEvents(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("QueryMissingEvents req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
+func (t *RoomserverInternalAPITrace) QueryStateAndAuthChain(
+	ctx context.Context,
+	req *QueryStateAndAuthChainRequest,
+	res *QueryStateAndAuthChainResponse,
+) error {
+	err := t.Impl.QueryStateAndAuthChain(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("QueryStateAndAuthChain req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
+func (t *RoomserverInternalAPITrace) PerformBackfill(
+	ctx context.Context,
+	req *PerformBackfillRequest,
+	res *PerformBackfillResponse,
+) error {
+	err := t.Impl.PerformBackfill(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("PerformBackfill req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
+func (t *RoomserverInternalAPITrace) QueryRoomVersionCapabilities(
+	ctx context.Context,
+	req *QueryRoomVersionCapabilitiesRequest,
+	res *QueryRoomVersionCapabilitiesResponse,
+) error {
+	err := t.Impl.QueryRoomVersionCapabilities(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("QueryRoomVersionCapabilities req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
+func (t *RoomserverInternalAPITrace) QueryRoomVersionForRoom(
+	ctx context.Context,
+	req *QueryRoomVersionForRoomRequest,
+	res *QueryRoomVersionForRoomResponse,
+) error {
+	err := t.Impl.QueryRoomVersionForRoom(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("QueryRoomVersionForRoom req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
+func (t *RoomserverInternalAPITrace) SetRoomAlias(
+	ctx context.Context,
+	req *SetRoomAliasRequest,
+	res *SetRoomAliasResponse,
+) error {
+	err := t.Impl.SetRoomAlias(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("SetRoomAlias req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
+func (t *RoomserverInternalAPITrace) GetRoomIDForAlias(
+	ctx context.Context,
+	req *GetRoomIDForAliasRequest,
+	res *GetRoomIDForAliasResponse,
+) error {
+	err := t.Impl.GetRoomIDForAlias(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("GetRoomIDForAlias req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
+func (t *RoomserverInternalAPITrace) GetAliasesForRoomID(
+	ctx context.Context,
+	req *GetAliasesForRoomIDRequest,
+	res *GetAliasesForRoomIDResponse,
+) error {
+	err := t.Impl.GetAliasesForRoomID(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("GetAliasesForRoomID req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
+func (t *RoomserverInternalAPITrace) GetCreatorIDForAlias(
+	ctx context.Context,
+	req *GetCreatorIDForAliasRequest,
+	res *GetCreatorIDForAliasResponse,
+) error {
+	err := t.Impl.GetCreatorIDForAlias(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("GetCreatorIDForAlias req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
+func (t *RoomserverInternalAPITrace) RemoveRoomAlias(
+	ctx context.Context,
+	req *RemoveRoomAliasRequest,
+	res *RemoveRoomAliasResponse,
+) error {
+	err := t.Impl.RemoveRoomAlias(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("RemoveRoomAlias req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
+func js(thing interface{}) string {
+	b, err := json.Marshal(thing)
+	if err != nil {
+		return fmt.Sprintf("Marshal error:%s", err)
+	}
+	return string(b)
+}

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -98,11 +98,6 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 	ctx context.Context, msg api.OutputNewRoomEvent,
 ) error {
 	ev := msg.Event
-	log.WithFields(log.Fields{
-		"event_id":     ev.EventID(),
-		"room_id":      ev.RoomID(),
-		"room_version": ev.RoomVersion,
-	}).Info("received event from roomserver")
 
 	addsStateEvents := msg.AddsState()
 


### PR DESCRIPTION
This is a wrapper around whatever impl we have which then logs
the function name/request/response/error.

Also tweak when we log on kafka streams: only log on the producer
side not the consumer side: we've never had issues with comms and
having 1 message rather than N would be nice.

Enabled via `DENDRITE_TRACE_INTERNAL=1` which then produces output like:
```
time="2020-06-12T10:34:17.177711900Z" level=info msg="Producing to topic 'roomserverOutput'" func="github.com/matrix-org/dendrite/roomserver/internal.(*RoomserverInternalAPI).WriteOutputEvents" file="/src/roomserver/internal/input.go:58" adds_state=1 event_id="$DbnaI0tOyoyFRrJYvreOqsnjMQO8aFmRuKPDa3omrhA" event_type=m.room.member removes_state=0 room_id="!e5KPhuCoqZxFXClb:localhost:8800" send_as_server="localhost:8800" sender="@anon-20200612_103100-298:localhost:8800" type=new_room_event
time="2020-06-12T10:34:17.179706900Z" level=info msg="GetAliasesForRoomID req={\"room_id\":\"!e5KPhuCoqZxFXClb:localhost:8800\"} res={\"aliases\":null}" func="github.com/matrix-org/dendrite/roomserver/api.(*RoomserverInternalAPITrace).GetAliasesForRoomID" file="/src/roomserver/api/api_trace.go:188" context=missing error="<nil>"
time="2020-06-12T10:34:17.181720900Z" level=info msg="PerformJoin req={\"room_id_or_alias\":\"!e5KPhuCoqZxFXClb:localhost:8800\",\"user_id\":\"@anon-20200612_103100-298:localhost:8800\",\"content\":{\"avatar_url\":\"\",\"displayname\":\"\",\"membership\":\"join\"},\"server_names\":[\"localhost:8800\"]} res={\"room_id\":\"!e5KPhuCoqZxFXClb:localhost:8800\"}" func="github.com/matrix-org/dendrite/roomserver/api.(*RoomserverInternalAPITrace).PerformJoin" file="/src/roomserver/api/api_trace.go:38" error="<nil>" req.id=JvSjwnDRpcc3 req.method=POST req.path="/_matrix/client/r0/join/!e5KPhuCoqZxFXClb:localhost:8800" user_id="@anon-20200612_103100-298:localhost:8800"
```
