### PR TITLE
Current wiring

### DIFF
--- a/clientapi/clientapi.go
+++ b/clientapi/clientapi.go
@@ -41,7 +41,6 @@ func AddPublicRoutes(
 	deviceDB devices.Database,
 	accountsDB accounts.Database,
 	federation *gomatrixserverlib.FederationClient,
-	keyRing *gomatrixserverlib.KeyRing,
 	rsAPI roomserverAPI.RoomserverInternalAPI,
 	eduInputAPI eduServerAPI.EDUServerInputAPI,
 	asAPI appserviceAPI.AppServiceQueryAPI,
@@ -62,7 +61,7 @@ func AddPublicRoutes(
 
 	routing.Setup(
 		router, cfg, eduInputAPI, rsAPI, asAPI,
-		accountsDB, deviceDB, federation, *keyRing,
+		accountsDB, deviceDB, federation,
 		syncProducer, transactionsCache, fsAPI,
 	)
 }

--- a/clientapi/routing/getevent.go
+++ b/clientapi/routing/getevent.go
@@ -32,7 +32,6 @@ type getEventRequest struct {
 	eventID        string
 	cfg            *config.Dendrite
 	federation     *gomatrixserverlib.FederationClient
-	keyRing        gomatrixserverlib.KeyRing
 	requestedEvent gomatrixserverlib.Event
 }
 
@@ -46,7 +45,6 @@ func GetEvent(
 	cfg *config.Dendrite,
 	rsAPI api.RoomserverInternalAPI,
 	federation *gomatrixserverlib.FederationClient,
-	keyRing gomatrixserverlib.KeyRing,
 ) util.JSONResponse {
 	eventsReq := api.QueryEventsByIDRequest{
 		EventIDs: []string{eventID},
@@ -75,7 +73,6 @@ func GetEvent(
 		eventID:        eventID,
 		cfg:            cfg,
 		federation:     federation,
-		keyRing:        keyRing,
 		requestedEvent: requestedEvent,
 	}
 

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -55,7 +55,6 @@ func Setup(
 	accountDB accounts.Database,
 	deviceDB devices.Database,
 	federation *gomatrixserverlib.FederationClient,
-	keyRing gomatrixserverlib.KeyRing,
 	syncProducer *producers.SyncAPIProducer,
 	transactionsCache *transactions.Cache,
 	federationSender federationSenderAPI.FederationSenderInternalAPI,
@@ -154,7 +153,7 @@ func Setup(
 			if err != nil {
 				return util.ErrorResponse(err)
 			}
-			return GetEvent(req, device, vars["roomID"], vars["eventID"], cfg, rsAPI, federation, keyRing)
+			return GetEvent(req, device, vars["roomID"], vars["eventID"], cfg, rsAPI, federation)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 

--- a/docs/WIRING-Current.md
+++ b/docs/WIRING-Current.md
@@ -10,18 +10,18 @@ Note in Monolith mode these are actually direct function calls and are not seria
 
 ```
    Tier 1            Sync        PublicRooms      FederationAPI      ClientAPI    MediaAPI
-Public Facing        | .-----1------`              | | |     |         | | | |
-                     2 | .-------3-----------------` | |     |         | | | |
-                     | | | .--------4----------------------------------` | | |
-                     | | | |         .---5-----------` |     |           | | |
-                     | | | |         |  .---6----------------------------` | |
-                     | | | |         |  |              |  .-----7----------` |
-                     | | | |         |  |              8  |  |               10
-                     | | | |         |  |              |  |  `---9----.      |
-                     V V V V         V  V              V  V           V      V
+Public Facing        | .-----1------`              | | |    | |        | | | |
+                     2 | .-------3-----------------` | |    | `--------|-|-|-|--11--------------------.
+                     | | | .--------4----------------------------------` | | |                        |
+                     | | | |         .---5-----------` |    |            | | |                        |
+                     | | | |         |  .---6----------------------------` | |                        |
+                     | | | |         |  |              |  .-----7----------` |                        |
+                     | | | |         |  |              8  | |                10                       |
+                     | | | |         |  |              |  | `---9----.       |                        |
+                     V V V V         V  V              V  V          V       V                        V
    Tier 2           Roomserver     EDUServer         FedSender       AppService    KeyServer   ServerKeyAPI
-Internal only
-
+Internal only               |                               `------------------------12----------^   ^
+                            `------------------------------------------------------------13----------`
 
  Client ---> Server
 ```
@@ -32,9 +32,12 @@ Internal only
 - 5 (FedAPI -> EDUServer): Sending typing/send-to-device events
 - 6 (ClientAPI -> EDUServer): Sending typing/send-to-device events
 - 7 (ClientAPI -> FedSender): Handling directory lookups
-- 8 (FedAPI -> FedSender): Resetting backoffs when receiving traffic from a server. Querying joined hosts when handling alias lookup requests.
-- 9 (FedAPI -> AppService): Working out if the client is an appservice user. 
-- 10 (ClientAPI -> AppService): Working out if the client is an appservice user.
+- 8 (FedAPI -> FedSender): Resetting backoffs when receiving traffic from a server. Querying joined hosts when handling alias lookup requests
+- 9 (FedAPI -> AppService): Working out if the client is an appservice user
+- 10 (ClientAPI -> AppService): Working out if the client is an appservice user
+- 11 (FedAPI -> ServerKeyAPI): Verifying incoming event signatures
+- 12 (FedSender -> ServerKeyAPI): Verifying event signatures of responses (e.g from send_join)
+- 13 (Roomserver -> ServerKeyAPI): Verifying event signatures of backfilled events
 
 ## Kafka logs
 

--- a/docs/WIRING-Current.md
+++ b/docs/WIRING-Current.md
@@ -1,0 +1,68 @@
+This document details how various components communicate with each other. There are two kinds of components:
+ - Public-facing: exposes CS/SS API endpoints and need to be routed to via client-api-proxy or equivalent.
+ - Internal-only: exposes internal APIs and produces Kafka events.
+
+## Internal HTTP APIs
+
+Not everything can be done using Kafka logs. For example, requesting the latest events in a room is much better suited to
+a request/response model like HTTP or RPC. Therefore, components can expose "internal APIs" which sit outside of Kafka logs.
+Note in Monolith mode these are actually direct function calls and are not serialised HTTP requests.
+
+```
+   Tier 1            Sync        PublicRooms      FederationAPI      ClientAPI    MediaAPI
+Public Facing        | .-----1------`              | | |     |         | | | |
+                     2 | .-------3-----------------` | |     |         | | | |
+                     | | | .--------4----------------------------------` | | |
+                     | | | |         .---5-----------` |     |           | | |
+                     | | | |         |  .---6----------------------------` | |
+                     | | | |         |  |              |  .-----7----------` |
+                     | | | |         |  |              8  |  |               10
+                     | | | |         |  |              |  |  `---9----.      |
+                     V V V V         V  V              V  V           V      V
+   Tier 2           Roomserver     EDUServer         FedSender       AppService    KeyServer   ServerKeyAPI
+Internal only
+
+
+ Client ---> Server
+```
+- 1 (PublicRooms -> Roomserver): Calculating current auth for changing visibility
+- 2 (Sync -> Roomserver): When making backfill requests
+- 3 (FedAPI -> Roomserver): Calculating (prev/auth events) and sending new events, processing backfill/state/state_ids requests
+- 4 (ClientAPI -> Roomserver): Calculating (prev/auth events) and sending new events, processing /state requests
+- 5 (FedAPI -> EDUServer): Sending typing/send-to-device events
+- 6 (ClientAPI -> EDUServer): Sending typing/send-to-device events
+- 7 (ClientAPI -> FedSender): Handling directory lookups
+- 8 (FedAPI -> FedSender): Resetting backoffs when receiving traffic from a server. Querying joined hosts when handling alias lookup requests.
+- 9 (FedAPI -> AppService): Working out if the client is an appservice user. 
+- 10 (ClientAPI -> AppService): Working out if the client is an appservice user.
+
+## Kafka logs
+
+```
+                       .----1--------------------------------------------.
+                       V                                                 |
+   Tier 1            Sync        PublicRooms      FederationAPI      ClientAPI    MediaAPI
+Public Facing        ^   ^           ^                                 ^  
+                     |   |           |                                 |
+                     2   |           |                                 |
+                     |   `-3------------.                              |
+                     |               |  |                              |
+                     |               |  |                              |
+                     | .------4------`  |                              |
+                     | | .--------5-----|------------------------------`             
+                     | | |              |           
+   Tier 2           Roomserver     EDUServer         FedSender       AppService    KeyServer   ServerKeyAPI
+Internal only              |          |                ^ ^
+                           |          `-----6----------` |
+                           `--------------------7--------`
+
+
+Producer ----> Consumer
+```
+- 1 (ClientAPI -> Sync): For tracking account data
+- 2 (Roomserver -> Sync): For all data to send to clients
+- 3 (EDUServer -> Sync): For typing/send-to-device data to send to clients
+- 4 (Roomserver -> PublicRooms): For tracking the current room name/topic/joined count/etc.
+- 5 (Roomserver -> ClientAPI): For tracking memberships for profile updates.
+- 6 (EDUServer -> FedSender): For sending EDUs over federation
+- 7 (Roomserver -> FedSender): For sending PDUs over federation, for tracking joined hosts.

--- a/internal/setup/monolith.go
+++ b/internal/setup/monolith.go
@@ -67,7 +67,7 @@ type Monolith struct {
 func (m *Monolith) AddAllPublicRoutes(publicMux *mux.Router) {
 	clientapi.AddPublicRoutes(
 		publicMux, m.Config, m.KafkaConsumer, m.KafkaProducer, m.DeviceDB, m.AccountDB,
-		m.FedClient, m.KeyRing, m.RoomserverAPI,
+		m.FedClient, m.RoomserverAPI,
 		m.EDUInternalAPI, m.AppserviceAPI, transactions.New(),
 		m.FederationSenderAPI,
 	)


### PR DESCRIPTION
Closes #893 as we now justify each arrow of communication between components.

There are major rooms for improvement here, notably:
 - Add a `UserAPI` to guard access to device/user DB: #1124
 - Add internal API for `UserAPI` to expose profile info, moving arrows (Fed|ClientAPI->AS) to (Fed|ClientAPI->UserAPI), allowing us to remove the internal APIs from AS entirely.
 - Reconsider Kafka log (Roomserver -> ClientAPI) - we could expose a "all joined rooms for this user" endpoint on Roomserver which means ClientAPI doesn't need to have an entire database devoted to this just for profile updates.
