### PR TITLE
Do not wrap send_join errors on /v1/send_join

### DIFF
--- a/federationapi/routing/join.go
+++ b/federationapi/routing/join.go
@@ -28,6 +28,10 @@ import (
 	"github.com/matrix-org/util"
 )
 
+type JoinError struct {
+	Error interface{}
+}
+
 // MakeJoin implements the /make_join API
 func MakeJoin(
 	httpReq *http.Request,
@@ -224,7 +228,9 @@ func SendJoin(
 	if verifyResults[0].Error != nil {
 		return util.JSONResponse{
 			Code: http.StatusForbidden,
-			JSON: jsonerror.Forbidden("Signature check failed: " + verifyResults[0].Error.Error()),
+			JSON: JoinError{
+				Error: jsonerror.Forbidden("Signature check failed: " + verifyResults[0].Error.Error()),
+			},
 		}
 	}
 

--- a/federationapi/routing/join.go
+++ b/federationapi/routing/join.go
@@ -28,10 +28,6 @@ import (
 	"github.com/matrix-org/util"
 )
 
-type JoinError struct {
-	Error interface{}
-}
-
 // MakeJoin implements the /make_join API
 func MakeJoin(
 	httpReq *http.Request,
@@ -228,9 +224,7 @@ func SendJoin(
 	if verifyResults[0].Error != nil {
 		return util.JSONResponse{
 			Code: http.StatusForbidden,
-			JSON: JoinError{
-				Error: jsonerror.Forbidden("Signature check failed: " + verifyResults[0].Error.Error()),
-			},
+			JSON: jsonerror.Forbidden("Signature check failed: " + verifyResults[0].Error.Error()),
 		}
 	}
 

--- a/federationapi/routing/routing.go
+++ b/federationapi/routing/routing.go
@@ -203,12 +203,20 @@ func Setup(
 			res := SendJoin(
 				httpReq, request, cfg, rsAPI, keys, roomID, eventID,
 			)
+			// not all responses get wrapped in [code, body]
+			var body interface{}
+			body = []interface{}{
+				res.Code, res.JSON,
+			}
+			jerr, ok := res.JSON.(JoinError)
+			if ok {
+				body = jerr.Error
+			}
+
 			return util.JSONResponse{
 				Headers: res.Headers,
 				Code:    res.Code,
-				JSON: []interface{}{
-					res.Code, res.JSON,
-				},
+				JSON:    body,
 			}
 		},
 	)).Methods(http.MethodPut)

--- a/federationapi/routing/routing.go
+++ b/federationapi/routing/routing.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	eduserverAPI "github.com/matrix-org/dendrite/eduserver/api"
 	federationSenderAPI "github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/dendrite/internal/config"
@@ -208,9 +209,9 @@ func Setup(
 			body = []interface{}{
 				res.Code, res.JSON,
 			}
-			jerr, ok := res.JSON.(JoinError)
+			jerr, ok := res.JSON.(*jsonerror.MatrixError)
 			if ok {
-				body = jerr.Error
+				body = jerr
 			}
 
 			return util.JSONResponse{


### PR DESCRIPTION
Because Sytest demands it. Requires https://github.com/matrix-org/sytest/pull/894 to land first before:
```
    Test 7 Inbound /v1/send_join rejects incorrectly-signed joins... OK
    Test 8 Inbound /v1/send_join rejects joins from other servers... OK
```
will pass.