### PR TITLE
/send auth errors are silent

### DIFF
--- a/sytest-blacklist
+++ b/sytest-blacklist
@@ -44,3 +44,7 @@ Existing members see new members' join events
 Can recv device messages over federation
 Device messages over federation wake up /sync
 Wildcard device messages over federation wake up /sync
+
+# We don't implement soft-failed events yet, but because the /send response is vague,
+# this test thinks it's all fine...
+Inbound federation accepts a second soft-failed event


### PR DESCRIPTION
This may make some sytests pass.

Separately, we need to handle rejected events in general...