### PR TITLE
Refactor account data

### DIFF
--- a/clientapi/routing/account_data.go
+++ b/clientapi/routing/account_data.go
@@ -104,6 +104,11 @@ func SaveAccountData(
 		}
 	}
 
+	if err := syncProducer.SendData(userID, roomID, dataType); err != nil {
+		util.GetLogger(req.Context()).WithError(err).Error("syncProducer.SendData failed")
+		return jsonerror.InternalServerError()
+	}
+
 	dataReq := api.InputAccountDataRequest{
 		UserID:      userID,
 		DataType:    dataType,

--- a/clientapi/routing/room_tagging.go
+++ b/clientapi/routing/room_tagging.go
@@ -69,7 +69,7 @@ func GetTags(
 
 	return util.JSONResponse{
 		Code: http.StatusOK,
-		JSON: data.Content,
+		JSON: data,
 	}
 }
 
@@ -106,7 +106,7 @@ func PutTag(
 
 	var tagContent gomatrix.TagContent
 	if data != nil {
-		if err = json.Unmarshal(data.Content, &tagContent); err != nil {
+		if err = json.Unmarshal(data, &tagContent); err != nil {
 			util.GetLogger(req.Context()).WithError(err).Error("json.Unmarshal failed")
 			return jsonerror.InternalServerError()
 		}
@@ -169,7 +169,7 @@ func DeleteTag(
 	}
 
 	var tagContent gomatrix.TagContent
-	err = json.Unmarshal(data.Content, &tagContent)
+	err = json.Unmarshal(data, &tagContent)
 	if err != nil {
 		util.GetLogger(req.Context()).WithError(err).Error("json.Unmarshal failed")
 		return jsonerror.InternalServerError()
@@ -211,7 +211,7 @@ func obtainSavedTags(
 	userID string,
 	roomID string,
 	accountDB accounts.Database,
-) (string, *gomatrixserverlib.ClientEvent, error) {
+) (string, json.RawMessage, error) {
 	localpart, _, err := gomatrixserverlib.SplitID('@', userID)
 	if err != nil {
 		return "", nil, err
@@ -237,5 +237,5 @@ func saveTagData(
 		return err
 	}
 
-	return accountDB.SaveAccountData(req.Context(), localpart, roomID, "m.tag", string(newTagData))
+	return accountDB.SaveAccountData(req.Context(), localpart, roomID, "m.tag", json.RawMessage(newTagData))
 }

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -604,7 +604,7 @@ func Setup(
 			if err != nil {
 				return util.ErrorResponse(err)
 			}
-			return GetTags(req, accountDB, device, vars["userId"], vars["roomId"], syncProducer)
+			return GetTags(req, userAPI, device, vars["userId"], vars["roomId"], syncProducer)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
@@ -614,7 +614,7 @@ func Setup(
 			if err != nil {
 				return util.ErrorResponse(err)
 			}
-			return PutTag(req, accountDB, device, vars["userId"], vars["roomId"], vars["tag"], syncProducer)
+			return PutTag(req, userAPI, device, vars["userId"], vars["roomId"], vars["tag"], syncProducer)
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 
@@ -624,7 +624,7 @@ func Setup(
 			if err != nil {
 				return util.ErrorResponse(err)
 			}
-			return DeleteTag(req, accountDB, device, vars["userId"], vars["roomId"], vars["tag"], syncProducer)
+			return DeleteTag(req, userAPI, device, vars["userId"], vars["roomId"], vars["tag"], syncProducer)
 		}),
 	).Methods(http.MethodDelete, http.MethodOptions)
 

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -476,7 +476,7 @@ func Setup(
 			if err != nil {
 				return util.ErrorResponse(err)
 			}
-			return SaveAccountData(req, accountDB, device, vars["userID"], "", vars["type"], syncProducer)
+			return SaveAccountData(req, userAPI, device, vars["userID"], "", vars["type"], syncProducer)
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 
@@ -486,7 +486,7 @@ func Setup(
 			if err != nil {
 				return util.ErrorResponse(err)
 			}
-			return SaveAccountData(req, accountDB, device, vars["userID"], vars["roomID"], vars["type"], syncProducer)
+			return SaveAccountData(req, userAPI, device, vars["userID"], vars["roomID"], vars["type"], syncProducer)
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 
@@ -496,7 +496,7 @@ func Setup(
 			if err != nil {
 				return util.ErrorResponse(err)
 			}
-			return GetAccountData(req, accountDB, device, vars["userID"], "", vars["type"])
+			return GetAccountData(req, userAPI, device, vars["userID"], "", vars["type"])
 		}),
 	).Methods(http.MethodGet)
 
@@ -506,7 +506,7 @@ func Setup(
 			if err != nil {
 				return util.ErrorResponse(err)
 			}
-			return GetAccountData(req, accountDB, device, vars["userID"], vars["roomID"], vars["type"])
+			return GetAccountData(req, userAPI, device, vars["userID"], vars["roomID"], vars["type"])
 		}),
 	).Methods(http.MethodGet)
 

--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -230,6 +230,7 @@ func (rp *RequestPool) appendAccountData(
 						Content: gomatrixserverlib.RawJSON(databody),
 					},
 				)
+				data.Rooms.Join[r] = j
 			}
 		}
 		return data, nil

--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -205,14 +205,14 @@ func (rp *RequestPool) appendAccountData(
 	if req.since == nil {
 		// If this is the initial sync, we don't need to check if a data has
 		// already been sent. Instead, we send the whole batch.
-		var res userapi.QueryAccountDataResponse
-		err := rp.userAPI.QueryAccountData(req.ctx, &userapi.QueryAccountDataRequest{
+		dataReq := &userapi.QueryAccountDataRequest{
 			UserID: userID,
-		}, &res)
-		if err != nil {
+		}
+		dataRes := &userapi.QueryAccountDataResponse{}
+		if err := rp.userAPI.QueryAccountData(req.ctx, dataReq, dataRes); err != nil {
 			return nil, err
 		}
-		for datatype, databody := range res.GlobalAccountData {
+		for datatype, databody := range dataRes.GlobalAccountData {
 			data.AccountData.Events = append(
 				data.AccountData.Events,
 				gomatrixserverlib.ClientEvent{
@@ -222,7 +222,7 @@ func (rp *RequestPool) appendAccountData(
 			)
 		}
 		for r, j := range data.Rooms.Join {
-			for datatype, databody := range res.RoomAccountData[r] {
+			for datatype, databody := range dataRes.RoomAccountData[r] {
 				j.AccountData.Events = append(
 					j.AccountData.Events,
 					gomatrixserverlib.ClientEvent{

--- a/userapi/api/api.go
+++ b/userapi/api/api.go
@@ -36,7 +36,7 @@ type UserInternalAPI interface {
 type InputAccountDataRequest struct {
 	UserID      string          // required: the user to set account data for
 	RoomID      string          // optional: the room to associate the account data with
-	DataType    string          // required: the data type of the data
+	DataType    string          // optional: the data type of the data
 	AccountData json.RawMessage // required: the message content
 }
 

--- a/userapi/api/api.go
+++ b/userapi/api/api.go
@@ -16,18 +16,32 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
 // UserInternalAPI is the internal API for information about users and devices.
 type UserInternalAPI interface {
+	InputAccountData(ctx context.Context, req *InputAccountDataRequest, res *InputAccountDataResponse) error
 	PerformAccountCreation(ctx context.Context, req *PerformAccountCreationRequest, res *PerformAccountCreationResponse) error
 	PerformDeviceCreation(ctx context.Context, req *PerformDeviceCreationRequest, res *PerformDeviceCreationResponse) error
 	QueryProfile(ctx context.Context, req *QueryProfileRequest, res *QueryProfileResponse) error
 	QueryAccessToken(ctx context.Context, req *QueryAccessTokenRequest, res *QueryAccessTokenResponse) error
 	QueryDevices(ctx context.Context, req *QueryDevicesRequest, res *QueryDevicesResponse) error
 	QueryAccountData(ctx context.Context, req *QueryAccountDataRequest, res *QueryAccountDataResponse) error
+}
+
+// InputAccountDataRequest is the request for InputAccountData
+type InputAccountDataRequest struct {
+	UserID      string          // required: the user to set account data for
+	RoomID      string          // optional: the room to associate the account data with
+	DataType    string          // required: the data type of the data
+	AccountData json.RawMessage // required: the message content
+}
+
+// InputAccountDataResponse is the response for InputAccountData
+type InputAccountDataResponse struct {
 }
 
 // QueryAccessTokenRequest is the request for QueryAccessToken
@@ -46,18 +60,15 @@ type QueryAccessTokenResponse struct {
 
 // QueryAccountDataRequest is the request for QueryAccountData
 type QueryAccountDataRequest struct {
-	UserID string // required: the user to get account data for.
-	// TODO: This is a terribly confusing API shape :/
-	DataType string // optional: if specified returns only a single event matching this data type.
-	// optional: Only used if DataType is set. If blank returns global account data matching the data type.
-	// If set, returns only room account data matching this data type.
-	RoomID string
+	UserID   string // required: the user to get account data for.
+	RoomID   string // optional: the room ID, or global account data if not specified.
+	DataType string // optional: the data type, or all types if not specified.
 }
 
 // QueryAccountDataResponse is the response for QueryAccountData
 type QueryAccountDataResponse struct {
-	GlobalAccountData []gomatrixserverlib.ClientEvent
-	RoomAccountData   map[string][]gomatrixserverlib.ClientEvent
+	GlobalAccountData map[string]json.RawMessage            // type -> data
+	RoomAccountData   map[string]map[string]json.RawMessage // room -> type -> data
 }
 
 // QueryDevicesRequest is the request for QueryDevices

--- a/userapi/internal/api.go
+++ b/userapi/internal/api.go
@@ -137,6 +137,8 @@ func (a *UserInternalAPI) QueryDevices(ctx context.Context, req *api.QueryDevice
 }
 
 func (a *UserInternalAPI) QueryAccountData(ctx context.Context, req *api.QueryAccountDataRequest, res *api.QueryAccountDataResponse) error {
+	res.GlobalAccountData = make(map[string]json.RawMessage)
+	res.RoomAccountData = make(map[string]map[string]json.RawMessage)
 	local, domain, err := gomatrixserverlib.SplitID('@', req.UserID)
 	if err != nil {
 		return err
@@ -153,7 +155,7 @@ func (a *UserInternalAPI) QueryAccountData(ctx context.Context, req *api.QueryAc
 		if data != nil {
 			if req.RoomID != "" {
 				if _, ok := res.RoomAccountData[req.RoomID]; !ok {
-					res.RoomAccountData[req.RoomID] = map[string]json.RawMessage{}
+					res.RoomAccountData[req.RoomID] = make(map[string]json.RawMessage)
 				}
 				res.RoomAccountData[req.RoomID][req.DataType] = data
 			} else {

--- a/userapi/internal/api.go
+++ b/userapi/internal/api.go
@@ -137,8 +137,6 @@ func (a *UserInternalAPI) QueryDevices(ctx context.Context, req *api.QueryDevice
 }
 
 func (a *UserInternalAPI) QueryAccountData(ctx context.Context, req *api.QueryAccountDataRequest, res *api.QueryAccountDataResponse) error {
-	res.GlobalAccountData = make(map[string]json.RawMessage)
-	res.RoomAccountData = make(map[string]map[string]json.RawMessage)
 	local, domain, err := gomatrixserverlib.SplitID('@', req.UserID)
 	if err != nil {
 		return err
@@ -152,6 +150,8 @@ func (a *UserInternalAPI) QueryAccountData(ctx context.Context, req *api.QueryAc
 		if err != nil {
 			return err
 		}
+		res.RoomAccountData = make(map[string]map[string]json.RawMessage)
+		res.GlobalAccountData = make(map[string]json.RawMessage)
 		if data != nil {
 			if req.RoomID != "" {
 				if _, ok := res.RoomAccountData[req.RoomID]; !ok {

--- a/userapi/inthttp/client.go
+++ b/userapi/inthttp/client.go
@@ -26,6 +26,8 @@ import (
 
 // HTTP paths for the internal HTTP APIs
 const (
+	InputAccountDataPath = "/userapi/inputAccountData"
+
 	PerformDeviceCreationPath  = "/userapi/performDeviceCreation"
 	PerformAccountCreationPath = "/userapi/performAccountCreation"
 
@@ -53,6 +55,14 @@ func NewUserAPIClient(
 type httpUserInternalAPI struct {
 	apiURL     string
 	httpClient *http.Client
+}
+
+func (h *httpUserInternalAPI) InputAccountData(ctx context.Context, req *api.InputAccountDataRequest, res *api.InputAccountDataResponse) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "InputAccountData")
+	defer span.Finish()
+
+	apiURL := h.apiURL + InputAccountDataPath
+	return httputil.PostJSON(ctx, span, h.httpClient, apiURL, req, res)
 }
 
 func (h *httpUserInternalAPI) PerformAccountCreation(

--- a/userapi/storage/accounts/interface.go
+++ b/userapi/storage/accounts/interface.go
@@ -16,6 +16,7 @@ package accounts
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
@@ -39,13 +40,13 @@ type Database interface {
 	GetMembershipInRoomByLocalpart(ctx context.Context, localpart, roomID string) (authtypes.Membership, error)
 	GetRoomIDsByLocalPart(ctx context.Context, localpart string) ([]string, error)
 	GetMembershipsByLocalpart(ctx context.Context, localpart string) (memberships []authtypes.Membership, err error)
-	SaveAccountData(ctx context.Context, localpart, roomID, dataType, content string) error
-	GetAccountData(ctx context.Context, localpart string) (global []gomatrixserverlib.ClientEvent, rooms map[string][]gomatrixserverlib.ClientEvent, err error)
+	SaveAccountData(ctx context.Context, localpart, roomID, dataType string, content json.RawMessage) error
+	GetAccountData(ctx context.Context, localpart string) (global map[string]json.RawMessage, rooms map[string]map[string]json.RawMessage, err error)
 	// GetAccountDataByType returns account data matching a given
 	// localpart, room ID and type.
 	// If no account data could be found, returns nil
 	// Returns an error if there was an issue with the retrieval
-	GetAccountDataByType(ctx context.Context, localpart, roomID, dataType string) (data *gomatrixserverlib.ClientEvent, err error)
+	GetAccountDataByType(ctx context.Context, localpart, roomID, dataType string) (data json.RawMessage, err error)
 	GetNewNumericLocalpart(ctx context.Context) (int64, error)
 	SaveThreePIDAssociation(ctx context.Context, threepid, localpart, medium string) (err error)
 	RemoveThreePIDAssociation(ctx context.Context, threepid string, medium string) (err error)

--- a/userapi/storage/accounts/postgres/account_data_table.go
+++ b/userapi/storage/accounts/postgres/account_data_table.go
@@ -99,7 +99,7 @@ func (s *accountDataStatements) selectAccountData(
 	for rows.Next() {
 		var roomID string
 		var dataType string
-		var content json.RawMessage
+		var content []byte
 
 		if err = rows.Scan(&roomID, &dataType, &content); err != nil {
 			return
@@ -121,12 +121,14 @@ func (s *accountDataStatements) selectAccountData(
 func (s *accountDataStatements) selectAccountDataByType(
 	ctx context.Context, localpart, roomID, dataType string,
 ) (data json.RawMessage, err error) {
+	var bytes []byte
 	stmt := s.selectAccountDataByTypeStmt
-	if err = stmt.QueryRowContext(ctx, localpart, roomID, dataType).Scan(&data); err != nil {
+	if err = stmt.QueryRowContext(ctx, localpart, roomID, dataType).Scan(&bytes); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
 		}
 		return
 	}
+	data = json.RawMessage(bytes)
 	return
 }

--- a/userapi/storage/accounts/postgres/account_data_table.go
+++ b/userapi/storage/accounts/postgres/account_data_table.go
@@ -83,18 +83,18 @@ func (s *accountDataStatements) insertAccountData(
 func (s *accountDataStatements) selectAccountData(
 	ctx context.Context, localpart string,
 ) (
-	global map[string]json.RawMessage,
-	rooms map[string]map[string]json.RawMessage,
-	err error,
+	/* global */ map[string]json.RawMessage,
+	/* rooms */ map[string]map[string]json.RawMessage,
+	error,
 ) {
 	rows, err := s.selectAccountDataStmt.QueryContext(ctx, localpart)
 	if err != nil {
-		return
+		return nil, nil, err
 	}
 	defer internal.CloseAndLogIfError(ctx, rows, "selectAccountData: rows.close() failed")
 
-	global = map[string]json.RawMessage{}
-	rooms = map[string]map[string]json.RawMessage{}
+	global := map[string]json.RawMessage{}
+	rooms := map[string]map[string]json.RawMessage{}
 
 	for rows.Next() {
 		var roomID string
@@ -102,7 +102,7 @@ func (s *accountDataStatements) selectAccountData(
 		var content []byte
 
 		if err = rows.Scan(&roomID, &dataType, &content); err != nil {
-			return
+			return nil, nil, err
 		}
 
 		if roomID != "" {

--- a/userapi/storage/accounts/postgres/account_data_table.go
+++ b/userapi/storage/accounts/postgres/account_data_table.go
@@ -17,9 +17,9 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 
 	"github.com/matrix-org/dendrite/internal"
-	"github.com/matrix-org/gomatrixserverlib"
 )
 
 const accountDataSchema = `
@@ -73,7 +73,7 @@ func (s *accountDataStatements) prepare(db *sql.DB) (err error) {
 }
 
 func (s *accountDataStatements) insertAccountData(
-	ctx context.Context, txn *sql.Tx, localpart, roomID, dataType, content string,
+	ctx context.Context, txn *sql.Tx, localpart, roomID, dataType string, content json.RawMessage,
 ) (err error) {
 	stmt := txn.Stmt(s.insertAccountDataStmt)
 	_, err = stmt.ExecContext(ctx, localpart, roomID, dataType, content)
@@ -83,8 +83,8 @@ func (s *accountDataStatements) insertAccountData(
 func (s *accountDataStatements) selectAccountData(
 	ctx context.Context, localpart string,
 ) (
-	global []gomatrixserverlib.ClientEvent,
-	rooms map[string][]gomatrixserverlib.ClientEvent,
+	global map[string]json.RawMessage,
+	rooms map[string]map[string]json.RawMessage,
 	err error,
 ) {
 	rows, err := s.selectAccountDataStmt.QueryContext(ctx, localpart)
@@ -93,50 +93,40 @@ func (s *accountDataStatements) selectAccountData(
 	}
 	defer internal.CloseAndLogIfError(ctx, rows, "selectAccountData: rows.close() failed")
 
-	global = []gomatrixserverlib.ClientEvent{}
-	rooms = make(map[string][]gomatrixserverlib.ClientEvent)
+	global = map[string]json.RawMessage{}
+	rooms = map[string]map[string]json.RawMessage{}
 
 	for rows.Next() {
 		var roomID string
 		var dataType string
-		var content []byte
+		var content json.RawMessage
 
 		if err = rows.Scan(&roomID, &dataType, &content); err != nil {
 			return
 		}
 
-		ac := gomatrixserverlib.ClientEvent{
-			Type:    dataType,
-			Content: content,
-		}
-
-		if len(roomID) > 0 {
-			rooms[roomID] = append(rooms[roomID], ac)
+		if roomID != "" {
+			if _, ok := rooms[roomID]; !ok {
+				rooms[roomID] = map[string]json.RawMessage{}
+			}
+			rooms[roomID][dataType] = content
 		} else {
-			global = append(global, ac)
+			global[dataType] = content
 		}
 	}
+
 	return global, rooms, rows.Err()
 }
 
 func (s *accountDataStatements) selectAccountDataByType(
 	ctx context.Context, localpart, roomID, dataType string,
-) (data *gomatrixserverlib.ClientEvent, err error) {
+) (data json.RawMessage, err error) {
 	stmt := s.selectAccountDataByTypeStmt
-	var content []byte
-
-	if err = stmt.QueryRowContext(ctx, localpart, roomID, dataType).Scan(&content); err != nil {
+	if err = stmt.QueryRowContext(ctx, localpart, roomID, dataType).Scan(&data); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
 		}
-
 		return
 	}
-
-	data = &gomatrixserverlib.ClientEvent{
-		Type:    dataType,
-		Content: content,
-	}
-
 	return
 }

--- a/userapi/storage/accounts/postgres/storage.go
+++ b/userapi/storage/accounts/postgres/storage.go
@@ -17,6 +17,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"strconv"
 
@@ -169,7 +170,7 @@ func (d *Database) createAccount(
 		return nil, err
 	}
 
-	if err := d.accountDatas.insertAccountData(ctx, txn, localpart, "", "m.push_rules", `{
+	if err := d.accountDatas.insertAccountData(ctx, txn, localpart, "", "m.push_rules", json.RawMessage(`{
 		"global": {
 			"content": [],
 			"override": [],
@@ -177,7 +178,7 @@ func (d *Database) createAccount(
 			"sender": [],
 			"underride": []
 		}
-	}`); err != nil {
+	}`)); err != nil {
 		return nil, err
 	}
 	return d.accounts.insertAccount(ctx, txn, localpart, hash, appserviceID)
@@ -295,7 +296,7 @@ func (d *Database) newMembership(
 // update the corresponding row with the new content
 // Returns a SQL error if there was an issue with the insertion/update
 func (d *Database) SaveAccountData(
-	ctx context.Context, localpart, roomID, dataType, content string,
+	ctx context.Context, localpart, roomID, dataType string, content json.RawMessage,
 ) error {
 	return sqlutil.WithTransaction(d.db, func(txn *sql.Tx) error {
 		return d.accountDatas.insertAccountData(ctx, txn, localpart, roomID, dataType, content)
@@ -306,8 +307,8 @@ func (d *Database) SaveAccountData(
 // If no account data could be found, returns an empty arrays
 // Returns an error if there was an issue with the retrieval
 func (d *Database) GetAccountData(ctx context.Context, localpart string) (
-	global []gomatrixserverlib.ClientEvent,
-	rooms map[string][]gomatrixserverlib.ClientEvent,
+	global map[string]json.RawMessage,
+	rooms map[string]map[string]json.RawMessage,
 	err error,
 ) {
 	return d.accountDatas.selectAccountData(ctx, localpart)
@@ -319,7 +320,7 @@ func (d *Database) GetAccountData(ctx context.Context, localpart string) (
 // Returns an error if there was an issue with the retrieval
 func (d *Database) GetAccountDataByType(
 	ctx context.Context, localpart, roomID, dataType string,
-) (data *gomatrixserverlib.ClientEvent, err error) {
+) (data json.RawMessage, err error) {
 	return d.accountDatas.selectAccountDataByType(
 		ctx, localpart, roomID, dataType,
 	)

--- a/userapi/storage/accounts/sqlite3/account_data_table.go
+++ b/userapi/storage/accounts/sqlite3/account_data_table.go
@@ -80,17 +80,17 @@ func (s *accountDataStatements) insertAccountData(
 func (s *accountDataStatements) selectAccountData(
 	ctx context.Context, localpart string,
 ) (
-	global map[string]json.RawMessage,
-	rooms map[string]map[string]json.RawMessage,
-	err error,
+	/* global */ map[string]json.RawMessage,
+	/* rooms */ map[string]map[string]json.RawMessage,
+	error,
 ) {
 	rows, err := s.selectAccountDataStmt.QueryContext(ctx, localpart)
 	if err != nil {
-		return
+		return nil, nil, err
 	}
 
-	global = map[string]json.RawMessage{}
-	rooms = map[string]map[string]json.RawMessage{}
+	global := map[string]json.RawMessage{}
+	rooms := map[string]map[string]json.RawMessage{}
 
 	for rows.Next() {
 		var roomID string
@@ -98,7 +98,7 @@ func (s *accountDataStatements) selectAccountData(
 		var content []byte
 
 		if err = rows.Scan(&roomID, &dataType, &content); err != nil {
-			return
+			return nil, nil, err
 		}
 
 		if roomID != "" {
@@ -111,7 +111,7 @@ func (s *accountDataStatements) selectAccountData(
 		}
 	}
 
-	return
+	return global, rooms, nil
 }
 
 func (s *accountDataStatements) selectAccountDataByType(

--- a/userapi/storage/accounts/sqlite3/account_data_table.go
+++ b/userapi/storage/accounts/sqlite3/account_data_table.go
@@ -117,12 +117,14 @@ func (s *accountDataStatements) selectAccountData(
 func (s *accountDataStatements) selectAccountDataByType(
 	ctx context.Context, localpart, roomID, dataType string,
 ) (data json.RawMessage, err error) {
+	var bytes []byte
 	stmt := s.selectAccountDataByTypeStmt
-	if err = stmt.QueryRowContext(ctx, localpart, roomID, dataType).Scan(&data); err != nil {
+	if err = stmt.QueryRowContext(ctx, localpart, roomID, dataType).Scan(&bytes); err != nil {
 		if err == sql.ErrNoRows {
 			return nil, nil
 		}
 		return
 	}
+	data = json.RawMessage(bytes)
 	return
 }


### PR DESCRIPTION
This refactors account data so that it is:

1. Fully stored and handled internally by the User API as `json.RawMessage`
2. Sync API turns account data into `gomatrixserverlib.ClientEvent` only when needed