### PR TITLE
Add appservices component to docker scripts

### DIFF
--- a/build/docker/config/dendrite-config.yaml
+++ b/build/docker/config/dendrite-config.yaml
@@ -118,6 +118,7 @@ listen:
     edu_server: "edu_server:7777"
     key_server: "key_server:7779"
     user_api: "user_api:7780"
+    appservice_api: "appservice_api:7781"
 
 # The configuration for tracing the dendrite components.
 tracing:

--- a/build/docker/docker-compose.polylith.yml
+++ b/build/docker/docker-compose.polylith.yml
@@ -163,6 +163,20 @@ services:
     networks:
         - internal
 
+  appservice_api:
+    hostname: appservice_api
+    image: matrixdotorg/dendrite:appservice
+    command: [
+      "--config=dendrite.yaml"
+    ]
+    volumes:
+      - ./config:/etc/dendrite
+    networks:
+      - internal
+    depends_on:
+      - room_server
+      - user_api
+
 networks:
   internal:
     attachable: true

--- a/build/docker/images-build.sh
+++ b/build/docker/images-build.sh
@@ -6,6 +6,7 @@ docker build -f build/docker/Dockerfile -t matrixdotorg/dendrite:latest .
 
 docker build -t matrixdotorg/dendrite:monolith          --build-arg component=dendrite-monolith-server          -f build/docker/Dockerfile.component .
 
+docker build -t matrixdotorg/dendrite:appservice        --build-arg component=dendrite-appservice-server        -f build/docker/Dockerfile.component .
 docker build -t matrixdotorg/dendrite:clientapi         --build-arg component=dendrite-client-api-server        -f build/docker/Dockerfile.component .
 docker build -t matrixdotorg/dendrite:clientproxy       --build-arg component=client-api-proxy                  -f build/docker/Dockerfile.component .
 docker build -t matrixdotorg/dendrite:eduserver         --build-arg component=dendrite-edu-server               -f build/docker/Dockerfile.component .

--- a/build/docker/images-pull.sh
+++ b/build/docker/images-pull.sh
@@ -2,6 +2,7 @@
 
 docker pull matrixdotorg/dendrite:monolith
 
+docker pull matrixdotorg/dendrite:appservice
 docker pull matrixdotorg/dendrite:clientapi
 docker pull matrixdotorg/dendrite:clientproxy
 docker pull matrixdotorg/dendrite:eduserver

--- a/build/docker/images-push.sh
+++ b/build/docker/images-push.sh
@@ -2,6 +2,7 @@
 
 docker push matrixdotorg/dendrite:monolith
 
+docker push matrixdotorg/dendrite:appservice
 docker push matrixdotorg/dendrite:clientapi
 docker push matrixdotorg/dendrite:clientproxy
 docker push matrixdotorg/dendrite:eduserver

--- a/build/scripts/build-test-lint.sh
+++ b/build/scripts/build-test-lint.sh
@@ -10,7 +10,7 @@ set -eu
 echo "Checking that it builds..."
 go build ./cmd/...
 
-./scripts/find-lint.sh
+./build/scripts/find-lint.sh
 
 echo "Testing..."
 go test -v ./...

--- a/cmd/dendrite-user-api-server/main.go
+++ b/cmd/dendrite-user-api-server/main.go
@@ -1,0 +1,35 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/matrix-org/dendrite/internal/setup"
+	"github.com/matrix-org/dendrite/userapi"
+)
+
+func main() {
+	cfg := setup.ParseFlags(false)
+	base := setup.NewBaseDendrite(cfg, "UserAPI", true)
+	defer base.Close() // nolint: errcheck
+
+	accountDB := base.CreateAccountsDB()
+	deviceDB := base.CreateDeviceDB()
+
+	userAPI := userapi.NewInternalAPI(accountDB, deviceDB, cfg.Matrix.ServerName, cfg.Derived.ApplicationServices)
+
+	userapi.AddInternalRoutes(base.InternalAPIMux, userAPI)
+
+	base.SetupAndServeHTTP(string(base.Cfg.Bind.UserAPI), string(base.Cfg.Listen.UserAPI))
+}


### PR DESCRIPTION
Signed-off-by: Ashley Nelson <amn@fantashley.com>

I set up appservice to deploy in docker in order to resolve #515 and I verified it spins up as part of the docker-compose polylith deployment. I also added the binary for `dendrite-user-api-server` because the image build script wouldn't complete without it. Please let me know if there's anything I'm missing, thanks!

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] I have added any new tests that need to pass to `testfile` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/CONTRIBUTING.md#sign-off)
