### PR TITLE
Push serverkeyapi docker image to registry as well

### DIFF
--- a/build/docker/images-push.sh
+++ b/build/docker/images-push.sh
@@ -14,4 +14,5 @@ docker push matrixdotorg/dendrite:mediaapi
 docker push matrixdotorg/dendrite:publicroomsapi
 docker push matrixdotorg/dendrite:roomserver
 docker push matrixdotorg/dendrite:syncapi
+docker push matrixdotorg/dendrite:serverkeyapi
 docker push matrixdotorg/dendrite:userapi


### PR DESCRIPTION
I tried to get dendrite running with the images from docker hub. I realized the `serverkeyapi` as well as `userapi` tags are missing. The `userapi` was already in the push script but seems to not have been pushed yet. Could you make sure both get pushed?

Thanks.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] I have added any new tests that need to pass to `testfile` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/CONTRIBUTING.md#sign-off)
