### PR TITLE
Fix room checks for /state and /state_ids

### DIFF
--- a/federationapi/routing/state.go
+++ b/federationapi/routing/state.go
@@ -98,13 +98,17 @@ func getState(
 	roomID string,
 	eventID string,
 ) (*gomatrixserverlib.RespState, *util.JSONResponse) {
-	event, resErr := getEvent(ctx, request, rsAPI, eventID)
+	event, resErr := fetchEvent(ctx, rsAPI, eventID)
 	if resErr != nil {
 		return nil, resErr
 	}
 
 	if event.RoomID() != roomID {
-		return nil, &util.JSONResponse{Code: http.StatusNotFound, JSON: nil}
+		return nil, &util.JSONResponse{Code: http.StatusNotFound, JSON: jsonerror.NotFound("event does not belong to this room")}
+	}
+	resErr = allowedToSeeEvent(ctx, request.Origin(), rsAPI, eventID)
+	if resErr != nil {
+		return nil, resErr
 	}
 
 	var response api.QueryStateAndAuthChainResponse

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -350,3 +350,5 @@ setting 'm.room.name' respects room powerlevel
 Syncing a new room with a large timeline limit isn't limited
 Left rooms appear in the leave section of sync
 Banned rooms appear in the leave section of sync
+Getting state checks the events requested belong to the room
+Getting state IDs checks the events requested belong to the room


### PR DESCRIPTION
We would return a 403 first (as the server would not be allowed to
see this event) and only then return a 404 if the event is not in
the given room. We now invert those checks for /state and /state_ids
to make the tests pass.
