### PR TITLE
Remove trailing slash in client api proxy

### DIFF
--- a/cmd/client-api-proxy/main.go
+++ b/cmd/client-api-proxy/main.go
@@ -58,9 +58,8 @@ var (
 )
 
 func makeProxy(targetURL string) (*httputil.ReverseProxy, error) {
-	if !strings.HasSuffix(targetURL, "/") {
-		targetURL += "/"
-	}
+	targetURL = strings.TrimSuffix(targetURL, "/")
+
 	// Check that we can parse the URL.
 	_, err := url.Parse(targetURL)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Ashley Nelson <amn@fantashley.com>

This removes the trailing slash that causes proxied requests to the client API to result in 404 Not Found errors. Previously it would result in this URL: `http://client_api:7771//_matrix/client/versions` with a double slash after the port. I was able to successfully connect Riot to my polylith deployment once I removed this and I don't see any components emitting errors, so I don't _think_ it causes problems for anything else. I was going to wait to investigate why the trailing slash was explicitly added but someone else from #dendrite ran into this as well so I figured I'd bring it up now.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] I have added any new tests that need to pass to `testfile` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/CONTRIBUTING.md#sign-off)
