### PR TITLE
Fix rejoining rooms we created after wiping the database

### DIFF
--- a/roomserver/internal/perform_join.go
+++ b/roomserver/internal/perform_join.go
@@ -124,7 +124,13 @@ func (r *RoomserverInternalAPI) performJoinRoomByID(
 			Msg:  fmt.Sprintf("Room ID %q is invalid: %s", req.RoomIDOrAlias, err),
 		}
 	}
-	req.ServerNames = append(req.ServerNames, domain)
+
+	// If the server name in the room ID isn't ours then it's a
+	// possible candidate for finding the room via federation. Add
+	// it to the list of servers to try.
+	if domain != r.Cfg.Matrix.ServerName {
+		req.ServerNames = append(req.ServerNames, domain)
+	}
 
 	// Prepare the template for the join event.
 	userID := req.UserID
@@ -233,13 +239,18 @@ func (r *RoomserverInternalAPI) performJoinRoomByID(
 		}
 
 	case eventutil.ErrRoomNoExists:
-		// The room doesn't exist. First of all check if the room is a local
-		// room. If it is then there's nothing more to do - the room just
-		// hasn't been created yet.
+		// The room doesn't exist locally. If the room ID looks like it should
+		// be ours then this probably means that we've nuked our database at
+		// some point.
 		if domain == r.Cfg.Matrix.ServerName {
-			return "", &api.PerformError{
-				Code: api.PerformErrorNoRoom,
-				Msg:  fmt.Sprintf("Room ID %q does not exist", req.RoomIDOrAlias),
+			// If there are no more server names to try then give up here.
+			// Otherwise we'll try a federated join as normal, since it's quite
+			// possible that the room still exists on other servers.
+			if len(req.ServerNames) == 0 {
+				return "", &api.PerformError{
+					Code: api.PerformErrorNoRoom,
+					Msg:  fmt.Sprintf("Room ID %q does not exist", req.RoomIDOrAlias),
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR fixes a bug in the roomserver perform join code that meant that we could give up if we didn't know about a room when the room ID contained our own server name. Not that this is something that should happen every day but it can stop you from rejoining rooms after wiping your database.