### PR TITLE
Hydrate destination queues at startup

### DIFF
--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -251,8 +251,10 @@ func (oq *destinationQueue) backgroundSend() {
 					oq.cleanPendingInvites()
 					return
 				} else {
-					// We haven't been told to give up terminally yet
-					// but we still need to wake up the next iteration.
+					// We haven't been told to give up terminally yet but we still have
+					// PDUs waiting to be sent. By sending a message into the wake chan,
+					// the next loop iteration will try processing these PDUs again,
+					// subject to the backoff.
 					oq.wakeServerCh <- true
 				}
 			} else if transaction {

--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -250,6 +250,10 @@ func (oq *destinationQueue) backgroundSend() {
 					oq.cleanPendingEDUs()
 					oq.cleanPendingInvites()
 					return
+				} else {
+					// We haven't been told to give up terminally yet
+					// but we still need to wake up the next iteration.
+					oq.wakeServerCh <- true
 				}
 			} else if transaction {
 				// If we successfully sent the transaction then clear out

--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -61,10 +61,12 @@ func NewOutgoingQueues(
 		queues:     map[gomatrixserverlib.ServerName]*destinationQueue{},
 	}
 	// Look up which servers we have pending items for and then rehydrate those queues.
-	if serverNames, err := db.GetPendingServerNames(context.TODO()); err == nil {
+	if serverNames, err := db.GetPendingServerNames(context.Background()); err == nil {
 		for _, serverName := range serverNames {
 			queues.getQueue(serverName).wakeQueueIfNeeded()
 		}
+	} else {
+		log.WithError(err).Error("Failed to get server names for destination queue hydration")
 	}
 	return queues
 }

--- a/federationsender/storage/interface.go
+++ b/federationsender/storage/interface.go
@@ -31,4 +31,5 @@ type Database interface {
 	GetNextTransactionPDUs(ctx context.Context, serverName gomatrixserverlib.ServerName, limit int) (gomatrixserverlib.TransactionID, []*gomatrixserverlib.HeaderedEvent, error)
 	CleanTransactionPDUs(ctx context.Context, serverName gomatrixserverlib.ServerName, transactionID gomatrixserverlib.TransactionID) error
 	GetPendingPDUCount(ctx context.Context, serverName gomatrixserverlib.ServerName) (int64, error)
+	GetPendingServerNames(ctx context.Context) ([]gomatrixserverlib.ServerName, error)
 }

--- a/federationsender/storage/postgres/queue_pdus_table.go
+++ b/federationsender/storage/postgres/queue_pdus_table.go
@@ -63,6 +63,9 @@ const selectQueuePDUsCountSQL = "" +
 	"SELECT COUNT(*) FROM federationsender_queue_pdus" +
 	" WHERE server_name = $1"
 
+const selectQueueServerNamesSQL = "" +
+	"SELECT DISTINCT server_name FROM federationsender_queue_pdus"
+
 type queuePDUsStatements struct {
 	insertQueuePDUStmt                *sql.Stmt
 	deleteQueueTransactionPDUsStmt    *sql.Stmt
@@ -70,6 +73,7 @@ type queuePDUsStatements struct {
 	selectQueuePDUsByTransactionStmt  *sql.Stmt
 	selectQueueReferenceJSONCountStmt *sql.Stmt
 	selectQueuePDUsCountStmt          *sql.Stmt
+	selectQueueServerNamesStmt        *sql.Stmt
 }
 
 func (s *queuePDUsStatements) prepare(db *sql.DB) (err error) {
@@ -93,6 +97,9 @@ func (s *queuePDUsStatements) prepare(db *sql.DB) (err error) {
 		return
 	}
 	if s.selectQueuePDUsCountStmt, err = db.Prepare(selectQueuePDUsCountSQL); err != nil {
+		return
+	}
+	if s.selectQueueServerNamesStmt, err = db.Prepare(selectQueueServerNamesSQL); err != nil {
 		return
 	}
 	return
@@ -186,6 +193,27 @@ func (s *queuePDUsStatements) selectQueuePDUs(
 			return nil, err
 		}
 		result = append(result, nid)
+	}
+
+	return result, rows.Err()
+}
+
+func (s *queuePDUsStatements) selectQueueServerNames(
+	ctx context.Context, txn *sql.Tx,
+) ([]gomatrixserverlib.ServerName, error) {
+	stmt := sqlutil.TxStmt(txn, s.selectQueueServerNamesStmt)
+	rows, err := stmt.QueryContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer internal.CloseAndLogIfError(ctx, rows, "queueFromStmt: rows.close() failed")
+	var result []gomatrixserverlib.ServerName
+	for rows.Next() {
+		var serverName gomatrixserverlib.ServerName
+		if err = rows.Scan(&serverName); err != nil {
+			return nil, err
+		}
+		result = append(result, serverName)
 	}
 
 	return result, rows.Err()

--- a/federationsender/storage/postgres/storage.go
+++ b/federationsender/storage/postgres/storage.go
@@ -264,3 +264,11 @@ func (d *Database) GetPendingPDUCount(
 ) (int64, error) {
 	return d.selectQueuePDUCount(ctx, nil, serverName)
 }
+
+// GetPendingServerNames returns the server names that have PDUs
+// waiting to be sent.
+func (d *Database) GetPendingServerNames(
+	ctx context.Context,
+) ([]gomatrixserverlib.ServerName, error) {
+	return d.selectQueueServerNames(ctx, nil)
+}

--- a/federationsender/storage/sqlite3/queue_pdus_table.go
+++ b/federationsender/storage/sqlite3/queue_pdus_table.go
@@ -64,6 +64,9 @@ const selectQueuePDUsCountSQL = "" +
 	"SELECT COUNT(*) FROM federationsender_queue_pdus" +
 	" WHERE server_name = $1"
 
+const selectQueueServerNamesSQL = "" +
+	"SELECT DISTINCT server_name FROM federationsender_queue_pdus"
+
 type queuePDUsStatements struct {
 	insertQueuePDUStmt                *sql.Stmt
 	deleteQueueTransactionPDUsStmt    *sql.Stmt
@@ -71,6 +74,7 @@ type queuePDUsStatements struct {
 	selectQueuePDUsByTransactionStmt  *sql.Stmt
 	selectQueueReferenceJSONCountStmt *sql.Stmt
 	selectQueuePDUsCountStmt          *sql.Stmt
+	selectQueueServerNamesStmt        *sql.Stmt
 }
 
 func (s *queuePDUsStatements) prepare(db *sql.DB) (err error) {
@@ -94,6 +98,9 @@ func (s *queuePDUsStatements) prepare(db *sql.DB) (err error) {
 		return
 	}
 	if s.selectQueuePDUsCountStmt, err = db.Prepare(selectQueuePDUsCountSQL); err != nil {
+		return
+	}
+	if s.selectQueueServerNamesStmt, err = db.Prepare(selectQueueServerNamesSQL); err != nil {
 		return
 	}
 	return
@@ -184,6 +191,27 @@ func (s *queuePDUsStatements) selectQueuePDUs(
 			return nil, err
 		}
 		result = append(result, nid)
+	}
+
+	return result, rows.Err()
+}
+
+func (s *queuePDUsStatements) selectQueueServerNames(
+	ctx context.Context, txn *sql.Tx,
+) ([]gomatrixserverlib.ServerName, error) {
+	stmt := sqlutil.TxStmt(txn, s.selectQueueServerNamesStmt)
+	rows, err := stmt.QueryContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer internal.CloseAndLogIfError(ctx, rows, "queueFromStmt: rows.close() failed")
+	var result []gomatrixserverlib.ServerName
+	for rows.Next() {
+		var serverName gomatrixserverlib.ServerName
+		if err = rows.Scan(&serverName); err != nil {
+			return nil, err
+		}
+		result = append(result, serverName)
 	}
 
 	return result, rows.Err()

--- a/federationsender/storage/sqlite3/storage.go
+++ b/federationsender/storage/sqlite3/storage.go
@@ -270,3 +270,11 @@ func (d *Database) GetPendingPDUCount(
 ) (int64, error) {
 	return d.selectQueuePDUCount(ctx, nil, serverName)
 }
+
+// GetPendingServerNames returns the server names that have PDUs
+// waiting to be sent.
+func (d *Database) GetPendingServerNames(
+	ctx context.Context,
+) ([]gomatrixserverlib.ServerName, error) {
+	return d.selectQueueServerNames(ctx, nil)
+}


### PR DESCRIPTION
This PR asks the database which servers we have pending events for at startup and then starts those queues. This is particularly important for the iOS P2P demo where the app doesn't survive in the background. 