### PR TITLE
Implement local redaction

### DIFF
--- a/clientapi/routing/createroom.go
+++ b/clientapi/routing/createroom.go
@@ -382,7 +382,7 @@ func createRoom(
 			continue
 		}
 		// Build some stripped state for the invite.
-		candidates := append(gomatrixserverlib.UnwrapEventHeaders(builtEvents), *inviteEvent)
+		candidates := append(gomatrixserverlib.UnwrapEventHeaders(builtEvents), inviteEvent.Event)
 		var strippedState []gomatrixserverlib.InviteV2StrippedState
 		for _, event := range candidates {
 			switch event.Type() {

--- a/clientapi/routing/membership.go
+++ b/clientapi/routing/membership.go
@@ -77,7 +77,7 @@ func sendMembership(ctx context.Context, accountDB accounts.Database, device *us
 
 	_, err = roomserverAPI.SendEvents(
 		ctx, rsAPI,
-		[]gomatrixserverlib.HeaderedEvent{*event},
+		[]gomatrixserverlib.HeaderedEvent{event.Event.Headered(roomVer)},
 		cfg.Matrix.ServerName,
 		nil,
 	)

--- a/clientapi/routing/membership.go
+++ b/clientapi/routing/membership.go
@@ -77,7 +77,7 @@ func sendMembership(ctx context.Context, accountDB accounts.Database, device *us
 
 	_, err = roomserverAPI.SendEvents(
 		ctx, rsAPI,
-		[]gomatrixserverlib.HeaderedEvent{event.Headered(roomVer)},
+		[]gomatrixserverlib.HeaderedEvent{*event},
 		cfg.Matrix.ServerName,
 		nil,
 	)
@@ -210,7 +210,7 @@ func SendInvite(
 
 	perr := roomserverAPI.SendInvite(
 		req.Context(), rsAPI,
-		event.Headered(roomVer),
+		event.Event.Headered(roomVer),
 		nil, // ask the roomserver to draw up invite room state for us
 		cfg.Matrix.ServerName,
 		nil,
@@ -232,7 +232,7 @@ func buildMembershipEvent(
 	membership, roomID string, isDirect bool,
 	cfg *config.Dendrite, evTime time.Time,
 	rsAPI roomserverAPI.RoomserverInternalAPI, asAPI appserviceAPI.AppServiceQueryAPI,
-) (*gomatrixserverlib.Event, error) {
+) (*gomatrixserverlib.HeaderedEvent, error) {
 	profile, err := loadProfile(ctx, targetUserID, cfg, accountDB, asAPI)
 	if err != nil {
 		return nil, err

--- a/clientapi/routing/redaction.go
+++ b/clientapi/routing/redaction.go
@@ -74,14 +74,16 @@ func SendRedaction(
 		if plEvent == nil {
 			return util.JSONResponse{
 				Code: 403,
-				JSON: jsonerror.Forbidden("cannot redact event, missing pl event"),
+				JSON: jsonerror.Forbidden("You don't have permission to redact this event, no power_levels event in this room."),
 			}
 		}
 		pl, err := plEvent.PowerLevels()
 		if err != nil {
 			return util.JSONResponse{
 				Code: 403,
-				JSON: jsonerror.Forbidden("cannot redact event, malformed pl event"),
+				JSON: jsonerror.Forbidden(
+					"You don't have permission to redact this event, the power_levels event for this room is malformed so auth checks cannot be performed.",
+				),
 			}
 		}
 		allowedToRedact = pl.UserLevel(device.UserID) >= pl.Redact
@@ -89,7 +91,7 @@ func SendRedaction(
 	if !allowedToRedact {
 		return util.JSONResponse{
 			Code: 403,
-			JSON: jsonerror.Forbidden("cannot redact event"),
+			JSON: jsonerror.Forbidden("You don't have permission to redact this event, power level too low."),
 		}
 	}
 

--- a/clientapi/routing/redaction.go
+++ b/clientapi/routing/redaction.go
@@ -15,6 +15,7 @@
 package routing
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -118,6 +119,11 @@ func SendRedaction(
 			Code: http.StatusNotFound,
 			JSON: jsonerror.NotFound("Room does not exist"),
 		}
+	}
+	_, err = roomserverAPI.SendEvents(context.Background(), rsAPI, []gomatrixserverlib.HeaderedEvent{*e}, cfg.Matrix.ServerName, nil)
+	if err != nil {
+		util.GetLogger(req.Context()).WithError(err).Errorf("failed to SendEvents")
+		return jsonerror.InternalServerError()
 	}
 	return util.JSONResponse{
 		Code: 200,

--- a/clientapi/routing/redaction.go
+++ b/clientapi/routing/redaction.go
@@ -1,0 +1,128 @@
+// Copyright 2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/matrix-org/dendrite/clientapi/httputil"
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	currentstateAPI "github.com/matrix-org/dendrite/currentstateserver/api"
+	"github.com/matrix-org/dendrite/internal/config"
+	"github.com/matrix-org/dendrite/internal/eventutil"
+	"github.com/matrix-org/dendrite/roomserver/api"
+	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
+	userapi "github.com/matrix-org/dendrite/userapi/api"
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/util"
+)
+
+type redactionContent struct {
+	Reason string `json:"reason"`
+}
+
+type redactionResponse struct {
+	EventID string `json:"event_id"`
+}
+
+func SendRedaction(
+	req *http.Request, device *userapi.Device, roomID, eventID string, cfg *config.Dendrite,
+	rsAPI roomserverAPI.RoomserverInternalAPI, stateAPI currentstateAPI.CurrentStateInternalAPI,
+) util.JSONResponse {
+	resErr := checkMemberInRoom(req.Context(), stateAPI, device.UserID, roomID)
+	if resErr != nil {
+		return *resErr
+	}
+
+	ev := roomserverAPI.GetEvent(req.Context(), rsAPI, eventID)
+	if ev == nil {
+		return util.JSONResponse{
+			Code: 400,
+			JSON: jsonerror.NotFound("unknown event ID"), // TODO: is it ok to leak existence?
+		}
+	}
+	if ev.RoomID() != roomID {
+		return util.JSONResponse{
+			Code: 400,
+			JSON: jsonerror.NotFound("cannot redact event in another room"),
+		}
+	}
+
+	// "Users may redact their own events, and any user with a power level greater than or equal
+	// to the redact power level of the room may redact events there"
+	// https://matrix.org/docs/spec/client_server/r0.6.1#put-matrix-client-r0-rooms-roomid-redact-eventid-txnid
+	allowedToRedact := ev.Sender() == device.UserID
+	if !allowedToRedact {
+		plEvent := currentstateAPI.GetEvent(req.Context(), stateAPI, roomID, gomatrixserverlib.StateKeyTuple{
+			EventType: gomatrixserverlib.MRoomPowerLevels,
+			StateKey:  "",
+		})
+		if plEvent == nil {
+			return util.JSONResponse{
+				Code: 403,
+				JSON: jsonerror.Forbidden("cannot redact event, missing pl event"),
+			}
+		}
+		pl, err := plEvent.PowerLevels()
+		if err != nil {
+			return util.JSONResponse{
+				Code: 403,
+				JSON: jsonerror.Forbidden("cannot redact event, malformed pl event"),
+			}
+		}
+		allowedToRedact = pl.UserLevel(device.UserID) >= pl.Redact
+	}
+	if !allowedToRedact {
+		return util.JSONResponse{
+			Code: 403,
+			JSON: jsonerror.Forbidden("cannot redact event"),
+		}
+	}
+
+	var r redactionContent
+	resErr = httputil.UnmarshalJSONRequest(req, &r)
+	if resErr != nil {
+		return *resErr
+	}
+
+	// create the new event and set all the fields we can
+	builder := gomatrixserverlib.EventBuilder{
+		Sender:  device.UserID,
+		RoomID:  roomID,
+		Type:    gomatrixserverlib.MRoomRedaction,
+		Redacts: eventID,
+	}
+	err := builder.SetContent(r)
+	if err != nil {
+		util.GetLogger(req.Context()).WithError(err).Error("builder.SetContent failed")
+		return jsonerror.InternalServerError()
+	}
+
+	var queryRes api.QueryLatestEventsAndStateResponse
+	e, err := eventutil.BuildEvent(req.Context(), &builder, cfg, time.Now(), rsAPI, &queryRes)
+	if err == eventutil.ErrRoomNoExists {
+		return util.JSONResponse{
+			Code: http.StatusNotFound,
+			JSON: jsonerror.NotFound("Room does not exist"),
+		}
+	}
+	return util.JSONResponse{
+		Code: 200,
+		JSON: redactionResponse{
+			EventID: e.EventID(),
+		},
+	}
+}

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -338,6 +338,15 @@ func Setup(
 			return SendTyping(req, device, vars["roomID"], vars["userID"], accountDB, eduAPI, stateAPI)
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
+	r0mux.Handle("/rooms/{roomID}/redact/{eventID}",
+		httputil.MakeAuthAPI("rooms_redact", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
+			if err != nil {
+				return util.ErrorResponse(err)
+			}
+			return SendRedaction(req, device, vars["roomID"], vars["eventID"], cfg, rsAPI, stateAPI)
+		}),
+	).Methods(http.MethodPost, http.MethodOptions)
 
 	r0mux.Handle("/sendToDevice/{eventType}/{txnID}",
 		httputil.MakeAuthAPI("send_to_device", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {

--- a/clientapi/routing/sendevent.go
+++ b/clientapi/routing/sendevent.go
@@ -180,11 +180,11 @@ func generateSendEvent(
 		stateEvents[i] = &queryRes.StateEvents[i].Event
 	}
 	provider := gomatrixserverlib.NewAuthEvents(stateEvents)
-	if err = gomatrixserverlib.Allowed(*e, &provider); err != nil {
+	if err = gomatrixserverlib.Allowed(e.Event, &provider); err != nil {
 		return nil, &util.JSONResponse{
 			Code: http.StatusForbidden,
 			JSON: jsonerror.Forbidden(err.Error()), // TODO: Is this error string comprehensible to the client?
 		}
 	}
-	return e, nil
+	return &e.Event, nil
 }

--- a/currentstateserver/api/wrapper.go
+++ b/currentstateserver/api/wrapper.go
@@ -7,6 +7,24 @@ import (
 	"github.com/matrix-org/util"
 )
 
+// GetEvent returns the current state event in the room or nil.
+func GetEvent(ctx context.Context, stateAPI CurrentStateInternalAPI, roomID string, tuple gomatrixserverlib.StateKeyTuple) *gomatrixserverlib.HeaderedEvent {
+	var res QueryCurrentStateResponse
+	err := stateAPI.QueryCurrentState(ctx, &QueryCurrentStateRequest{
+		RoomID:      roomID,
+		StateTuples: []gomatrixserverlib.StateKeyTuple{tuple},
+	}, &res)
+	if err != nil {
+		util.GetLogger(ctx).WithError(err).Error("Failed to QueryCurrentState")
+		return nil
+	}
+	ev, ok := res.StateEvents[tuple]
+	if ok {
+		return ev
+	}
+	return nil
+}
+
 // PopulatePublicRooms extracts PublicRoom information for all the provided room IDs. The IDs are not checked to see if they are visible in the
 // published room directory.
 // due to lots of switches

--- a/federationapi/routing/join.go
+++ b/federationapi/routing/join.go
@@ -118,7 +118,7 @@ func MakeJoin(
 	}
 
 	provider := gomatrixserverlib.NewAuthEvents(stateEvents)
-	if err = gomatrixserverlib.Allowed(*event, &provider); err != nil {
+	if err = gomatrixserverlib.Allowed(event.Event, &provider); err != nil {
 		return util.JSONResponse{
 			Code: http.StatusForbidden,
 			JSON: jsonerror.Forbidden(err.Error()),

--- a/federationapi/routing/leave.go
+++ b/federationapi/routing/leave.go
@@ -32,15 +32,6 @@ func MakeLeave(
 	rsAPI api.RoomserverInternalAPI,
 	roomID, userID string,
 ) util.JSONResponse {
-	verReq := api.QueryRoomVersionForRoomRequest{RoomID: roomID}
-	verRes := api.QueryRoomVersionForRoomResponse{}
-	if err := rsAPI.QueryRoomVersionForRoom(httpReq.Context(), &verReq, &verRes); err != nil {
-		return util.JSONResponse{
-			Code: http.StatusInternalServerError,
-			JSON: jsonerror.InternalServerError(),
-		}
-	}
-
 	_, domain, err := gomatrixserverlib.SplitID('@', userID)
 	if err != nil {
 		return util.JSONResponse{
@@ -91,7 +82,7 @@ func MakeLeave(
 		stateEvents[i] = &queryRes.StateEvents[i].Event
 	}
 	provider := gomatrixserverlib.NewAuthEvents(stateEvents)
-	if err = gomatrixserverlib.Allowed(*event, &provider); err != nil {
+	if err = gomatrixserverlib.Allowed(event.Event, &provider); err != nil {
 		return util.JSONResponse{
 			Code: http.StatusForbidden,
 			JSON: jsonerror.Forbidden(err.Error()),
@@ -101,7 +92,7 @@ func MakeLeave(
 	return util.JSONResponse{
 		Code: http.StatusOK,
 		JSON: map[string]interface{}{
-			"room_version": verRes.RoomVersion,
+			"room_version": event.RoomVersion,
 			"event":        builder,
 		},
 	}

--- a/roomserver/api/wrapper.go
+++ b/roomserver/api/wrapper.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/util"
 )
 
 // SendEvents to the roomserver The events are written with KindNew.
@@ -114,4 +115,20 @@ func SendInvite(
 		return response.Error
 	}
 	return nil
+}
+
+// GetEvent returns the event or nil, even on errors.
+func GetEvent(ctx context.Context, rsAPI RoomserverInternalAPI, eventID string) *gomatrixserverlib.HeaderedEvent {
+	var res QueryEventsByIDResponse
+	err := rsAPI.QueryEventsByID(ctx, &QueryEventsByIDRequest{
+		EventIDs: []string{eventID},
+	}, &res)
+	if err != nil {
+		util.GetLogger(ctx).WithError(err).Error("Failed to QueryEventsByID")
+		return nil
+	}
+	if len(res.Events) != 1 {
+		return nil
+	}
+	return &res.Events[0]
 }

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -289,6 +289,10 @@ Inbound federation can return events
 Inbound federation can return missing events for world_readable visibility
 Inbound federation can return missing events for invite visibility
 Inbound federation can get public room list
+POST /rooms/:room_id/redact/:event_id as power user redacts message
+POST /rooms/:room_id/redact/:event_id as original message sender redacts message
+POST /rooms/:room_id/redact/:event_id as random user does not redact message
+POST /redact disallows redaction of event in different room
 An event which redacts itself should be ignored
 A pair of events which redact each other should be ignored
 Outbound federation can backfill events


### PR DESCRIPTION
- Add `/redact` endpoint.
- Perform checks according to spec.
- Make redaction events.
- Send them to the roomserver.

Few minor refactors:
 - Add more wrapper functions for interacting with internal APIs (one liners are nice).
 - Return a headered event when building an event as we must know the room version by then.

Critically this does not:
 - Redact events in the roomserver database or mark them as redacted.
 - Redact events in the syncapi database or mark them as redacted.

See work by @Cnly at https://github.com/matrix-org/dendrite/pull/768 for what this might entail - and we have room versions now so we can finish it all up. Unknown if this works currently over federation.