### PR TITLE
 bugfix: continue sending PDUs if ones are added whilst sending another PDU

### DIFF
--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -65,6 +65,7 @@ type destinationQueue struct {
 func (oq *destinationQueue) sendEvent(nid int64) {
 	if oq.statistics.Blacklisted() {
 		// If the destination is blacklisted then drop the event.
+		log.Infof("%s is blacklisted; dropping event", oq.destination)
 		return
 	}
 	oq.wakeQueueIfNeeded()
@@ -214,6 +215,7 @@ func (oq *destinationQueue) backgroundSend() {
 		// backoff duration to complete first, or until explicitly
 		// told to retry.
 		if backoff, duration := oq.statistics.BackoffDuration(); backoff {
+			log.WithField("duration", duration).Infof("Backing off %s", oq.destination)
 			oq.backingOff.Store(true)
 			select {
 			case <-time.After(duration):
@@ -336,6 +338,7 @@ func (oq *destinationQueue) nextTransaction(
 	// If we didn't get anything from the database and there are no
 	// pending EDUs then there's nothing to do - stop here.
 	if len(pdus) == 0 && len(pendingEDUs) == 0 {
+		log.Warnf("no pdus/edus for nextTransaction for destination %q", oq.destination)
 		return false, nil
 	}
 

--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -225,7 +225,7 @@ func (oq *destinationQueue) backgroundSend() {
 		}
 
 		// If we have pending PDUs or EDUs then construct a transaction.
-		if oq.pendingPDUs.Load() > 0 || len(oq.pendingEDUs) > 0 {
+		for oq.pendingPDUs.Load() > 0 || len(oq.pendingEDUs) > 0 {
 			// Try sending the next transaction and see what happens.
 			transaction, terr := oq.nextTransaction(oq.pendingEDUs)
 			if terr != nil {

--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -276,10 +276,10 @@ func (oq *destinationQueue) backgroundSend() {
 			}
 		}
 
-		// If something else has come along since we sent the previous
-		// transactions then we want the next loop iteration to skip the
-		// wait and not go to sleep. In which case, if there isn't a
-		// wake-up message already, send one.
+		// If something else has come along while we were busy sending
+		// the previous transaction then we don't want the next loop
+		// iteration to sleep. Send a message if someone else hasn't
+		// already sent a wake-up.
 		if oq.pendingPDUs.Load() > 0 {
 			select {
 			case oq.notifyPDUs <- true:

--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -250,8 +250,6 @@ func (oq *destinationQueue) backgroundSend() {
 				oq.statistics.Success()
 				// Clean up the in-memory buffers.
 				oq.cleanPendingEDUs()
-			} else {
-				break
 			}
 		}
 

--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -250,6 +250,8 @@ func (oq *destinationQueue) backgroundSend() {
 				oq.statistics.Success()
 				// Clean up the in-memory buffers.
 				oq.cleanPendingEDUs()
+			} else {
+				break
 			}
 		}
 

--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -93,7 +93,7 @@ func (oqs *OutgoingQueues) getQueue(destination gomatrixserverlib.ServerName) *d
 			statistics:       oqs.statistics.ForServer(destination),
 			incomingEDUs:     make(chan *gomatrixserverlib.EDU, 128),
 			incomingInvites:  make(chan *gomatrixserverlib.InviteV2Request, 128),
-			notifyPDUs:       make(chan bool, 128),
+			notifyPDUs:       make(chan bool, 1),
 			interruptBackoff: make(chan bool),
 			signing:          oqs.signing,
 		}


### PR DESCRIPTION

Without this, the queue goes back to sleep on `<-oq.notifyPDUs` which won't
fire because `pendingPDUs` is already > 0. This should fix a flakey sytest.