### PR TITLE
Add /v1/upload to media API

### DIFF
--- a/mediaapi/routing/routing.go
+++ b/mediaapi/routing/routing.go
@@ -53,12 +53,16 @@ func Setup(
 	activeThumbnailGeneration := &types.ActiveThumbnailGeneration{
 		PathToResult: map[string]*types.ThumbnailGenerationResult{},
 	}
-	r0mux.Handle("/upload", httputil.MakeAuthAPI(
+
+	uploadHandler := httputil.MakeAuthAPI(
 		"upload", userAPI,
 		func(req *http.Request, _ *userapi.Device) util.JSONResponse {
 			return Upload(req, cfg, db, activeThumbnailGeneration)
 		},
-	)).Methods(http.MethodPost, http.MethodOptions)
+	)
+
+	r0mux.Handle("/upload", uploadHandler).Methods(http.MethodPost, http.MethodOptions)
+	v1mux.Handle("/upload", uploadHandler).Methods(http.MethodPost, http.MethodOptions)
 
 	activeRemoteRequests := &types.ActiveRemoteRequests{
 		MXCToResult: map[string]*types.RemoteRequestResult{},


### PR DESCRIPTION
Riot iOS apparently uses `v1` instead of `r0` so this adds `/upload` to both.