### PR TITLE
Adding the e2ekey database to the create_db script and docs

### DIFF
--- a/build/docker/postgres/create_db.sh
+++ b/build/docker/postgres/create_db.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-for db in account device mediaapi syncapi roomserver serverkey federationsender currentstate appservice naffka; do
+for db in account device mediaapi syncapi roomserver serverkey federationsender currentstate appservice e2ekey naffka; do
     createdb -U dendrite -O dendrite dendrite_$db
 done

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -109,7 +109,7 @@ Assuming that Postgres 9.5 (or later) is installed:
 * Create the component databases:
 
   ```bash
-  for i in account device mediaapi syncapi roomserver serverkey federationsender currentstate appservice naffka; do
+  for i in account device mediaapi syncapi roomserver serverkey federationsender currentstate appservice e2ekey naffka; do
       sudo -u postgres createdb -O dendrite dendrite_$i
   done
   ```


### PR DESCRIPTION
Just adding a the `e2ekey` database to the `create_db.sh` and `INSTALL.md`. I had just noticed it wasn't already created when I tried running it locally recently.

Signed-off-by: Creed Haymond <creedasaurus@gmail.com>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] I have added any new tests that need to pass to `testfile` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/CONTRIBUTING.md#sign-off)
