### PR TITLE
currentstate: Add QuerySharedUsers

### DIFF
--- a/currentstateserver/api/api.go
+++ b/currentstateserver/api/api.go
@@ -31,6 +31,16 @@ type CurrentStateInternalAPI interface {
 	QueryRoomsForUser(ctx context.Context, req *QueryRoomsForUserRequest, res *QueryRoomsForUserResponse) error
 	// QueryBulkStateContent does a bulk query for state event content in the given rooms.
 	QueryBulkStateContent(ctx context.Context, req *QueryBulkStateContentRequest, res *QueryBulkStateContentResponse) error
+	// QuerySharedUsers returns a list of users who share at least 1 room in common with the given user.
+	QuerySharedUsers(ctx context.Context, req *QuerySharedUsersRequest, res *QuerySharedUsersResponse) error
+}
+
+type QuerySharedUsersRequest struct {
+	UserID string
+}
+
+type QuerySharedUsersResponse struct {
+	UserIDs []string
 }
 
 type QueryRoomsForUserRequest struct {

--- a/currentstateserver/internal/api.go
+++ b/currentstateserver/internal/api.go
@@ -68,3 +68,16 @@ func (a *CurrentStateInternalAPI) QueryBulkStateContent(ctx context.Context, req
 	}
 	return nil
 }
+
+func (a *CurrentStateInternalAPI) QuerySharedUsers(ctx context.Context, req *api.QuerySharedUsersRequest, res *api.QuerySharedUsersResponse) error {
+	roomIDs, err := a.DB.GetRoomsByMembership(ctx, req.UserID, "join")
+	if err != nil {
+		return err
+	}
+	users, err := a.DB.JoinedUsersSetInRooms(ctx, roomIDs)
+	if err != nil {
+		return err
+	}
+	res.UserIDs = users
+	return nil
+}

--- a/currentstateserver/inthttp/client.go
+++ b/currentstateserver/inthttp/client.go
@@ -29,6 +29,7 @@ const (
 	QueryCurrentStatePath     = "/currentstateserver/queryCurrentState"
 	QueryRoomsForUserPath     = "/currentstateserver/queryRoomsForUser"
 	QueryBulkStateContentPath = "/currentstateserver/queryBulkStateContent"
+	QuerySharedUsersPath      = "/currentstateserver/querySharedUsers"
 )
 
 // NewCurrentStateAPIClient creates a CurrentStateInternalAPI implemented by talking to a HTTP POST API.
@@ -85,4 +86,14 @@ func (h *httpCurrentStateInternalAPI) QueryBulkStateContent(
 
 	apiURL := h.apiURL + QueryBulkStateContentPath
 	return httputil.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+}
+
+func (h *httpCurrentStateInternalAPI) QuerySharedUsers(
+	ctx context.Context, req *api.QuerySharedUsersRequest, res *api.QuerySharedUsersResponse,
+) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "QuerySharedUsers")
+	defer span.Finish()
+
+	apiURL := h.apiURL + QuerySharedUsersPath
+	return httputil.PostJSON(ctx, span, h.httpClient, apiURL, req, res)
 }

--- a/currentstateserver/inthttp/server.go
+++ b/currentstateserver/inthttp/server.go
@@ -64,4 +64,17 @@ func AddRoutes(internalAPIMux *mux.Router, intAPI api.CurrentStateInternalAPI) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
+	internalAPIMux.Handle(QuerySharedUsersPath,
+		httputil.MakeInternalAPI("querySharedUsers", func(req *http.Request) util.JSONResponse {
+			request := api.QuerySharedUsersRequest{}
+			response := api.QuerySharedUsersResponse{}
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.MessageResponse(http.StatusBadRequest, err.Error())
+			}
+			if err := intAPI.QuerySharedUsers(req.Context(), &request, &response); err != nil {
+				return util.ErrorResponse(err)
+			}
+			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
+		}),
+	)
 }

--- a/currentstateserver/storage/interface.go
+++ b/currentstateserver/storage/interface.go
@@ -37,4 +37,6 @@ type Database interface {
 	GetBulkStateContent(ctx context.Context, roomIDs []string, tuples []gomatrixserverlib.StateKeyTuple, allowWildcards bool) ([]tables.StrippedEvent, error)
 	// Redact a state event
 	RedactEvent(ctx context.Context, redactedEventID string, redactedBecause gomatrixserverlib.HeaderedEvent) error
+	// JoinedUsersSetInRooms returns all joined users in the rooms given.
+	JoinedUsersSetInRooms(ctx context.Context, roomIDs []string) ([]string, error)
 }

--- a/currentstateserver/storage/shared/storage.go
+++ b/currentstateserver/storage/shared/storage.go
@@ -85,3 +85,7 @@ func (d *Database) StoreStateEvents(ctx context.Context, addStateEvents []gomatr
 func (d *Database) GetRoomsByMembership(ctx context.Context, userID, membership string) ([]string, error) {
 	return d.CurrentRoomState.SelectRoomIDsWithMembership(ctx, nil, userID, membership)
 }
+
+func (d *Database) JoinedUsersSetInRooms(ctx context.Context, roomIDs []string) ([]string, error) {
+	return d.CurrentRoomState.SelectJoinedUsersSetForRooms(ctx, roomIDs)
+}

--- a/currentstateserver/storage/tables/interface.go
+++ b/currentstateserver/storage/tables/interface.go
@@ -36,6 +36,8 @@ type CurrentRoomState interface {
 	// SelectRoomIDsWithMembership returns the list of room IDs which have the given user in the given membership state.
 	SelectRoomIDsWithMembership(ctx context.Context, txn *sql.Tx, userID string, membership string) ([]string, error)
 	SelectBulkStateContent(ctx context.Context, roomIDs []string, tuples []gomatrixserverlib.StateKeyTuple, allowWildcards bool) ([]StrippedEvent, error)
+	// SelectJoinedUsersSetForRooms returns the set of all users in the rooms who are joined to any of these rooms.
+	SelectJoinedUsersSetForRooms(ctx context.Context, roomIDs []string) ([]string, error)
 }
 
 // StrippedEvent represents a stripped event for returning extracted content values.


### PR DESCRIPTION
This will be used to determine who to send device list updates to. It
can also be used to determine who to send presence info to.

Synapse aggressively caches the result of this. Postgres has correct indexes in place as per:
```
dendrite=# EXPLAIN SELECT DISTINCT state_key FROM currentstate_current_room_state WHERE room_id IN ('!foo:bar', '!foo2:bar') AND type = 'm.room.member' and content_value = 'join';
                                                        QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
 Unique  (cost=0.14..8.17 rows=1 width=32)
   ->  Index Scan using currentstate_membership_idx on currentstate_current_room_state  (cost=0.14..8.17 rows=1 width=32)
         Index Cond: (content_value = 'join'::text)
         Filter: (room_id = ANY ('{!foo:bar,!foo2:bar}'::text[]))
```

We can investigate performance of this long term. At present, this will be called every time a room state change occurs or a new device gets added, so optimising it would be worthwhile.