### PR TITLE
Modify QuerySharedUsers to handle counts/include/exclude

### DIFF
--- a/currentstateserver/api/api.go
+++ b/currentstateserver/api/api.go
@@ -36,11 +36,13 @@ type CurrentStateInternalAPI interface {
 }
 
 type QuerySharedUsersRequest struct {
-	UserID string
+	UserID         string
+	ExcludeRoomIDs []string
+	IncludeRoomIDs []string
 }
 
 type QuerySharedUsersResponse struct {
-	UserIDs []string
+	UserIDsToCount map[string]int
 }
 
 type QueryRoomsForUserRequest struct {

--- a/currentstateserver/internal/api.go
+++ b/currentstateserver/internal/api.go
@@ -74,10 +74,29 @@ func (a *CurrentStateInternalAPI) QuerySharedUsers(ctx context.Context, req *api
 	if err != nil {
 		return err
 	}
+	for _, roomID := range req.IncludeRoomIDs {
+		roomIDs = append(roomIDs, roomID)
+	}
+	excludeMap := make(map[string]bool)
+	for _, roomID := range req.ExcludeRoomIDs {
+		excludeMap[roomID] = true
+	}
+	// filter out excluded rooms
+	j := 0
+	for i := range roomIDs {
+		// move elements to include to the beginning of the slice
+		// then trim elements on the right
+		if !excludeMap[roomIDs[i]] {
+			roomIDs[j] = roomIDs[i]
+			j++
+		}
+	}
+	roomIDs = roomIDs[:j]
+
 	users, err := a.DB.JoinedUsersSetInRooms(ctx, roomIDs)
 	if err != nil {
 		return err
 	}
-	res.UserIDs = users
+	res.UserIDsToCount = users
 	return nil
 }

--- a/currentstateserver/internal/api.go
+++ b/currentstateserver/internal/api.go
@@ -74,9 +74,7 @@ func (a *CurrentStateInternalAPI) QuerySharedUsers(ctx context.Context, req *api
 	if err != nil {
 		return err
 	}
-	for _, roomID := range req.IncludeRoomIDs {
-		roomIDs = append(roomIDs, roomID)
-	}
+	roomIDs = append(roomIDs, req.IncludeRoomIDs...)
 	excludeMap := make(map[string]bool)
 	for _, roomID := range req.ExcludeRoomIDs {
 		excludeMap[roomID] = true

--- a/currentstateserver/storage/interface.go
+++ b/currentstateserver/storage/interface.go
@@ -37,6 +37,6 @@ type Database interface {
 	GetBulkStateContent(ctx context.Context, roomIDs []string, tuples []gomatrixserverlib.StateKeyTuple, allowWildcards bool) ([]tables.StrippedEvent, error)
 	// Redact a state event
 	RedactEvent(ctx context.Context, redactedEventID string, redactedBecause gomatrixserverlib.HeaderedEvent) error
-	// JoinedUsersSetInRooms returns all joined users in the rooms given.
-	JoinedUsersSetInRooms(ctx context.Context, roomIDs []string) ([]string, error)
+	// JoinedUsersSetInRooms returns all joined users in the rooms given, along with the count of how many times they appear.
+	JoinedUsersSetInRooms(ctx context.Context, roomIDs []string) (map[string]int, error)
 }

--- a/currentstateserver/storage/shared/storage.go
+++ b/currentstateserver/storage/shared/storage.go
@@ -86,6 +86,6 @@ func (d *Database) GetRoomsByMembership(ctx context.Context, userID, membership 
 	return d.CurrentRoomState.SelectRoomIDsWithMembership(ctx, nil, userID, membership)
 }
 
-func (d *Database) JoinedUsersSetInRooms(ctx context.Context, roomIDs []string) ([]string, error) {
+func (d *Database) JoinedUsersSetInRooms(ctx context.Context, roomIDs []string) (map[string]int, error) {
 	return d.CurrentRoomState.SelectJoinedUsersSetForRooms(ctx, roomIDs)
 }

--- a/currentstateserver/storage/tables/interface.go
+++ b/currentstateserver/storage/tables/interface.go
@@ -36,8 +36,9 @@ type CurrentRoomState interface {
 	// SelectRoomIDsWithMembership returns the list of room IDs which have the given user in the given membership state.
 	SelectRoomIDsWithMembership(ctx context.Context, txn *sql.Tx, userID string, membership string) ([]string, error)
 	SelectBulkStateContent(ctx context.Context, roomIDs []string, tuples []gomatrixserverlib.StateKeyTuple, allowWildcards bool) ([]StrippedEvent, error)
-	// SelectJoinedUsersSetForRooms returns the set of all users in the rooms who are joined to any of these rooms.
-	SelectJoinedUsersSetForRooms(ctx context.Context, roomIDs []string) ([]string, error)
+	// SelectJoinedUsersSetForRooms returns the set of all users in the rooms who are joined to any of these rooms, along with the
+	// counts of how many rooms they are joined.
+	SelectJoinedUsersSetForRooms(ctx context.Context, roomIDs []string) (map[string]int, error)
 }
 
 // StrippedEvent represents a stripped event for returning extracted content values.


### PR DESCRIPTION
We will need this functionality when working out whether to
send device list changes to users who have joined/left a room.
