### PR TITLE
SelectJoinedHostsForRooms should use QueryVariadic on SQLite

### DIFF
--- a/federationsender/storage/sqlite3/joined_hosts_table.go
+++ b/federationsender/storage/sqlite3/joined_hosts_table.go
@@ -166,7 +166,7 @@ func (s *joinedHostsStatements) SelectJoinedHostsForRooms(
 		iRoomIDs[i] = roomIDs[i]
 	}
 
-	sql := strings.Replace(s.selectJoinedHostsForRoomsSQL, "($1)", sqlutil.QueryVariadic(len(iRoomIDs)), 1)
+	sql := strings.Replace(selectJoinedHostsForRoomsSQL, "($1)", sqlutil.QueryVariadic(len(iRoomIDs)), 1)
 	rows, err := s.db.QueryContext(ctx, sql, iRoomIDs...)
 	if err != nil {
 		return nil, err

--- a/federationsender/storage/sqlite3/joined_hosts_table.go
+++ b/federationsender/storage/sqlite3/joined_hosts_table.go
@@ -166,7 +166,7 @@ func (s *joinedHostsStatements) SelectJoinedHostsForRooms(
 		iRoomIDs[i] = roomIDs[i]
 	}
 
-	sql := strings.Replace(s.selectJoinedHostsForRoomsSQL, "($1)", sqlutil.QueryVariadic(len(iRoomIDs)))
+	sql := strings.Replace(s.selectJoinedHostsForRoomsSQL, "($1)", sqlutil.QueryVariadic(len(iRoomIDs)), 1)
 	rows, err := s.db.QueryContext(ctx, sql, iRoomIDs...)
 	if err != nil {
 		return nil, err

--- a/federationsender/storage/sqlite3/joined_hosts_table.go
+++ b/federationsender/storage/sqlite3/joined_hosts_table.go
@@ -18,6 +18,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
+	"strings"
 
 	"github.com/matrix-org/dendrite/federationsender/types"
 	"github.com/matrix-org/dendrite/internal"
@@ -63,13 +64,13 @@ const selectJoinedHostsForRoomsSQL = "" +
 	"SELECT DISTINCT server_name FROM federationsender_joined_hosts WHERE room_id IN ($1)"
 
 type joinedHostsStatements struct {
-	db                            *sql.DB
-	writer                        *sqlutil.TransactionWriter
-	insertJoinedHostsStmt         *sql.Stmt
-	deleteJoinedHostsStmt         *sql.Stmt
-	selectJoinedHostsStmt         *sql.Stmt
-	selectAllJoinedHostsStmt      *sql.Stmt
-	selectJoinedHostsForRoomsStmt *sql.Stmt
+	db                       *sql.DB
+	writer                   *sqlutil.TransactionWriter
+	insertJoinedHostsStmt    *sql.Stmt
+	deleteJoinedHostsStmt    *sql.Stmt
+	selectJoinedHostsStmt    *sql.Stmt
+	selectAllJoinedHostsStmt *sql.Stmt
+	// selectJoinedHostsForRoomsStmt *sql.Stmt - prepared at runtime due to variadic
 }
 
 func NewSQLiteJoinedHostsTable(db *sql.DB) (s *joinedHostsStatements, err error) {
@@ -91,9 +92,6 @@ func NewSQLiteJoinedHostsTable(db *sql.DB) (s *joinedHostsStatements, err error)
 		return
 	}
 	if s.selectAllJoinedHostsStmt, err = db.Prepare(selectAllJoinedHostsSQL); err != nil {
-		return
-	}
-	if s.selectJoinedHostsForRoomsStmt, err = db.Prepare(selectJoinedHostsForRoomsSQL); err != nil {
 		return
 	}
 	return
@@ -168,7 +166,8 @@ func (s *joinedHostsStatements) SelectJoinedHostsForRooms(
 		iRoomIDs[i] = roomIDs[i]
 	}
 
-	rows, err := s.selectJoinedHostsForRoomsStmt.QueryContext(ctx, iRoomIDs...)
+	sql := strings.Replace(s.selectJoinedHostsForRoomsSQL, "($1)", sqlutil.QueryVariadic(len(iRoomIDs)))
+	rows, err := s.db.QueryContext(ctx, sql, iRoomIDs...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`SelectJoinedHostsForRooms` was preparing the statement and calling it directly, rather than replacing `($1)` with the correct variadic query.

It should fix a whole load of errors like this:
```
time="2020-08-04T16:30:10.697400278Z" level=error msg="failed to calculate joined hosts for rooms user is in" func="github.com/matrix-org/dendrite/federationsender/consumers.(*KeyChangeConsumer).onMessage" file="/src/federationsender/consumers/keychange.go:106" error="sql: expected 1 arguments, got 0" user_id="@anon-20200804_162958-24:localhost:8800"
```