### PR TITLE
Tweak log levels of some federation logging

### DIFF
--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -218,7 +218,9 @@ func (t *txnReq) processTransaction() (*gomatrixserverlib.RespSend, *util.JSONRe
 	}
 
 	t.processEDUs(t.EDUs)
-	util.GetLogger(t.context).Infof("Processed %d PDUs from transaction %q", len(results), t.TransactionID)
+	if c := len(results); c > 0 {
+		util.GetLogger(t.context).Infof("Processed %d PDUs from transaction %q", c, t.TransactionID)
+	}
 	return &gomatrixserverlib.RespSend{PDUs: results}, nil
 }
 
@@ -315,7 +317,7 @@ func (t *txnReq) processEDUs(edus []gomatrixserverlib.EDU) {
 		case gomatrixserverlib.MDeviceListUpdate:
 			t.processDeviceListUpdate(e)
 		default:
-			util.GetLogger(t.context).WithField("type", e.Type).Warn("unhandled edu")
+			util.GetLogger(t.context).WithField("type", e.Type).Debug("Unhandled EDU")
 		}
 	}
 }

--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -255,7 +255,7 @@ func (oq *destinationQueue) backgroundSend() {
 			// The worker is idle so stop the goroutine. It'll get
 			// restarted automatically the next time we have an event to
 			// send.
-			log.Infof("Queue %q has been idle for %s, going to sleep", oq.destination, queueIdleTimeout)
+			log.Debugf("Queue %q has been idle for %s, going to sleep", oq.destination, queueIdleTimeout)
 			return
 		}
 
@@ -263,12 +263,12 @@ func (oq *destinationQueue) backgroundSend() {
 		// backoff duration to complete first, or until explicitly
 		// told to retry.
 		if backoff, duration := oq.statistics.BackoffDuration(); backoff {
-			log.WithField("duration", duration).Infof("Backing off %s", oq.destination)
+			log.WithField("duration", duration).Debugf("Backing off %s", oq.destination)
 			oq.backingOff.Store(true)
 			select {
 			case <-time.After(duration):
 			case <-oq.interruptBackoff:
-				log.Infof("Interrupting backoff for %q", oq.destination)
+				log.Debugf("Interrupting backoff for %q", oq.destination)
 			}
 			oq.backingOff.Store(false)
 		}
@@ -414,7 +414,7 @@ func (oq *destinationQueue) nextTransaction() (bool, error) {
 		t.EDUs = append(t.EDUs, *edu)
 	}
 
-	logrus.WithField("server_name", oq.destination).Infof("Sending transaction %q containing %d PDUs, %d EDUs", t.TransactionID, len(t.PDUs), len(t.EDUs))
+	logrus.WithField("server_name", oq.destination).Debugf("Sending transaction %q containing %d PDUs, %d EDUs", t.TransactionID, len(t.PDUs), len(t.EDUs))
 
 	// Try to send the transaction to the destination server.
 	// TODO: we should check for 500-ish fails vs 400-ish here,

--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -136,7 +136,7 @@ func (oqs *OutgoingQueues) SendEvent(
 
 	log.WithFields(log.Fields{
 		"destinations": destinations, "event": ev.EventID(),
-	}).Info("Sending event")
+	}).Infof("Sending event")
 
 	headeredJSON, err := json.Marshal(ev)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -21,9 +21,9 @@ require (
 	github.com/matrix-org/go-http-js-libp2p v0.0.0-20200518170932-783164aeeda4
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20200522092705-bc8506ccbcf3
 	github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20200807122736-eb1a0b991914
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20200807132727-7b8c09bcdfb2
 	github.com/matrix-org/naffka v0.0.0-20200422140631-181f1ee7401f
-	github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7
+	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4
 	github.com/mattn/go-sqlite3 v2.0.2+incompatible
 	github.com/nfnt/resize v0.0.0-20160724205520-891127d8d1b5
 	github.com/ngrok/sqlmw v0.0.0-20200129213757-d5c93a81bec6

--- a/go.sum
+++ b/go.sum
@@ -421,12 +421,14 @@ github.com/matrix-org/go-sqlite3-js v0.0.0-20200522092705-bc8506ccbcf3 h1:Yb+Wlf
 github.com/matrix-org/go-sqlite3-js v0.0.0-20200522092705-bc8506ccbcf3/go.mod h1:e+cg2q7C7yE5QnAXgzo512tgFh1RbQLC0+jozuegKgo=
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26 h1:Hr3zjRsq2bhrnp3Ky1qgx/fzCtCALOoGYylh2tpS9K4=
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200807122736-eb1a0b991914 h1:VSGCvSUB1/Y32F/JSjmTaIW9jr1BmBHEd0ok4AaT/lo=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200807122736-eb1a0b991914/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200807132727-7b8c09bcdfb2 h1:3eJsj8uJcr/rrxuIAY+kkIYBJUOeJkzQ8Vb4juvddXU=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200807132727-7b8c09bcdfb2/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
 github.com/matrix-org/naffka v0.0.0-20200422140631-181f1ee7401f h1:pRz4VTiRCO4zPlEMc3ESdUOcW4PXHH4Kj+YDz1XyE+Y=
 github.com/matrix-org/naffka v0.0.0-20200422140631-181f1ee7401f/go.mod h1:y0oDTjZDv5SM9a2rp3bl+CU+bvTRINQsdb7YlDql5Go=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7 h1:ntrLa/8xVzeSs8vHFHK25k0C+NV74sYMJnNSg5NoSRo=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7/go.mod h1:vVQlW/emklohkZnOPwD3LrZUBqdfsbiyO3p1lNV8F6U=
+github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4 h1:eCEHXWDv9Rm335MSuB49mFUK44bwZPFSDde3ORE3syk=
+github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4/go.mod h1:vVQlW/emklohkZnOPwD3LrZUBqdfsbiyO3p1lNV8F6U=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.1 h1:G1f5SKeVxmagw/IyvzvtZE4Gybcc4Tr1tf7I8z0XgOg=
 github.com/mattn/go-colorable v0.1.1/go.mod h1:FuOcm+DKB9mbwrcAfNl7/TZVBZ6rcnceauSikq3lYCQ=


### PR DESCRIPTION
This reduces the logging level of some of the federation logging from `Info` to `Debug`. 

Associated with #1244.