### PR TITLE
API setup refactoring

### DIFF
--- a/build/gobind/monolith.go
+++ b/build/gobind/monolith.go
@@ -184,8 +184,8 @@ func (m *DendriteMonolith) Start() {
 	httpRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
 
 	yggRouter := mux.NewRouter()
-	httpRouter.PathPrefix(httputil.ExternalFederationPathPrefix).Handler(base.ExternalFederationAPIMux)
-	httpRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
+	yggRouter.PathPrefix(httputil.ExternalFederationPathPrefix).Handler(base.ExternalFederationAPIMux)
+	yggRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
 
 	// Build both ends of a HTTP multiplex.
 	m.httpServer = &http.Server{

--- a/build/gobind/monolith.go
+++ b/build/gobind/monolith.go
@@ -184,7 +184,7 @@ func (m *DendriteMonolith) Start() {
 	httpRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
 
 	yggRouter := mux.NewRouter()
-	httpRouter.PathPrefix(httputil.ExternalFederationPathPrefix).Handler(base.ExternalClientAPIMux)
+	httpRouter.PathPrefix(httputil.ExternalFederationPathPrefix).Handler(base.ExternalFederationAPIMux)
 	httpRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
 
 	// Build both ends of a HTTP multiplex.

--- a/build/gobind/monolith.go
+++ b/build/gobind/monolith.go
@@ -18,7 +18,6 @@ import (
 	"github.com/matrix-org/dendrite/federationsender"
 	"github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/dendrite/internal/config"
-	"github.com/matrix-org/dendrite/internal/httputil"
 	"github.com/matrix-org/dendrite/internal/setup"
 	"github.com/matrix-org/dendrite/keyserver"
 	"github.com/matrix-org/dendrite/roomserver"
@@ -172,14 +171,6 @@ func (m *DendriteMonolith) Start() {
 	}
 	monolith.AddAllPublicRoutes(base.PublicAPIMux)
 
-	httputil.SetupHTTPAPI(
-		base.BaseMux,
-		base.PublicAPIMux,
-		base.InternalAPIMux,
-		&cfg.Global,
-		base.UseHTTPAPIs,
-	)
-
 	// Build both ends of a HTTP multiplex.
 	m.httpServer = &http.Server{
 		Addr:         ":0",
@@ -190,7 +181,7 @@ func (m *DendriteMonolith) Start() {
 		BaseContext: func(_ net.Listener) context.Context {
 			return context.Background()
 		},
-		Handler: base.BaseMux,
+		Handler: base.PublicAPIMux,
 	}
 
 	go func() {

--- a/build/gobind/monolith.go
+++ b/build/gobind/monolith.go
@@ -172,20 +172,20 @@ func (m *DendriteMonolith) Start() {
 		),
 	}
 	monolith.AddAllPublicRoutes(
-		base.ExternalClientAPIMux,
-		base.ExternalFederationAPIMux,
-		base.ExternalKeyAPIMux,
-		base.ExternalMediaAPIMux,
+		base.PublicClientAPIMux,
+		base.PublicFederationAPIMux,
+		base.PublicKeyAPIMux,
+		base.PublicMediaAPIMux,
 	)
 
 	httpRouter := mux.NewRouter()
 	httpRouter.PathPrefix(httputil.InternalPathPrefix).Handler(base.InternalAPIMux)
-	httpRouter.PathPrefix(httputil.ExternalClientPathPrefix).Handler(base.ExternalClientAPIMux)
-	httpRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
+	httpRouter.PathPrefix(httputil.PublicClientPathPrefix).Handler(base.PublicClientAPIMux)
+	httpRouter.PathPrefix(httputil.PublicMediaPathPrefix).Handler(base.PublicMediaAPIMux)
 
 	yggRouter := mux.NewRouter()
-	yggRouter.PathPrefix(httputil.ExternalFederationPathPrefix).Handler(base.ExternalFederationAPIMux)
-	yggRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
+	yggRouter.PathPrefix(httputil.PublicFederationPathPrefix).Handler(base.PublicFederationAPIMux)
+	yggRouter.PathPrefix(httputil.PublicMediaPathPrefix).Handler(base.PublicMediaAPIMux)
 
 	// Build both ends of a HTTP multiplex.
 	m.httpServer = &http.Server{

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -40,9 +40,9 @@ import (
 	"github.com/matrix-org/util"
 )
 
-const pathPrefixV1 = "/client/api/v1"
-const pathPrefixR0 = "/client/r0"
-const pathPrefixUnstable = "/client/unstable"
+const pathPrefixV1 = "/api/v1"
+const pathPrefixR0 = "/r0"
+const pathPrefixUnstable = "/unstable"
 
 // Setup registers HTTP handlers with the given ServeMux. It also supplies the given http.Client
 // to clients which need to make outbound HTTP requests.
@@ -68,7 +68,7 @@ func Setup(
 ) {
 	userInteractiveAuth := auth.NewUserInteractive(accountDB.GetAccountByPassword, cfg)
 
-	publicAPIMux.Handle("/client/versions",
+	publicAPIMux.Handle("/versions",
 		httputil.MakeExternalAPI("versions", func(req *http.Request) util.JSONResponse {
 			return util.JSONResponse{
 				Code: http.StatusOK,

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -40,10 +40,6 @@ import (
 	"github.com/matrix-org/util"
 )
 
-const pathPrefixV1 = "/api/v1"
-const pathPrefixR0 = "/r0"
-const pathPrefixUnstable = "/unstable"
-
 // Setup registers HTTP handlers with the given ServeMux. It also supplies the given http.Client
 // to clients which need to make outbound HTTP requests.
 //
@@ -84,9 +80,9 @@ func Setup(
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
-	r0mux := publicAPIMux.PathPrefix(pathPrefixR0).Subrouter()
-	v1mux := publicAPIMux.PathPrefix(pathPrefixV1).Subrouter()
-	unstableMux := publicAPIMux.PathPrefix(pathPrefixUnstable).Subrouter()
+	r0mux := publicAPIMux.PathPrefix("/r0").Subrouter()
+	v1mux := publicAPIMux.PathPrefix("/api/v1").Subrouter()
+	unstableMux := publicAPIMux.PathPrefix("/unstable").Subrouter()
 
 	r0mux.Handle("/createRoom",
 		httputil.MakeAuthAPI("createRoom", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {

--- a/cmd/dendrite-appservice-server/main.go
+++ b/cmd/dendrite-appservice-server/main.go
@@ -33,5 +33,6 @@ func main() {
 	base.SetupAndServeHTTP(
 		base.Cfg.AppServiceAPI.InternalAPI.Listen,
 		setup.NoExternalListener,
+		nil, nil,
 	)
 }

--- a/cmd/dendrite-appservice-server/main.go
+++ b/cmd/dendrite-appservice-server/main.go
@@ -30,6 +30,8 @@ func main() {
 	intAPI := appservice.NewInternalAPI(base, userAPI, rsAPI)
 	appservice.AddInternalRoutes(base.InternalAPIMux, intAPI)
 
-	base.SetupAndServeHTTP(string(base.Cfg.AppServiceAPI.Bind), string(base.Cfg.AppServiceAPI.Listen))
-
+	base.SetupAndServeHTTP(
+		base.Cfg.AppServiceAPI.InternalAPI.Listen,
+		setup.NoExternalListener,
+	)
 }

--- a/cmd/dendrite-client-api-server/main.go
+++ b/cmd/dendrite-client-api-server/main.go
@@ -39,7 +39,7 @@ func main() {
 	keyAPI := base.KeyServerHTTPClient()
 
 	clientapi.AddPublicRoutes(
-		base.PublicAPIMux, &base.Cfg.ClientAPI, base.KafkaProducer, deviceDB, accountDB, federation,
+		base.ExternalClientAPIMux, &base.Cfg.ClientAPI, base.KafkaProducer, deviceDB, accountDB, federation,
 		rsAPI, eduInputAPI, asQuery, stateAPI, transactions.New(), fsAPI, userAPI, keyAPI, nil,
 	)
 

--- a/cmd/dendrite-client-api-server/main.go
+++ b/cmd/dendrite-client-api-server/main.go
@@ -43,6 +43,8 @@ func main() {
 		rsAPI, eduInputAPI, asQuery, stateAPI, transactions.New(), fsAPI, userAPI, keyAPI, nil,
 	)
 
-	base.SetupAndServeHTTP(string(base.Cfg.ClientAPI.Bind), string(base.Cfg.ClientAPI.Listen))
-
+	base.SetupAndServeHTTP(
+		base.Cfg.ClientAPI.InternalAPI.Listen,
+		base.Cfg.ClientAPI.ExternalAPI.Listen,
+	)
 }

--- a/cmd/dendrite-client-api-server/main.go
+++ b/cmd/dendrite-client-api-server/main.go
@@ -39,7 +39,7 @@ func main() {
 	keyAPI := base.KeyServerHTTPClient()
 
 	clientapi.AddPublicRoutes(
-		base.ExternalClientAPIMux, &base.Cfg.ClientAPI, base.KafkaProducer, deviceDB, accountDB, federation,
+		base.PublicClientAPIMux, &base.Cfg.ClientAPI, base.KafkaProducer, deviceDB, accountDB, federation,
 		rsAPI, eduInputAPI, asQuery, stateAPI, transactions.New(), fsAPI, userAPI, keyAPI, nil,
 	)
 

--- a/cmd/dendrite-client-api-server/main.go
+++ b/cmd/dendrite-client-api-server/main.go
@@ -46,5 +46,6 @@ func main() {
 	base.SetupAndServeHTTP(
 		base.Cfg.ClientAPI.InternalAPI.Listen,
 		base.Cfg.ClientAPI.ExternalAPI.Listen,
+		nil, nil,
 	)
 }

--- a/cmd/dendrite-current-state-server/main.go
+++ b/cmd/dendrite-current-state-server/main.go
@@ -31,5 +31,6 @@ func main() {
 	base.SetupAndServeHTTP(
 		base.Cfg.CurrentStateServer.InternalAPI.Listen,
 		setup.NoExternalListener,
+		nil, nil,
 	)
 }

--- a/cmd/dendrite-current-state-server/main.go
+++ b/cmd/dendrite-current-state-server/main.go
@@ -28,6 +28,8 @@ func main() {
 
 	currentstateserver.AddInternalRoutes(base.InternalAPIMux, stateAPI)
 
-	base.SetupAndServeHTTP(string(base.Cfg.CurrentStateServer.Bind), string(base.Cfg.CurrentStateServer.Listen))
-
+	base.SetupAndServeHTTP(
+		base.Cfg.CurrentStateServer.InternalAPI.Listen,
+		setup.NoExternalListener,
+	)
 }

--- a/cmd/dendrite-demo-libp2p/main.go
+++ b/cmd/dendrite-demo-libp2p/main.go
@@ -31,7 +31,6 @@ import (
 	"github.com/matrix-org/dendrite/eduserver"
 	"github.com/matrix-org/dendrite/federationsender"
 	"github.com/matrix-org/dendrite/internal/config"
-	"github.com/matrix-org/dendrite/internal/httputil"
 	"github.com/matrix-org/dendrite/internal/setup"
 	"github.com/matrix-org/dendrite/keyserver"
 	"github.com/matrix-org/dendrite/roomserver"
@@ -192,19 +191,11 @@ func main() {
 	}
 	monolith.AddAllPublicRoutes(base.Base.PublicAPIMux)
 
-	httputil.SetupHTTPAPI(
-		base.Base.BaseMux,
-		base.Base.PublicAPIMux,
-		base.Base.InternalAPIMux,
-		&cfg.Global,
-		base.Base.UseHTTPAPIs,
-	)
-
 	// Expose the matrix APIs directly rather than putting them under a /api path.
 	go func() {
 		httpBindAddr := fmt.Sprintf(":%d", *instancePort)
 		logrus.Info("Listening on ", httpBindAddr)
-		logrus.Fatal(http.ListenAndServe(httpBindAddr, base.Base.BaseMux))
+		logrus.Fatal(http.ListenAndServe(httpBindAddr, base.Base.PublicAPIMux))
 	}()
 	// Expose the matrix APIs also via libp2p
 	if base.LibP2P != nil {
@@ -217,7 +208,7 @@ func main() {
 			defer func() {
 				logrus.Fatal(listener.Close())
 			}()
-			logrus.Fatal(http.Serve(listener, base.Base.BaseMux))
+			logrus.Fatal(http.Serve(listener, base.Base.PublicAPIMux))
 		}()
 	}
 

--- a/cmd/dendrite-demo-libp2p/main.go
+++ b/cmd/dendrite-demo-libp2p/main.go
@@ -204,9 +204,9 @@ func main() {
 	httpRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.Base.ExternalMediaAPIMux)
 
 	libp2pRouter := mux.NewRouter()
-	httpRouter.PathPrefix(httputil.ExternalFederationPathPrefix).Handler(base.Base.ExternalFederationAPIMux)
-	httpRouter.PathPrefix(httputil.ExternalKeyPathPrefix).Handler(base.Base.ExternalKeyAPIMux)
-	httpRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.Base.ExternalMediaAPIMux)
+	libp2pRouter.PathPrefix(httputil.ExternalFederationPathPrefix).Handler(base.Base.ExternalFederationAPIMux)
+	libp2pRouter.PathPrefix(httputil.ExternalKeyPathPrefix).Handler(base.Base.ExternalKeyAPIMux)
+	libp2pRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.Base.ExternalMediaAPIMux)
 
 	// Expose the matrix APIs directly rather than putting them under a /api path.
 	go func() {

--- a/cmd/dendrite-demo-libp2p/main.go
+++ b/cmd/dendrite-demo-libp2p/main.go
@@ -204,8 +204,8 @@ func main() {
 	httpRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.Base.ExternalMediaAPIMux)
 
 	libp2pRouter := mux.NewRouter()
-	httpRouter.PathPrefix(httputil.ExternalFederationPathPrefix).Handler(base.Base.ExternalClientAPIMux)
-	httpRouter.PathPrefix(httputil.ExternalKeyPathPrefix).Handler(base.Base.ExternalClientAPIMux)
+	httpRouter.PathPrefix(httputil.ExternalFederationPathPrefix).Handler(base.Base.ExternalFederationAPIMux)
+	httpRouter.PathPrefix(httputil.ExternalKeyPathPrefix).Handler(base.Base.ExternalKeyAPIMux)
 	httpRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.Base.ExternalMediaAPIMux)
 
 	// Expose the matrix APIs directly rather than putting them under a /api path.

--- a/cmd/dendrite-demo-libp2p/main.go
+++ b/cmd/dendrite-demo-libp2p/main.go
@@ -192,21 +192,21 @@ func main() {
 		ExtPublicRoomsProvider: provider,
 	}
 	monolith.AddAllPublicRoutes(
-		base.Base.ExternalClientAPIMux,
-		base.Base.ExternalFederationAPIMux,
-		base.Base.ExternalKeyAPIMux,
-		base.Base.ExternalMediaAPIMux,
+		base.Base.PublicClientAPIMux,
+		base.Base.PublicFederationAPIMux,
+		base.Base.PublicKeyAPIMux,
+		base.Base.PublicMediaAPIMux,
 	)
 
 	httpRouter := mux.NewRouter()
 	httpRouter.PathPrefix(httputil.InternalPathPrefix).Handler(base.Base.InternalAPIMux)
-	httpRouter.PathPrefix(httputil.ExternalClientPathPrefix).Handler(base.Base.ExternalClientAPIMux)
-	httpRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.Base.ExternalMediaAPIMux)
+	httpRouter.PathPrefix(httputil.PublicClientPathPrefix).Handler(base.Base.PublicClientAPIMux)
+	httpRouter.PathPrefix(httputil.PublicMediaPathPrefix).Handler(base.Base.PublicMediaAPIMux)
 
 	libp2pRouter := mux.NewRouter()
-	libp2pRouter.PathPrefix(httputil.ExternalFederationPathPrefix).Handler(base.Base.ExternalFederationAPIMux)
-	libp2pRouter.PathPrefix(httputil.ExternalKeyPathPrefix).Handler(base.Base.ExternalKeyAPIMux)
-	libp2pRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.Base.ExternalMediaAPIMux)
+	libp2pRouter.PathPrefix(httputil.PublicFederationPathPrefix).Handler(base.Base.PublicFederationAPIMux)
+	libp2pRouter.PathPrefix(httputil.PublicKeyPathPrefix).Handler(base.Base.PublicKeyAPIMux)
+	libp2pRouter.PathPrefix(httputil.PublicMediaPathPrefix).Handler(base.Base.PublicMediaAPIMux)
 
 	// Expose the matrix APIs directly rather than putting them under a /api path.
 	go func() {

--- a/cmd/dendrite-demo-yggdrasil/main.go
+++ b/cmd/dendrite-demo-yggdrasil/main.go
@@ -133,7 +133,7 @@ func main() {
 
 	rsComponent.SetFederationSenderAPI(fsAPI)
 
-	embed.Embed(base.ExternalClientAPIMux, *instancePort, "Yggdrasil Demo")
+	embed.Embed(base.PublicClientAPIMux, *instancePort, "Yggdrasil Demo")
 
 	monolith := setup.Monolith{
 		Config:        base.Cfg,
@@ -157,20 +157,20 @@ func main() {
 		),
 	}
 	monolith.AddAllPublicRoutes(
-		base.ExternalClientAPIMux,
-		base.ExternalFederationAPIMux,
-		base.ExternalKeyAPIMux,
-		base.ExternalMediaAPIMux,
+		base.PublicClientAPIMux,
+		base.PublicFederationAPIMux,
+		base.PublicKeyAPIMux,
+		base.PublicMediaAPIMux,
 	)
 
 	httpRouter := mux.NewRouter()
 	httpRouter.PathPrefix(httputil.InternalPathPrefix).Handler(base.InternalAPIMux)
-	httpRouter.PathPrefix(httputil.ExternalClientPathPrefix).Handler(base.ExternalClientAPIMux)
-	httpRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
+	httpRouter.PathPrefix(httputil.PublicClientPathPrefix).Handler(base.PublicClientAPIMux)
+	httpRouter.PathPrefix(httputil.PublicMediaPathPrefix).Handler(base.PublicMediaAPIMux)
 
 	yggRouter := mux.NewRouter()
-	yggRouter.PathPrefix(httputil.ExternalFederationPathPrefix).Handler(base.ExternalFederationAPIMux)
-	yggRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
+	yggRouter.PathPrefix(httputil.PublicFederationPathPrefix).Handler(base.PublicFederationAPIMux)
+	yggRouter.PathPrefix(httputil.PublicMediaPathPrefix).Handler(base.PublicMediaAPIMux)
 
 	// Build both ends of a HTTP multiplex.
 	httpServer := &http.Server{

--- a/cmd/dendrite-demo-yggdrasil/main.go
+++ b/cmd/dendrite-demo-yggdrasil/main.go
@@ -169,7 +169,7 @@ func main() {
 	httpRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
 
 	yggRouter := mux.NewRouter()
-	httpRouter.PathPrefix(httputil.ExternalFederationPathPrefix).Handler(base.ExternalClientAPIMux)
+	httpRouter.PathPrefix(httputil.ExternalFederationPathPrefix).Handler(base.ExternalFederationAPIMux)
 	httpRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
 
 	// Build both ends of a HTTP multiplex.

--- a/cmd/dendrite-demo-yggdrasil/main.go
+++ b/cmd/dendrite-demo-yggdrasil/main.go
@@ -169,8 +169,8 @@ func main() {
 	httpRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
 
 	yggRouter := mux.NewRouter()
-	httpRouter.PathPrefix(httputil.ExternalFederationPathPrefix).Handler(base.ExternalFederationAPIMux)
-	httpRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
+	yggRouter.PathPrefix(httputil.ExternalFederationPathPrefix).Handler(base.ExternalFederationAPIMux)
+	yggRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
 
 	// Build both ends of a HTTP multiplex.
 	httpServer := &http.Server{

--- a/cmd/dendrite-edu-server/main.go
+++ b/cmd/dendrite-edu-server/main.go
@@ -36,5 +36,6 @@ func main() {
 	base.SetupAndServeHTTP(
 		base.Cfg.EDUServer.InternalAPI.Listen,
 		setup.NoExternalListener,
+		nil, nil,
 	)
 }

--- a/cmd/dendrite-edu-server/main.go
+++ b/cmd/dendrite-edu-server/main.go
@@ -33,6 +33,8 @@ func main() {
 	intAPI := eduserver.NewInternalAPI(base, cache.New(), base.UserAPIClient())
 	eduserver.AddInternalRoutes(base.InternalAPIMux, intAPI)
 
-	base.SetupAndServeHTTP(string(base.Cfg.EDUServer.Bind), string(base.Cfg.EDUServer.Listen))
-
+	base.SetupAndServeHTTP(
+		base.Cfg.EDUServer.InternalAPI.Listen,
+		setup.NoExternalListener,
+	)
 }

--- a/cmd/dendrite-federation-api-server/main.go
+++ b/cmd/dendrite-federation-api-server/main.go
@@ -33,7 +33,8 @@ func main() {
 	keyAPI := base.KeyServerHTTPClient()
 
 	federationapi.AddPublicRoutes(
-		base.PublicAPIMux, &base.Cfg.FederationAPI, userAPI, federation, keyRing,
+		base.ExternalFederationAPIMux, base.ExternalKeyAPIMux,
+		&base.Cfg.FederationAPI, userAPI, federation, keyRing,
 		rsAPI, fsAPI, base.EDUServerClient(), base.CurrentStateAPIClient(), keyAPI,
 	)
 

--- a/cmd/dendrite-federation-api-server/main.go
+++ b/cmd/dendrite-federation-api-server/main.go
@@ -40,5 +40,6 @@ func main() {
 	base.SetupAndServeHTTP(
 		base.Cfg.FederationAPI.InternalAPI.Listen,
 		base.Cfg.FederationAPI.ExternalAPI.Listen,
+		nil, nil,
 	)
 }

--- a/cmd/dendrite-federation-api-server/main.go
+++ b/cmd/dendrite-federation-api-server/main.go
@@ -37,6 +37,8 @@ func main() {
 		rsAPI, fsAPI, base.EDUServerClient(), base.CurrentStateAPIClient(), keyAPI,
 	)
 
-	base.SetupAndServeHTTP(string(base.Cfg.FederationAPI.Bind), string(base.Cfg.FederationAPI.Listen))
-
+	base.SetupAndServeHTTP(
+		base.Cfg.FederationAPI.InternalAPI.Listen,
+		base.Cfg.FederationAPI.ExternalAPI.Listen,
+	)
 }

--- a/cmd/dendrite-federation-api-server/main.go
+++ b/cmd/dendrite-federation-api-server/main.go
@@ -33,7 +33,7 @@ func main() {
 	keyAPI := base.KeyServerHTTPClient()
 
 	federationapi.AddPublicRoutes(
-		base.ExternalFederationAPIMux, base.ExternalKeyAPIMux,
+		base.PublicFederationAPIMux, base.PublicKeyAPIMux,
 		&base.Cfg.FederationAPI, userAPI, federation, keyRing,
 		rsAPI, fsAPI, base.EDUServerClient(), base.CurrentStateAPIClient(), keyAPI,
 	)

--- a/cmd/dendrite-federation-sender-server/main.go
+++ b/cmd/dendrite-federation-sender-server/main.go
@@ -38,5 +38,6 @@ func main() {
 	base.SetupAndServeHTTP(
 		base.Cfg.FederationSender.InternalAPI.Listen,
 		setup.NoExternalListener,
+		nil, nil,
 	)
 }

--- a/cmd/dendrite-federation-sender-server/main.go
+++ b/cmd/dendrite-federation-sender-server/main.go
@@ -35,6 +35,8 @@ func main() {
 	)
 	federationsender.AddInternalRoutes(base.InternalAPIMux, fsAPI)
 
-	base.SetupAndServeHTTP(string(base.Cfg.FederationSender.Bind), string(base.Cfg.FederationSender.Listen))
-
+	base.SetupAndServeHTTP(
+		base.Cfg.FederationSender.InternalAPI.Listen,
+		setup.NoExternalListener,
+	)
 }

--- a/cmd/dendrite-key-server/main.go
+++ b/cmd/dendrite-key-server/main.go
@@ -29,6 +29,8 @@ func main() {
 
 	keyserver.AddInternalRoutes(base.InternalAPIMux, intAPI)
 
-	base.SetupAndServeHTTP(string(base.Cfg.KeyServer.Bind), string(base.Cfg.KeyServer.Listen))
-
+	base.SetupAndServeHTTP(
+		base.Cfg.KeyServer.InternalAPI.Listen,
+		setup.NoExternalListener,
+	)
 }

--- a/cmd/dendrite-key-server/main.go
+++ b/cmd/dendrite-key-server/main.go
@@ -32,5 +32,6 @@ func main() {
 	base.SetupAndServeHTTP(
 		base.Cfg.KeyServer.InternalAPI.Listen,
 		setup.NoExternalListener,
+		nil, nil,
 	)
 }

--- a/cmd/dendrite-media-api-server/main.go
+++ b/cmd/dendrite-media-api-server/main.go
@@ -33,5 +33,6 @@ func main() {
 	base.SetupAndServeHTTP(
 		base.Cfg.MediaAPI.InternalAPI.Listen,
 		base.Cfg.MediaAPI.ExternalAPI.Listen,
+		nil, nil,
 	)
 }

--- a/cmd/dendrite-media-api-server/main.go
+++ b/cmd/dendrite-media-api-server/main.go
@@ -28,7 +28,7 @@ func main() {
 	userAPI := base.UserAPIClient()
 	client := gomatrixserverlib.NewClient(cfg.FederationSender.DisableTLSValidation)
 
-	mediaapi.AddPublicRoutes(base.ExternalMediaAPIMux, &base.Cfg.MediaAPI, userAPI, client)
+	mediaapi.AddPublicRoutes(base.PublicMediaAPIMux, &base.Cfg.MediaAPI, userAPI, client)
 
 	base.SetupAndServeHTTP(
 		base.Cfg.MediaAPI.InternalAPI.Listen,

--- a/cmd/dendrite-media-api-server/main.go
+++ b/cmd/dendrite-media-api-server/main.go
@@ -30,6 +30,8 @@ func main() {
 
 	mediaapi.AddPublicRoutes(base.PublicAPIMux, &base.Cfg.MediaAPI, userAPI, client)
 
-	base.SetupAndServeHTTP(string(base.Cfg.MediaAPI.Bind), string(base.Cfg.MediaAPI.Listen))
-
+	base.SetupAndServeHTTP(
+		base.Cfg.MediaAPI.InternalAPI.Listen,
+		base.Cfg.MediaAPI.ExternalAPI.Listen,
+	)
 }

--- a/cmd/dendrite-media-api-server/main.go
+++ b/cmd/dendrite-media-api-server/main.go
@@ -28,7 +28,7 @@ func main() {
 	userAPI := base.UserAPIClient()
 	client := gomatrixserverlib.NewClient(cfg.FederationSender.DisableTLSValidation)
 
-	mediaapi.AddPublicRoutes(base.PublicAPIMux, &base.Cfg.MediaAPI, userAPI, client)
+	mediaapi.AddPublicRoutes(base.ExternalMediaAPIMux, &base.Cfg.MediaAPI, userAPI, client)
 
 	base.SetupAndServeHTTP(
 		base.Cfg.MediaAPI.InternalAPI.Listen,

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"flag"
-	"net/http"
+	"fmt"
 	"os"
 
 	"github.com/matrix-org/dendrite/appservice"
@@ -25,7 +25,6 @@ import (
 	"github.com/matrix-org/dendrite/eduserver/cache"
 	"github.com/matrix-org/dendrite/federationsender"
 	"github.com/matrix-org/dendrite/internal/config"
-	"github.com/matrix-org/dendrite/internal/httputil"
 	"github.com/matrix-org/dendrite/internal/setup"
 	"github.com/matrix-org/dendrite/keyserver"
 	"github.com/matrix-org/dendrite/roomserver"
@@ -33,8 +32,6 @@ import (
 	"github.com/matrix-org/dendrite/serverkeyapi"
 	"github.com/matrix-org/dendrite/userapi"
 	"github.com/matrix-org/gomatrixserverlib"
-
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -48,23 +45,25 @@ var (
 
 func main() {
 	cfg := setup.ParseFlags(true)
+	httpAddr := config.HTTPAddress("http://" + *httpBindAddr)
+	httpsAddr := config.HTTPAddress("https://" + *httpsBindAddr)
+
 	if *enableHTTPAPIs {
 		// If the HTTP APIs are enabled then we need to update the Listen
 		// statements in the configuration so that we know where to find
 		// the API endpoints. They'll listen on the same port as the monolith
 		// itself.
-		addr := config.HTTPAddress("http://" + *httpBindAddr)
-		cfg.AppServiceAPI.InternalAPI.Connect = addr
-		cfg.ClientAPI.InternalAPI.Connect = addr
-		cfg.CurrentStateServer.InternalAPI.Connect = addr
-		cfg.EDUServer.InternalAPI.Connect = addr
-		cfg.FederationAPI.InternalAPI.Connect = addr
-		cfg.FederationSender.InternalAPI.Connect = addr
-		cfg.KeyServer.InternalAPI.Connect = addr
-		cfg.MediaAPI.InternalAPI.Connect = addr
-		cfg.RoomServer.InternalAPI.Connect = addr
-		cfg.ServerKeyAPI.InternalAPI.Connect = addr
-		cfg.SyncAPI.InternalAPI.Connect = addr
+		cfg.AppServiceAPI.InternalAPI.Connect = httpAddr
+		cfg.ClientAPI.InternalAPI.Connect = httpAddr
+		cfg.CurrentStateServer.InternalAPI.Connect = httpAddr
+		cfg.EDUServer.InternalAPI.Connect = httpAddr
+		cfg.FederationAPI.InternalAPI.Connect = httpAddr
+		cfg.FederationSender.InternalAPI.Connect = httpAddr
+		cfg.KeyServer.InternalAPI.Connect = httpAddr
+		cfg.MediaAPI.InternalAPI.Connect = httpAddr
+		cfg.RoomServer.InternalAPI.Connect = httpAddr
+		cfg.ServerKeyAPI.InternalAPI.Connect = httpAddr
+		cfg.SyncAPI.InternalAPI.Connect = httpAddr
 	}
 
 	base := setup.NewBaseDendrite(cfg, "Monolith", *enableHTTPAPIs)
@@ -149,31 +148,42 @@ func main() {
 	}
 	monolith.AddAllPublicRoutes(base.PublicAPIMux)
 
-	httputil.SetupHTTPAPI(
-		base.BaseMux,
-		base.PublicAPIMux,
-		base.InternalAPIMux,
-		&cfg.Global,
-		base.UseHTTPAPIs,
-	)
+	fmt.Printf("Public: %+v\n", base.PublicAPIMux)
+	fmt.Printf("Internal: %+v\n", base.InternalAPIMux)
+
+	/*
+		httputil.SetupHTTPAPI(
+			base.BaseMux,
+			base.PublicAPIMux,
+			base.InternalAPIMux,
+			&cfg.Global,
+			base.UseHTTPAPIs,
+		)
+	*/
 
 	// Expose the matrix APIs directly rather than putting them under a /api path.
 	go func() {
-		base.SetupAndServeHTTP(*httpBindAddr, *httpBindAddr)
+		base.SetupAndServeHTTP(
+			config.HTTPAddress(httpAddr), // internal API
+			config.HTTPAddress(httpAddr), // external API
+		)
 	}()
 	// Handle HTTPS if certificate and key are provided
-	if *certFile != "" && *keyFile != "" {
-		go func() {
-			serv := http.Server{
-				Addr:         *httpsBindAddr,
-				WriteTimeout: setup.HTTPServerTimeout,
-				Handler:      base.BaseMux,
-			}
+	_ = httpsAddr
+	/*
+		if *certFile != "" && *keyFile != "" {
+			go func() {
+				serv := http.Server{
+					Addr:         config.HTTPAddress(httpsAddr).,
+					WriteTimeout: setup.HTTPServerTimeout,
+					Handler:      base.BaseMux,
+				}
 
-			logrus.Info("Listening on ", serv.Addr)
-			logrus.Fatal(serv.ListenAndServeTLS(*certFile, *keyFile))
-		}()
-	}
+				logrus.Info("Listening on ", serv.Addr)
+				logrus.Fatal(serv.ListenAndServeTLS(*certFile, *keyFile))
+			}()
+		}
+	*/
 
 	// We want to block forever to let the HTTP and HTTPS handler serve the APIs
 	select {}

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -146,10 +146,10 @@ func main() {
 		KeyAPI:              keyAPI,
 	}
 	monolith.AddAllPublicRoutes(
-		base.ExternalClientAPIMux,
-		base.ExternalFederationAPIMux,
-		base.ExternalKeyAPIMux,
-		base.ExternalMediaAPIMux,
+		base.PublicClientAPIMux,
+		base.PublicFederationAPIMux,
+		base.PublicKeyAPIMux,
+		base.PublicMediaAPIMux,
 	)
 
 	// Expose the matrix APIs directly rather than putting them under a /api path.

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -145,7 +145,12 @@ func main() {
 		UserAPI:             userAPI,
 		KeyAPI:              keyAPI,
 	}
-	monolith.AddAllPublicRoutes(base.PublicAPIMux)
+	monolith.AddAllPublicRoutes(
+		base.ExternalClientAPIMux,
+		base.ExternalFederationAPIMux,
+		base.ExternalKeyAPIMux,
+		base.ExternalMediaAPIMux,
+	)
 
 	// Expose the matrix APIs directly rather than putting them under a /api path.
 	go func() {

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -53,18 +53,18 @@ func main() {
 		// statements in the configuration so that we know where to find
 		// the API endpoints. They'll listen on the same port as the monolith
 		// itself.
-		addr := config.Address(*httpBindAddr)
-		cfg.AppServiceAPI.Listen = addr
-		cfg.ClientAPI.Listen = addr
-		cfg.CurrentStateServer.Listen = addr
-		cfg.EDUServer.Listen = addr
-		cfg.FederationAPI.Listen = addr
-		cfg.FederationSender.Listen = addr
-		cfg.KeyServer.Listen = addr
-		cfg.MediaAPI.Listen = addr
-		cfg.RoomServer.Listen = addr
-		cfg.ServerKeyAPI.Listen = addr
-		cfg.SyncAPI.Listen = addr
+		addr := config.HTTPAddress("http://" + *httpBindAddr)
+		cfg.AppServiceAPI.InternalAPI.Connect = addr
+		cfg.ClientAPI.InternalAPI.Connect = addr
+		cfg.CurrentStateServer.InternalAPI.Connect = addr
+		cfg.EDUServer.InternalAPI.Connect = addr
+		cfg.FederationAPI.InternalAPI.Connect = addr
+		cfg.FederationSender.InternalAPI.Connect = addr
+		cfg.KeyServer.InternalAPI.Connect = addr
+		cfg.MediaAPI.InternalAPI.Connect = addr
+		cfg.RoomServer.InternalAPI.Connect = addr
+		cfg.ServerKeyAPI.InternalAPI.Connect = addr
+		cfg.SyncAPI.InternalAPI.Connect = addr
 	}
 
 	base := setup.NewBaseDendrite(cfg, "Monolith", *enableHTTPAPIs)
@@ -159,14 +159,7 @@ func main() {
 
 	// Expose the matrix APIs directly rather than putting them under a /api path.
 	go func() {
-		serv := http.Server{
-			Addr:         *httpBindAddr,
-			WriteTimeout: setup.HTTPServerTimeout,
-			Handler:      base.BaseMux,
-		}
-
-		logrus.Info("Listening on ", serv.Addr)
-		logrus.Fatal(serv.ListenAndServe())
+		base.SetupAndServeHTTP(*httpBindAddr, *httpBindAddr)
 	}()
 	// Handle HTTPS if certificate and key are provided
 	if *certFile != "" && *keyFile != "" {

--- a/cmd/dendrite-room-server/main.go
+++ b/cmd/dendrite-room-server/main.go
@@ -33,6 +33,8 @@ func main() {
 	rsAPI.SetFederationSenderAPI(fsAPI)
 	roomserver.AddInternalRoutes(base.InternalAPIMux, rsAPI)
 
-	base.SetupAndServeHTTP(string(base.Cfg.RoomServer.Bind), string(base.Cfg.RoomServer.Listen))
-
+	base.SetupAndServeHTTP(
+		base.Cfg.RoomServer.InternalAPI.Listen,
+		setup.NoExternalListener,
+	)
 }

--- a/cmd/dendrite-room-server/main.go
+++ b/cmd/dendrite-room-server/main.go
@@ -36,5 +36,6 @@ func main() {
 	base.SetupAndServeHTTP(
 		base.Cfg.RoomServer.InternalAPI.Listen,
 		setup.NoExternalListener,
+		nil, nil,
 	)
 }

--- a/cmd/dendrite-server-key-api-server/main.go
+++ b/cmd/dendrite-server-key-api-server/main.go
@@ -29,5 +29,8 @@ func main() {
 	intAPI := serverkeyapi.NewInternalAPI(&base.Cfg.ServerKeyAPI, federation, base.Caches)
 	serverkeyapi.AddInternalRoutes(base.InternalAPIMux, intAPI, base.Caches)
 
-	base.SetupAndServeHTTP(string(base.Cfg.ServerKeyAPI.Bind), string(base.Cfg.ServerKeyAPI.Listen))
+	base.SetupAndServeHTTP(
+		base.Cfg.ServerKeyAPI.InternalAPI.Listen,
+		setup.NoExternalListener,
+	)
 }

--- a/cmd/dendrite-server-key-api-server/main.go
+++ b/cmd/dendrite-server-key-api-server/main.go
@@ -32,5 +32,6 @@ func main() {
 	base.SetupAndServeHTTP(
 		base.Cfg.ServerKeyAPI.InternalAPI.Listen,
 		setup.NoExternalListener,
+		nil, nil,
 	)
 }

--- a/cmd/dendrite-sync-api-server/main.go
+++ b/cmd/dendrite-sync-api-server/main.go
@@ -30,8 +30,10 @@ func main() {
 	rsAPI := base.RoomserverHTTPClient()
 
 	syncapi.AddPublicRoutes(
-		base.PublicAPIMux, base.KafkaConsumer, userAPI, rsAPI, base.KeyServerHTTPClient(), base.CurrentStateAPIClient(),
-		federation, &cfg.SyncAPI)
+		base.ExternalClientAPIMux, base.KafkaConsumer, userAPI, rsAPI,
+		base.KeyServerHTTPClient(), base.CurrentStateAPIClient(),
+		federation, &cfg.SyncAPI,
+	)
 
 	base.SetupAndServeHTTP(
 		base.Cfg.SyncAPI.InternalAPI.Listen,

--- a/cmd/dendrite-sync-api-server/main.go
+++ b/cmd/dendrite-sync-api-server/main.go
@@ -30,7 +30,7 @@ func main() {
 	rsAPI := base.RoomserverHTTPClient()
 
 	syncapi.AddPublicRoutes(
-		base.ExternalClientAPIMux, base.KafkaConsumer, userAPI, rsAPI,
+		base.PublicClientAPIMux, base.KafkaConsumer, userAPI, rsAPI,
 		base.KeyServerHTTPClient(), base.CurrentStateAPIClient(),
 		federation, &cfg.SyncAPI,
 	)

--- a/cmd/dendrite-sync-api-server/main.go
+++ b/cmd/dendrite-sync-api-server/main.go
@@ -33,6 +33,8 @@ func main() {
 		base.PublicAPIMux, base.KafkaConsumer, userAPI, rsAPI, base.KeyServerHTTPClient(), base.CurrentStateAPIClient(),
 		federation, &cfg.SyncAPI)
 
-	base.SetupAndServeHTTP(string(base.Cfg.SyncAPI.Bind), string(base.Cfg.SyncAPI.Listen))
-
+	base.SetupAndServeHTTP(
+		base.Cfg.SyncAPI.InternalAPI.Listen,
+		setup.NoExternalListener,
+	)
 }

--- a/cmd/dendrite-sync-api-server/main.go
+++ b/cmd/dendrite-sync-api-server/main.go
@@ -36,5 +36,6 @@ func main() {
 	base.SetupAndServeHTTP(
 		base.Cfg.SyncAPI.InternalAPI.Listen,
 		setup.NoExternalListener,
+		nil, nil,
 	)
 }

--- a/cmd/dendrite-user-api-server/main.go
+++ b/cmd/dendrite-user-api-server/main.go
@@ -31,5 +31,8 @@ func main() {
 
 	userapi.AddInternalRoutes(base.InternalAPIMux, userAPI)
 
-	base.SetupAndServeHTTP(string(base.Cfg.UserAPI.Bind), string(base.Cfg.UserAPI.Listen))
+	base.SetupAndServeHTTP(
+		base.Cfg.UserAPI.InternalAPI.Listen,
+		setup.NoExternalListener,
+	)
 }

--- a/cmd/dendrite-user-api-server/main.go
+++ b/cmd/dendrite-user-api-server/main.go
@@ -34,5 +34,6 @@ func main() {
 	base.SetupAndServeHTTP(
 		base.Cfg.UserAPI.InternalAPI.Listen,
 		setup.NoExternalListener,
+		nil, nil,
 	)
 }

--- a/cmd/dendritejs/main.go
+++ b/cmd/dendritejs/main.go
@@ -236,20 +236,20 @@ func main() {
 		ExtPublicRoomsProvider: p2pPublicRoomProvider,
 	}
 	monolith.AddAllPublicRoutes(
-		base.ExternalClientAPIMux,
-		base.ExternalFederationAPIMux,
-		base.ExternalKeyAPIMux,
-		base.ExternalMediaAPIMux,
+		base.PublicClientAPIMux,
+		base.PublicFederationAPIMux,
+		base.PublicKeyAPIMux,
+		base.PublicMediaAPIMux,
 	)
 
 	httpRouter := mux.NewRouter()
 	httpRouter.PathPrefix(httputil.InternalPathPrefix).Handler(base.InternalAPIMux)
-	httpRouter.PathPrefix(httputil.ExternalClientPathPrefix).Handler(base.ExternalClientAPIMux)
-	httpRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
+	httpRouter.PathPrefix(httputil.PublicClientPathPrefix).Handler(base.PublicClientAPIMux)
+	httpRouter.PathPrefix(httputil.PublicMediaPathPrefix).Handler(base.PublicMediaAPIMux)
 
 	libp2pRouter := mux.NewRouter()
-	libp2pRouter.PathPrefix(httputil.ExternalFederationPathPrefix).Handler(base.ExternalFederationAPIMux)
-	libp2pRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
+	libp2pRouter.PathPrefix(httputil.PublicFederationPathPrefix).Handler(base.PublicFederationAPIMux)
+	libp2pRouter.PathPrefix(httputil.PublicMediaPathPrefix).Handler(base.PublicMediaAPIMux)
 
 	// Expose the matrix APIs via libp2p-js - for federation traffic
 	if node != nil {

--- a/cmd/dendritejs/main.go
+++ b/cmd/dendritejs/main.go
@@ -248,8 +248,8 @@ func main() {
 	httpRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
 
 	libp2pRouter := mux.NewRouter()
-	httpRouter.PathPrefix(httputil.ExternalFederationPathPrefix).Handler(base.ExternalFederationAPIMux)
-	httpRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
+	libp2pRouter.PathPrefix(httputil.ExternalFederationPathPrefix).Handler(base.ExternalFederationAPIMux)
+	libp2pRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
 
 	// Expose the matrix APIs via libp2p-js - for federation traffic
 	if node != nil {

--- a/cmd/dendritejs/main.go
+++ b/cmd/dendritejs/main.go
@@ -248,7 +248,7 @@ func main() {
 	httpRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
 
 	libp2pRouter := mux.NewRouter()
-	httpRouter.PathPrefix(httputil.ExternalFederationPathPrefix).Handler(base.ExternalClientAPIMux)
+	httpRouter.PathPrefix(httputil.ExternalFederationPathPrefix).Handler(base.ExternalFederationAPIMux)
 	httpRouter.PathPrefix(httputil.ExternalMediaPathPrefix).Handler(base.ExternalMediaAPIMux)
 
 	// Expose the matrix APIs via libp2p-js - for federation traffic

--- a/cmd/generate-keys/main.go
+++ b/cmd/generate-keys/main.go
@@ -45,6 +45,11 @@ func main() {
 
 	flag.Parse()
 
+	if *tlsCertFile == "" && *tlsKeyFile == "" && *privateKeyFile == "" {
+		flag.Usage()
+		return
+	}
+
 	if *tlsCertFile != "" || *tlsKeyFile != "" {
 		if *tlsCertFile == "" || *tlsKeyFile == "" {
 			log.Fatal("Zero or both of --tls-key and --tls-cert must be supplied")

--- a/cmd/mediaapi-integration-tests/main.go
+++ b/cmd/mediaapi-integration-tests/main.go
@@ -120,7 +120,7 @@ func startMediaAPI(suffix string, dynamicThumbnails bool) (*exec.Cmd, chan error
 		serverArgs,
 	)
 
-	fmt.Printf("==TESTSERVER== STARTED %v -> %v : %v\n", proxyAddr, cfg.MediaAPI.Listen, dir)
+	fmt.Printf("==TESTSERVER== STARTED %v -> %v : %v\n", proxyAddr, cfg.MediaAPI.InternalAPI.Listen, dir)
 	return cmd, cmdChan, proxyCmd, proxyAddr, dir
 }
 

--- a/cmd/roomserver-integration-tests/main.go
+++ b/cmd/roomserver-integration-tests/main.go
@@ -278,7 +278,7 @@ func testRoomserver(input []string, wantOutput []string, checkQueries func(api.R
 	cmd.Args = []string{"dendrite-room-server", "--config", filepath.Join(dir, test.ConfigFile)}
 
 	gotOutput, err := runAndReadFromTopic(cmd, cfg.RoomServerURL()+"/metrics", doInput, outputTopic, len(wantOutput), func() {
-		queryAPI, _ := inthttp.NewRoomserverClient("http://"+string(cfg.RoomServer.Listen), &http.Client{Timeout: timeoutHTTP}, cache)
+		queryAPI, _ := inthttp.NewRoomserverClient("http://"+string(cfg.RoomServer.InternalAPI.Connect), &http.Client{Timeout: timeoutHTTP}, cache)
 		checkQueries(queryAPI)
 	})
 	if err != nil {

--- a/cmd/syncserver-integration-tests/main.go
+++ b/cmd/syncserver-integration-tests/main.go
@@ -133,7 +133,8 @@ func startSyncServer() (*exec.Cmd, chan error) {
 	}
 	// TODO use the address assigned by the config generator rather than clobbering.
 	cfg.Global.ServerName = "localhost"
-	cfg.SyncAPI.Listen = config.Address(syncserverAddr)
+	cfg.SyncAPI.InternalAPI.Listen = config.HTTPAddress("http://" + syncserverAddr)
+	cfg.SyncAPI.InternalAPI.Connect = cfg.SyncAPI.InternalAPI.Listen
 
 	if err := test.WriteConfig(cfg, dir); err != nil {
 		panic(err)

--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -88,8 +88,9 @@ global:
 
 # Configuration for the Appservice API.
 app_service_api:
-  listen: localhost:7777
-  bind: localhost:7777
+  internal_api:
+    listen: http://localhost:7777
+    connect: http://localhost:7777
   database:
     connection_string: file:appservice.db
     max_open_conns: 100
@@ -101,8 +102,11 @@ app_service_api:
 
 # Configuration for the Client API.
 client_api:
-  listen: localhost:7771
-  bind: localhost:7771
+  internal_api:
+    listen: http://localhost:7771
+    connect: http://localhost:7771
+  external_api:
+    listen: http://[::]:8071
 
   # Prevents new users from being able to register on this homeserver, except when
   # using the registration shared secret below.
@@ -131,8 +135,9 @@ client_api:
 
 # Configuration for the Current State Server.
 current_state_server:
-  listen: localhost:7782
-  bind: localhost:7782
+  internal_api:
+    listen: http://localhost:7782
+    connect: http://localhost:7782
   database:
     connection_string: file:currentstate.db
     max_open_conns: 100
@@ -141,13 +146,17 @@ current_state_server:
 
 # Configuration for the EDU server.
 edu_server:
-  listen: localhost:7778
-  bind: localhost:7778
+  internal_api:
+    listen: http://localhost:7778
+    connect: http://localhost:7778
 
 # Configuration for the Federation API.
 federation_api:
-  listen: localhost:7772
-  bind: localhost:7772
+  internal_api:
+    listen: http://localhost:7772
+    connect: http://localhost:7772
+  external_api:
+    listen: http://[::]:8072
 
   # List of paths to X.509 certificates to be used by the external federation listeners.
   # These certificates will be used to calculate the TLS fingerprints and other servers
@@ -157,8 +166,9 @@ federation_api:
 
 # Configuration for the Federation Sender.
 federation_sender:
-  listen: localhost:7775
-  bind: localhost:7775
+  internal_api:
+    listen: http://localhost:7775
+    connect: http://localhost:7775
   database:
     connection_string: file:federationsender.db
     max_open_conns: 100
@@ -182,8 +192,9 @@ federation_sender:
 
 # Configuration for the Key Server (for end-to-end encryption).
 key_server:
-  listen: localhost:7779
-  bind: localhost:7779
+  internal_api:
+    listen: http://localhost:7779
+    connect: http://localhost:7779
   database:
     connection_string: file:keyserver.db
     max_open_conns: 100
@@ -192,8 +203,11 @@ key_server:
 
 # Configuration for the Media API.
 media_api:
-  listen: localhost:7774
-  bind: localhost:7774
+  internal_api:
+    listen: http://localhost:7774
+    connect: http://localhost:7774
+  external_api:
+    listen: http://[::]:8074
   database:
     connection_string: file:mediaapi.db
     max_open_conns: 100
@@ -227,8 +241,9 @@ media_api:
 
 # Configuration for the Room Server.
 room_server:
-  listen: localhost:7770
-  bind: localhost:7770
+  internal_api:
+    listen: http://localhost:7770
+    connect: http://localhost:7770
   database:
     connection_string: file:roomserver.db
     max_open_conns: 100
@@ -237,8 +252,9 @@ room_server:
 
 # Configuration for the Server Key API (for server signing keys).
 server_key_api:
-  listen: localhost:7780
-  bind: localhost:7780
+  internal_api:
+    listen: http://localhost:7780
+    connect: http://localhost:7780
   database:
     connection_string: file:serverkeyapi.db
     max_open_conns: 100
@@ -258,8 +274,9 @@ server_key_api:
 
 # Configuration for the Sync API.
 sync_api:
-  listen: localhost:7773
-  bind: localhost:7773
+  internal_api:
+    listen: http://localhost:7773
+    connect: http://localhost:7773
   database:
     connection_string: file:syncapi.db
     max_open_conns: 100
@@ -268,8 +285,9 @@ sync_api:
 
 # Configuration for the User API.
 user_api:
-  listen: localhost:7781
-  bind: localhost:7781
+  internal_api:
+    listen: http://localhost:7781
+    connect: http://localhost:7781
   account_database:
     connection_string: file:userapi_accounts.db
     max_open_conns: 100

--- a/federationapi/federationapi.go
+++ b/federationapi/federationapi.go
@@ -30,7 +30,7 @@ import (
 
 // AddPublicRoutes sets up and registers HTTP handlers on the base API muxes for the FederationAPI component.
 func AddPublicRoutes(
-	router *mux.Router,
+	fedRouter, keyRouter *mux.Router,
 	cfg *config.FederationAPI,
 	userAPI userapi.UserInternalAPI,
 	federation *gomatrixserverlib.FederationClient,
@@ -42,7 +42,7 @@ func AddPublicRoutes(
 	keyAPI keyserverAPI.KeyInternalAPI,
 ) {
 	routing.Setup(
-		router, cfg, rsAPI,
+		fedRouter, keyRouter, cfg, rsAPI,
 		eduAPI, federationSenderAPI, keyRing,
 		federation, userAPI, stateAPI, keyAPI,
 	)

--- a/federationapi/federationapi_test.go
+++ b/federationapi/federationapi_test.go
@@ -31,8 +31,8 @@ func TestRoomsV3URLEscapeDoNot404(t *testing.T) {
 	fsAPI := base.FederationSenderHTTPClient()
 	// TODO: This is pretty fragile, as if anything calls anything on these nils this test will break.
 	// Unfortunately, it makes little sense to instantiate these dependencies when we just want to test routing.
-	federationapi.AddPublicRoutes(base.ExternalFederationAPIMux, base.ExternalKeyAPIMux, &cfg.FederationAPI, nil, nil, keyRing, nil, fsAPI, nil, nil, nil)
-	baseURL, cancel := test.ListenAndServe(t, base.ExternalFederationAPIMux, true)
+	federationapi.AddPublicRoutes(base.PublicFederationAPIMux, base.PublicKeyAPIMux, &cfg.FederationAPI, nil, nil, keyRing, nil, fsAPI, nil, nil, nil)
+	baseURL, cancel := test.ListenAndServe(t, base.PublicFederationAPIMux, true)
 	defer cancel()
 	serverName := gomatrixserverlib.ServerName(strings.TrimPrefix(baseURL, "https://"))
 

--- a/federationapi/federationapi_test.go
+++ b/federationapi/federationapi_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/matrix-org/dendrite/federationapi"
 	"github.com/matrix-org/dendrite/internal/config"
-	"github.com/matrix-org/dendrite/internal/httputil"
 	"github.com/matrix-org/dendrite/internal/setup"
 	"github.com/matrix-org/dendrite/internal/test"
 	"github.com/matrix-org/gomatrix"
@@ -33,14 +32,7 @@ func TestRoomsV3URLEscapeDoNot404(t *testing.T) {
 	// TODO: This is pretty fragile, as if anything calls anything on these nils this test will break.
 	// Unfortunately, it makes little sense to instantiate these dependencies when we just want to test routing.
 	federationapi.AddPublicRoutes(base.PublicAPIMux, &cfg.FederationAPI, nil, nil, keyRing, nil, fsAPI, nil, nil, nil)
-	httputil.SetupHTTPAPI(
-		base.BaseMux,
-		base.PublicAPIMux,
-		base.InternalAPIMux,
-		&cfg.Global,
-		base.UseHTTPAPIs,
-	)
-	baseURL, cancel := test.ListenAndServe(t, base.BaseMux, true)
+	baseURL, cancel := test.ListenAndServe(t, base.PublicAPIMux, true)
 	defer cancel()
 	serverName := gomatrixserverlib.ServerName(strings.TrimPrefix(baseURL, "https://"))
 

--- a/federationapi/federationapi_test.go
+++ b/federationapi/federationapi_test.go
@@ -31,8 +31,8 @@ func TestRoomsV3URLEscapeDoNot404(t *testing.T) {
 	fsAPI := base.FederationSenderHTTPClient()
 	// TODO: This is pretty fragile, as if anything calls anything on these nils this test will break.
 	// Unfortunately, it makes little sense to instantiate these dependencies when we just want to test routing.
-	federationapi.AddPublicRoutes(base.PublicAPIMux, &cfg.FederationAPI, nil, nil, keyRing, nil, fsAPI, nil, nil, nil)
-	baseURL, cancel := test.ListenAndServe(t, base.PublicAPIMux, true)
+	federationapi.AddPublicRoutes(base.ExternalFederationAPIMux, base.ExternalKeyAPIMux, &cfg.FederationAPI, nil, nil, keyRing, nil, fsAPI, nil, nil, nil)
+	baseURL, cancel := test.ListenAndServe(t, base.ExternalFederationAPIMux, true)
 	defer cancel()
 	serverName := gomatrixserverlib.ServerName(strings.TrimPrefix(baseURL, "https://"))
 

--- a/federationapi/routing/routing.go
+++ b/federationapi/routing/routing.go
@@ -31,12 +31,6 @@ import (
 	"github.com/matrix-org/util"
 )
 
-const (
-	pathPrefixV2Keys       = "/v2"
-	pathPrefixV1Federation = "/v1"
-	pathPrefixV2Federation = "/v2"
-)
-
 // Setup registers HTTP handlers with the given ServeMux.
 // The provided publicAPIMux MUST have `UseEncodedPath()` enabled or else routes will incorrectly
 // path unescape twice (once from the router, once from MakeFedAPI). We need to have this enabled
@@ -57,9 +51,9 @@ func Setup(
 	stateAPI currentstateAPI.CurrentStateInternalAPI,
 	keyAPI keyserverAPI.KeyInternalAPI,
 ) {
-	v2keysmux := keyMux.PathPrefix(pathPrefixV2Keys).Subrouter()
-	v1fedmux := fedMux.PathPrefix(pathPrefixV1Federation).Subrouter()
-	v2fedmux := fedMux.PathPrefix(pathPrefixV2Federation).Subrouter()
+	v2keysmux := keyMux.PathPrefix("/v2").Subrouter()
+	v1fedmux := fedMux.PathPrefix("/v1").Subrouter()
+	v2fedmux := fedMux.PathPrefix("/v2").Subrouter()
 
 	wakeup := &httputil.FederationWakeups{
 		FsAPI: fsAPI,

--- a/federationapi/routing/routing.go
+++ b/federationapi/routing/routing.go
@@ -32,9 +32,9 @@ import (
 )
 
 const (
-	pathPrefixV2Keys       = "/key/v2"
-	pathPrefixV1Federation = "/federation/v1"
-	pathPrefixV2Federation = "/federation/v2"
+	pathPrefixV2Keys       = "/v2"
+	pathPrefixV1Federation = "/v1"
+	pathPrefixV2Federation = "/v2"
 )
 
 // Setup registers HTTP handlers with the given ServeMux.
@@ -46,7 +46,7 @@ const (
 // applied:
 // nolint: gocyclo
 func Setup(
-	publicAPIMux *mux.Router,
+	fedMux, keyMux *mux.Router,
 	cfg *config.FederationAPI,
 	rsAPI roomserverAPI.RoomserverInternalAPI,
 	eduAPI eduserverAPI.EDUServerInputAPI,
@@ -57,9 +57,9 @@ func Setup(
 	stateAPI currentstateAPI.CurrentStateInternalAPI,
 	keyAPI keyserverAPI.KeyInternalAPI,
 ) {
-	v2keysmux := publicAPIMux.PathPrefix(pathPrefixV2Keys).Subrouter()
-	v1fedmux := publicAPIMux.PathPrefix(pathPrefixV1Federation).Subrouter()
-	v2fedmux := publicAPIMux.PathPrefix(pathPrefixV2Federation).Subrouter()
+	v2keysmux := keyMux.PathPrefix(pathPrefixV2Keys).Subrouter()
+	v1fedmux := fedMux.PathPrefix(pathPrefixV1Federation).Subrouter()
+	v2fedmux := fedMux.PathPrefix(pathPrefixV2Federation).Subrouter()
 
 	wakeup := &httputil.FederationWakeups{
 		FsAPI: fsAPI,

--- a/federationsender/inthttp/server.go
+++ b/federationsender/inthttp/server.go
@@ -26,7 +26,8 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	internalAPIMux.Handle(FederationSenderPerformJoinRequestPath,
+	internalAPIMux.Handle(
+		FederationSenderPerformJoinRequestPath,
 		httputil.MakeInternalAPI("PerformJoinRequest", func(req *http.Request) util.JSONResponse {
 			var request api.PerformJoinRequest
 			var response api.PerformJoinResponse
@@ -37,7 +38,8 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	internalAPIMux.Handle(FederationSenderPerformLeaveRequestPath,
+	internalAPIMux.Handle(
+		FederationSenderPerformLeaveRequestPath,
 		httputil.MakeInternalAPI("PerformLeaveRequest", func(req *http.Request) util.JSONResponse {
 			var request api.PerformLeaveRequest
 			var response api.PerformLeaveResponse
@@ -50,7 +52,8 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	internalAPIMux.Handle(FederationSenderPerformDirectoryLookupRequestPath,
+	internalAPIMux.Handle(
+		FederationSenderPerformDirectoryLookupRequestPath,
 		httputil.MakeInternalAPI("PerformDirectoryLookupRequest", func(req *http.Request) util.JSONResponse {
 			var request api.PerformDirectoryLookupRequest
 			var response api.PerformDirectoryLookupResponse
@@ -63,7 +66,8 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	internalAPIMux.Handle(FederationSenderPerformServersAlivePath,
+	internalAPIMux.Handle(
+		FederationSenderPerformServersAlivePath,
 		httputil.MakeInternalAPI("PerformServersAliveRequest", func(req *http.Request) util.JSONResponse {
 			var request api.PerformServersAliveRequest
 			var response api.PerformServersAliveResponse
@@ -76,7 +80,8 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	internalAPIMux.Handle(FederationSenderPerformBroadcastEDUPath,
+	internalAPIMux.Handle(
+		FederationSenderPerformBroadcastEDUPath,
 		httputil.MakeInternalAPI("PerformBroadcastEDU", func(req *http.Request) util.JSONResponse {
 			var request api.PerformBroadcastEDURequest
 			var response api.PerformBroadcastEDUResponse

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/url"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -110,6 +111,15 @@ type Derived struct {
 	// servers from creating RoomIDs in exclusive application service namespaces
 }
 
+type InternalAPIOptions struct {
+	Listen  HTTPAddress `yaml:"listen"`
+	Connect HTTPAddress `yaml:"connect"`
+}
+
+type ExternalAPIOptions struct {
+	Listen HTTPAddress `yaml:"listen"`
+}
+
 // A Path on the filesystem.
 type Path string
 
@@ -131,6 +141,17 @@ type Topic string
 
 // An Address to listen on.
 type Address string
+
+// An HTTPAddress to listen on, starting with either http:// or https://.
+type HTTPAddress string
+
+func (h HTTPAddress) GetAddress() (Address, error) {
+	url, err := url.Parse(string(h))
+	if err != nil {
+		return "", err
+	}
+	return Address(url.Host), nil
+}
 
 // FileSizeBytes is a file size in bytes
 type FileSizeBytes int64
@@ -360,6 +381,26 @@ func checkPositive(configErrs *ConfigErrors, key string, value int64) {
 	}
 }
 
+// checkURL verifies that the parameter is a valid URL
+func checkURL(configErrs *ConfigErrors, key, value string) {
+	if value == "" {
+		configErrs.Add(fmt.Sprintf("missing config key %q", key))
+		return
+	}
+	url, err := url.Parse(value)
+	if err != nil {
+		configErrs.Add(fmt.Sprintf("config key %q contains invalid URL (%s)", key, err.Error()))
+		return
+	}
+	switch url.Scheme {
+	case "http":
+	case "https":
+	default:
+		configErrs.Add(fmt.Sprintf("config key %q URL should be http:// or https://", key))
+		return
+	}
+}
+
 // checkLogging verifies the parameters logging.* are valid.
 func (config *Dendrite) checkLogging(configErrs *ConfigErrors) {
 	for _, logrusHook := range config.Logging {
@@ -450,7 +491,7 @@ func (config *Dendrite) AppServiceURL() string {
 	// If we support HTTPS we need to think of a practical way to do certificate validation.
 	// People setting up servers shouldn't need to get a certificate valid for the public
 	// internet for an internal API.
-	return "http://" + string(config.AppServiceAPI.Listen)
+	return string(config.AppServiceAPI.InternalAPI.Connect)
 }
 
 // RoomServerURL returns an HTTP URL for where the roomserver is listening.
@@ -459,7 +500,7 @@ func (config *Dendrite) RoomServerURL() string {
 	// If we support HTTPS we need to think of a practical way to do certificate validation.
 	// People setting up servers shouldn't need to get a certificate valid for the public
 	// internet for an internal API.
-	return "http://" + string(config.RoomServer.Listen)
+	return string(config.RoomServer.InternalAPI.Connect)
 }
 
 // UserAPIURL returns an HTTP URL for where the userapi is listening.
@@ -468,7 +509,7 @@ func (config *Dendrite) UserAPIURL() string {
 	// If we support HTTPS we need to think of a practical way to do certificate validation.
 	// People setting up servers shouldn't need to get a certificate valid for the public
 	// internet for an internal API.
-	return "http://" + string(config.UserAPI.Listen)
+	return string(config.UserAPI.InternalAPI.Connect)
 }
 
 // CurrentStateAPIURL returns an HTTP URL for where the currentstateserver is listening.
@@ -477,7 +518,7 @@ func (config *Dendrite) CurrentStateAPIURL() string {
 	// If we support HTTPS we need to think of a practical way to do certificate validation.
 	// People setting up servers shouldn't need to get a certificate valid for the public
 	// internet for an internal API.
-	return "http://" + string(config.CurrentStateServer.Listen)
+	return string(config.CurrentStateServer.InternalAPI.Connect)
 }
 
 // EDUServerURL returns an HTTP URL for where the EDU server is listening.
@@ -486,7 +527,7 @@ func (config *Dendrite) EDUServerURL() string {
 	// If we support HTTPS we need to think of a practical way to do certificate validation.
 	// People setting up servers shouldn't need to get a certificate valid for the public
 	// internet for an internal API.
-	return "http://" + string(config.EDUServer.Listen)
+	return string(config.EDUServer.InternalAPI.Connect)
 }
 
 // FederationSenderURL returns an HTTP URL for where the federation sender is listening.
@@ -495,7 +536,7 @@ func (config *Dendrite) FederationSenderURL() string {
 	// If we support HTTPS we need to think of a practical way to do certificate validation.
 	// People setting up servers shouldn't need to get a certificate valid for the public
 	// internet for an internal API.
-	return "http://" + string(config.FederationSender.Listen)
+	return string(config.FederationSender.InternalAPI.Connect)
 }
 
 // ServerKeyAPIURL returns an HTTP URL for where the server key API is listening.
@@ -504,7 +545,7 @@ func (config *Dendrite) ServerKeyAPIURL() string {
 	// If we support HTTPS we need to think of a practical way to do certificate validation.
 	// People setting up servers shouldn't need to get a certificate valid for the public
 	// internet for an internal API.
-	return "http://" + string(config.ServerKeyAPI.Listen)
+	return string(config.ServerKeyAPI.InternalAPI.Connect)
 }
 
 // KeyServerURL returns an HTTP URL for where the key server is listening.
@@ -513,7 +554,7 @@ func (config *Dendrite) KeyServerURL() string {
 	// If we support HTTPS we need to think of a practical way to do certificate validation.
 	// People setting up servers shouldn't need to get a certificate valid for the public
 	// internet for an internal API.
-	return "http://" + string(config.KeyServer.Listen)
+	return string(config.KeyServer.InternalAPI.Connect)
 }
 
 // SetupTracing configures the opentracing using the supplied configuration.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,7 +145,7 @@ type Address string
 // An HTTPAddress to listen on, starting with either http:// or https://.
 type HTTPAddress string
 
-func (h HTTPAddress) GetAddress() (Address, error) {
+func (h HTTPAddress) Address() (Address, error) {
 	url, err := url.Parse(string(h))
 	if err != nil {
 		return "", err

--- a/internal/config/config_appservice.go
+++ b/internal/config/config_appservice.go
@@ -29,8 +29,7 @@ type AppServiceAPI struct {
 	Matrix  *Global  `yaml:"-"`
 	Derived *Derived `yaml:"-"` // TODO: Nuke Derived from orbit
 
-	Listen Address `yaml:"listen"`
-	Bind   Address `yaml:"bind"`
+	InternalAPI InternalAPIOptions `yaml:"internal_api"`
 
 	Database DatabaseOptions `yaml:"database"`
 
@@ -38,15 +37,15 @@ type AppServiceAPI struct {
 }
 
 func (c *AppServiceAPI) Defaults() {
-	c.Listen = "localhost:7777"
-	c.Bind = "localhost:7777"
+	c.InternalAPI.Listen = "http://localhost:7777"
+	c.InternalAPI.Connect = "http://localhost:7777"
 	c.Database.Defaults()
 	c.Database.ConnectionString = "file:appservice.db"
 }
 
 func (c *AppServiceAPI) Verify(configErrs *ConfigErrors, isMonolith bool) {
-	checkNotEmpty(configErrs, "app_service_api.listen", string(c.Listen))
-	checkNotEmpty(configErrs, "app_service_api.bind", string(c.Bind))
+	checkURL(configErrs, "app_service_api.internal_api.listen", string(c.InternalAPI.Listen))
+	checkURL(configErrs, "app_service_api.internal_api.bind", string(c.InternalAPI.Connect))
 	checkNotEmpty(configErrs, "app_service_api.database.connection_string", string(c.Database.ConnectionString))
 }
 

--- a/internal/config/config_clientapi.go
+++ b/internal/config/config_clientapi.go
@@ -9,8 +9,8 @@ type ClientAPI struct {
 	Matrix  *Global  `yaml:"-"`
 	Derived *Derived `yaml:"-"` // TODO: Nuke Derived from orbit
 
-	Listen Address `yaml:"listen"`
-	Bind   Address `yaml:"bind"`
+	InternalAPI InternalAPIOptions `yaml:"internal_api"`
+	ExternalAPI ExternalAPIOptions `yaml:"external_api"`
 
 	// If set disables new users from registering (except via shared
 	// secrets)
@@ -37,8 +37,9 @@ type ClientAPI struct {
 }
 
 func (c *ClientAPI) Defaults() {
-	c.Listen = "localhost:7771"
-	c.Bind = "localhost:7771"
+	c.InternalAPI.Listen = "http://localhost:7771"
+	c.InternalAPI.Connect = "http://localhost:7771"
+	c.ExternalAPI.Listen = "http://[::]:8071"
 	c.RegistrationSharedSecret = ""
 	c.RecaptchaPublicKey = ""
 	c.RecaptchaPrivateKey = ""
@@ -49,8 +50,11 @@ func (c *ClientAPI) Defaults() {
 }
 
 func (c *ClientAPI) Verify(configErrs *ConfigErrors, isMonolith bool) {
-	checkNotEmpty(configErrs, "client_api.listen", string(c.Listen))
-	checkNotEmpty(configErrs, "client_api.bind", string(c.Bind))
+	checkURL(configErrs, "client_api.internal_api.listen", string(c.InternalAPI.Listen))
+	checkURL(configErrs, "client_api.internal_api.connect", string(c.InternalAPI.Connect))
+	if !isMonolith {
+		checkURL(configErrs, "client_api.external_api.listen", string(c.ExternalAPI.Listen))
+	}
 	if c.RecaptchaEnabled {
 		checkNotEmpty(configErrs, "client_api.recaptcha_public_key", string(c.RecaptchaPublicKey))
 		checkNotEmpty(configErrs, "client_api.recaptcha_private_key", string(c.RecaptchaPrivateKey))

--- a/internal/config/config_currentstate.go
+++ b/internal/config/config_currentstate.go
@@ -3,8 +3,7 @@ package config
 type CurrentStateServer struct {
 	Matrix *Global `yaml:"-"`
 
-	Listen Address `yaml:"listen"`
-	Bind   Address `yaml:"bind"`
+	InternalAPI InternalAPIOptions `yaml:"internal_api"`
 
 	// The CurrentState database stores the current state of all rooms.
 	// It is accessed by the CurrentStateServer.
@@ -12,14 +11,14 @@ type CurrentStateServer struct {
 }
 
 func (c *CurrentStateServer) Defaults() {
-	c.Listen = "localhost:7782"
-	c.Bind = "localhost:7782"
+	c.InternalAPI.Listen = "http://localhost:7782"
+	c.InternalAPI.Connect = "http://localhost:7782"
 	c.Database.Defaults()
 	c.Database.ConnectionString = "file:currentstate.db"
 }
 
 func (c *CurrentStateServer) Verify(configErrs *ConfigErrors, isMonolith bool) {
-	checkNotEmpty(configErrs, "current_state_server.listen", string(c.Listen))
-	checkNotEmpty(configErrs, "current_state_server.bind", string(c.Bind))
+	checkURL(configErrs, "current_state_server.internal_api.listen", string(c.InternalAPI.Listen))
+	checkURL(configErrs, "current_state_server.internal_api.connect", string(c.InternalAPI.Connect))
 	checkNotEmpty(configErrs, "current_state_server.database.connection_string", string(c.Database.ConnectionString))
 }

--- a/internal/config/config_eduserver.go
+++ b/internal/config/config_eduserver.go
@@ -3,16 +3,15 @@ package config
 type EDUServer struct {
 	Matrix *Global `yaml:"-"`
 
-	Listen Address `yaml:"listen"`
-	Bind   Address `yaml:"bind"`
+	InternalAPI InternalAPIOptions `yaml:"internal_api"`
 }
 
 func (c *EDUServer) Defaults() {
-	c.Listen = "localhost:7778"
-	c.Bind = "localhost:7778"
+	c.InternalAPI.Listen = "http://localhost:7778"
+	c.InternalAPI.Connect = "http://localhost:7778"
 }
 
 func (c *EDUServer) Verify(configErrs *ConfigErrors, isMonolith bool) {
-	checkNotEmpty(configErrs, "edu_server.listen", string(c.Listen))
-	checkNotEmpty(configErrs, "edu_server.bind", string(c.Bind))
+	checkURL(configErrs, "edu_server.internal_api.listen", string(c.InternalAPI.Listen))
+	checkURL(configErrs, "edu_server.internal_api.connect", string(c.InternalAPI.Connect))
 }

--- a/internal/config/config_federationapi.go
+++ b/internal/config/config_federationapi.go
@@ -5,8 +5,8 @@ import "github.com/matrix-org/gomatrixserverlib"
 type FederationAPI struct {
 	Matrix *Global `yaml:"-"`
 
-	Listen Address `yaml:"listen"`
-	Bind   Address `yaml:"bind"`
+	InternalAPI InternalAPIOptions `yaml:"internal_api"`
+	ExternalAPI ExternalAPIOptions `yaml:"external_api"`
 
 	// List of paths to X509 certificates used by the external federation listeners.
 	// These are used to calculate the TLS fingerprints to publish for this server.
@@ -21,13 +21,17 @@ type FederationAPI struct {
 }
 
 func (c *FederationAPI) Defaults() {
-	c.Listen = "localhost:7772"
-	c.Bind = "localhost:7772"
+	c.InternalAPI.Listen = "http://localhost:7772"
+	c.InternalAPI.Connect = "http://localhost:7772"
+	c.ExternalAPI.Listen = "http://[::]:8072"
 }
 
 func (c *FederationAPI) Verify(configErrs *ConfigErrors, isMonolith bool) {
-	checkNotEmpty(configErrs, "federation_api.listen", string(c.Listen))
-	checkNotEmpty(configErrs, "federation_api.bind", string(c.Bind))
+	checkURL(configErrs, "federation_api.internal_api.listen", string(c.InternalAPI.Listen))
+	checkURL(configErrs, "federation_api.internal_api.connect", string(c.InternalAPI.Connect))
+	if !isMonolith {
+		checkURL(configErrs, "federation_api.external_api.listen", string(c.ExternalAPI.Listen))
+	}
 	// TODO: not applicable always, e.g. in demos
 	//checkNotZero(configErrs, "federation_api.federation_certificates", int64(len(c.FederationCertificatePaths)))
 }

--- a/internal/config/config_federationsender.go
+++ b/internal/config/config_federationsender.go
@@ -3,8 +3,7 @@ package config
 type FederationSender struct {
 	Matrix *Global `yaml:"-"`
 
-	Listen Address `yaml:"listen"`
-	Bind   Address `yaml:"bind"`
+	InternalAPI InternalAPIOptions `yaml:"internal_api"`
 
 	// The FederationSender database stores information used by the FederationSender
 	// It is only accessed by the FederationSender.
@@ -24,8 +23,8 @@ type FederationSender struct {
 }
 
 func (c *FederationSender) Defaults() {
-	c.Listen = "localhost:7775"
-	c.Bind = "localhost:7775"
+	c.InternalAPI.Listen = "http://localhost:7775"
+	c.InternalAPI.Connect = "http://localhost:7775"
 	c.Database.Defaults()
 	c.Database.ConnectionString = "file:federationsender.db"
 
@@ -36,8 +35,8 @@ func (c *FederationSender) Defaults() {
 }
 
 func (c *FederationSender) Verify(configErrs *ConfigErrors, isMonolith bool) {
-	checkNotEmpty(configErrs, "federation_sender.listen", string(c.Listen))
-	checkNotEmpty(configErrs, "federation_sender.bind", string(c.Bind))
+	checkURL(configErrs, "federation_sender.internal_api.listen", string(c.InternalAPI.Listen))
+	checkURL(configErrs, "federation_sender.internal_api.connect", string(c.InternalAPI.Connect))
 	checkNotEmpty(configErrs, "federation_sender.database.connection_string", string(c.Database.ConnectionString))
 }
 

--- a/internal/config/config_keyserver.go
+++ b/internal/config/config_keyserver.go
@@ -3,21 +3,20 @@ package config
 type KeyServer struct {
 	Matrix *Global `yaml:"-"`
 
-	Listen Address `yaml:"listen"`
-	Bind   Address `yaml:"bind"`
+	InternalAPI InternalAPIOptions `yaml:"internal_api"`
 
 	Database DatabaseOptions `yaml:"database"`
 }
 
 func (c *KeyServer) Defaults() {
-	c.Listen = "localhost:7779"
-	c.Bind = "localhost:7779"
+	c.InternalAPI.Listen = "http://localhost:7779"
+	c.InternalAPI.Connect = "http://localhost:7779"
 	c.Database.Defaults()
 	c.Database.ConnectionString = "file:keyserver.db"
 }
 
 func (c *KeyServer) Verify(configErrs *ConfigErrors, isMonolith bool) {
-	checkNotEmpty(configErrs, "key_server.listen", string(c.Listen))
-	checkNotEmpty(configErrs, "key_server.bind", string(c.Bind))
+	checkURL(configErrs, "key_server.internal_api.listen", string(c.InternalAPI.Listen))
+	checkURL(configErrs, "key_server.internal_api.bind", string(c.InternalAPI.Connect))
 	checkNotEmpty(configErrs, "key_server.database.connection_string", string(c.Database.ConnectionString))
 }

--- a/internal/config/config_mediaapi.go
+++ b/internal/config/config_mediaapi.go
@@ -7,8 +7,8 @@ import (
 type MediaAPI struct {
 	Matrix *Global `yaml:"-"`
 
-	Listen Address `yaml:"listen"`
-	Bind   Address `yaml:"bind"`
+	InternalAPI InternalAPIOptions `yaml:"internal_api"`
+	ExternalAPI ExternalAPIOptions `yaml:"external_api"`
 
 	// The MediaAPI database stores information about files uploaded and downloaded
 	// by local users. It is only accessed by the MediaAPI.
@@ -36,8 +36,9 @@ type MediaAPI struct {
 }
 
 func (c *MediaAPI) Defaults() {
-	c.Listen = "localhost:7774"
-	c.Bind = "localhost:7774"
+	c.InternalAPI.Listen = "http://localhost:7774"
+	c.InternalAPI.Connect = "http://localhost:7774"
+	c.ExternalAPI.Listen = "http://[::]:8074"
 	c.Database.Defaults()
 	c.Database.ConnectionString = "file:mediaapi.db"
 
@@ -48,8 +49,11 @@ func (c *MediaAPI) Defaults() {
 }
 
 func (c *MediaAPI) Verify(configErrs *ConfigErrors, isMonolith bool) {
-	checkNotEmpty(configErrs, "media_api.listen", string(c.Listen))
-	checkNotEmpty(configErrs, "media_api.bind", string(c.Bind))
+	checkURL(configErrs, "media_api.internal_api.listen", string(c.InternalAPI.Listen))
+	checkURL(configErrs, "media_api.internal_api.connect", string(c.InternalAPI.Connect))
+	if !isMonolith {
+		checkURL(configErrs, "media_api.external_api.listen", string(c.ExternalAPI.Listen))
+	}
 	checkNotEmpty(configErrs, "media_api.database.connection_string", string(c.Database.ConnectionString))
 
 	checkNotEmpty(configErrs, "media_api.base_path", string(c.BasePath))

--- a/internal/config/config_roomserver.go
+++ b/internal/config/config_roomserver.go
@@ -3,21 +3,20 @@ package config
 type RoomServer struct {
 	Matrix *Global `yaml:"-"`
 
-	Listen Address `yaml:"listen"`
-	Bind   Address `yaml:"bind"`
+	InternalAPI InternalAPIOptions `yaml:"internal_api"`
 
 	Database DatabaseOptions `yaml:"database"`
 }
 
 func (c *RoomServer) Defaults() {
-	c.Listen = "localhost:7770"
-	c.Bind = "localhost:7770"
+	c.InternalAPI.Listen = "http://localhost:7770"
+	c.InternalAPI.Connect = "http://localhost:7770"
 	c.Database.Defaults()
 	c.Database.ConnectionString = "file:roomserver.db"
 }
 
 func (c *RoomServer) Verify(configErrs *ConfigErrors, isMonolith bool) {
-	checkNotEmpty(configErrs, "room_server.listen", string(c.Listen))
-	checkNotEmpty(configErrs, "room_server.bind", string(c.Bind))
+	checkURL(configErrs, "room_server.internal_api.listen", string(c.InternalAPI.Listen))
+	checkURL(configErrs, "room_server.internal_ap.bind", string(c.InternalAPI.Connect))
 	checkNotEmpty(configErrs, "room_server.database.connection_string", string(c.Database.ConnectionString))
 }

--- a/internal/config/config_serverkey.go
+++ b/internal/config/config_serverkey.go
@@ -5,8 +5,7 @@ import "github.com/matrix-org/gomatrixserverlib"
 type ServerKeyAPI struct {
 	Matrix *Global `yaml:"-"`
 
-	Listen Address `yaml:"listen"`
-	Bind   Address `yaml:"bind"`
+	InternalAPI InternalAPIOptions `yaml:"internal_api"`
 
 	// The ServerKey database caches the public keys of remote servers.
 	// It may be accessed by the FederationAPI, the ClientAPI, and the MediaAPI.
@@ -18,15 +17,15 @@ type ServerKeyAPI struct {
 }
 
 func (c *ServerKeyAPI) Defaults() {
-	c.Listen = "localhost:7780"
-	c.Bind = "localhost:7780"
+	c.InternalAPI.Listen = "http://localhost:7780"
+	c.InternalAPI.Connect = "http://localhost:7780"
 	c.Database.Defaults()
 	c.Database.ConnectionString = "file:serverkeyapi.db"
 }
 
 func (c *ServerKeyAPI) Verify(configErrs *ConfigErrors, isMonolith bool) {
-	checkNotEmpty(configErrs, "server_key_api.listen", string(c.Listen))
-	checkNotEmpty(configErrs, "server_key_api.bind", string(c.Bind))
+	checkURL(configErrs, "server_key_api.internal_api.listen", string(c.InternalAPI.Listen))
+	checkURL(configErrs, "server_key_api.internal_api.bind", string(c.InternalAPI.Connect))
 	checkNotEmpty(configErrs, "server_key_api.database.connection_string", string(c.Database.ConnectionString))
 }
 

--- a/internal/config/config_syncapi.go
+++ b/internal/config/config_syncapi.go
@@ -3,21 +3,20 @@ package config
 type SyncAPI struct {
 	Matrix *Global `yaml:"-"`
 
-	Listen Address `yaml:"listen"`
-	Bind   Address `yaml:"bind"`
+	InternalAPI InternalAPIOptions `yaml:"internal_api"`
 
 	Database DatabaseOptions `yaml:"database"`
 }
 
 func (c *SyncAPI) Defaults() {
-	c.Listen = "localhost:7773"
-	c.Bind = "localhost:7773"
+	c.InternalAPI.Listen = "http://localhost:7773"
+	c.InternalAPI.Connect = "http://localhost:7773"
 	c.Database.Defaults()
 	c.Database.ConnectionString = "file:syncapi.db"
 }
 
 func (c *SyncAPI) Verify(configErrs *ConfigErrors, isMonolith bool) {
-	checkNotEmpty(configErrs, "sync_api.listen", string(c.Listen))
-	checkNotEmpty(configErrs, "sync_api.bind", string(c.Bind))
+	checkURL(configErrs, "sync_api.internal_api.listen", string(c.InternalAPI.Listen))
+	checkURL(configErrs, "sync_api.internal_api.bind", string(c.InternalAPI.Connect))
 	checkNotEmpty(configErrs, "sync_api.database", string(c.Database.ConnectionString))
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -43,7 +43,8 @@ global:
   - matrix.org
   - vector.im
   kafka:
-    addresses: []
+    addresses:
+    - localhost:2181
     topic_prefix: Dendrite
     use_naffka: true
     naffka_database:
@@ -57,8 +58,9 @@ global:
       username: metrics
       password: metrics
 app_service_api:
-  listen: localhost:7777
-  bind: localhost:7777
+  internal_api:
+    listen: http://localhost:7777
+    connect: http://localhost:7777
   database:
     connection_string: file:appservice.db
     max_open_conns: 100
@@ -66,8 +68,11 @@ app_service_api:
     conn_max_lifetime: -1
   config_files: []
 client_api:
-  listen: localhost:7771
-  bind: localhost:7771
+  internal_api:
+    listen: http://localhost:7771
+    connect: http://localhost:7771
+  external_api:
+    listen: http://[::]:8071
   registration_disabled: false
   registration_shared_secret: ""
   enable_registration_captcha: false
@@ -82,23 +87,29 @@ client_api:
     turn_username: ""
     turn_password: ""
 current_state_server:
-  listen: localhost:7782
-  bind: localhost:7782
+  internal_api:
+    listen: http://localhost:7782
+    connect: http://localhost:7782
   database:
     connection_string: file:currentstate.db
     max_open_conns: 100
     max_idle_conns: 2
     conn_max_lifetime: -1
 edu_server:
-  listen: localhost:7778
-  bind: localhost:7778
+  internal_api:
+    listen: http://localhost:7778
+    connect: http://localhost:7778
 federation_api:
-  listen: localhost:7772
-  bind: localhost:7772
+  internal_api:
+    listen: http://localhost:7772
+    connect: http://localhost:7772
+  external_api:
+    listen: http://[::]:8072
   federation_certificates: []
 federation_sender:
-  listen: localhost:7775
-  bind: localhost:7775
+  internal_api:
+    listen: http://localhost:7775
+    connect: http://localhost:7775
   database:
     connection_string: file:federationsender.db
     max_open_conns: 100
@@ -112,16 +123,20 @@ federation_sender:
     host: localhost
     port: 8080
 key_server:
-  listen: localhost:7779
-  bind: localhost:7779
+  internal_api:
+    listen: http://localhost:7779
+    connect: http://localhost:7779
   database:
     connection_string: file:keyserver.db
     max_open_conns: 100
     max_idle_conns: 2
     conn_max_lifetime: -1
 media_api:
-  listen: localhost:7774
-  bind: localhost:7774
+  internal_api:
+    listen: http://localhost:7774
+    connect: http://localhost:7774
+  external_api:
+    listen: http://[::]:8074
   database:
     connection_string: file:mediaapi.db
     max_open_conns: 100
@@ -142,16 +157,18 @@ media_api:
     height: 480
     method: scale
 room_server:
-  listen: localhost:7770
-  bind: localhost:7770
+  internal_api:
+    listen: http://localhost:7770
+    connect: http://localhost:7770
   database:
     connection_string: file:roomserver.db
     max_open_conns: 100
     max_idle_conns: 2
     conn_max_lifetime: -1
 server_key_api:
-  listen: localhost:7780
-  bind: localhost:7780
+  internal_api:
+    listen: http://localhost:7780
+    connect: http://localhost:7780
   database:
     connection_string: file:serverkeyapi.db
     max_open_conns: 100
@@ -165,16 +182,18 @@ server_key_api:
     - key_id: ed25519:a_RXGa
       public_key: l8Hft5qXKn1vfHrg3p4+W8gELQVo8N13JkluMfmn2sQ
 sync_api:
-  listen: localhost:7773
-  bind: localhost:7773
+  internal_api:
+    listen: http://localhost:7773
+    connect: http://localhost:7773
   database:
     connection_string: file:syncapi.db
     max_open_conns: 100
     max_idle_conns: 2
     conn_max_lifetime: -1
 user_api:
-  listen: localhost:7781
-  bind: localhost:7781
+  internal_api:
+    listen: http://localhost:7781
+    connect: http://localhost:7781
   account_database:
     connection_string: file:userapi_accounts.db
     max_open_conns: 100

--- a/internal/config/config_userapi.go
+++ b/internal/config/config_userapi.go
@@ -3,8 +3,7 @@ package config
 type UserAPI struct {
 	Matrix *Global `yaml:"-"`
 
-	Listen Address `yaml:"listen"`
-	Bind   Address `yaml:"bind"`
+	InternalAPI InternalAPIOptions `yaml:"internal_api"`
 
 	// The Account database stores the login details and account information
 	// for local users. It is accessed by the UserAPI.
@@ -15,8 +14,8 @@ type UserAPI struct {
 }
 
 func (c *UserAPI) Defaults() {
-	c.Listen = "localhost:7781"
-	c.Bind = "localhost:7781"
+	c.InternalAPI.Listen = "http://localhost:7781"
+	c.InternalAPI.Connect = "http://localhost:7781"
 	c.AccountDatabase.Defaults()
 	c.DeviceDatabase.Defaults()
 	c.AccountDatabase.ConnectionString = "file:userapi_accounts.db"
@@ -24,8 +23,8 @@ func (c *UserAPI) Defaults() {
 }
 
 func (c *UserAPI) Verify(configErrs *ConfigErrors, isMonolith bool) {
-	checkNotEmpty(configErrs, "user_api.listen", string(c.Listen))
-	checkNotEmpty(configErrs, "user_api.bind", string(c.Bind))
+	checkURL(configErrs, "user_api.internal_api.listen", string(c.InternalAPI.Listen))
+	checkURL(configErrs, "user_api.internal_api.connect", string(c.InternalAPI.Connect))
 	checkNotEmpty(configErrs, "user_api.account_database.connection_string", string(c.AccountDatabase.ConnectionString))
 	checkNotEmpty(configErrs, "user_api.device_database.connection_string", string(c.DeviceDatabase.ConnectionString))
 }

--- a/internal/httputil/httpapi.go
+++ b/internal/httputil/httpapi.go
@@ -233,14 +233,24 @@ func (f *FederationWakeups) Wakeup(ctx context.Context, origin gomatrixserverlib
 	}
 }
 
-// SetupHTTPAPI registers an HTTP API mux under /api and sets up a metrics listener
+// SetupHTTPAPI registers both internal and external HTTP APIs.
 func SetupHTTPAPI(servMux, publicApiMux, internalApiMux *mux.Router, cfg *config.Global, enableHTTPAPIs bool) {
+	SetupInternalHTTPAPI(servMux, internalApiMux, cfg, enableHTTPAPIs)
+	SetupExternalHTTPAPI(servMux, publicApiMux, cfg)
+}
+
+// SetupInternalHTTPAPI registers internal APIs and metrics only.
+func SetupInternalHTTPAPI(servMux, internalApiMux *mux.Router, cfg *config.Global, enableHTTPAPIs bool) {
 	if cfg.Metrics.Enabled {
 		servMux.Handle("/metrics", WrapHandlerInBasicAuth(promhttp.Handler(), cfg.Metrics.BasicAuth))
 	}
 	if enableHTTPAPIs {
 		servMux.Handle(InternalPathPrefix, internalApiMux)
 	}
+}
+
+// SetupExternalHTTPAPI registers public APIs only.
+func SetupExternalHTTPAPI(servMux, publicApiMux *mux.Router, cfg *config.Global) {
 	servMux.Handle(PublicPathPrefix, WrapHandlerInCORS(publicApiMux))
 }
 

--- a/internal/httputil/httpapi.go
+++ b/internal/httputil/httpapi.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/clientapi/auth"
 	federationsenderAPI "github.com/matrix-org/dendrite/federationsender/api"
-	"github.com/matrix-org/dendrite/internal/config"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
@@ -231,27 +230,6 @@ func (f *FederationWakeups) Wakeup(ctx context.Context, origin gomatrixserverlib
 	} else {
 		f.origins.Store(origin, time.Now())
 	}
-}
-
-// SetupHTTPAPI registers both internal and external HTTP APIs.
-func SetupHTTPAPI(servMux, publicApiMux, internalApiMux *mux.Router, cfg *config.Global, enableHTTPAPIs bool) {
-	SetupInternalHTTPAPI(servMux, internalApiMux, cfg, enableHTTPAPIs)
-	SetupExternalHTTPAPI(servMux, publicApiMux, cfg)
-}
-
-// SetupInternalHTTPAPI registers internal APIs and metrics only.
-func SetupInternalHTTPAPI(servMux, internalApiMux *mux.Router, cfg *config.Global, enableHTTPAPIs bool) {
-	if cfg.Metrics.Enabled {
-		servMux.Handle("/metrics", WrapHandlerInBasicAuth(promhttp.Handler(), cfg.Metrics.BasicAuth))
-	}
-	if enableHTTPAPIs {
-		servMux.Handle(InternalPathPrefix, internalApiMux)
-	}
-}
-
-// SetupExternalHTTPAPI registers public APIs only.
-func SetupExternalHTTPAPI(servMux, publicApiMux *mux.Router, cfg *config.Global) {
-	servMux.Handle(PublicPathPrefix, WrapHandlerInCORS(publicApiMux))
 }
 
 // WrapHandlerInBasicAuth adds basic auth to a handler. Only used for /metrics

--- a/internal/httputil/paths.go
+++ b/internal/httputil/paths.go
@@ -15,6 +15,9 @@
 package httputil
 
 const (
-	PublicPathPrefix   = "/_matrix/"
-	InternalPathPrefix = "/api/"
+	ExternalClientPathPrefix     = "/_matrix/client/"
+	ExternalFederationPathPrefix = "/_matrix/federation/"
+	ExternalKeyPathPrefix        = "/_matrix/key/"
+	ExternalMediaPathPrefix      = "/_matrix/media/"
+	InternalPathPrefix           = "/api/"
 )

--- a/internal/httputil/paths.go
+++ b/internal/httputil/paths.go
@@ -15,6 +15,6 @@
 package httputil
 
 const (
-	PublicPathPrefix   = "/_matrix"
-	InternalPathPrefix = "/api"
+	PublicPathPrefix   = "/_matrix/"
+	InternalPathPrefix = "/api/"
 )

--- a/internal/httputil/paths.go
+++ b/internal/httputil/paths.go
@@ -15,6 +15,6 @@
 package httputil
 
 const (
-	PublicPathPrefix   = "/_matrix/"
-	InternalPathPrefix = "/api/"
+	PublicPathPrefix   = "/_matrix"
+	InternalPathPrefix = "/api"
 )

--- a/internal/httputil/paths.go
+++ b/internal/httputil/paths.go
@@ -15,9 +15,9 @@
 package httputil
 
 const (
-	ExternalClientPathPrefix     = "/_matrix/client/"
-	ExternalFederationPathPrefix = "/_matrix/federation/"
-	ExternalKeyPathPrefix        = "/_matrix/key/"
-	ExternalMediaPathPrefix      = "/_matrix/media/"
-	InternalPathPrefix           = "/api/"
+	PublicClientPathPrefix     = "/_matrix/client/"
+	PublicFederationPathPrefix = "/_matrix/federation/"
+	PublicKeyPathPrefix        = "/_matrix/key/"
+	PublicMediaPathPrefix      = "/_matrix/media/"
+	InternalPathPrefix         = "/api/"
 )

--- a/internal/setup/base.go
+++ b/internal/setup/base.go
@@ -269,6 +269,7 @@ func (b *BaseDendrite) CreateFederationClient() *gomatrixserverlib.FederationCli
 
 // SetupAndServeHTTP sets up the HTTP server to serve endpoints registered on
 // ApiMux under /api/ and adds a prometheus handler under /metrics.
+// nolint:gocyclo
 func (b *BaseDendrite) SetupAndServeHTTP(
 	internalHTTPAddr, externalHTTPAddr config.HTTPAddress,
 	certFile, keyFile *string,

--- a/internal/setup/base.go
+++ b/internal/setup/base.go
@@ -280,7 +280,7 @@ func (b *BaseDendrite) SetupAndServeHTTP(internalHTTPAddr, externalHTTPAddr conf
 	}
 	externalServ := internalServ
 
-	if externalAddr != internalAddr {
+	if externalAddr != "" && externalAddr != internalAddr {
 		externalRouter = mux.NewRouter()
 		externalServ = &http.Server{
 			Addr:         string(externalAddr),

--- a/internal/setup/monolith.go
+++ b/internal/setup/monolith.go
@@ -63,21 +63,21 @@ type Monolith struct {
 }
 
 // AddAllPublicRoutes attaches all public paths to the given router
-func (m *Monolith) AddAllPublicRoutes(publicMux *mux.Router) {
+func (m *Monolith) AddAllPublicRoutes(csMux, ssMux, keyMux, mediaMux *mux.Router) {
 	clientapi.AddPublicRoutes(
-		publicMux, &m.Config.ClientAPI, m.KafkaProducer, m.DeviceDB, m.AccountDB,
+		csMux, &m.Config.ClientAPI, m.KafkaProducer, m.DeviceDB, m.AccountDB,
 		m.FedClient, m.RoomserverAPI,
 		m.EDUInternalAPI, m.AppserviceAPI, m.StateAPI, transactions.New(),
 		m.FederationSenderAPI, m.UserAPI, m.KeyAPI, m.ExtPublicRoomsProvider,
 	)
 	federationapi.AddPublicRoutes(
-		publicMux, &m.Config.FederationAPI, m.UserAPI, m.FedClient,
+		ssMux, keyMux, &m.Config.FederationAPI, m.UserAPI, m.FedClient,
 		m.KeyRing, m.RoomserverAPI, m.FederationSenderAPI,
 		m.EDUInternalAPI, m.StateAPI, m.KeyAPI,
 	)
-	mediaapi.AddPublicRoutes(publicMux, &m.Config.MediaAPI, m.UserAPI, m.Client)
+	mediaapi.AddPublicRoutes(mediaMux, &m.Config.MediaAPI, m.UserAPI, m.Client)
 	syncapi.AddPublicRoutes(
-		publicMux, m.KafkaConsumer, m.UserAPI, m.RoomserverAPI,
+		csMux, m.KafkaConsumer, m.UserAPI, m.RoomserverAPI,
 		m.KeyAPI, m.StateAPI, m.FedClient, &m.Config.SyncAPI,
 	)
 }

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -52,8 +52,8 @@ func MakeConfig(configDir, kafkaURI, database, host string, startPort int) (*con
 	cfg.Defaults()
 
 	port := startPort
-	assignAddress := func() config.Address {
-		result := config.Address(fmt.Sprintf("%s:%d", host, port))
+	assignAddress := func() config.HTTPAddress {
+		result := config.HTTPAddress(fmt.Sprintf("http://%s:%d", host, port))
 		port++
 		return result
 	}
@@ -97,29 +97,29 @@ func MakeConfig(configDir, kafkaURI, database, host string, startPort int) (*con
 	cfg.UserAPI.AccountDatabase.ConnectionString = config.DataSource(database)
 	cfg.UserAPI.DeviceDatabase.ConnectionString = config.DataSource(database)
 
-	cfg.AppServiceAPI.Listen = assignAddress()
-	cfg.CurrentStateServer.Listen = assignAddress()
-	cfg.EDUServer.Listen = assignAddress()
-	cfg.FederationAPI.Listen = assignAddress()
-	cfg.FederationSender.Listen = assignAddress()
-	cfg.KeyServer.Listen = assignAddress()
-	cfg.MediaAPI.Listen = assignAddress()
-	cfg.RoomServer.Listen = assignAddress()
-	cfg.ServerKeyAPI.Listen = assignAddress()
-	cfg.SyncAPI.Listen = assignAddress()
-	cfg.UserAPI.Listen = assignAddress()
+	cfg.AppServiceAPI.InternalAPI.Listen = assignAddress()
+	cfg.CurrentStateServer.InternalAPI.Listen = assignAddress()
+	cfg.EDUServer.InternalAPI.Listen = assignAddress()
+	cfg.FederationAPI.InternalAPI.Listen = assignAddress()
+	cfg.FederationSender.InternalAPI.Listen = assignAddress()
+	cfg.KeyServer.InternalAPI.Listen = assignAddress()
+	cfg.MediaAPI.InternalAPI.Listen = assignAddress()
+	cfg.RoomServer.InternalAPI.Listen = assignAddress()
+	cfg.ServerKeyAPI.InternalAPI.Listen = assignAddress()
+	cfg.SyncAPI.InternalAPI.Listen = assignAddress()
+	cfg.UserAPI.InternalAPI.Listen = assignAddress()
 
-	cfg.AppServiceAPI.Bind = cfg.AppServiceAPI.Listen
-	cfg.CurrentStateServer.Bind = cfg.CurrentStateServer.Listen
-	cfg.EDUServer.Bind = cfg.EDUServer.Listen
-	cfg.FederationAPI.Bind = cfg.FederationAPI.Listen
-	cfg.FederationSender.Bind = cfg.FederationSender.Listen
-	cfg.KeyServer.Bind = cfg.KeyServer.Listen
-	cfg.MediaAPI.Bind = cfg.MediaAPI.Listen
-	cfg.RoomServer.Bind = cfg.RoomServer.Listen
-	cfg.ServerKeyAPI.Bind = cfg.ServerKeyAPI.Listen
-	cfg.SyncAPI.Bind = cfg.SyncAPI.Listen
-	cfg.UserAPI.Bind = cfg.UserAPI.Listen
+	cfg.AppServiceAPI.InternalAPI.Connect = cfg.AppServiceAPI.InternalAPI.Listen
+	cfg.CurrentStateServer.InternalAPI.Connect = cfg.CurrentStateServer.InternalAPI.Listen
+	cfg.EDUServer.InternalAPI.Connect = cfg.EDUServer.InternalAPI.Listen
+	cfg.FederationAPI.InternalAPI.Connect = cfg.FederationAPI.InternalAPI.Listen
+	cfg.FederationSender.InternalAPI.Connect = cfg.FederationSender.InternalAPI.Listen
+	cfg.KeyServer.InternalAPI.Connect = cfg.KeyServer.InternalAPI.Listen
+	cfg.MediaAPI.InternalAPI.Connect = cfg.MediaAPI.InternalAPI.Listen
+	cfg.RoomServer.InternalAPI.Connect = cfg.RoomServer.InternalAPI.Listen
+	cfg.ServerKeyAPI.InternalAPI.Connect = cfg.ServerKeyAPI.InternalAPI.Listen
+	cfg.SyncAPI.InternalAPI.Connect = cfg.SyncAPI.InternalAPI.Listen
+	cfg.UserAPI.InternalAPI.Connect = cfg.UserAPI.InternalAPI.Listen
 
 	return &cfg, port, nil
 }

--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -96,9 +96,9 @@ func InitDatabase(postgresDatabase, postgresContainerName string, databases []st
 func StartProxy(bindAddr string, cfg *config.Dendrite) (*exec.Cmd, chan error) {
 	proxyArgs := []string{
 		"--bind-address", bindAddr,
-		"--sync-api-server-url", "http://" + string(cfg.SyncAPI.Listen),
-		"--client-api-server-url", "http://" + string(cfg.ClientAPI.Listen),
-		"--media-api-server-url", "http://" + string(cfg.MediaAPI.Listen),
+		"--sync-api-server-url", "http://" + string(cfg.SyncAPI.InternalAPI.Connect),
+		"--client-api-server-url", "http://" + string(cfg.ClientAPI.InternalAPI.Connect),
+		"--media-api-server-url", "http://" + string(cfg.MediaAPI.InternalAPI.Connect),
 		"--tls-cert", "server.crt",
 		"--tls-key", "server.key",
 	}

--- a/mediaapi/routing/routing.go
+++ b/mediaapi/routing/routing.go
@@ -32,9 +32,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-const pathPrefixR0 = "/media/r0"
-const pathPrefixV1 = "/media/v1" // TODO: remove when synapse is fixed
-
 // Setup registers the media API HTTP handlers
 //
 // Due to Setup being used to call many other functions, a gocyclo nolint is
@@ -47,8 +44,8 @@ func Setup(
 	userAPI userapi.UserInternalAPI,
 	client *gomatrixserverlib.Client,
 ) {
-	r0mux := publicAPIMux.PathPrefix(pathPrefixR0).Subrouter()
-	v1mux := publicAPIMux.PathPrefix(pathPrefixV1).Subrouter()
+	r0mux := publicAPIMux.PathPrefix("/media/r0").Subrouter()
+	v1mux := publicAPIMux.PathPrefix("/media/v1").Subrouter()
 
 	activeThumbnailGeneration := &types.ActiveThumbnailGeneration{
 		PathToResult: map[string]*types.ThumbnailGenerationResult{},

--- a/mediaapi/routing/routing.go
+++ b/mediaapi/routing/routing.go
@@ -44,8 +44,8 @@ func Setup(
 	userAPI userapi.UserInternalAPI,
 	client *gomatrixserverlib.Client,
 ) {
-	r0mux := publicAPIMux.PathPrefix("/media/r0").Subrouter()
-	v1mux := publicAPIMux.PathPrefix("/media/v1").Subrouter()
+	r0mux := publicAPIMux.PathPrefix("/r0").Subrouter()
+	v1mux := publicAPIMux.PathPrefix("/v1").Subrouter()
 
 	activeThumbnailGeneration := &types.ActiveThumbnailGeneration{
 		PathToResult: map[string]*types.ThumbnailGenerationResult{},

--- a/syncapi/routing/routing.go
+++ b/syncapi/routing/routing.go
@@ -28,20 +28,18 @@ import (
 	"github.com/matrix-org/util"
 )
 
-const pathPrefixR0 = "/client/r0"
-
 // Setup configures the given mux with sync-server listeners
 //
 // Due to Setup being used to call many other functions, a gocyclo nolint is
 // applied:
 // nolint: gocyclo
 func Setup(
-	publicAPIMux *mux.Router, srp *sync.RequestPool, syncDB storage.Database,
+	csMux *mux.Router, srp *sync.RequestPool, syncDB storage.Database,
 	userAPI userapi.UserInternalAPI, federation *gomatrixserverlib.FederationClient,
 	rsAPI api.RoomserverInternalAPI,
 	cfg *config.SyncAPI,
 ) {
-	r0mux := publicAPIMux.PathPrefix(pathPrefixR0).Subrouter()
+	r0mux := csMux.PathPrefix("/r0").Subrouter()
 
 	// TODO: Add AS support for all handlers below.
 	r0mux.Handle("/sync", httputil.MakeAuthAPI("sync", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {


### PR DESCRIPTION
This makes a number of changes:

- Removes `BaseMux` in favour of flexible HTTP listeners
- Breaks apart the public and internal muxes into CS API, SS API, media API, key API and internal API muxes
- Allows internal and externally facing APIs to be set up on different HTTP listeners
- Listen addresses are now configured for internal and external components separately in the config, e.g.
```
client_api:
  internal_api:
    listen: http://localhost:7771
    connect: http://localhost:7771
  external_api:
    listen: http://[::]:8071
```