### PR TITLE
AWSY: new groups and add AS API section

### DIFF
--- a/are-we-synapse-yet.list
+++ b/are-we-synapse-yet.list
@@ -496,24 +496,24 @@ f,dvk If remote user leaves room, changes device and rejoins we see update in /k
 dvk Get left notifs in sync and /keys/changes when other user leaves 
 dvk Get left notifs for other users in sync and /keys/changes when user leaves 
 f,dvk If user leaves room, remote user changes device and rejoins we see update in /sync and /keys/changes 
-dvk Can create backup version 
-dvk Can update backup version 
-dvk Responds correctly when backup is empty 
-dvk Can backup keys 
-dvk Can update keys with better versions 
-dvk Will not update keys with worse versions 
-dvk Will not back up to an old backup version 
-dvk Can delete backup 
-dvk Deleted & recreated backups are empty 
-dvk Can create more than 10 backup versions 
-dvk Can upload self-signing keys 
-dvk Fails to upload self-signing keys with no auth 
-dvk Fails to upload self-signing key without master key 
-dvk Changing master key notifies local users 
-dvk Changing user-signing key notifies local users 
-f,dvk can fetch self-signing keys over federation 
-f,dvk uploading self-signing key notifies over federation 
-f,dvk uploading signed devices gets propagated over federation 
+dkb Can create backup version 
+dkb Can update backup version 
+dkb Responds correctly when backup is empty 
+dkb Can backup keys 
+dkb Can update keys with better versions 
+dkb Will not update keys with worse versions 
+dkb Will not back up to an old backup version 
+dkb Can delete backup 
+dkb Deleted & recreated backups are empty 
+dkb Can create more than 10 backup versions 
+xsk Can upload self-signing keys 
+xsk Fails to upload self-signing keys with no auth 
+xsk Fails to upload self-signing key without master key 
+xsk Changing master key notifies local users 
+xsk Changing user-signing key notifies local users 
+f,xsk can fetch self-signing keys over federation 
+f,xsk uploading self-signing key notifies over federation 
+f,xsk uploading signed devices gets propagated over federation 
 tag Can add tag
 tag Can remove tag
 tag Can list tags for a room

--- a/are-we-synapse-yet.py
+++ b/are-we-synapse-yet.py
@@ -34,6 +34,7 @@ import sys
 test_mappings = {
     "nsp": "Non-Spec API",
     "unk": "Unknown API (no group specified)",
+    "app": "Application Services API",
     "f": "Federation", # flag to mark test involves federation
 
     "federation_apis": {
@@ -63,6 +64,8 @@ test_mappings = {
         "pro": "Profile",
         "dev": "Devices",
         "dvk": "Device Keys",
+        "dkb": "Device Key Backup",
+        "xsk": "Cross-signing Keys",
         "pre": "Presence",
         "crm": "Create Room",
         "syn": "Sync API",
@@ -100,7 +103,6 @@ test_mappings = {
         "adm": "Server Admin API",
         "ign": "Ignore Users",
         "udr": "User Directory APIs",
-        "app": "Application Services API",
 		"jso": "Enforced canonical JSON",
     },
 }
@@ -216,6 +218,9 @@ def main(results_tap_path, verbose):
             #   test_name: OK
             # }
         },
+        "appservice": {
+            "app": {},
+        },
         "nonspec": {
             "nsp": {},
             "unk": {}
@@ -232,6 +237,8 @@ def main(results_tap_path, verbose):
                 summary["nonspec"]["unk"][name] = test_result["ok"]
             if group_id == "nsp":
                 summary["nonspec"]["nsp"][name] = test_result["ok"]
+            elif group_id == "app":
+                summary["appservice"]["app"][name] = test_result["ok"]
             elif group_id in test_mappings["federation_apis"]:
                 group = summary["federation"].get(group_id, {})
                 group[name] = test_result["ok"]
@@ -247,6 +254,7 @@ def main(results_tap_path, verbose):
     print_stats("Non-Spec APIs", summary["nonspec"], test_mappings, verbose)
     print_stats("Client-Server APIs", summary["client"], test_mappings["client_apis"], verbose)
     print_stats("Federation APIs", summary["federation"], test_mappings["federation_apis"], verbose)
+    print_stats("Application Services APIs", summary["appservice"], test_mappings, verbose)
 
 
 


### PR DESCRIPTION
Really we should never have put the AS API bits under CS API to
begin with, as it is a completely different versioned spec: split
it out (which bumps the CS API % slightly).

Also, split out Device Keys into 2 extra sections: Device Key Backup
and Cross-signing Keys. The point of AWSY is for it to be easy for
anyone to see which features are implemented in Dendrite, and bundling
three distinct features under the umbrella of Device Keys was just
unclear.
