### PR TITLE
Synchronous invites

### DIFF
--- a/clientapi/routing/createroom.go
+++ b/clientapi/routing/createroom.go
@@ -371,10 +371,7 @@ func createRoom(
 	}
 
 	// If this is a direct message then we should invite the participants.
-	fmt.Println("INVITEES:")
 	for _, invitee := range r.Invite {
-		fmt.Println("*", invitee)
-
 		// Build the invite event.
 		inviteEvent, err := buildMembershipEvent(
 			req.Context(), invitee, "", accountDB, device, gomatrixserverlib.Invite,
@@ -389,6 +386,10 @@ func createRoom(
 		var strippedState []gomatrixserverlib.InviteV2StrippedState
 		for _, event := range candidates {
 			switch event.Type() {
+			case gomatrixserverlib.MRoomName:
+				fallthrough
+			case gomatrixserverlib.MRoomCanonicalAlias:
+				fallthrough
 			case "m.room.encryption": // TODO: move this to gmsl
 				fallthrough
 			case gomatrixserverlib.MRoomMember:

--- a/clientapi/routing/membership.go
+++ b/clientapi/routing/membership.go
@@ -221,16 +221,20 @@ func SendInvite(
 		cfg.Matrix.ServerName,
 		nil,
 	)
-	if err != nil {
+	switch e := err.(type) {
+	case *roomserverAPI.PerformError:
+		return e.JSONResponse()
+	case nil:
+		return util.JSONResponse{
+			Code: http.StatusOK,
+			JSON: struct{}{},
+		}
+	default:
 		util.GetLogger(req.Context()).WithError(err).Error("roomserverAPI.SendInvite failed")
 		return util.JSONResponse{
-			Code: http.StatusForbidden,
-			JSON: jsonerror.Forbidden(err.Error()),
+			Code: http.StatusInternalServerError,
+			JSON: jsonerror.InternalServerError(),
 		}
-	}
-	return util.JSONResponse{
-		Code: http.StatusOK,
-		JSON: struct{}{},
 	}
 }
 

--- a/clientapi/routing/membership.go
+++ b/clientapi/routing/membership.go
@@ -26,7 +26,6 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/clientapi/threepid"
 	currentstateAPI "github.com/matrix-org/dendrite/currentstateserver/api"
-	federationSenderAPI "github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/dendrite/internal/config"
 	"github.com/matrix-org/dendrite/internal/eventutil"
 	"github.com/matrix-org/dendrite/roomserver/api"
@@ -173,7 +172,6 @@ func SendInvite(
 	req *http.Request, accountDB accounts.Database, device *userapi.Device,
 	roomID string, cfg *config.ClientAPI,
 	rsAPI roomserverAPI.RoomserverInternalAPI, asAPI appserviceAPI.AppServiceQueryAPI,
-	fsAPI federationSenderAPI.FederationSenderInternalAPI,
 ) util.JSONResponse {
 	body, evTime, _, reqErr := extractRequestData(req, roomID, rsAPI)
 	if reqErr != nil {

--- a/clientapi/routing/membership.go
+++ b/clientapi/routing/membership.go
@@ -223,7 +223,10 @@ func SendInvite(
 	)
 	if err != nil {
 		util.GetLogger(req.Context()).WithError(err).Error("roomserverAPI.SendInvite failed")
-		return jsonerror.InternalServerError()
+		return util.JSONResponse{
+			Code: http.StatusForbidden,
+			JSON: jsonerror.Forbidden(err.Error()),
+		}
 	}
 	return util.JSONResponse{
 		Code: http.StatusOK,

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -142,7 +142,7 @@ func Setup(
 			if err != nil {
 				return util.ErrorResponse(err)
 			}
-			return SendInvite(req, accountDB, device, vars["roomID"], cfg, rsAPI, asAPI, federationSender)
+			return SendInvite(req, accountDB, device, vars["roomID"], cfg, rsAPI, asAPI)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 	r0mux.Handle("/rooms/{roomID}/kick",

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -142,7 +142,7 @@ func Setup(
 			if err != nil {
 				return util.ErrorResponse(err)
 			}
-			return SendInvite(req, accountDB, device, vars["roomID"], cfg, rsAPI, asAPI)
+			return SendInvite(req, accountDB, device, vars["roomID"], cfg, rsAPI, asAPI, federationSender)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 	r0mux.Handle("/rooms/{roomID}/kick",

--- a/federationapi/routing/invite.go
+++ b/federationapi/routing/invite.go
@@ -143,11 +143,11 @@ func processInvite(
 	)
 
 	// Add the invite event to the roomserver.
-	if perr := api.SendInvite(
+	if err := api.SendInvite(
 		ctx, rsAPI, signedEvent.Headered(roomVer), strippedState, event.Origin(), nil,
-	); perr != nil {
+	); err != nil {
 		util.GetLogger(ctx).WithError(err).Error("producer.SendInvite failed")
-		return perr.JSONResponse()
+		return jsonerror.InternalServerError()
 	}
 
 	// Return the signed event to the originating server, it should then tell

--- a/federationapi/routing/invite.go
+++ b/federationapi/routing/invite.go
@@ -144,7 +144,7 @@ func processInvite(
 
 	// Add the invite event to the roomserver.
 	if err := api.SendInvite(
-		ctx, rsAPI, signedEvent.Headered(roomVer), strippedState, event.Origin(), nil,
+		ctx, rsAPI, signedEvent.Headered(roomVer), strippedState, api.DoNotSendToOtherServers, nil,
 	); err != nil {
 		util.GetLogger(ctx).WithError(err).Error("producer.SendInvite failed")
 		return jsonerror.InternalServerError()

--- a/federationapi/routing/leave.go
+++ b/federationapi/routing/leave.go
@@ -25,6 +25,7 @@ import (
 )
 
 // MakeLeave implements the /make_leave API
+// nolint:gocyclo
 func MakeLeave(
 	httpReq *http.Request,
 	request *gomatrixserverlib.FederationRequest,

--- a/federationapi/routing/leave.go
+++ b/federationapi/routing/leave.go
@@ -76,6 +76,23 @@ func MakeLeave(
 		return jsonerror.InternalServerError()
 	}
 
+	// If the user has already left then just return their last leave
+	// event. This means that /send_leave will be a no-op, which helps
+	// to reject invites multiple times - hopefully.
+	for _, state := range queryRes.StateEvents {
+		if state.Type() == gomatrixserverlib.MRoomMember && state.StateKeyEquals(userID) {
+			if mem, merr := state.Membership(); merr == nil && mem == gomatrixserverlib.Leave {
+				return util.JSONResponse{
+					Code: http.StatusOK,
+					JSON: map[string]interface{}{
+						"room_version": event.RoomVersion,
+						"event":        state,
+					},
+				}
+			}
+		}
+	}
+
 	// Check that the leave is allowed or not
 	stateEvents := make([]*gomatrixserverlib.Event, len(queryRes.StateEvents))
 	for i := range queryRes.StateEvents {
@@ -99,6 +116,7 @@ func MakeLeave(
 }
 
 // SendLeave implements the /send_leave API
+// nolint:gocyclo
 func SendLeave(
 	httpReq *http.Request,
 	request *gomatrixserverlib.FederationRequest,
@@ -149,6 +167,48 @@ func SendLeave(
 		}
 	}
 
+	// Check if the user has already left. If so, no-op!
+	queryReq := &api.QueryLatestEventsAndStateRequest{
+		RoomID: roomID,
+		StateToFetch: []gomatrixserverlib.StateKeyTuple{
+			{
+				EventType: gomatrixserverlib.MRoomMember,
+				StateKey:  *event.StateKey(),
+			},
+		},
+	}
+	queryRes := &api.QueryLatestEventsAndStateResponse{}
+	err = rsAPI.QueryLatestEventsAndState(httpReq.Context(), queryReq, queryRes)
+	if err != nil {
+		util.GetLogger(httpReq.Context()).WithError(err).Error("rsAPI.QueryLatestEventsAndState failed")
+		return jsonerror.InternalServerError()
+	}
+	// The room doesn't exist or we weren't ever joined to it. Might as well
+	// no-op here.
+	if !queryRes.RoomExists || len(queryRes.StateEvents) == 0 {
+		return util.JSONResponse{
+			Code: http.StatusOK,
+			JSON: struct{}{},
+		}
+	}
+	// Check if we're recycling a previous leave event.
+	if event.EventID() == queryRes.StateEvents[0].EventID() {
+		return util.JSONResponse{
+			Code: http.StatusOK,
+			JSON: struct{}{},
+		}
+	}
+	// We are/were joined/invited/banned or something. Check if
+	// we can no-op here.
+	if len(queryRes.StateEvents) == 1 {
+		if mem, merr := queryRes.StateEvents[0].Membership(); merr == nil && mem == gomatrixserverlib.Leave {
+			return util.JSONResponse{
+				Code: http.StatusOK,
+				JSON: struct{}{},
+			}
+		}
+	}
+
 	// Check that the event is signed by the server sending the request.
 	redacted := event.Redact()
 	verifyRequests := []gomatrixserverlib.VerifyJSONRequest{{
@@ -174,7 +234,8 @@ func SendLeave(
 	if err != nil {
 		util.GetLogger(httpReq.Context()).WithError(err).Error("event.Membership failed")
 		return jsonerror.InternalServerError()
-	} else if mem != gomatrixserverlib.Leave {
+	}
+	if mem != gomatrixserverlib.Leave {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.BadJSON("The membership in the event content must be set to leave"),

--- a/federationapi/routing/routing.go
+++ b/federationapi/routing/routing.go
@@ -90,16 +90,10 @@ func Setup(
 					JSON: jsonerror.Forbidden("Forbidden by server ACLs"),
 				}
 			}
-			res := InviteV1(
+			return InviteV1(
 				httpReq, request, vars["roomID"], vars["eventID"],
 				cfg, rsAPI, keys,
 			)
-			return util.JSONResponse{
-				Code: res.Code,
-				JSON: []interface{}{
-					res.Code, res.JSON,
-				},
-			}
 		},
 	)).Methods(http.MethodPut, http.MethodOptions)
 

--- a/federationapi/routing/send_test.go
+++ b/federationapi/routing/send_test.go
@@ -102,7 +102,8 @@ func (t *testRoomserverAPI) PerformInvite(
 	ctx context.Context,
 	req *api.PerformInviteRequest,
 	res *api.PerformInviteResponse,
-) {
+) error {
+	return nil
 }
 
 func (t *testRoomserverAPI) PerformJoin(

--- a/federationsender/api/api.go
+++ b/federationsender/api/api.go
@@ -36,6 +36,12 @@ type FederationSenderInternalAPI interface {
 		request *PerformLeaveRequest,
 		response *PerformLeaveResponse,
 	) error
+	// Handle sending an invite to a remote server.
+	PerformInvite(
+		ctx context.Context,
+		request *PerformInviteRequest,
+		response *PerformInviteResponse,
+	) error
 	// Notifies the federation sender that these servers may be online and to retry sending messages.
 	PerformServersAlive(
 		ctx context.Context,
@@ -79,6 +85,16 @@ type PerformLeaveRequest struct {
 }
 
 type PerformLeaveResponse struct {
+}
+
+type PerformInviteRequest struct {
+	RoomVersion     gomatrixserverlib.RoomVersion             `json:"room_version"`
+	Event           gomatrixserverlib.HeaderedEvent           `json:"event"`
+	InviteRoomState []gomatrixserverlib.InviteV2StrippedState `json:"invite_room_state"`
+}
+
+type PerformInviteResponse struct {
+	SignedEvent gomatrixserverlib.HeaderedEvent `json:"signed_event"`
 }
 
 type PerformServersAliveRequest struct {

--- a/federationsender/api/api.go
+++ b/federationsender/api/api.go
@@ -94,7 +94,7 @@ type PerformInviteRequest struct {
 }
 
 type PerformInviteResponse struct {
-	SignedEvent gomatrixserverlib.HeaderedEvent `json:"signed_event"`
+	Event gomatrixserverlib.HeaderedEvent `json:"event"`
 }
 
 type PerformServersAliveRequest struct {

--- a/federationsender/internal/perform.go
+++ b/federationsender/internal/perform.go
@@ -329,12 +329,7 @@ func (r *FederationSenderInternalAPI) PerformInvite(
 		return fmt.Errorf("r.federation.SendInviteV2: %w", err)
 	}
 
-	response.SignedEvent = inviteRes.Event.Sign(
-		string(r.cfg.Matrix.ServerName),
-		r.cfg.Matrix.KeyID,
-		r.cfg.Matrix.PrivateKey,
-	).Headered(request.RoomVersion)
-
+	response.Event = inviteRes.Event.Headered(request.RoomVersion)
 	return nil
 }
 

--- a/federationsender/internal/perform.go
+++ b/federationsender/internal/perform.go
@@ -296,6 +296,48 @@ func (r *FederationSenderInternalAPI) PerformLeave(
 	)
 }
 
+// PerformLeaveRequest implements api.FederationSenderInternalAPI
+func (r *FederationSenderInternalAPI) PerformInvite(
+	ctx context.Context,
+	request *api.PerformInviteRequest,
+	response *api.PerformInviteResponse,
+) (err error) {
+	if request.Event.StateKey() == nil {
+		return errors.New("invite must be a state event")
+	}
+
+	_, destination, err := gomatrixserverlib.SplitID('@', *request.Event.StateKey())
+	if err != nil {
+		return fmt.Errorf("gomatrixserverlib.SplitID: %w", err)
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"event_id":     request.Event.EventID(),
+		"user_id":      *request.Event.StateKey(),
+		"room_id":      request.Event.RoomID(),
+		"room_version": request.RoomVersion,
+		"destination":  destination,
+	}).Info("Sending invite")
+
+	inviteReq, err := gomatrixserverlib.NewInviteV2Request(&request.Event, request.InviteRoomState)
+	if err != nil {
+		return fmt.Errorf("gomatrixserverlib.NewInviteV2Request: %w", err)
+	}
+
+	inviteRes, err := r.federation.SendInviteV2(ctx, destination, inviteReq)
+	if err != nil {
+		return fmt.Errorf("r.federation.SendInviteV2: %w", err)
+	}
+
+	response.SignedEvent = inviteRes.Event.Sign(
+		string(r.cfg.Matrix.ServerName),
+		r.cfg.Matrix.KeyID,
+		r.cfg.Matrix.PrivateKey,
+	).Headered(request.RoomVersion)
+
+	return nil
+}
+
 // PerformServersAlive implements api.FederationSenderInternalAPI
 func (r *FederationSenderInternalAPI) PerformServersAlive(
 	ctx context.Context,

--- a/federationsender/inthttp/client.go
+++ b/federationsender/inthttp/client.go
@@ -18,6 +18,7 @@ const (
 	FederationSenderPerformDirectoryLookupRequestPath = "/federationsender/performDirectoryLookup"
 	FederationSenderPerformJoinRequestPath            = "/federationsender/performJoinRequest"
 	FederationSenderPerformLeaveRequestPath           = "/federationsender/performLeaveRequest"
+	FederationSenderPerformInviteRequestPath          = "/federationsender/performInviteRequest"
 	FederationSenderPerformServersAlivePath           = "/federationsender/performServersAlive"
 	FederationSenderPerformBroadcastEDUPath           = "/federationsender/performBroadcastEDU"
 )
@@ -46,6 +47,19 @@ func (h *httpFederationSenderInternalAPI) PerformLeave(
 	defer span.Finish()
 
 	apiURL := h.federationSenderURL + FederationSenderPerformLeaveRequestPath
+	return httputil.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+}
+
+// Handle sending an invite to a remote server.
+func (h *httpFederationSenderInternalAPI) PerformInvite(
+	ctx context.Context,
+	request *api.PerformInviteRequest,
+	response *api.PerformInviteResponse,
+) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "PerformInviteRequest")
+	defer span.Finish()
+
+	apiURL := h.federationSenderURL + FederationSenderPerformInviteRequestPath
 	return httputil.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }
 

--- a/federationsender/inthttp/server.go
+++ b/federationsender/inthttp/server.go
@@ -53,6 +53,20 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		}),
 	)
 	internalAPIMux.Handle(
+		FederationSenderPerformInviteRequestPath,
+		httputil.MakeInternalAPI("PerformInviteRequest", func(req *http.Request) util.JSONResponse {
+			var request api.PerformInviteRequest
+			var response api.PerformInviteResponse
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.MessageResponse(http.StatusBadRequest, err.Error())
+			}
+			if err := intAPI.PerformInvite(req.Context(), &request, &response); err != nil {
+				return util.ErrorResponse(err)
+			}
+			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
+		}),
+	)
+	internalAPIMux.Handle(
 		FederationSenderPerformDirectoryLookupRequestPath,
 		httputil.MakeInternalAPI("PerformDirectoryLookupRequest", func(req *http.Request) util.JSONResponse {
 			var request api.PerformDirectoryLookupRequest

--- a/federationsender/inthttp/server.go
+++ b/federationsender/inthttp/server.go
@@ -11,6 +11,7 @@ import (
 )
 
 // AddRoutes adds the FederationSenderInternalAPI handlers to the http.ServeMux.
+// nolint:gocyclo
 func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Router) {
 	internalAPIMux.Handle(
 		FederationSenderQueryJoinedHostServerNamesInRoomPath,

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/matrix-org/dendrite
 
+replace github.com/matrix-org/gomatrixserverlib => /Users/neilalexander/Desktop/gomatrixserverlib/
+
 require (
 	github.com/Shopify/sarama v1.26.1
-	github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
-	github.com/ghodss/yaml v1.0.0
 	github.com/gologme/log v1.2.0
 	github.com/gorilla/mux v1.7.3
 	github.com/hashicorp/golang-lru v0.5.4
@@ -23,7 +23,7 @@ require (
 	github.com/matrix-org/go-http-js-libp2p v0.0.0-20200518170932-783164aeeda4
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20200522092705-bc8506ccbcf3
 	github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20200807145008-79c173b65786
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20200817095438-5be6e67209c8
 	github.com/matrix-org/naffka v0.0.0-20200422140631-181f1ee7401f
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4
 	github.com/mattn/go-sqlite3 v2.0.2+incompatible

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/matrix-org/dendrite
 
-replace github.com/matrix-org/gomatrixserverlib => /Users/neilalexander/Desktop/gomatrixserverlib/
-
 require (
 	github.com/Shopify/sarama v1.26.1
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/matrix-org/go-http-js-libp2p v0.0.0-20200518170932-783164aeeda4
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20200522092705-bc8506ccbcf3
 	github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20200817095438-5be6e67209c8
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20200817100842-9d02141812f2
 	github.com/matrix-org/naffka v0.0.0-20200422140631-181f1ee7401f
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4
 	github.com/mattn/go-sqlite3 v2.0.2+incompatible

--- a/go.sum
+++ b/go.sum
@@ -51,9 +51,6 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cheekybits/genny v1.0.0 h1:uGGa4nei+j20rOSeDeP5Of12XVm7TGUd4dJA9RDitfE=
 github.com/cheekybits/genny v1.0.0/go.mod h1:+tQajlRqAUrPI7DOSpB0XAqZYtQakVtB7wXkRAgjxjQ=
 github.com/cheggaaa/pb/v3 v3.0.4/go.mod h1:7rgWxLrAUcFMkvJuv09+DYi7mMUYi8nO9iOWcvGJPfw=
-github.com/circonus-labs/circonus-gometrics v1.2.0 h1:Kqa/+nIJhqFJ12B07aeekgC6F95J7yYgEtpD57NQzrE=
-github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible h1:C29Ae4G5GtYyYMm1aztcyj/J5ckgJm2zwdDajFbx1NY=
-github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible/go.mod h1:nmEj6Dob7S7YxXgwXpfOuvO54S+tGdZdw9fuRZt25Ag=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
@@ -425,8 +422,6 @@ github.com/matrix-org/go-sqlite3-js v0.0.0-20200522092705-bc8506ccbcf3 h1:Yb+Wlf
 github.com/matrix-org/go-sqlite3-js v0.0.0-20200522092705-bc8506ccbcf3/go.mod h1:e+cg2q7C7yE5QnAXgzo512tgFh1RbQLC0+jozuegKgo=
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26 h1:Hr3zjRsq2bhrnp3Ky1qgx/fzCtCALOoGYylh2tpS9K4=
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200807145008-79c173b65786 h1:HQclx5J2CrCBqP88t5Di9IkVDJZn5+h4ZL48viY4FJ4=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200807145008-79c173b65786/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
 github.com/matrix-org/naffka v0.0.0-20200422140631-181f1ee7401f h1:pRz4VTiRCO4zPlEMc3ESdUOcW4PXHH4Kj+YDz1XyE+Y=
 github.com/matrix-org/naffka v0.0.0-20200422140631-181f1ee7401f/go.mod h1:y0oDTjZDv5SM9a2rp3bl+CU+bvTRINQsdb7YlDql5Go=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7 h1:ntrLa/8xVzeSs8vHFHK25k0C+NV74sYMJnNSg5NoSRo=

--- a/go.sum
+++ b/go.sum
@@ -422,6 +422,8 @@ github.com/matrix-org/go-sqlite3-js v0.0.0-20200522092705-bc8506ccbcf3 h1:Yb+Wlf
 github.com/matrix-org/go-sqlite3-js v0.0.0-20200522092705-bc8506ccbcf3/go.mod h1:e+cg2q7C7yE5QnAXgzo512tgFh1RbQLC0+jozuegKgo=
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26 h1:Hr3zjRsq2bhrnp3Ky1qgx/fzCtCALOoGYylh2tpS9K4=
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200817100842-9d02141812f2 h1:9wKwfd5KDcXuqZ7/kAaYe0QM4DGM+2awjjvXQtrDa6k=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200817100842-9d02141812f2/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
 github.com/matrix-org/naffka v0.0.0-20200422140631-181f1ee7401f h1:pRz4VTiRCO4zPlEMc3ESdUOcW4PXHH4Kj+YDz1XyE+Y=
 github.com/matrix-org/naffka v0.0.0-20200422140631-181f1ee7401f/go.mod h1:y0oDTjZDv5SM9a2rp3bl+CU+bvTRINQsdb7YlDql5Go=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7 h1:ntrLa/8xVzeSs8vHFHK25k0C+NV74sYMJnNSg5NoSRo=

--- a/roomserver/api/api.go
+++ b/roomserver/api/api.go
@@ -22,7 +22,7 @@ type RoomserverInternalAPI interface {
 		ctx context.Context,
 		req *PerformInviteRequest,
 		res *PerformInviteResponse,
-	)
+	) error
 
 	PerformJoin(
 		ctx context.Context,

--- a/roomserver/api/api_trace.go
+++ b/roomserver/api/api_trace.go
@@ -33,9 +33,9 @@ func (t *RoomserverInternalAPITrace) PerformInvite(
 	ctx context.Context,
 	req *PerformInviteRequest,
 	res *PerformInviteResponse,
-) {
-	t.Impl.PerformInvite(ctx, req, res)
+) error {
 	util.GetLogger(ctx).Infof("PerformInvite req=%+v res=%+v", js(req), js(res))
+	return t.Impl.PerformInvite(ctx, req, res)
 }
 
 func (t *RoomserverInternalAPITrace) PerformJoin(

--- a/roomserver/api/perform.go
+++ b/roomserver/api/perform.go
@@ -105,8 +105,6 @@ type PerformInviteRequest struct {
 }
 
 type PerformInviteResponse struct {
-	// If non-nil, the invite request failed. Contains more information why it failed.
-	Error *PerformError
 }
 
 // PerformBackfillRequest is a request to PerformBackfill.

--- a/roomserver/api/perform.go
+++ b/roomserver/api/perform.go
@@ -105,6 +105,7 @@ type PerformInviteRequest struct {
 }
 
 type PerformInviteResponse struct {
+	Error *PerformError `json:"error"`
 }
 
 // PerformBackfillRequest is a request to PerformBackfill.

--- a/roomserver/api/perform.go
+++ b/roomserver/api/perform.go
@@ -105,7 +105,7 @@ type PerformInviteRequest struct {
 }
 
 type PerformInviteResponse struct {
-	Error *PerformError `json:"error"`
+	Error *PerformError
 }
 
 // PerformBackfillRequest is a request to PerformBackfill.

--- a/roomserver/api/wrapper.go
+++ b/roomserver/api/wrapper.go
@@ -112,10 +112,10 @@ func SendInvite(
 	}
 	response := &PerformInviteResponse{}
 	if err := rsAPI.PerformInvite(ctx, request, response); err != nil {
-		if response.Error != nil {
-			return response.Error
-		}
 		return fmt.Errorf("rsAPI.PerformInvite: %w", err)
+	}
+	if response.Error != nil {
+		return response.Error
 	}
 
 	// Now send the invite event into the roomserver. If the room is known

--- a/roomserver/api/wrapper.go
+++ b/roomserver/api/wrapper.go
@@ -125,7 +125,7 @@ func SendInvite(
 				Kind:         KindNew,
 				Event:        inviteEvent,
 				AuthEventIDs: inviteEvent.AuthEventIDs(),
-				SendAsServer: DoNotSendToOtherServers,
+				SendAsServer: string(sendAsServer),
 			},
 		},
 	}

--- a/roomserver/api/wrapper.go
+++ b/roomserver/api/wrapper.go
@@ -112,6 +112,9 @@ func SendInvite(
 	}
 	response := &PerformInviteResponse{}
 	if err := rsAPI.PerformInvite(ctx, request, response); err != nil {
+		if response.Error != nil {
+			return response.Error
+		}
 		return fmt.Errorf("rsAPI.PerformInvite: %w", err)
 	}
 

--- a/roomserver/api/wrapper.go
+++ b/roomserver/api/wrapper.go
@@ -99,22 +99,16 @@ func SendInvite(
 	rsAPI RoomserverInternalAPI, inviteEvent gomatrixserverlib.HeaderedEvent,
 	inviteRoomState []gomatrixserverlib.InviteV2StrippedState,
 	sendAsServer gomatrixserverlib.ServerName, txnID *TransactionID,
-) *PerformError {
-	request := PerformInviteRequest{
+) error {
+	request := &PerformInviteRequest{
 		Event:           inviteEvent,
 		InviteRoomState: inviteRoomState,
 		RoomVersion:     inviteEvent.RoomVersion,
 		SendAsServer:    string(sendAsServer),
 		TransactionID:   txnID,
 	}
-	var response PerformInviteResponse
-	rsAPI.PerformInvite(ctx, &request, &response)
-	// we need to do this because many places people will use `var err error` as the return
-	// arg and a nil interface != nil pointer to a concrete interface (in this case PerformError)
-	if response.Error != nil && response.Error.Msg != "" {
-		return response.Error
-	}
-	return nil
+	response := &PerformInviteResponse{}
+	return rsAPI.PerformInvite(ctx, request, response)
 }
 
 // GetEvent returns the event or nil, even on errors.

--- a/roomserver/internal/perform_invite.go
+++ b/roomserver/internal/perform_invite.go
@@ -96,10 +96,10 @@ func (r *RoomserverInternalAPI) PerformInvite(
 		// mechanism it will be equivalent to option 1, and we don't have a
 		// signalling mechanism to implement option 3.
 		res.Error = &api.PerformError{
-			Code: api.PerformErrorNoOperation,
+			Code: api.PerformErrorNotAllowed,
 			Msg:  "User is already joined to room",
 		}
-		return res.Error
+		return nil
 	}
 
 	if isOriginLocal {
@@ -115,9 +115,9 @@ func (r *RoomserverInternalAPI) PerformInvite(
 					Msg:  err.Error(),
 					Code: api.PerformErrorNotAllowed,
 				}
-				return fmt.Errorf("checkAuthEvents: %w", err)
+				return nil
 			}
-			return err
+			return fmt.Errorf("checkAuthEvents: %w", err)
 		}
 
 		// If the invite originated from us and the target isn't local then we
@@ -136,7 +136,8 @@ func (r *RoomserverInternalAPI) PerformInvite(
 					Msg:  err.Error(),
 					Code: api.PerformErrorNoOperation,
 				}
-				return fmt.Errorf("r.fsAPI.PerformInvite: %w", err)
+				log.WithError(err).WithField("event_id", event.EventID()).Error("r.fsAPI.PerformInvite failed")
+				return nil
 			}
 			event = fsRes.SignedEvent
 		}

--- a/roomserver/internal/perform_invite.go
+++ b/roomserver/internal/perform_invite.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	federationSenderAPI "github.com/matrix-org/dendrite/federationsender/api"
@@ -95,10 +96,7 @@ func (r *RoomserverInternalAPI) PerformInvite(
 		// For now we will implement option 2. Since in the abesence of a retry
 		// mechanism it will be equivalent to option 1, and we don't have a
 		// signalling mechanism to implement option 3.
-		return &api.PerformError{
-			Code: api.PerformErrorNoOperation,
-			Msg:  "user is already joined to room",
-		}
+		return errors.New("The user is already in the room")
 	}
 
 	if isOriginLocal {

--- a/roomserver/internal/perform_invite.go
+++ b/roomserver/internal/perform_invite.go
@@ -2,9 +2,9 @@ package internal
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	federationSenderAPI "github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/roomserver/state"
@@ -14,73 +14,50 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// PerformInvite handles inviting to matrix rooms, including over federation by talking to the federationsender.
+// nolint:gocyclo
 func (r *RoomserverInternalAPI) PerformInvite(
 	ctx context.Context,
 	req *api.PerformInviteRequest,
 	res *api.PerformInviteResponse,
-) {
-	err := r.performInvite(ctx, req)
-	if err != nil {
-		perr, ok := err.(*api.PerformError)
-		if ok {
-			res.Error = perr
-		} else {
-			res.Error = &api.PerformError{
-				Msg: err.Error(),
-			}
-		}
-	}
-}
-
-func (r *RoomserverInternalAPI) performInvite(ctx context.Context,
-	req *api.PerformInviteRequest,
 ) error {
-	loopback, err := r.processInviteEvent(ctx, r, req)
-	if err != nil {
-		return err
-	}
-	// The processInviteEvent function can optionally return a
-	// loopback room event containing the invite, for local invites.
-	// If it does, we should process it with the room events below.
-	if loopback != nil {
-		var loopbackRes api.InputRoomEventsResponse
-		err := r.InputRoomEvents(ctx, &api.InputRoomEventsRequest{
-			InputRoomEvents: []api.InputRoomEvent{*loopback},
-		}, &loopbackRes)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// nolint:gocyclo
-func (r *RoomserverInternalAPI) processInviteEvent(
-	ctx context.Context,
-	ow *RoomserverInternalAPI,
-	input *api.PerformInviteRequest,
-) (*api.InputRoomEvent, error) {
-	if input.Event.StateKey() == nil {
-		return nil, fmt.Errorf("invite must be a state event")
+	event := req.Event
+	if event.StateKey() == nil {
+		return fmt.Errorf("invite must be a state event")
 	}
 
-	roomID := input.Event.RoomID()
-	targetUserID := *input.Event.StateKey()
+	roomID := event.RoomID()
+	targetUserID := *event.StateKey()
 
 	log.WithFields(log.Fields{
-		"event_id":       input.Event.EventID(),
+		"event_id":       event.EventID(),
 		"room_id":        roomID,
-		"room_version":   input.RoomVersion,
+		"room_version":   req.RoomVersion,
 		"target_user_id": targetUserID,
 	}).Info("processing invite event")
 
 	_, domain, _ := gomatrixserverlib.SplitID('@', targetUserID)
 	isTargetLocalUser := domain == r.Cfg.Matrix.ServerName
+	isOriginLocalUser := event.Origin() == r.Cfg.Matrix.ServerName
 
-	updater, err := r.DB.MembershipUpdater(ctx, roomID, targetUserID, isTargetLocalUser, input.RoomVersion)
+	// If the invite originated from us and the target isn't local then we
+	// should try and send the invite over federation first. It might be
+	// that the remote user doesn't exist, in which case we can give up
+	// processing here.
+	if isOriginLocalUser && !isTargetLocalUser {
+		fsReq := &federationSenderAPI.PerformInviteRequest{
+			RoomVersion: req.RoomVersion,
+			Event:       req.Event,
+		}
+		fsRes := &federationSenderAPI.PerformInviteResponse{}
+		if err := r.fsAPI.PerformInvite(ctx, fsReq, fsRes); err != nil {
+			return fmt.Errorf("r.fsAPI.PerformInvite: %w", err)
+		}
+		event = fsRes.SignedEvent
+	}
+
+	updater, err := r.DB.MembershipUpdater(ctx, roomID, targetUserID, isTargetLocalUser, req.RoomVersion)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	succeeded := false
 	defer func() {
@@ -118,109 +95,87 @@ func (r *RoomserverInternalAPI) processInviteEvent(
 		// For now we will implement option 2. Since in the abesence of a retry
 		// mechanism it will be equivalent to option 1, and we don't have a
 		// signalling mechanism to implement option 3.
-		return nil, &api.PerformError{
+		return &api.PerformError{
 			Code: api.PerformErrorNoOperation,
 			Msg:  "user is already joined to room",
 		}
 	}
 
-	// Normally, with a federated invite, the federation sender would do
-	// the /v2/invite request (in which the remote server signs the invite)
-	// and then the signed event gets sent back to the roomserver as an input
-	// event. When the invite is local, we don't interact with the federation
-	// sender therefore we need to generate the loopback invite event for
-	// the room ourselves.
-	loopback, err := localInviteLoopback(ow, input)
-	if err != nil {
-		return nil, err
-	}
-
-	event := input.Event.Unwrap()
-
 	// check that the user is allowed to do this. We can only do this check if it is
 	// a local invite as we have the auth events, else we have to take it on trust.
-	if loopback != nil {
-		_, err = checkAuthEvents(ctx, r.DB, input.Event, input.Event.AuthEventIDs())
+	if isOriginLocalUser {
+		_, err = checkAuthEvents(ctx, r.DB, req.Event, req.Event.AuthEventIDs())
 		if err != nil {
 			log.WithError(err).WithField("event_id", event.EventID()).WithField("auth_event_ids", event.AuthEventIDs()).Error(
 				"processInviteEvent.checkAuthEvents failed for event",
 			)
 			if _, ok := err.(*gomatrixserverlib.NotAllowed); ok {
-				return nil, &api.PerformError{
+				return &api.PerformError{
 					Msg:  err.Error(),
 					Code: api.PerformErrorNotAllowed,
 				}
 			}
-			return nil, err
+			return err
 		}
 	}
 
-	if len(input.InviteRoomState) > 0 {
+	if len(req.InviteRoomState) > 0 {
 		// If we were supplied with some invite room state already (which is
 		// most likely to be if the event came in over federation) then use
 		// that.
-		if err = event.SetUnsignedField("invite_room_state", input.InviteRoomState); err != nil {
-			return nil, err
+		if err = event.SetUnsignedField("invite_room_state", req.InviteRoomState); err != nil {
+			return err
 		}
 	} else {
 		// There's no invite room state, so let's have a go at building it
 		// up from local data (which is most likely to be if the event came
 		// from the CS API). If we know about the room then we can insert
 		// the invite room state, if we don't then we just fail quietly.
-		if irs, ierr := buildInviteStrippedState(ctx, r.DB, input); ierr == nil {
+		if irs, ierr := buildInviteStrippedState(ctx, r.DB, req); ierr == nil {
 			if err = event.SetUnsignedField("invite_room_state", irs); err != nil {
-				return nil, err
+				return err
 			}
 		} else {
-			log.WithError(ierr).Error("failed to build invite stripped state")
+			log.WithError(ierr).Warn("failed to build invite stripped state")
 			// still set the field else synapse deployments don't process the invite
 			if err = event.SetUnsignedField("invite_room_state", struct{}{}); err != nil {
-				return nil, err
+				return err
 			}
 		}
 	}
 
-	outputUpdates, err := updateToInviteMembership(updater, &event, nil, input.Event.RoomVersion)
-	if err != nil {
-		return nil, err
+	// If we're the sender of the event then we should send the invite
+	// event into the room so that the room state is updated and other
+	// room participants will see the invite.
+	if isOriginLocalUser {
+		inputReq := &api.InputRoomEventsRequest{
+			InputRoomEvents: []api.InputRoomEvent{
+				{
+					Kind:         api.KindNew,
+					Event:        event,
+					AuthEventIDs: event.AuthEventIDs(),
+					SendAsServer: api.DoNotSendToOtherServers,
+				},
+			},
+		}
+		inputRes := &api.InputRoomEventsResponse{}
+		if err = r.InputRoomEvents(ctx, inputReq, inputRes); err != nil {
+			return fmt.Errorf("r.InputRoomEvents: %w", err)
+		}
 	}
 
-	if err = ow.WriteOutputEvents(roomID, outputUpdates); err != nil {
-		return nil, err
+	unwrapped := event.Unwrap()
+	outputUpdates, err := updateToInviteMembership(updater, &unwrapped, nil, req.Event.RoomVersion)
+	if err != nil {
+		return err
+	}
+
+	if err = r.WriteOutputEvents(roomID, outputUpdates); err != nil {
+		return err
 	}
 
 	succeeded = true
-	return loopback, nil
-}
-
-func localInviteLoopback(
-	ow *RoomserverInternalAPI,
-	input *api.PerformInviteRequest,
-) (ire *api.InputRoomEvent, err error) {
-	if input.Event.StateKey() == nil {
-		return nil, errors.New("no state key on invite event")
-	}
-	ourServerName := string(ow.Cfg.Matrix.ServerName)
-	_, theirServerName, err := gomatrixserverlib.SplitID('@', *input.Event.StateKey())
-	if err != nil {
-		return nil, err
-	}
-	// Check if the invite originated locally and is destined locally.
-	if input.Event.Origin() == ow.Cfg.Matrix.ServerName && string(theirServerName) == ourServerName {
-		rsEvent := input.Event.Sign(
-			ourServerName,
-			ow.Cfg.Matrix.KeyID,
-			ow.Cfg.Matrix.PrivateKey,
-		).Headered(input.RoomVersion)
-		ire = &api.InputRoomEvent{
-			Kind:          api.KindNew,
-			Event:         rsEvent,
-			AuthEventIDs:  rsEvent.AuthEventIDs(),
-			SendAsServer:  ourServerName,
-			TransactionID: nil,
-		}
-	}
-	return ire, nil
+	return nil
 }
 
 func buildInviteStrippedState(

--- a/roomserver/internal/perform_invite.go
+++ b/roomserver/internal/perform_invite.go
@@ -139,7 +139,7 @@ func (r *RoomserverInternalAPI) PerformInvite(
 				log.WithError(err).WithField("event_id", event.EventID()).Error("r.fsAPI.PerformInvite failed")
 				return nil
 			}
-			event = fsRes.SignedEvent
+			event = fsRes.Event
 		}
 	}
 

--- a/roomserver/inthttp/client.go
+++ b/roomserver/inthttp/client.go
@@ -154,17 +154,12 @@ func (h *httpRoomserverInternalAPI) PerformInvite(
 	ctx context.Context,
 	request *api.PerformInviteRequest,
 	response *api.PerformInviteResponse,
-) {
+) error {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "PerformInvite")
 	defer span.Finish()
 
 	apiURL := h.roomserverURL + RoomserverPerformInvitePath
-	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
-	if err != nil {
-		response.Error = &api.PerformError{
-			Msg: fmt.Sprintf("failed to communicate with roomserver: %s", err),
-		}
-	}
+	return httputil.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }
 
 func (h *httpRoomserverInternalAPI) PerformJoin(

--- a/roomserver/inthttp/server.go
+++ b/roomserver/inthttp/server.go
@@ -33,7 +33,9 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
-			r.PerformInvite(req.Context(), &request, &response)
+			if err := r.PerformInvite(req.Context(), &request, &response); err != nil {
+				return util.ErrorResponse(err)
+			}
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -454,3 +454,5 @@ Banned servers cannot get missing events
 Banned servers cannot get room state ids
 Banned servers cannot backfill
 Inbound /v1/send_leave rejects leaves from other servers
+Guest users can accept invites to private rooms over federation
+

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -411,6 +411,7 @@ PUT /rooms/:room_id/typing/:user_id sets typing notification
 Typing notification sent to local room members
 Typing notifications also sent to remote room members
 Typing can be explicitly stopped
+Banned user is kicked and may not rejoin until unbanned
 Inbound federation rejects attempts to join v1 rooms from servers without v1 support
 Inbound federation rejects attempts to join v2 rooms from servers lacking version support
 Inbound federation rejects attempts to join v2 rooms from servers only supporting v1
@@ -453,4 +454,4 @@ Banned servers cannot get room state ids
 Banned servers cannot backfill
 Inbound /v1/send_leave rejects leaves from other servers
 Guest users can accept invites to private rooms over federation
-
+AS user (not ghost) can join room without registering

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -411,14 +411,12 @@ PUT /rooms/:room_id/typing/:user_id sets typing notification
 Typing notification sent to local room members
 Typing notifications also sent to remote room members
 Typing can be explicitly stopped
-Banned user is kicked and may not rejoin until unbanned
 Inbound federation rejects attempts to join v1 rooms from servers without v1 support
 Inbound federation rejects attempts to join v2 rooms from servers lacking version support
 Inbound federation rejects attempts to join v2 rooms from servers only supporting v1
 Outbound federation passes make_join failures through to the client
 Outbound federation correctly handles unsupported room versions
 Remote users may not join unfederated rooms
-Guest users denied access over federation if guest access prohibited
 Non-numeric ports in server names are rejected
 Invited user can reject invite over federation
 Invited user can reject invite over federation for empty room


### PR DESCRIPTION
This PR removes invite queues from the federation sender and instead wires up the APIs so that they are sent synchronously. The room server will send a federation request if it is required.