### PR TITLE
Add SkipClean and UseEncodedPaths to intermediate routers

### DIFF
--- a/cmd/dendrite-demo-libp2p/main.go
+++ b/cmd/dendrite-demo-libp2p/main.go
@@ -198,12 +198,12 @@ func main() {
 		base.Base.PublicMediaAPIMux,
 	)
 
-	httpRouter := mux.NewRouter()
+	httpRouter := mux.NewRouter().SkipClean(true).UseEncodedPath()
 	httpRouter.PathPrefix(httputil.InternalPathPrefix).Handler(base.Base.InternalAPIMux)
 	httpRouter.PathPrefix(httputil.PublicClientPathPrefix).Handler(base.Base.PublicClientAPIMux)
 	httpRouter.PathPrefix(httputil.PublicMediaPathPrefix).Handler(base.Base.PublicMediaAPIMux)
 
-	libp2pRouter := mux.NewRouter()
+	libp2pRouter := mux.NewRouter().SkipClean(true).UseEncodedPath()
 	libp2pRouter.PathPrefix(httputil.PublicFederationPathPrefix).Handler(base.Base.PublicFederationAPIMux)
 	libp2pRouter.PathPrefix(httputil.PublicKeyPathPrefix).Handler(base.Base.PublicKeyAPIMux)
 	libp2pRouter.PathPrefix(httputil.PublicMediaPathPrefix).Handler(base.Base.PublicMediaAPIMux)

--- a/cmd/dendrite-demo-yggdrasil/main.go
+++ b/cmd/dendrite-demo-yggdrasil/main.go
@@ -163,12 +163,12 @@ func main() {
 		base.PublicMediaAPIMux,
 	)
 
-	httpRouter := mux.NewRouter()
+	httpRouter := mux.NewRouter().SkipClean(true).UseEncodedPath()
 	httpRouter.PathPrefix(httputil.InternalPathPrefix).Handler(base.InternalAPIMux)
 	httpRouter.PathPrefix(httputil.PublicClientPathPrefix).Handler(base.PublicClientAPIMux)
 	httpRouter.PathPrefix(httputil.PublicMediaPathPrefix).Handler(base.PublicMediaAPIMux)
 
-	yggRouter := mux.NewRouter()
+	yggRouter := mux.NewRouter().SkipClean(true).UseEncodedPath()
 	yggRouter.PathPrefix(httputil.PublicFederationPathPrefix).Handler(base.PublicFederationAPIMux)
 	yggRouter.PathPrefix(httputil.PublicMediaPathPrefix).Handler(base.PublicMediaAPIMux)
 

--- a/cmd/dendritejs/main.go
+++ b/cmd/dendritejs/main.go
@@ -242,12 +242,12 @@ func main() {
 		base.PublicMediaAPIMux,
 	)
 
-	httpRouter := mux.NewRouter()
+	httpRouter := mux.NewRouter().SkipClean(true).UseEncodedPath()
 	httpRouter.PathPrefix(httputil.InternalPathPrefix).Handler(base.InternalAPIMux)
 	httpRouter.PathPrefix(httputil.PublicClientPathPrefix).Handler(base.PublicClientAPIMux)
 	httpRouter.PathPrefix(httputil.PublicMediaPathPrefix).Handler(base.PublicMediaAPIMux)
 
-	libp2pRouter := mux.NewRouter()
+	libp2pRouter := mux.NewRouter().SkipClean(true).UseEncodedPath()
 	libp2pRouter.PathPrefix(httputil.PublicFederationPathPrefix).Handler(base.PublicFederationAPIMux)
 	libp2pRouter.PathPrefix(httputil.PublicMediaPathPrefix).Handler(base.PublicMediaAPIMux)
 

--- a/internal/setup/base.go
+++ b/internal/setup/base.go
@@ -277,7 +277,7 @@ func (b *BaseDendrite) SetupAndServeHTTP(
 	internalAddr, _ := internalHTTPAddr.Address()
 	externalAddr, _ := externalHTTPAddr.Address()
 
-	internalRouter := mux.NewRouter()
+	internalRouter := mux.NewRouter().SkipClean(true).UseEncodedPath()
 	externalRouter := internalRouter
 
 	internalServ := &http.Server{
@@ -288,7 +288,7 @@ func (b *BaseDendrite) SetupAndServeHTTP(
 	externalServ := internalServ
 
 	if externalAddr != NoExternalListener && externalAddr != internalAddr {
-		externalRouter = mux.NewRouter()
+		externalRouter = mux.NewRouter().SkipClean(true).UseEncodedPath()
 		externalServ = &http.Server{
 			Addr:         string(externalAddr),
 			WriteTimeout: HTTPServerTimeout,


### PR DESCRIPTION
This should hopefully fix the newly-reappearing problems with room version 3 event IDs.