### PR TITLE
Make PerformJoin responsible for sending invite to RS input 

### DIFF
--- a/roomserver/api/wrapper.go
+++ b/roomserver/api/wrapper.go
@@ -118,23 +118,6 @@ func SendInvite(
 		return response.Error
 	}
 
-	// Now send the invite event into the roomserver. If the room is known
-	// locally then this will succeed, notifying existing users in the room
-	// about the new invite. If the room isn't known locally then this will
-	// fail - and that's also OK.
-	inputReq := &InputRoomEventsRequest{
-		InputRoomEvents: []InputRoomEvent{
-			{
-				Kind:         KindNew,
-				Event:        inviteEvent,
-				AuthEventIDs: inviteEvent.AuthEventIDs(),
-				SendAsServer: string(sendAsServer),
-			},
-		},
-	}
-	inputRes := &InputRoomEventsResponse{}
-	_ = rsAPI.InputRoomEvents(ctx, inputReq, inputRes)
-
 	return nil
 }
 

--- a/roomserver/internal/perform_invite.go
+++ b/roomserver/internal/perform_invite.go
@@ -57,7 +57,10 @@ func (r *RoomserverInternalAPI) PerformInvite(
 	var isAlreadyJoined bool
 	roomNID, err := r.DB.RoomNID(ctx, roomID)
 	if err == nil {
-		_, isAlreadyJoined, _ = r.DB.GetMembership(ctx, roomNID, *event.StateKey())
+		_, isAlreadyJoined, err = r.DB.GetMembership(ctx, roomNID, *event.StateKey())
+		if err != nil {
+			return fmt.Errorf("r.DB.GetMembership: %w", err)
+		}
 	}
 	if isAlreadyJoined {
 		// If the user is joined to the room then that takes precedence over this
@@ -146,7 +149,7 @@ func (r *RoomserverInternalAPI) PerformInvite(
 					Kind:         api.KindNew,
 					Event:        event,
 					AuthEventIDs: event.AuthEventIDs(),
-					SendAsServer: string(r.Cfg.Matrix.ServerName),
+					SendAsServer: req.SendAsServer,
 				},
 			},
 		}

--- a/roomserver/internal/perform_invite.go
+++ b/roomserver/internal/perform_invite.go
@@ -169,6 +169,10 @@ func (r *RoomserverInternalAPI) PerformInvite(
 			return fmt.Errorf("updateToInviteMembership: %w", err)
 		}
 
+		if err = updater.Commit(); err != nil {
+			return fmt.Errorf("updater.Commit: %w", err)
+		}
+
 		if err = r.WriteOutputEvents(roomID, outputUpdates); err != nil {
 			return fmt.Errorf("r.WriteOutputEvents: %w", err)
 		}

--- a/roomserver/internal/perform_invite.go
+++ b/roomserver/internal/perform_invite.go
@@ -57,7 +57,7 @@ func (r *RoomserverInternalAPI) PerformInvite(
 	var isAlreadyJoined bool
 	roomNID, err := r.DB.RoomNID(ctx, roomID)
 	if err == nil {
-		_, isAlreadyJoined, _ = r.DB.GetMembership(ctx, roomNID, "")
+		_, isAlreadyJoined, _ = r.DB.GetMembership(ctx, roomNID, *event.StateKey())
 	}
 	if isAlreadyJoined {
 		// If the user is joined to the room then that takes precedence over this

--- a/roomserver/internal/perform_invite.go
+++ b/roomserver/internal/perform_invite.go
@@ -158,7 +158,7 @@ func (r *RoomserverInternalAPI) PerformInvite(
 		},
 	}
 	inputRes := &api.InputRoomEventsResponse{}
-	_ = r.InputRoomEvents(ctx, inputReq, inputRes)
+	go r.InputRoomEvents(ctx, inputReq, inputRes) // nolint:errcheck
 
 	succeeded = true
 	return nil

--- a/roomserver/internal/perform_invite.go
+++ b/roomserver/internal/perform_invite.go
@@ -158,7 +158,7 @@ func (r *RoomserverInternalAPI) PerformInvite(
 		},
 	}
 	inputRes := &api.InputRoomEventsResponse{}
-	go r.InputRoomEvents(ctx, inputReq, inputRes) // nolint:errcheck
+	go r.InputRoomEvents(context.Background(), inputReq, inputRes) // nolint:errcheck
 
 	succeeded = true
 	return nil

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -455,3 +455,4 @@ Banned servers cannot backfill
 Inbound /v1/send_leave rejects leaves from other servers
 Guest users can accept invites to private rooms over federation
 AS user (not ghost) can join room without registering
+If user leaves room, remote user changes device and rejoins we see update in /sync and /keys/changes


### PR DESCRIPTION
This PR changes the API shape slightly:

For invites originated locally, we send the federation request, get the signed invite and send it to the roomserver input API. This means that we know about the invite and the invitee can use it as an auth event properly, and the output events are generated by the roomserver automatically.

For invites originated over federation, we use a membership updater directly so that we don't upset the roomserver with a bunch of auth event IDs that we don't have for a room we don't know about. We generate output events manually so that the sync API etc will learn about the invite and present it to the user.