### PR TITLE
Add FederationClient interface to federationsender

### DIFF
--- a/federationsender/api/api.go
+++ b/federationsender/api/api.go
@@ -2,14 +2,38 @@ package api
 
 import (
 	"context"
+	"fmt"
+	"time"
 
 	"github.com/matrix-org/dendrite/federationsender/types"
 	"github.com/matrix-org/gomatrix"
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
+// FederationClient is a subset of gomatrixserverlib.FederationClient functions which the fedsender
+// implements as proxy calls, with built-in backoff/retries/etc. Errors returned from functions in
+// this interface are of type FederationClientError
+type FederationClient interface {
+	GetUserDevices(ctx context.Context, s gomatrixserverlib.ServerName, userID string) (res gomatrixserverlib.RespUserDevices, err error)
+	ClaimKeys(ctx context.Context, s gomatrixserverlib.ServerName, oneTimeKeys map[string]map[string]string) (res gomatrixserverlib.RespClaimKeys, err error)
+	QueryKeys(ctx context.Context, s gomatrixserverlib.ServerName, keys map[string][]string) (res gomatrixserverlib.RespQueryKeys, err error)
+}
+
+// FederationClientError is returned from FederationClient methods in the event of a problem.
+type FederationClientError struct {
+	Err         string
+	RetryAfter  time.Duration
+	Blacklisted bool
+}
+
+func (e *FederationClientError) Error() string {
+	return fmt.Sprintf("%s - (retry_after=%d, blacklisted=%v", e.Err, e.RetryAfter, e.Blacklisted)
+}
+
 // FederationSenderInternalAPI is used to query information from the federation sender.
 type FederationSenderInternalAPI interface {
+	FederationClient
+
 	// PerformDirectoryLookup looks up a remote room ID from a room alias.
 	PerformDirectoryLookup(
 		ctx context.Context,

--- a/federationsender/api/api.go
+++ b/federationsender/api/api.go
@@ -27,7 +27,7 @@ type FederationClientError struct {
 }
 
 func (e *FederationClientError) Error() string {
-	return fmt.Sprintf("%s - (retry_after=%d, blacklisted=%v", e.Err, e.RetryAfter, e.Blacklisted)
+	return fmt.Sprintf("%s - (retry_after=%d, blacklisted=%v)", e.Err, e.RetryAfter, e.Blacklisted)
 }
 
 // FederationSenderInternalAPI is used to query information from the federation sender.

--- a/federationsender/internal/api.go
+++ b/federationsender/internal/api.go
@@ -12,7 +12,6 @@ import (
 	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrix"
 	"github.com/matrix-org/gomatrixserverlib"
-	"github.com/matrix-org/util"
 )
 
 // FederationSenderInternalAPI is an implementation of api.FederationSenderInternalAPI
@@ -82,7 +81,6 @@ func (a *FederationSenderInternalAPI) doRequest(
 ) (interface{}, error) {
 	stats, err := a.isBlacklistedOrBackingOff(s)
 	if err != nil {
-		util.GetLogger(ctx).Infof("isBlacklistedOrBackingOff %v", err)
 		return nil, err
 	}
 	res, err := request()
@@ -107,7 +105,6 @@ func (a *FederationSenderInternalAPI) GetUserDevices(
 	ctx context.Context, s gomatrixserverlib.ServerName, userID string,
 ) (gomatrixserverlib.RespUserDevices, error) {
 	ires, err := a.doRequest(ctx, s, func() (interface{}, error) {
-		util.GetLogger(ctx).Infof("GetUserDevices being called now")
 		return a.federation.GetUserDevices(ctx, s, userID)
 	})
 	if err != nil {

--- a/federationsender/internal/api.go
+++ b/federationsender/internal/api.go
@@ -71,7 +71,7 @@ func failBlacklistableError(err error, stats *statistics.ServerStatistics) (unti
 	if !ok {
 		return stats.Failure()
 	}
-	if mxerr.Code >= 500 || mxerr.Code < 600 {
+	if mxerr.Code >= 500 && mxerr.Code < 600 {
 		return stats.Failure()
 	}
 	return

--- a/federationsender/internal/api.go
+++ b/federationsender/internal/api.go
@@ -1,12 +1,17 @@
 package internal
 
 import (
+	"context"
+	"time"
+
+	"github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/dendrite/federationsender/queue"
 	"github.com/matrix-org/dendrite/federationsender/statistics"
 	"github.com/matrix-org/dendrite/federationsender/storage"
 	"github.com/matrix-org/dendrite/internal/config"
-	"github.com/matrix-org/dendrite/roomserver/api"
+	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
+	"go.uber.org/atomic"
 )
 
 // FederationSenderInternalAPI is an implementation of api.FederationSenderInternalAPI
@@ -14,7 +19,7 @@ type FederationSenderInternalAPI struct {
 	db         storage.Database
 	cfg        *config.FederationSender
 	statistics *statistics.Statistics
-	rsAPI      api.RoomserverInternalAPI
+	rsAPI      roomserverAPI.RoomserverInternalAPI
 	federation *gomatrixserverlib.FederationClient
 	keyRing    *gomatrixserverlib.KeyRing
 	queues     *queue.OutgoingQueues
@@ -22,7 +27,7 @@ type FederationSenderInternalAPI struct {
 
 func NewFederationSenderInternalAPI(
 	db storage.Database, cfg *config.FederationSender,
-	rsAPI api.RoomserverInternalAPI,
+	rsAPI roomserverAPI.RoomserverInternalAPI,
 	federation *gomatrixserverlib.FederationClient,
 	keyRing *gomatrixserverlib.KeyRing,
 	statistics *statistics.Statistics,
@@ -37,4 +42,84 @@ func NewFederationSenderInternalAPI(
 		statistics: statistics,
 		queues:     queues,
 	}
+}
+
+func (a *FederationSenderInternalAPI) isBlacklistedOrBackingOff(s gomatrixserverlib.ServerName) (*statistics.ServerStatistics, error) {
+	stats := a.statistics.ForServer(s)
+	if stats.Blacklisted() {
+		return stats, &api.FederationClientError{
+			Blacklisted: true,
+		}
+	}
+	// Call BackoffIfRequired with a closed channel to make it return immediately.
+	// It will return the duration to backoff for.
+	var duration time.Duration
+	interrupt := make(chan bool)
+	close(interrupt)
+	var bo atomic.Bool
+	duration, _ = stats.BackoffIfRequired(bo, interrupt)
+	if duration > 0 {
+		return stats, &api.FederationClientError{
+			RetryAfter: duration,
+		}
+	}
+
+	return stats, nil
+}
+
+func (a *FederationSenderInternalAPI) GetUserDevices(
+	ctx context.Context, s gomatrixserverlib.ServerName, userID string,
+) (gomatrixserverlib.RespUserDevices, error) {
+	var res gomatrixserverlib.RespUserDevices
+	stats, err := a.isBlacklistedOrBackingOff(s)
+	if err != nil {
+		return res, err
+	}
+	res, err = a.federation.GetUserDevices(ctx, s, userID)
+	if err != nil {
+		stats.Failure()
+		return res, &api.FederationClientError{
+			Err: err.Error(),
+		}
+	}
+	stats.Success()
+	return res, nil
+}
+
+func (a *FederationSenderInternalAPI) ClaimKeys(
+	ctx context.Context, s gomatrixserverlib.ServerName, oneTimeKeys map[string]map[string]string,
+) (gomatrixserverlib.RespClaimKeys, error) {
+	var res gomatrixserverlib.RespClaimKeys
+	stats, err := a.isBlacklistedOrBackingOff(s)
+	if err != nil {
+		return res, err
+	}
+	res, err = a.federation.ClaimKeys(ctx, s, oneTimeKeys)
+	if err != nil {
+		stats.Failure()
+		return res, &api.FederationClientError{
+			Err: err.Error(),
+		}
+	}
+	stats.Success()
+	return res, nil
+}
+
+func (a *FederationSenderInternalAPI) QueryKeys(
+	ctx context.Context, s gomatrixserverlib.ServerName, keys map[string][]string,
+) (gomatrixserverlib.RespQueryKeys, error) {
+	var res gomatrixserverlib.RespQueryKeys
+	stats, err := a.isBlacklistedOrBackingOff(s)
+	if err != nil {
+		return res, err
+	}
+	res, err = a.federation.QueryKeys(ctx, s, keys)
+	if err != nil {
+		stats.Failure()
+		return res, &api.FederationClientError{
+			Err: err.Error(),
+		}
+	}
+	stats.Success()
+	return res, nil
 }

--- a/federationsender/internal/api.go
+++ b/federationsender/internal/api.go
@@ -55,7 +55,7 @@ func (a *FederationSenderInternalAPI) isBlacklistedOrBackingOff(s gomatrixserver
 	now := time.Now()
 	if until != nil && now.Before(*until) {
 		return stats, &api.FederationClientError{
-			RetryAfter: until.Sub(now),
+			RetryAfter: time.Until(*until),
 		}
 	}
 
@@ -77,7 +77,7 @@ func failBlacklistableError(err error, stats *statistics.ServerStatistics) (unti
 }
 
 func (a *FederationSenderInternalAPI) doRequest(
-	ctx context.Context, s gomatrixserverlib.ServerName, request func() (interface{}, error),
+	s gomatrixserverlib.ServerName, request func() (interface{}, error),
 ) (interface{}, error) {
 	stats, err := a.isBlacklistedOrBackingOff(s)
 	if err != nil {
@@ -89,7 +89,7 @@ func (a *FederationSenderInternalAPI) doRequest(
 		now := time.Now()
 		var retryAfter time.Duration
 		if until.After(now) {
-			retryAfter = until.Sub(now)
+			retryAfter = time.Until(until)
 		}
 		return res, &api.FederationClientError{
 			Err:         err.Error(),
@@ -104,7 +104,7 @@ func (a *FederationSenderInternalAPI) doRequest(
 func (a *FederationSenderInternalAPI) GetUserDevices(
 	ctx context.Context, s gomatrixserverlib.ServerName, userID string,
 ) (gomatrixserverlib.RespUserDevices, error) {
-	ires, err := a.doRequest(ctx, s, func() (interface{}, error) {
+	ires, err := a.doRequest(s, func() (interface{}, error) {
 		return a.federation.GetUserDevices(ctx, s, userID)
 	})
 	if err != nil {
@@ -116,7 +116,7 @@ func (a *FederationSenderInternalAPI) GetUserDevices(
 func (a *FederationSenderInternalAPI) ClaimKeys(
 	ctx context.Context, s gomatrixserverlib.ServerName, oneTimeKeys map[string]map[string]string,
 ) (gomatrixserverlib.RespClaimKeys, error) {
-	ires, err := a.doRequest(ctx, s, func() (interface{}, error) {
+	ires, err := a.doRequest(s, func() (interface{}, error) {
 		return a.federation.ClaimKeys(ctx, s, oneTimeKeys)
 	})
 	if err != nil {
@@ -128,7 +128,7 @@ func (a *FederationSenderInternalAPI) ClaimKeys(
 func (a *FederationSenderInternalAPI) QueryKeys(
 	ctx context.Context, s gomatrixserverlib.ServerName, keys map[string][]string,
 ) (gomatrixserverlib.RespQueryKeys, error) {
-	ires, err := a.doRequest(ctx, s, func() (interface{}, error) {
+	ires, err := a.doRequest(s, func() (interface{}, error) {
 		return a.federation.QueryKeys(ctx, s, keys)
 	})
 	if err != nil {

--- a/federationsender/internal/api.go
+++ b/federationsender/internal/api.go
@@ -77,7 +77,7 @@ func failBlacklistableError(err error, stats *statistics.ServerStatistics) {
 		stats.Failure()
 		return
 	}
-	if mxerr.Code == 500 {
+	if mxerr.Code >= 500 || mxerr.Code < 600 {
 		stats.Failure()
 		return
 	}

--- a/federationsender/inthttp/client.go
+++ b/federationsender/inthttp/client.go
@@ -159,7 +159,7 @@ func (h *httpFederationSenderInternalAPI) GetUserDevices(
 	}
 	var response getUserDevices
 	apiURL := h.federationSenderURL + FederationSenderGetUserDevicesPath
-	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, &request, &response)
 	if err != nil {
 		return result, err
 	}
@@ -189,7 +189,7 @@ func (h *httpFederationSenderInternalAPI) ClaimKeys(
 	}
 	var response claimKeys
 	apiURL := h.federationSenderURL + FederationSenderClaimKeysPath
-	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, &request, &response)
 	if err != nil {
 		return result, err
 	}
@@ -219,7 +219,7 @@ func (h *httpFederationSenderInternalAPI) QueryKeys(
 	}
 	var response queryKeys
 	apiURL := h.federationSenderURL + FederationSenderQueryKeysPath
-	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, &request, &response)
 	if err != nil {
 		return result, err
 	}

--- a/federationsender/inthttp/client.go
+++ b/federationsender/inthttp/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/dendrite/internal/httputil"
 	"github.com/matrix-org/gomatrix"
+	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/opentracing/opentracing-go"
 )
 
@@ -21,6 +22,10 @@ const (
 	FederationSenderPerformInviteRequestPath          = "/federationsender/performInviteRequest"
 	FederationSenderPerformServersAlivePath           = "/federationsender/performServersAlive"
 	FederationSenderPerformBroadcastEDUPath           = "/federationsender/performBroadcastEDU"
+
+	FederationSenderGetUserDevicesPath = "/federationsender/client/getUserDevices"
+	FederationSenderClaimKeysPath      = "/federationsender/client/claimKeys"
+	FederationSenderQueryKeysPath      = "/federationsender/client/queryKeys"
 )
 
 // NewFederationSenderClient creates a FederationSenderInternalAPI implemented by talking to a HTTP POST API.
@@ -132,4 +137,94 @@ func (h *httpFederationSenderInternalAPI) PerformBroadcastEDU(
 
 	apiURL := h.federationSenderURL + FederationSenderPerformBroadcastEDUPath
 	return httputil.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+}
+
+type getUserDevices struct {
+	S      gomatrixserverlib.ServerName
+	UserID string
+	Res    *gomatrixserverlib.RespUserDevices
+	Err    *api.FederationClientError
+}
+
+func (h *httpFederationSenderInternalAPI) GetUserDevices(
+	ctx context.Context, s gomatrixserverlib.ServerName, userID string,
+) (gomatrixserverlib.RespUserDevices, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "GetUserDevices")
+	defer span.Finish()
+
+	var result gomatrixserverlib.RespUserDevices
+	request := getUserDevices{
+		S:      s,
+		UserID: userID,
+	}
+	var response getUserDevices
+	apiURL := h.federationSenderURL + FederationSenderGetUserDevicesPath
+	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+	if err != nil {
+		return result, err
+	}
+	if response.Err != nil {
+		return result, response.Err
+	}
+	return *response.Res, nil
+}
+
+type claimKeys struct {
+	S           gomatrixserverlib.ServerName
+	OneTimeKeys map[string]map[string]string
+	Res         *gomatrixserverlib.RespClaimKeys
+	Err         *api.FederationClientError
+}
+
+func (h *httpFederationSenderInternalAPI) ClaimKeys(
+	ctx context.Context, s gomatrixserverlib.ServerName, oneTimeKeys map[string]map[string]string,
+) (gomatrixserverlib.RespClaimKeys, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "ClaimKeys")
+	defer span.Finish()
+
+	var result gomatrixserverlib.RespClaimKeys
+	request := claimKeys{
+		S:           s,
+		OneTimeKeys: oneTimeKeys,
+	}
+	var response claimKeys
+	apiURL := h.federationSenderURL + FederationSenderClaimKeysPath
+	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+	if err != nil {
+		return result, err
+	}
+	if response.Err != nil {
+		return result, response.Err
+	}
+	return *response.Res, nil
+}
+
+type queryKeys struct {
+	S    gomatrixserverlib.ServerName
+	Keys map[string][]string
+	Res  *gomatrixserverlib.RespQueryKeys
+	Err  *api.FederationClientError
+}
+
+func (h *httpFederationSenderInternalAPI) QueryKeys(
+	ctx context.Context, s gomatrixserverlib.ServerName, keys map[string][]string,
+) (gomatrixserverlib.RespQueryKeys, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "QueryKeys")
+	defer span.Finish()
+
+	var result gomatrixserverlib.RespQueryKeys
+	request := queryKeys{
+		S:    s,
+		Keys: keys,
+	}
+	var response queryKeys
+	apiURL := h.federationSenderURL + FederationSenderQueryKeysPath
+	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+	if err != nil {
+		return result, err
+	}
+	if response.Err != nil {
+		return result, response.Err
+	}
+	return *response.Res, nil
 }

--- a/federationsender/inthttp/server.go
+++ b/federationsender/inthttp/server.go
@@ -109,4 +109,70 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
+	internalAPIMux.Handle(
+		FederationSenderGetUserDevicesPath,
+		httputil.MakeInternalAPI("GetUserDevices", func(req *http.Request) util.JSONResponse {
+			var request getUserDevices
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.MessageResponse(http.StatusBadRequest, err.Error())
+			}
+			res, err := intAPI.GetUserDevices(req.Context(), request.S, request.UserID)
+			if err != nil {
+				ferr, ok := err.(*api.FederationClientError)
+				if ok {
+					request.Err = ferr
+				} else {
+					request.Err = &api.FederationClientError{
+						Err: err.Error(),
+					}
+				}
+			}
+			request.Res = &res
+			return util.JSONResponse{Code: http.StatusOK, JSON: request}
+		}),
+	)
+	internalAPIMux.Handle(
+		FederationSenderClaimKeysPath,
+		httputil.MakeInternalAPI("ClaimKeys", func(req *http.Request) util.JSONResponse {
+			var request claimKeys
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.MessageResponse(http.StatusBadRequest, err.Error())
+			}
+			res, err := intAPI.ClaimKeys(req.Context(), request.S, request.OneTimeKeys)
+			if err != nil {
+				ferr, ok := err.(*api.FederationClientError)
+				if ok {
+					request.Err = ferr
+				} else {
+					request.Err = &api.FederationClientError{
+						Err: err.Error(),
+					}
+				}
+			}
+			request.Res = &res
+			return util.JSONResponse{Code: http.StatusOK, JSON: request}
+		}),
+	)
+	internalAPIMux.Handle(
+		FederationSenderQueryKeysPath,
+		httputil.MakeInternalAPI("QueryKeys", func(req *http.Request) util.JSONResponse {
+			var request queryKeys
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.MessageResponse(http.StatusBadRequest, err.Error())
+			}
+			res, err := intAPI.QueryKeys(req.Context(), request.S, request.Keys)
+			if err != nil {
+				ferr, ok := err.(*api.FederationClientError)
+				if ok {
+					request.Err = ferr
+				} else {
+					request.Err = &api.FederationClientError{
+						Err: err.Error(),
+					}
+				}
+			}
+			request.Res = &res
+			return util.JSONResponse{Code: http.StatusOK, JSON: request}
+		}),
+	)
 }

--- a/federationsender/statistics/statistics.go
+++ b/federationsender/statistics/statistics.go
@@ -126,6 +126,16 @@ func (s *ServerStatistics) Failure() (time.Time, bool) {
 	return until, false
 }
 
+// BackoffInfo returns information about the current or previous backoff.
+// Returns the last backoffUntil time and whether the server is currently blacklisted or not.
+func (s *ServerStatistics) BackoffInfo() (*time.Time, bool) {
+	until, ok := s.backoffUntil.Load().(time.Time)
+	if ok {
+		return &until, s.blacklisted.Load()
+	}
+	return nil, s.blacklisted.Load()
+}
+
 // BackoffIfRequired will block for as long as the current
 // backoff requires, if needed. Otherwise it will do nothing.
 // Returns the amount of time to backoff for and whether to give up or not.

--- a/federationsender/statistics/statistics_test.go
+++ b/federationsender/statistics/statistics_test.go
@@ -36,7 +36,10 @@ func TestBackoff(t *testing.T) {
 		// completes but we will find out how long the backoff should
 		// have been.
 		interrupt := make(chan bool, 1)
-		close(interrupt)
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			close(interrupt)
+		}()
 
 		// Get the duration.
 		duration, blacklist := server.BackoffIfRequired(backingOff, interrupt)

--- a/federationsender/statistics/statistics_test.go
+++ b/federationsender/statistics/statistics_test.go
@@ -36,10 +36,7 @@ func TestBackoff(t *testing.T) {
 		// completes but we will find out how long the backoff should
 		// have been.
 		interrupt := make(chan bool, 1)
-		go func() {
-			time.Sleep(10 * time.Millisecond)
-			close(interrupt)
-		}()
+		close(interrupt)
 
 		// Get the duration.
 		duration, blacklist := server.BackoffIfRequired(backingOff, interrupt)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/Shopify/sarama v1.26.1
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
 	github.com/gologme/log v1.2.0
-	github.com/gorilla/mux v1.7.3
+	github.com/gorilla/mux v1.7.4
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/lib/pq v1.2.0
 	github.com/libp2p/go-libp2p v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,8 @@ github.com/googleapis/gax-go/v2 v2.0.3/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE0
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
+github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/keyserver/internal/device_list_update.go
+++ b/keyserver/internal/device_list_update.go
@@ -305,7 +305,7 @@ func (u *DeviceListUpdater) worker(ch chan gomatrixserverlib.ServerName) {
 				continue
 			} else {
 				scheduledRetries[serverName] = time.Now().Add(cooloffPeriod)
-				go inject(serverName, cooloffPeriod) // TODO: Backoff?
+				go inject(serverName, cooloffPeriod)
 				continue
 			}
 		}
@@ -313,7 +313,7 @@ func (u *DeviceListUpdater) worker(ch chan gomatrixserverlib.ServerName) {
 		shouldRetry := u.processServer(serverName)
 		if shouldRetry {
 			scheduledRetries[serverName] = time.Now().Add(cooloffPeriod)
-			go inject(serverName, cooloffPeriod) // TODO: Backoff?
+			go inject(serverName, cooloffPeriod)
 		}
 	}
 }

--- a/keyserver/internal/device_list_update.go
+++ b/keyserver/internal/device_list_update.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	fedsenderapi "github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/dendrite/keyserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
@@ -65,7 +66,7 @@ type DeviceListUpdater struct {
 
 	db          DeviceListUpdaterDatabase
 	producer    KeyChangeProducer
-	fedClient   *gomatrixserverlib.FederationClient
+	fedClient   fedsenderapi.FederationClient
 	workerChans []chan gomatrixserverlib.ServerName
 
 	// When device lists are stale for a user, they get inserted into this map with a channel which `Update` will
@@ -103,7 +104,7 @@ type KeyChangeProducer interface {
 
 // NewDeviceListUpdater creates a new updater which fetches fresh device lists when they go stale.
 func NewDeviceListUpdater(
-	db DeviceListUpdaterDatabase, producer KeyChangeProducer, fedClient *gomatrixserverlib.FederationClient,
+	db DeviceListUpdaterDatabase, producer KeyChangeProducer, fedClient fedsenderapi.FederationClient,
 	numWorkers int,
 ) *DeviceListUpdater {
 	return &DeviceListUpdater{

--- a/keyserver/internal/internal.go
+++ b/keyserver/internal/internal.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	fedsenderapi "github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/dendrite/keyserver/api"
 	"github.com/matrix-org/dendrite/keyserver/producers"
 	"github.com/matrix-org/dendrite/keyserver/storage"
@@ -36,7 +37,7 @@ import (
 type KeyInternalAPI struct {
 	DB         storage.Database
 	ThisServer gomatrixserverlib.ServerName
-	FedClient  *gomatrixserverlib.FederationClient
+	FedClient  fedsenderapi.FederationClient
 	UserAPI    userapi.UserInternalAPI
 	Producer   *producers.KeyChange
 	Updater    *DeviceListUpdater

--- a/keyserver/keyserver.go
+++ b/keyserver/keyserver.go
@@ -17,13 +17,13 @@ package keyserver
 import (
 	"github.com/Shopify/sarama"
 	"github.com/gorilla/mux"
+	fedsenderapi "github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/dendrite/internal/config"
 	"github.com/matrix-org/dendrite/keyserver/api"
 	"github.com/matrix-org/dendrite/keyserver/internal"
 	"github.com/matrix-org/dendrite/keyserver/inthttp"
 	"github.com/matrix-org/dendrite/keyserver/producers"
 	"github.com/matrix-org/dendrite/keyserver/storage"
-	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/sirupsen/logrus"
 )
 
@@ -36,7 +36,7 @@ func AddInternalRoutes(router *mux.Router, intAPI api.KeyInternalAPI) {
 // NewInternalAPI returns a concerete implementation of the internal API. Callers
 // can call functions directly on the returned API or via an HTTP interface using AddInternalRoutes.
 func NewInternalAPI(
-	cfg *config.KeyServer, fedClient *gomatrixserverlib.FederationClient, producer sarama.SyncProducer,
+	cfg *config.KeyServer, fedClient fedsenderapi.FederationClient, producer sarama.SyncProducer,
 ) api.KeyInternalAPI {
 	db, err := storage.NewDatabase(&cfg.Database)
 	if err != nil {


### PR DESCRIPTION
- Use a shim struct in HTTP mode to keep the same API as `FederationClient`.
- Use `federationsender` instead of `FederationClient` in `keyserver`.
