### PR TITLE
Component-wide TransactionWriters

### DIFF
--- a/appservice/storage/postgres/storage.go
+++ b/appservice/storage/postgres/storage.go
@@ -32,6 +32,7 @@ type Database struct {
 	events eventsStatements
 	txnID  txnStatements
 	db     *sql.DB
+	writer sqlutil.TransactionWriter
 }
 
 // NewDatabase opens a new database
@@ -41,10 +42,11 @@ func NewDatabase(dbProperties *config.DatabaseOptions) (*Database, error) {
 	if result.db, err = sqlutil.Open(dbProperties); err != nil {
 		return nil, err
 	}
+	result.writer = sqlutil.NewDummyTransactionWriter()
 	if err = result.prepare(); err != nil {
 		return nil, err
 	}
-	if err = result.PartitionOffsetStatements.Prepare(result.db, "appservice"); err != nil {
+	if err = result.PartitionOffsetStatements.Prepare(result.db, result.writer, "appservice"); err != nil {
 		return nil, err
 	}
 	return &result, nil

--- a/appservice/storage/sqlite3/storage.go
+++ b/appservice/storage/sqlite3/storage.go
@@ -32,6 +32,7 @@ type Database struct {
 	events eventsStatements
 	txnID  txnStatements
 	db     *sql.DB
+	writer sqlutil.TransactionWriter
 }
 
 // NewDatabase opens a new database
@@ -41,10 +42,11 @@ func NewDatabase(dbProperties *config.DatabaseOptions) (*Database, error) {
 	if result.db, err = sqlutil.Open(dbProperties); err != nil {
 		return nil, err
 	}
+	result.writer = sqlutil.NewTransactionWriter()
 	if err = result.prepare(); err != nil {
 		return nil, err
 	}
-	if err = result.PartitionOffsetStatements.Prepare(result.db, "appservice"); err != nil {
+	if err = result.PartitionOffsetStatements.Prepare(result.db, result.writer, "appservice"); err != nil {
 		return nil, err
 	}
 	return &result, nil

--- a/currentstateserver/storage/postgres/storage.go
+++ b/currentstateserver/storage/postgres/storage.go
@@ -10,7 +10,8 @@ import (
 
 type Database struct {
 	shared.Database
-	db *sql.DB
+	db     *sql.DB
+	writer sqlutil.TransactionWriter
 	sqlutil.PartitionOffsetStatements
 }
 
@@ -21,7 +22,8 @@ func NewDatabase(dbProperties *config.DatabaseOptions) (*Database, error) {
 	if d.db, err = sqlutil.Open(dbProperties); err != nil {
 		return nil, err
 	}
-	if err = d.PartitionOffsetStatements.Prepare(d.db, "currentstate"); err != nil {
+	d.writer = sqlutil.NewDummyTransactionWriter()
+	if err = d.PartitionOffsetStatements.Prepare(d.db, d.writer, "currentstate"); err != nil {
 		return nil, err
 	}
 	currRoomState, err := NewPostgresCurrentRoomStateTable(d.db)

--- a/currentstateserver/storage/postgres/storage.go
+++ b/currentstateserver/storage/postgres/storage.go
@@ -32,6 +32,7 @@ func NewDatabase(dbProperties *config.DatabaseOptions) (*Database, error) {
 	}
 	d.Database = shared.Database{
 		DB:               d.db,
+		Writer:           d.writer,
 		CurrentRoomState: currRoomState,
 	}
 	return &d, nil

--- a/currentstateserver/storage/shared/storage.go
+++ b/currentstateserver/storage/shared/storage.go
@@ -27,6 +27,7 @@ import (
 
 type Database struct {
 	DB               *sql.DB
+	Writer           sqlutil.TransactionWriter
 	CurrentRoomState tables.CurrentRoomState
 }
 
@@ -59,7 +60,7 @@ func (d *Database) RedactEvent(ctx context.Context, redactedEventID string, reda
 
 func (d *Database) StoreStateEvents(ctx context.Context, addStateEvents []gomatrixserverlib.HeaderedEvent,
 	removeStateEventIDs []string) error {
-	return sqlutil.WithTransaction(d.DB, func(txn *sql.Tx) error {
+	return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
 		// remove first, then add, as we do not ever delete state, but do replace state which is a remove followed by an add.
 		for _, eventID := range removeStateEventIDs {
 			if err := d.CurrentRoomState.DeleteRoomStateByEventID(ctx, txn, eventID); err != nil {

--- a/currentstateserver/storage/sqlite3/storage.go
+++ b/currentstateserver/storage/sqlite3/storage.go
@@ -33,6 +33,7 @@ func NewDatabase(dbProperties *config.DatabaseOptions) (*Database, error) {
 	}
 	d.Database = shared.Database{
 		DB:               d.db,
+		Writer:           d.writer,
 		CurrentRoomState: currRoomState,
 	}
 	return &d, nil

--- a/currentstateserver/storage/sqlite3/storage.go
+++ b/currentstateserver/storage/sqlite3/storage.go
@@ -10,7 +10,8 @@ import (
 
 type Database struct {
 	shared.Database
-	db *sql.DB
+	db     *sql.DB
+	writer sqlutil.TransactionWriter
 	sqlutil.PartitionOffsetStatements
 }
 
@@ -22,7 +23,8 @@ func NewDatabase(dbProperties *config.DatabaseOptions) (*Database, error) {
 	if d.db, err = sqlutil.Open(dbProperties); err != nil {
 		return nil, err
 	}
-	if err = d.PartitionOffsetStatements.Prepare(d.db, "currentstate"); err != nil {
+	d.writer = sqlutil.NewTransactionWriter()
+	if err = d.PartitionOffsetStatements.Prepare(d.db, d.writer, "currentstate"); err != nil {
 		return nil, err
 	}
 	currRoomState, err := NewSqliteCurrentRoomStateTable(d.db)

--- a/federationsender/storage/postgres/storage.go
+++ b/federationsender/storage/postgres/storage.go
@@ -65,6 +65,7 @@ func NewDatabase(dbProperties *config.DatabaseOptions) (*Database, error) {
 	}
 	d.Database = shared.Database{
 		DB:                          d.db,
+		Writer:                      d.writer,
 		FederationSenderJoinedHosts: joinedHosts,
 		FederationSenderQueuePDUs:   queuePDUs,
 		FederationSenderQueueEDUs:   queueEDUs,

--- a/federationsender/storage/postgres/storage.go
+++ b/federationsender/storage/postgres/storage.go
@@ -27,7 +27,8 @@ import (
 type Database struct {
 	shared.Database
 	sqlutil.PartitionOffsetStatements
-	db *sql.DB
+	db     *sql.DB
+	writer sqlutil.TransactionWriter
 }
 
 // NewDatabase opens a new database
@@ -37,6 +38,7 @@ func NewDatabase(dbProperties *config.DatabaseOptions) (*Database, error) {
 	if d.db, err = sqlutil.Open(dbProperties); err != nil {
 		return nil, err
 	}
+	d.writer = sqlutil.NewDummyTransactionWriter()
 	joinedHosts, err := NewPostgresJoinedHostsTable(d.db)
 	if err != nil {
 		return nil, err
@@ -70,7 +72,7 @@ func NewDatabase(dbProperties *config.DatabaseOptions) (*Database, error) {
 		FederationSenderRooms:       rooms,
 		FederationSenderBlacklist:   blacklist,
 	}
-	if err = d.PartitionOffsetStatements.Prepare(d.db, "federationsender"); err != nil {
+	if err = d.PartitionOffsetStatements.Prepare(d.db, d.writer, "federationsender"); err != nil {
 		return nil, err
 	}
 	return &d, nil

--- a/federationsender/storage/shared/storage.go
+++ b/federationsender/storage/shared/storage.go
@@ -28,6 +28,7 @@ import (
 
 type Database struct {
 	DB                          *sql.DB
+	Writer                      sqlutil.TransactionWriter
 	FederationSenderQueuePDUs   tables.FederationSenderQueuePDUs
 	FederationSenderQueueEDUs   tables.FederationSenderQueueEDUs
 	FederationSenderQueueJSON   tables.FederationSenderQueueJSON
@@ -64,7 +65,7 @@ func (d *Database) UpdateRoom(
 	addHosts []types.JoinedHost,
 	removeHosts []string,
 ) (joinedHosts []types.JoinedHost, err error) {
-	err = sqlutil.WithTransaction(d.DB, func(txn *sql.Tx) error {
+	err = d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
 		err = d.FederationSenderRooms.InsertRoom(ctx, txn, roomID)
 		if err != nil {
 			return err
@@ -133,7 +134,12 @@ func (d *Database) GetJoinedHostsForRooms(ctx context.Context, roomIDs []string)
 func (d *Database) StoreJSON(
 	ctx context.Context, js string,
 ) (*Receipt, error) {
-	nid, err := d.FederationSenderQueueJSON.InsertQueueJSON(ctx, nil, js)
+	var nid int64
+	var err error
+	_ = d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
+		nid, err = d.FederationSenderQueueJSON.InsertQueueJSON(ctx, txn, js)
+		return nil
+	})
 	if err != nil {
 		return nil, fmt.Errorf("d.insertQueueJSON: %w", err)
 	}
@@ -143,11 +149,15 @@ func (d *Database) StoreJSON(
 }
 
 func (d *Database) AddServerToBlacklist(serverName gomatrixserverlib.ServerName) error {
-	return d.FederationSenderBlacklist.InsertBlacklist(context.TODO(), nil, serverName)
+	return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
+		return d.FederationSenderBlacklist.InsertBlacklist(context.TODO(), txn, serverName)
+	})
 }
 
 func (d *Database) RemoveServerFromBlacklist(serverName gomatrixserverlib.ServerName) error {
-	return d.FederationSenderBlacklist.DeleteBlacklist(context.TODO(), nil, serverName)
+	return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
+		return d.FederationSenderBlacklist.DeleteBlacklist(context.TODO(), txn, serverName)
+	})
 }
 
 func (d *Database) IsServerBlacklisted(serverName gomatrixserverlib.ServerName) (bool, error) {

--- a/federationsender/storage/sqlite3/blacklist_table.go
+++ b/federationsender/storage/sqlite3/blacklist_table.go
@@ -42,7 +42,6 @@ const deleteBlacklistSQL = "" +
 
 type blacklistStatements struct {
 	db                  *sql.DB
-	writer              sqlutil.TransactionWriter
 	insertBlacklistStmt *sql.Stmt
 	selectBlacklistStmt *sql.Stmt
 	deleteBlacklistStmt *sql.Stmt
@@ -50,8 +49,7 @@ type blacklistStatements struct {
 
 func NewSQLiteBlacklistTable(db *sql.DB) (s *blacklistStatements, err error) {
 	s = &blacklistStatements{
-		db:     db,
-		writer: sqlutil.NewTransactionWriter(),
+		db: db,
 	}
 	_, err = db.Exec(blacklistSchema)
 	if err != nil {
@@ -75,11 +73,9 @@ func NewSQLiteBlacklistTable(db *sql.DB) (s *blacklistStatements, err error) {
 func (s *blacklistStatements) InsertBlacklist(
 	ctx context.Context, txn *sql.Tx, serverName gomatrixserverlib.ServerName,
 ) error {
-	return s.writer.Do(s.db, txn, func(txn *sql.Tx) error {
-		stmt := sqlutil.TxStmt(txn, s.insertBlacklistStmt)
-		_, err := stmt.ExecContext(ctx, serverName)
-		return err
-	})
+	stmt := sqlutil.TxStmt(txn, s.insertBlacklistStmt)
+	_, err := stmt.ExecContext(ctx, serverName)
+	return err
 }
 
 // selectRoomForUpdate locks the row for the room and returns the last_event_id.
@@ -105,9 +101,7 @@ func (s *blacklistStatements) SelectBlacklist(
 func (s *blacklistStatements) DeleteBlacklist(
 	ctx context.Context, txn *sql.Tx, serverName gomatrixserverlib.ServerName,
 ) error {
-	return s.writer.Do(s.db, txn, func(txn *sql.Tx) error {
-		stmt := sqlutil.TxStmt(txn, s.deleteBlacklistStmt)
-		_, err := stmt.ExecContext(ctx, serverName)
-		return err
-	})
+	stmt := sqlutil.TxStmt(txn, s.deleteBlacklistStmt)
+	_, err := stmt.ExecContext(ctx, serverName)
+	return err
 }

--- a/federationsender/storage/sqlite3/queue_json_table.go
+++ b/federationsender/storage/sqlite3/queue_json_table.go
@@ -50,7 +50,6 @@ const selectJSONSQL = "" +
 
 type queueJSONStatements struct {
 	db             *sql.DB
-	writer         sqlutil.TransactionWriter
 	insertJSONStmt *sql.Stmt
 	//deleteJSONStmt *sql.Stmt - prepared at runtime due to variadic
 	//selectJSONStmt *sql.Stmt - prepared at runtime due to variadic
@@ -58,8 +57,7 @@ type queueJSONStatements struct {
 
 func NewSQLiteQueueJSONTable(db *sql.DB) (s *queueJSONStatements, err error) {
 	s = &queueJSONStatements{
-		db:     db,
-		writer: sqlutil.NewTransactionWriter(),
+		db: db,
 	}
 	_, err = db.Exec(queueJSONSchema)
 	if err != nil {
@@ -74,18 +72,15 @@ func NewSQLiteQueueJSONTable(db *sql.DB) (s *queueJSONStatements, err error) {
 func (s *queueJSONStatements) InsertQueueJSON(
 	ctx context.Context, txn *sql.Tx, json string,
 ) (lastid int64, err error) {
-	err = s.writer.Do(s.db, txn, func(txn *sql.Tx) error {
-		stmt := sqlutil.TxStmt(txn, s.insertJSONStmt)
-		res, err := stmt.ExecContext(ctx, json)
-		if err != nil {
-			return fmt.Errorf("stmt.QueryContext: %w", err)
-		}
-		lastid, err = res.LastInsertId()
-		if err != nil {
-			return fmt.Errorf("res.LastInsertId: %w", err)
-		}
-		return nil
-	})
+	stmt := sqlutil.TxStmt(txn, s.insertJSONStmt)
+	res, err := stmt.ExecContext(ctx, json)
+	if err != nil {
+		return 0, fmt.Errorf("stmt.QueryContext: %w", err)
+	}
+	lastid, err = res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("res.LastInsertId: %w", err)
+	}
 	return
 }
 
@@ -103,11 +98,9 @@ func (s *queueJSONStatements) DeleteQueueJSON(
 		iNIDs[k] = v
 	}
 
-	return s.writer.Do(s.db, txn, func(txn *sql.Tx) error {
-		stmt := sqlutil.TxStmt(txn, deleteStmt)
-		_, err = stmt.ExecContext(ctx, iNIDs...)
-		return err
-	})
+	stmt := sqlutil.TxStmt(txn, deleteStmt)
+	_, err = stmt.ExecContext(ctx, iNIDs...)
+	return err
 }
 
 func (s *queueJSONStatements) SelectQueueJSON(

--- a/federationsender/storage/sqlite3/storage.go
+++ b/federationsender/storage/sqlite3/storage.go
@@ -67,6 +67,7 @@ func NewDatabase(dbProperties *config.DatabaseOptions) (*Database, error) {
 	}
 	d.Database = shared.Database{
 		DB:                          d.db,
+		Writer:                      d.writer,
 		FederationSenderJoinedHosts: joinedHosts,
 		FederationSenderQueuePDUs:   queuePDUs,
 		FederationSenderQueueEDUs:   queueEDUs,

--- a/federationsender/storage/sqlite3/storage.go
+++ b/federationsender/storage/sqlite3/storage.go
@@ -29,7 +29,8 @@ import (
 type Database struct {
 	shared.Database
 	sqlutil.PartitionOffsetStatements
-	db *sql.DB
+	db     *sql.DB
+	writer sqlutil.TransactionWriter
 }
 
 // NewDatabase opens a new database
@@ -39,6 +40,7 @@ func NewDatabase(dbProperties *config.DatabaseOptions) (*Database, error) {
 	if d.db, err = sqlutil.Open(dbProperties); err != nil {
 		return nil, err
 	}
+	d.writer = sqlutil.NewTransactionWriter()
 	joinedHosts, err := NewSQLiteJoinedHostsTable(d.db)
 	if err != nil {
 		return nil, err
@@ -72,7 +74,7 @@ func NewDatabase(dbProperties *config.DatabaseOptions) (*Database, error) {
 		FederationSenderRooms:       rooms,
 		FederationSenderBlacklist:   blacklist,
 	}
-	if err = d.PartitionOffsetStatements.Prepare(d.db, "federationsender"); err != nil {
+	if err = d.PartitionOffsetStatements.Prepare(d.db, d.writer, "federationsender"); err != nil {
 		return nil, err
 	}
 	return &d, nil

--- a/internal/sqlutil/partition_offset_table.go
+++ b/internal/sqlutil/partition_offset_table.go
@@ -53,6 +53,8 @@ const upsertPartitionOffsetsSQL = "" +
 
 // PartitionOffsetStatements represents a set of statements that can be run on a partition_offsets table.
 type PartitionOffsetStatements struct {
+	db                         *sql.DB
+	writer                     TransactionWriter
 	selectPartitionOffsetsStmt *sql.Stmt
 	upsertPartitionOffsetStmt  *sql.Stmt
 }
@@ -60,7 +62,9 @@ type PartitionOffsetStatements struct {
 // Prepare converts the raw SQL statements into prepared statements.
 // Takes a prefix to prepend to the table name used to store the partition offsets.
 // This allows multiple components to share the same database schema.
-func (s *PartitionOffsetStatements) Prepare(db *sql.DB, prefix string) (err error) {
+func (s *PartitionOffsetStatements) Prepare(db *sql.DB, writer TransactionWriter, prefix string) (err error) {
+	s.db = db
+	s.writer = writer
 	_, err = db.Exec(strings.Replace(partitionOffsetsSchema, "${prefix}", prefix, -1))
 	if err != nil {
 		return
@@ -121,6 +125,9 @@ func (s *PartitionOffsetStatements) selectPartitionOffsets(
 func (s *PartitionOffsetStatements) upsertPartitionOffset(
 	ctx context.Context, topic string, partition int32, offset int64,
 ) error {
-	_, err := s.upsertPartitionOffsetStmt.ExecContext(ctx, topic, partition, offset)
-	return err
+	return s.writer.Do(s.db, nil, func(txn *sql.Tx) error {
+		stmt := TxStmt(txn, s.upsertPartitionOffsetStmt)
+		_, err := stmt.ExecContext(ctx, topic, partition, offset)
+		return err
+	})
 }

--- a/keyserver/storage/sqlite3/device_keys_table.go
+++ b/keyserver/storage/sqlite3/device_keys_table.go
@@ -71,10 +71,10 @@ type deviceKeysStatements struct {
 	deleteAllDeviceKeysStmt    *sql.Stmt
 }
 
-func NewSqliteDeviceKeysTable(db *sql.DB) (tables.DeviceKeys, error) {
+func NewSqliteDeviceKeysTable(db *sql.DB, writer sqlutil.TransactionWriter) (tables.DeviceKeys, error) {
 	s := &deviceKeysStatements{
 		db:     db,
-		writer: sqlutil.NewTransactionWriter(),
+		writer: writer,
 	}
 	_, err := db.Exec(deviceKeysSchema)
 	if err != nil {

--- a/keyserver/storage/sqlite3/key_changes_table.go
+++ b/keyserver/storage/sqlite3/key_changes_table.go
@@ -57,10 +57,10 @@ type keyChangesStatements struct {
 	selectKeyChangesStmt *sql.Stmt
 }
 
-func NewSqliteKeyChangesTable(db *sql.DB) (tables.KeyChanges, error) {
+func NewSqliteKeyChangesTable(db *sql.DB, writer sqlutil.TransactionWriter) (tables.KeyChanges, error) {
 	s := &keyChangesStatements{
 		db:     db,
-		writer: sqlutil.NewTransactionWriter(),
+		writer: writer,
 	}
 	_, err := db.Exec(keyChangesSchema)
 	if err != nil {

--- a/keyserver/storage/sqlite3/one_time_keys_table.go
+++ b/keyserver/storage/sqlite3/one_time_keys_table.go
@@ -68,10 +68,10 @@ type oneTimeKeysStatements struct {
 	deleteOneTimeKeyStmt     *sql.Stmt
 }
 
-func NewSqliteOneTimeKeysTable(db *sql.DB) (tables.OneTimeKeys, error) {
+func NewSqliteOneTimeKeysTable(db *sql.DB, writer sqlutil.TransactionWriter) (tables.OneTimeKeys, error) {
 	s := &oneTimeKeysStatements{
 		db:     db,
-		writer: sqlutil.NewTransactionWriter(),
+		writer: writer,
 	}
 	_, err := db.Exec(oneTimeKeysSchema)
 	if err != nil {

--- a/keyserver/storage/sqlite3/stale_device_lists.go
+++ b/keyserver/storage/sqlite3/stale_device_lists.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/matrix-org/dendrite/internal"
+	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/keyserver/storage/tables"
 	"github.com/matrix-org/gomatrixserverlib"
 )
@@ -49,13 +50,18 @@ const selectStaleDeviceListsSQL = "" +
 	"SELECT user_id FROM keyserver_stale_device_lists WHERE is_stale = $1"
 
 type staleDeviceListsStatements struct {
+	db                                    *sql.DB
+	writer                                sqlutil.TransactionWriter
 	upsertStaleDeviceListStmt             *sql.Stmt
 	selectStaleDeviceListsWithDomainsStmt *sql.Stmt
 	selectStaleDeviceListsStmt            *sql.Stmt
 }
 
-func NewSqliteStaleDeviceListsTable(db *sql.DB) (tables.StaleDeviceLists, error) {
-	s := &staleDeviceListsStatements{}
+func NewSqliteStaleDeviceListsTable(db *sql.DB, writer sqlutil.TransactionWriter) (tables.StaleDeviceLists, error) {
+	s := &staleDeviceListsStatements{
+		db:     db,
+		writer: writer,
+	}
 	_, err := db.Exec(staleDeviceListsSchema)
 	if err != nil {
 		return nil, err
@@ -77,8 +83,11 @@ func (s *staleDeviceListsStatements) InsertStaleDeviceList(ctx context.Context, 
 	if err != nil {
 		return err
 	}
-	_, err = s.upsertStaleDeviceListStmt.ExecContext(ctx, userID, string(domain), isStale, time.Now().Unix())
-	return err
+	return s.writer.Do(s.db, nil, func(txn *sql.Tx) error {
+		stmt := sqlutil.TxStmt(txn, s.upsertStaleDeviceListStmt)
+		_, err = stmt.ExecContext(ctx, userID, string(domain), isStale, time.Now().Unix())
+		return err
+	})
 }
 
 func (s *staleDeviceListsStatements) SelectUserIDsWithStaleDeviceLists(ctx context.Context, domains []gomatrixserverlib.ServerName) ([]string, error) {

--- a/keyserver/storage/sqlite3/storage.go
+++ b/keyserver/storage/sqlite3/storage.go
@@ -25,19 +25,20 @@ func NewDatabase(dbProperties *config.DatabaseOptions) (*shared.Database, error)
 	if err != nil {
 		return nil, err
 	}
-	otk, err := NewSqliteOneTimeKeysTable(db)
+	writer := sqlutil.NewTransactionWriter()
+	otk, err := NewSqliteOneTimeKeysTable(db, writer)
 	if err != nil {
 		return nil, err
 	}
-	dk, err := NewSqliteDeviceKeysTable(db)
+	dk, err := NewSqliteDeviceKeysTable(db, writer)
 	if err != nil {
 		return nil, err
 	}
-	kc, err := NewSqliteKeyChangesTable(db)
+	kc, err := NewSqliteKeyChangesTable(db, writer)
 	if err != nil {
 		return nil, err
 	}
-	sdl, err := NewSqliteStaleDeviceListsTable(db)
+	sdl, err := NewSqliteStaleDeviceListsTable(db, writer)
 	if err != nil {
 		return nil, err
 	}

--- a/mediaapi/storage/sqlite3/media_repository_table.go
+++ b/mediaapi/storage/sqlite3/media_repository_table.go
@@ -67,9 +67,9 @@ type mediaStatements struct {
 	selectMediaStmt *sql.Stmt
 }
 
-func (s *mediaStatements) prepare(db *sql.DB) (err error) {
+func (s *mediaStatements) prepare(db *sql.DB, writer sqlutil.TransactionWriter) (err error) {
 	s.db = db
-	s.writer = sqlutil.NewTransactionWriter()
+	s.writer = writer
 
 	_, err = db.Exec(mediaSchema)
 	if err != nil {

--- a/mediaapi/storage/sqlite3/sql.go
+++ b/mediaapi/storage/sqlite3/sql.go
@@ -17,6 +17,8 @@ package sqlite3
 
 import (
 	"database/sql"
+
+	"github.com/matrix-org/dendrite/internal/sqlutil"
 )
 
 type statements struct {
@@ -24,11 +26,11 @@ type statements struct {
 	thumbnail thumbnailStatements
 }
 
-func (s *statements) prepare(db *sql.DB) (err error) {
-	if err = s.media.prepare(db); err != nil {
+func (s *statements) prepare(db *sql.DB, writer sqlutil.TransactionWriter) (err error) {
+	if err = s.media.prepare(db, writer); err != nil {
 		return
 	}
-	if err = s.thumbnail.prepare(db); err != nil {
+	if err = s.thumbnail.prepare(db, writer); err != nil {
 		return
 	}
 

--- a/mediaapi/storage/sqlite3/storage.go
+++ b/mediaapi/storage/sqlite3/storage.go
@@ -31,16 +31,19 @@ import (
 type Database struct {
 	statements statements
 	db         *sql.DB
+	writer     sqlutil.TransactionWriter
 }
 
 // Open opens a postgres database.
 func Open(dbProperties *config.DatabaseOptions) (*Database, error) {
-	var d Database
+	d := Database{
+		writer: sqlutil.NewTransactionWriter(),
+	}
 	var err error
 	if d.db, err = sqlutil.Open(dbProperties); err != nil {
 		return nil, err
 	}
-	if err = d.statements.prepare(d.db); err != nil {
+	if err = d.statements.prepare(d.db, d.writer); err != nil {
 		return nil, err
 	}
 	return &d, nil

--- a/mediaapi/storage/sqlite3/thumbnail_table.go
+++ b/mediaapi/storage/sqlite3/thumbnail_table.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/matrix-org/dendrite/internal"
+	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/mediaapi/types"
 	"github.com/matrix-org/gomatrixserverlib"
 )
@@ -57,16 +58,20 @@ SELECT content_type, file_size_bytes, creation_ts, width, height, resize_method 
 `
 
 type thumbnailStatements struct {
+	db                   *sql.DB
+	writer               sqlutil.TransactionWriter
 	insertThumbnailStmt  *sql.Stmt
 	selectThumbnailStmt  *sql.Stmt
 	selectThumbnailsStmt *sql.Stmt
 }
 
-func (s *thumbnailStatements) prepare(db *sql.DB) (err error) {
+func (s *thumbnailStatements) prepare(db *sql.DB, writer sqlutil.TransactionWriter) (err error) {
 	_, err = db.Exec(thumbnailSchema)
 	if err != nil {
 		return
 	}
+	s.db = db
+	s.writer = writer
 
 	return statementList{
 		{&s.insertThumbnailStmt, insertThumbnailSQL},
@@ -79,18 +84,21 @@ func (s *thumbnailStatements) insertThumbnail(
 	ctx context.Context, thumbnailMetadata *types.ThumbnailMetadata,
 ) error {
 	thumbnailMetadata.MediaMetadata.CreationTimestamp = types.UnixMs(time.Now().UnixNano() / 1000000)
-	_, err := s.insertThumbnailStmt.ExecContext(
-		ctx,
-		thumbnailMetadata.MediaMetadata.MediaID,
-		thumbnailMetadata.MediaMetadata.Origin,
-		thumbnailMetadata.MediaMetadata.ContentType,
-		thumbnailMetadata.MediaMetadata.FileSizeBytes,
-		thumbnailMetadata.MediaMetadata.CreationTimestamp,
-		thumbnailMetadata.ThumbnailSize.Width,
-		thumbnailMetadata.ThumbnailSize.Height,
-		thumbnailMetadata.ThumbnailSize.ResizeMethod,
-	)
-	return err
+	return s.writer.Do(s.db, nil, func(txn *sql.Tx) error {
+		stmt := sqlutil.TxStmt(txn, s.insertThumbnailStmt)
+		_, err := stmt.ExecContext(
+			ctx,
+			thumbnailMetadata.MediaMetadata.MediaID,
+			thumbnailMetadata.MediaMetadata.Origin,
+			thumbnailMetadata.MediaMetadata.ContentType,
+			thumbnailMetadata.MediaMetadata.FileSizeBytes,
+			thumbnailMetadata.MediaMetadata.CreationTimestamp,
+			thumbnailMetadata.ThumbnailSize.Width,
+			thumbnailMetadata.ThumbnailSize.Height,
+			thumbnailMetadata.ThumbnailSize.ResizeMethod,
+		)
+		return err
+	})
 }
 
 func (s *thumbnailStatements) selectThumbnail(

--- a/serverkeyapi/storage/sqlite3/keydb.go
+++ b/serverkeyapi/storage/sqlite3/keydb.go
@@ -30,6 +30,7 @@ import (
 // A Database implements gomatrixserverlib.KeyDatabase and is used to store
 // the public keys for other matrix servers.
 type Database struct {
+	writer     sqlutil.TransactionWriter
 	statements serverKeyStatements
 }
 
@@ -47,8 +48,10 @@ func NewDatabase(
 	if err != nil {
 		return nil, err
 	}
-	d := &Database{}
-	err = d.statements.prepare(db)
+	d := &Database{
+		writer: sqlutil.NewTransactionWriter(),
+	}
+	err = d.statements.prepare(db, d.writer)
 	if err != nil {
 		return nil, err
 	}

--- a/serverkeyapi/storage/sqlite3/server_key_table.go
+++ b/serverkeyapi/storage/sqlite3/server_key_table.go
@@ -68,9 +68,9 @@ type serverKeyStatements struct {
 	upsertServerKeysStmt     *sql.Stmt
 }
 
-func (s *serverKeyStatements) prepare(db *sql.DB) (err error) {
+func (s *serverKeyStatements) prepare(db *sql.DB, writer sqlutil.TransactionWriter) (err error) {
 	s.db = db
-	s.writer = sqlutil.NewTransactionWriter()
+	s.writer = writer
 	_, err = db.Exec(serverKeysSchema)
 	if err != nil {
 		return

--- a/syncapi/storage/postgres/syncserver.go
+++ b/syncapi/storage/postgres/syncserver.go
@@ -30,7 +30,8 @@ import (
 // both the database for PDUs and caches for EDUs.
 type SyncServerDatasource struct {
 	shared.Database
-	db *sql.DB
+	db     *sql.DB
+	writer sqlutil.TransactionWriter
 	sqlutil.PartitionOffsetStatements
 }
 
@@ -41,7 +42,8 @@ func NewDatabase(dbProperties *config.DatabaseOptions) (*SyncServerDatasource, e
 	if d.db, err = sqlutil.Open(dbProperties); err != nil {
 		return nil, err
 	}
-	if err = d.PartitionOffsetStatements.Prepare(d.db, "syncapi"); err != nil {
+	d.writer = sqlutil.NewDummyTransactionWriter()
+	if err = d.PartitionOffsetStatements.Prepare(d.db, d.writer, "syncapi"); err != nil {
 		return nil, err
 	}
 	accountData, err := NewPostgresAccountDataTable(d.db)

--- a/syncapi/storage/sqlite3/account_data_table.go
+++ b/syncapi/storage/sqlite3/account_data_table.go
@@ -58,10 +58,10 @@ type accountDataStatements struct {
 	selectAccountDataInRangeStmt *sql.Stmt
 }
 
-func NewSqliteAccountDataTable(db *sql.DB, streamID *streamIDStatements) (tables.AccountData, error) {
+func NewSqliteAccountDataTable(db *sql.DB, writer sqlutil.TransactionWriter, streamID *streamIDStatements) (tables.AccountData, error) {
 	s := &accountDataStatements{
 		db:                 db,
-		writer:             sqlutil.NewTransactionWriter(),
+		writer:             writer,
 		streamIDStatements: streamID,
 	}
 	_, err := db.Exec(accountDataSchema)

--- a/syncapi/storage/sqlite3/backwards_extremities_table.go
+++ b/syncapi/storage/sqlite3/backwards_extremities_table.go
@@ -55,10 +55,10 @@ type backwardExtremitiesStatements struct {
 	deleteBackwardExtremityStmt          *sql.Stmt
 }
 
-func NewSqliteBackwardsExtremitiesTable(db *sql.DB) (tables.BackwardsExtremities, error) {
+func NewSqliteBackwardsExtremitiesTable(db *sql.DB, writer sqlutil.TransactionWriter) (tables.BackwardsExtremities, error) {
 	s := &backwardExtremitiesStatements{
 		db:     db,
-		writer: sqlutil.NewTransactionWriter(),
+		writer: writer,
 	}
 	_, err := db.Exec(backwardExtremitiesSchema)
 	if err != nil {

--- a/syncapi/storage/sqlite3/current_room_state_table.go
+++ b/syncapi/storage/sqlite3/current_room_state_table.go
@@ -95,10 +95,10 @@ type currentRoomStateStatements struct {
 	selectStateEventStmt            *sql.Stmt
 }
 
-func NewSqliteCurrentRoomStateTable(db *sql.DB, streamID *streamIDStatements) (tables.CurrentRoomState, error) {
+func NewSqliteCurrentRoomStateTable(db *sql.DB, writer sqlutil.TransactionWriter, streamID *streamIDStatements) (tables.CurrentRoomState, error) {
 	s := &currentRoomStateStatements{
 		db:                 db,
-		writer:             sqlutil.NewTransactionWriter(),
+		writer:             writer,
 		streamIDStatements: streamID,
 	}
 	_, err := db.Exec(currentRoomStateSchema)

--- a/syncapi/storage/sqlite3/filter_table.go
+++ b/syncapi/storage/sqlite3/filter_table.go
@@ -58,14 +58,14 @@ type filterStatements struct {
 	insertFilterStmt            *sql.Stmt
 }
 
-func NewSqliteFilterTable(db *sql.DB) (tables.Filter, error) {
+func NewSqliteFilterTable(db *sql.DB, writer sqlutil.TransactionWriter) (tables.Filter, error) {
 	_, err := db.Exec(filterSchema)
 	if err != nil {
 		return nil, err
 	}
 	s := &filterStatements{
 		db:     db,
-		writer: sqlutil.NewTransactionWriter(),
+		writer: writer,
 	}
 	if s.selectFilterStmt, err = db.Prepare(selectFilterSQL); err != nil {
 		return nil, err

--- a/syncapi/storage/sqlite3/invites_table.go
+++ b/syncapi/storage/sqlite3/invites_table.go
@@ -67,10 +67,10 @@ type inviteEventsStatements struct {
 	selectMaxInviteIDStmt         *sql.Stmt
 }
 
-func NewSqliteInvitesTable(db *sql.DB, streamID *streamIDStatements) (tables.Invites, error) {
+func NewSqliteInvitesTable(db *sql.DB, writer sqlutil.TransactionWriter, streamID *streamIDStatements) (tables.Invites, error) {
 	s := &inviteEventsStatements{
 		db:                 db,
-		writer:             sqlutil.NewTransactionWriter(),
+		writer:             writer,
 		streamIDStatements: streamID,
 	}
 	_, err := db.Exec(inviteEventsSchema)

--- a/syncapi/storage/sqlite3/output_room_events_table.go
+++ b/syncapi/storage/sqlite3/output_room_events_table.go
@@ -117,10 +117,10 @@ type outputRoomEventsStatements struct {
 	updateEventJSONStmt           *sql.Stmt
 }
 
-func NewSqliteEventsTable(db *sql.DB, streamID *streamIDStatements) (tables.Events, error) {
+func NewSqliteEventsTable(db *sql.DB, writer sqlutil.TransactionWriter, streamID *streamIDStatements) (tables.Events, error) {
 	s := &outputRoomEventsStatements{
 		db:                 db,
-		writer:             sqlutil.NewTransactionWriter(),
+		writer:             writer,
 		streamIDStatements: streamID,
 	}
 	_, err := db.Exec(outputRoomEventsSchema)

--- a/syncapi/storage/sqlite3/output_room_events_topology_table.go
+++ b/syncapi/storage/sqlite3/output_room_events_topology_table.go
@@ -75,10 +75,10 @@ type outputRoomEventsTopologyStatements struct {
 	selectMaxPositionInTopologyStmt *sql.Stmt
 }
 
-func NewSqliteTopologyTable(db *sql.DB) (tables.Topology, error) {
+func NewSqliteTopologyTable(db *sql.DB, writer sqlutil.TransactionWriter) (tables.Topology, error) {
 	s := &outputRoomEventsTopologyStatements{
 		db:     db,
-		writer: sqlutil.NewTransactionWriter(),
+		writer: writer,
 	}
 	_, err := db.Exec(outputRoomEventsTopologySchema)
 	if err != nil {

--- a/syncapi/storage/sqlite3/send_to_device_table.go
+++ b/syncapi/storage/sqlite3/send_to_device_table.go
@@ -79,10 +79,10 @@ type sendToDeviceStatements struct {
 	countSendToDeviceMessagesStmt  *sql.Stmt
 }
 
-func NewSqliteSendToDeviceTable(db *sql.DB) (tables.SendToDevice, error) {
+func NewSqliteSendToDeviceTable(db *sql.DB, writer sqlutil.TransactionWriter) (tables.SendToDevice, error) {
 	s := &sendToDeviceStatements{
 		db:     db,
-		writer: sqlutil.NewTransactionWriter(),
+		writer: writer,
 	}
 	_, err := db.Exec(sendToDeviceSchema)
 	if err != nil {

--- a/syncapi/storage/sqlite3/stream_id_table.go
+++ b/syncapi/storage/sqlite3/stream_id_table.go
@@ -33,9 +33,9 @@ type streamIDStatements struct {
 	selectStreamIDStmt   *sql.Stmt
 }
 
-func (s *streamIDStatements) prepare(db *sql.DB) (err error) {
+func (s *streamIDStatements) prepare(db *sql.DB, writer sqlutil.TransactionWriter) (err error) {
 	s.db = db
-	s.writer = sqlutil.NewTransactionWriter()
+	s.writer = writer
 	_, err = db.Exec(streamIDTableSchema)
 	if err != nil {
 		return

--- a/syncapi/storage/sqlite3/syncserver.go
+++ b/syncapi/storage/sqlite3/syncserver.go
@@ -56,38 +56,38 @@ func (d *SyncServerDatasource) prepare() (err error) {
 	if err = d.PartitionOffsetStatements.Prepare(d.db, d.writer, "syncapi"); err != nil {
 		return err
 	}
-	if err = d.streamID.prepare(d.db); err != nil {
+	if err = d.streamID.prepare(d.db, d.writer); err != nil {
 		return err
 	}
-	accountData, err := NewSqliteAccountDataTable(d.db, &d.streamID)
+	accountData, err := NewSqliteAccountDataTable(d.db, d.writer, &d.streamID)
 	if err != nil {
 		return err
 	}
-	events, err := NewSqliteEventsTable(d.db, &d.streamID)
+	events, err := NewSqliteEventsTable(d.db, d.writer, &d.streamID)
 	if err != nil {
 		return err
 	}
-	roomState, err := NewSqliteCurrentRoomStateTable(d.db, &d.streamID)
+	roomState, err := NewSqliteCurrentRoomStateTable(d.db, d.writer, &d.streamID)
 	if err != nil {
 		return err
 	}
-	invites, err := NewSqliteInvitesTable(d.db, &d.streamID)
+	invites, err := NewSqliteInvitesTable(d.db, d.writer, &d.streamID)
 	if err != nil {
 		return err
 	}
-	topology, err := NewSqliteTopologyTable(d.db)
+	topology, err := NewSqliteTopologyTable(d.db, d.writer)
 	if err != nil {
 		return err
 	}
-	bwExtrem, err := NewSqliteBackwardsExtremitiesTable(d.db)
+	bwExtrem, err := NewSqliteBackwardsExtremitiesTable(d.db, d.writer)
 	if err != nil {
 		return err
 	}
-	sendToDevice, err := NewSqliteSendToDeviceTable(d.db)
+	sendToDevice, err := NewSqliteSendToDeviceTable(d.db, d.writer)
 	if err != nil {
 		return err
 	}
-	filter, err := NewSqliteFilterTable(d.db)
+	filter, err := NewSqliteFilterTable(d.db, d.writer)
 	if err != nil {
 		return err
 	}

--- a/userapi/storage/accounts/postgres/storage.go
+++ b/userapi/storage/accounts/postgres/storage.go
@@ -34,7 +34,8 @@ import (
 
 // Database represents an account database
 type Database struct {
-	db *sql.DB
+	db     *sql.DB
+	writer sqlutil.TransactionWriter
 	sqlutil.PartitionOffsetStatements
 	accounts     accountsStatements
 	profiles     profilesStatements
@@ -49,27 +50,27 @@ func NewDatabase(dbProperties *config.DatabaseOptions, serverName gomatrixserver
 	if err != nil {
 		return nil, err
 	}
-	partitions := sqlutil.PartitionOffsetStatements{}
-	if err = partitions.Prepare(db, "account"); err != nil {
+	d := &Database{
+		serverName: serverName,
+		db:         db,
+		writer:     sqlutil.NewDummyTransactionWriter(),
+	}
+	if err = d.PartitionOffsetStatements.Prepare(db, d.writer, "account"); err != nil {
 		return nil, err
 	}
-	a := accountsStatements{}
-	if err = a.prepare(db, serverName); err != nil {
+	if err = d.accounts.prepare(db, serverName); err != nil {
 		return nil, err
 	}
-	p := profilesStatements{}
-	if err = p.prepare(db); err != nil {
+	if err = d.profiles.prepare(db); err != nil {
 		return nil, err
 	}
-	ac := accountDataStatements{}
-	if err = ac.prepare(db); err != nil {
+	if err = d.accountDatas.prepare(db); err != nil {
 		return nil, err
 	}
-	t := threepidStatements{}
-	if err = t.prepare(db); err != nil {
+	if err = d.threepids.prepare(db); err != nil {
 		return nil, err
 	}
-	return &Database{db, partitions, a, p, ac, t, serverName}, nil
+	return d, nil
 }
 
 // GetAccountByPassword returns the account associated with the given localpart and password.

--- a/userapi/storage/accounts/sqlite3/account_data_table.go
+++ b/userapi/storage/accounts/sqlite3/account_data_table.go
@@ -57,9 +57,9 @@ type accountDataStatements struct {
 	selectAccountDataByTypeStmt *sql.Stmt
 }
 
-func (s *accountDataStatements) prepare(db *sql.DB) (err error) {
+func (s *accountDataStatements) prepare(db *sql.DB, writer sqlutil.TransactionWriter) (err error) {
 	s.db = db
-	s.writer = sqlutil.NewTransactionWriter()
+	s.writer = writer
 	_, err = db.Exec(accountDataSchema)
 	if err != nil {
 		return

--- a/userapi/storage/accounts/sqlite3/accounts_table.go
+++ b/userapi/storage/accounts/sqlite3/accounts_table.go
@@ -67,9 +67,9 @@ type accountsStatements struct {
 	serverName                    gomatrixserverlib.ServerName
 }
 
-func (s *accountsStatements) prepare(db *sql.DB, server gomatrixserverlib.ServerName) (err error) {
+func (s *accountsStatements) prepare(db *sql.DB, writer sqlutil.TransactionWriter, server gomatrixserverlib.ServerName) (err error) {
 	s.db = db
-	s.writer = sqlutil.NewTransactionWriter()
+	s.writer = writer
 	_, err = db.Exec(accountsSchema)
 	if err != nil {
 		return

--- a/userapi/storage/accounts/sqlite3/profile_table.go
+++ b/userapi/storage/accounts/sqlite3/profile_table.go
@@ -61,9 +61,9 @@ type profilesStatements struct {
 	selectProfilesBySearchStmt   *sql.Stmt
 }
 
-func (s *profilesStatements) prepare(db *sql.DB) (err error) {
+func (s *profilesStatements) prepare(db *sql.DB, writer sqlutil.TransactionWriter) (err error) {
 	s.db = db
-	s.writer = sqlutil.NewTransactionWriter()
+	s.writer = writer
 	_, err = db.Exec(profilesSchema)
 	if err != nil {
 		return

--- a/userapi/storage/accounts/sqlite3/storage.go
+++ b/userapi/storage/accounts/sqlite3/storage.go
@@ -64,16 +64,16 @@ func NewDatabase(dbProperties *config.DatabaseOptions, serverName gomatrixserver
 	if err = partitions.Prepare(db, d.writer, "account"); err != nil {
 		return nil, err
 	}
-	if err = d.accounts.prepare(db, serverName); err != nil {
+	if err = d.accounts.prepare(db, d.writer, serverName); err != nil {
 		return nil, err
 	}
-	if err = d.profiles.prepare(db); err != nil {
+	if err = d.profiles.prepare(db, d.writer); err != nil {
 		return nil, err
 	}
-	if err = d.accountDatas.prepare(db); err != nil {
+	if err = d.accountDatas.prepare(db, d.writer); err != nil {
 		return nil, err
 	}
-	if err = d.threepids.prepare(db); err != nil {
+	if err = d.threepids.prepare(db, d.writer); err != nil {
 		return nil, err
 	}
 	return d, nil

--- a/userapi/storage/accounts/sqlite3/storage.go
+++ b/userapi/storage/accounts/sqlite3/storage.go
@@ -33,7 +33,9 @@ import (
 
 // Database represents an account database
 type Database struct {
-	db *sql.DB
+	db     *sql.DB
+	writer sqlutil.TransactionWriter
+
 	sqlutil.PartitionOffsetStatements
 	accounts     accountsStatements
 	profiles     profilesStatements
@@ -53,35 +55,28 @@ func NewDatabase(dbProperties *config.DatabaseOptions, serverName gomatrixserver
 	if err != nil {
 		return nil, err
 	}
+	d := &Database{
+		serverName: serverName,
+		db:         db,
+		writer:     sqlutil.NewTransactionWriter(),
+	}
 	partitions := sqlutil.PartitionOffsetStatements{}
-	if err = partitions.Prepare(db, "account"); err != nil {
+	if err = partitions.Prepare(db, d.writer, "account"); err != nil {
 		return nil, err
 	}
-	a := accountsStatements{}
-	if err = a.prepare(db, serverName); err != nil {
+	if err = d.accounts.prepare(db, serverName); err != nil {
 		return nil, err
 	}
-	p := profilesStatements{}
-	if err = p.prepare(db); err != nil {
+	if err = d.profiles.prepare(db); err != nil {
 		return nil, err
 	}
-	ac := accountDataStatements{}
-	if err = ac.prepare(db); err != nil {
+	if err = d.accountDatas.prepare(db); err != nil {
 		return nil, err
 	}
-	t := threepidStatements{}
-	if err = t.prepare(db); err != nil {
+	if err = d.threepids.prepare(db); err != nil {
 		return nil, err
 	}
-	return &Database{
-		db:                        db,
-		PartitionOffsetStatements: partitions,
-		accounts:                  a,
-		profiles:                  p,
-		accountDatas:              ac,
-		threepids:                 t,
-		serverName:                serverName,
-	}, nil
+	return d, nil
 }
 
 // GetAccountByPassword returns the account associated with the given localpart and password.

--- a/userapi/storage/accounts/sqlite3/threepid_table.go
+++ b/userapi/storage/accounts/sqlite3/threepid_table.go
@@ -61,9 +61,9 @@ type threepidStatements struct {
 	deleteThreePIDStmt              *sql.Stmt
 }
 
-func (s *threepidStatements) prepare(db *sql.DB) (err error) {
+func (s *threepidStatements) prepare(db *sql.DB, writer sqlutil.TransactionWriter) (err error) {
 	s.db = db
-	s.writer = sqlutil.NewTransactionWriter()
+	s.writer = writer
 	_, err = db.Exec(threepidSchema)
 	if err != nil {
 		return

--- a/userapi/storage/devices/sqlite3/devices_table.go
+++ b/userapi/storage/devices/sqlite3/devices_table.go
@@ -91,9 +91,9 @@ type devicesStatements struct {
 	serverName                   gomatrixserverlib.ServerName
 }
 
-func (s *devicesStatements) prepare(db *sql.DB, server gomatrixserverlib.ServerName) (err error) {
+func (s *devicesStatements) prepare(db *sql.DB, writer sqlutil.TransactionWriter, server gomatrixserverlib.ServerName) (err error) {
 	s.db = db
-	s.writer = sqlutil.NewTransactionWriter()
+	s.writer = writer
 	_, err = db.Exec(devicesSchema)
 	if err != nil {
 		return


### PR DESCRIPTION
This modifies the remaining components to use a global `TransactionWriter`. It also updates the partition offsets to use it too, so it *should* fix #1252. 