### PR TITLE
Add support for running Complement on current working directories

### DIFF
--- a/build/scripts/Complement.Dockerfile
+++ b/build/scripts/Complement.Dockerfile
@@ -1,0 +1,22 @@
+FROM golang:1.13-stretch as build
+RUN apt-get update && apt-get install sqlite3
+WORKDIR /build
+
+# Utilise Docker caching when downloading dependencies, this stops us needlessly
+# downloading dependencies every time.
+COPY go.mod .
+COPY go.sum .
+RUN go mod download
+
+COPY . .
+RUN go build ./cmd/dendrite-monolith-server
+RUN go build ./cmd/generate-keys
+RUN go build ./cmd/generate-config
+RUN ./generate-config > dendrite.yaml
+RUN sed -i "s/disable_tls_validation: false/disable_tls_validation: true/g" dendrite.yaml
+RUN ./generate-keys --private-key matrix_key.pem --tls-cert server.crt --tls-key server.key
+
+ENV SERVER_NAME=localhost
+EXPOSE 8008 8448
+
+CMD sed -i "s/server_name: localhost/server_name: ${SERVER_NAME}/g" dendrite.yaml && ./dendrite-monolith-server --tls-cert server.crt --tls-key server.key --config dendrite.yaml

--- a/build/scripts/complement.sh
+++ b/build/scripts/complement.sh
@@ -1,0 +1,19 @@
+#! /bin/bash -eu
+# This script is designed for developers who want to test their Dendrite code
+# against Complement.
+#
+# It makes a Dendrite image which represents the current checkout,
+# then downloads Complement and runs it with that image.
+
+# Make image
+cd `dirname $0`/../..
+docker build -t complement-dendrite -f build/scripts/Complement.Dockerfile .
+
+# Download Complement
+wget https://github.com/matrix-org/complement/archive/master.tar.gz
+tar -xzf master.tar.gz
+
+# Run the tests!
+cd complement-master
+COMPLEMENT_BASE_IMAGE=complement-dendrite:latest go test -v ./tests
+


### PR DESCRIPTION
This will be used in the future by Buildkite to run on CI.
