### PR TITLE
Select distinct on room memberships in sync API

### DIFF
--- a/syncapi/storage/postgres/current_room_state_table.go
+++ b/syncapi/storage/postgres/current_room_state_table.go
@@ -70,7 +70,7 @@ const deleteRoomStateByEventIDSQL = "" +
 	"DELETE FROM syncapi_current_room_state WHERE event_id = $1"
 
 const selectRoomIDsWithMembershipSQL = "" +
-	"SELECT room_id FROM syncapi_current_room_state WHERE type = 'm.room.member' AND state_key = $1 AND membership = $2"
+	"SELECT DISTINCT room_id FROM syncapi_current_room_state WHERE type = 'm.room.member' AND state_key = $1 AND membership = $2"
 
 const selectCurrentStateSQL = "" +
 	"SELECT headered_event_json FROM syncapi_current_room_state WHERE room_id = $1" +

--- a/syncapi/storage/sqlite3/current_room_state_table.go
+++ b/syncapi/storage/sqlite3/current_room_state_table.go
@@ -58,7 +58,7 @@ const deleteRoomStateByEventIDSQL = "" +
 	"DELETE FROM syncapi_current_room_state WHERE event_id = $1"
 
 const selectRoomIDsWithMembershipSQL = "" +
-	"SELECT room_id FROM syncapi_current_room_state WHERE type = 'm.room.member' AND state_key = $1 AND membership = $2"
+	"SELECT DISTINCT room_id FROM syncapi_current_room_state WHERE type = 'm.room.member' AND state_key = $1 AND membership = $2"
 
 const selectCurrentStateSQL = "" +
 	"SELECT headered_event_json FROM syncapi_current_room_state WHERE room_id = $1" +


### PR DESCRIPTION
This adds `DISTINCT` to the query that finds out the rooms you are joined to for the sync notifier. 

Without it, we were burning CPU cycles and allocations receiving the same room IDs possibly thousands of times in `SelectRoomIDsWithMembership`. This was showing quite high on the memory profiler for total number of allocations.