### PR TITLE
Don't overwrite global err before return

### DIFF
--- a/appservice/storage/sqlite3/appservice_events_table.go
+++ b/appservice/storage/sqlite3/appservice_events_table.go
@@ -116,25 +116,32 @@ func (s *eventsStatements) selectEventsByApplicationServiceID(
 	eventsRemaining bool,
 	err error,
 ) {
-	// Retrieve events from the database. Unsuccessfully sent events first
-	eventRows, err := s.selectEventsByApplicationServiceIDStmt.QueryContext(ctx, applicationServiceID)
-	if err != nil {
-		return
-	}
 	defer func() {
-		err = eventRows.Close()
 		if err != nil {
 			log.WithFields(log.Fields{
 				"appservice": applicationServiceID,
 			}).WithError(err).Fatalf("appservice unable to select new events to send")
 		}
 	}()
+	// Retrieve events from the database. Unsuccessfully sent events first
+	eventRows, err := s.selectEventsByApplicationServiceIDStmt.QueryContext(ctx, applicationServiceID)
+	if err != nil {
+		return
+	}
+	defer checkNamedErr(eventRows.Close, &err)
 	events, maxID, txnID, eventsRemaining, err = retrieveEvents(eventRows, limit)
 	if err != nil {
 		return
 	}
 
 	return
+}
+
+// checkNamedErr calls fn and overwrite err if it was nil and fn returned non-nil
+func checkNamedErr(fn func() error, err *error) {
+	if e := fn(); e != nil && *err == nil {
+		*err = e
+	}
 }
 
 func retrieveEvents(eventRows *sql.Rows, limit int) (events []gomatrixserverlib.HeaderedEvent, maxID, txnID int, eventsRemaining bool, err error) {

--- a/roomserver/internal/input_latest_events.go
+++ b/roomserver/internal/input_latest_events.go
@@ -60,12 +60,7 @@ func (r *RoomserverInternalAPI) updateLatestEvents(
 		return fmt.Errorf("r.DB.GetLatestEventsForUpdate: %w", err)
 	}
 	succeeded := false
-	defer func() {
-		txerr := sqlutil.EndTransaction(updater, &succeeded)
-		if err == nil && txerr != nil {
-			err = txerr
-		}
-	}()
+	defer sqlutil.EndTransactionWithCheck(updater, &succeeded, &err)
 
 	u := latestEventsUpdater{
 		ctx:           ctx,

--- a/syncapi/consumers/keychange.go
+++ b/syncapi/consumers/keychange.go
@@ -95,9 +95,8 @@ func (s *OutputKeyChangeEventConsumer) updateOffset(msg *sarama.ConsumerMessage)
 }
 
 func (s *OutputKeyChangeEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
-	defer func() {
-		s.updateOffset(msg)
-	}()
+	defer s.updateOffset(msg)
+
 	var output api.DeviceMessage
 	if err := json.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream

--- a/syncapi/storage/shared/syncserver.go
+++ b/syncapi/storage/shared/syncserver.go
@@ -455,13 +455,8 @@ func (d *Database) addPDUDeltaToResponse(
 	if err != nil {
 		return nil, err
 	}
-	var succeeded bool
-	defer func() {
-		txerr := sqlutil.EndTransaction(txn, &succeeded)
-		if err == nil && txerr != nil {
-			err = txerr
-		}
-	}()
+	succeeded := false
+	defer sqlutil.EndTransactionWithCheck(txn, &succeeded, &err)
 
 	stateFilter := gomatrixserverlib.DefaultStateFilter() // TODO: use filter provided in request
 
@@ -641,13 +636,8 @@ func (d *Database) getResponseWithPDUsForCompleteSync(
 	if err != nil {
 		return
 	}
-	var succeeded bool
-	defer func() {
-		txerr := sqlutil.EndTransaction(txn, &succeeded)
-		if err == nil && txerr != nil {
-			err = txerr
-		}
-	}()
+	succeeded := false
+	defer sqlutil.EndTransactionWithCheck(txn, &succeeded, &err)
 
 	// Get the current sync position which we will base the sync response on.
 	toPos, err = d.syncPositionTx(ctx, txn)


### PR DESCRIPTION
_Closes #846_ 

This PR adds a helper to overwrite the error returned by a function if it was previously nil and the deferred function returned a non-nil error.

I looked for occurrences of `defer func() {` and found a couple of packages where I this this helper improves the code.
Since there is no `util` package, I copied/paste the function : I am open to suggestion to reduce this code-duplication.

In `sqlutil`, I adapted the function to work for `EndTransaction`.

* [ ] I didn't add any new test (since this is not adding any feature), but feel free to hint any test that this PR could add
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/CONTRIBUTING.md#sign-off)
