### PR TITLE
Roomserver NID caches

### DIFF
--- a/internal/caching/cache_roomservernids.go
+++ b/internal/caching/cache_roomservernids.go
@@ -1,0 +1,79 @@
+package caching
+
+import (
+	"github.com/matrix-org/dendrite/roomserver/types"
+)
+
+const (
+	RoomServerStateKeyNIDsCacheName       = "roomserver_statekey_nids"
+	RoomServerStateKeyNIDsCacheMaxEntries = 1024
+	RoomServerStateKeyNIDsCacheMutable    = false
+
+	RoomServerEventTypeNIDsCacheName       = "roomserver_eventtype_nids"
+	RoomServerEventTypeNIDsCacheMaxEntries = 64
+	RoomServerEventTypeNIDsCacheMutable    = false
+
+	RoomServerRoomNIDsCacheName       = "roomserver_room_nids"
+	RoomServerRoomNIDsCacheMaxEntries = 1024
+	RoomServerRoomNIDsCacheMutable    = false
+)
+
+type RoomServerCaches interface {
+	RoomServerNIDsCache
+	RoomVersionCache
+}
+
+// RoomServerNIDsCache contains the subset of functions needed for
+// a roomserver NID cache.
+type RoomServerNIDsCache interface {
+	GetRoomServerStateKeyNID(stateKey string) (types.EventStateKeyNID, bool)
+	StoreRoomServerStateKeyNID(stateKey string, nid types.EventStateKeyNID)
+
+	GetRoomServerEventTypeNID(eventType string) (types.EventTypeNID, bool)
+	StoreRoomServerEventTypeNID(eventType string, nid types.EventTypeNID)
+
+	GetRoomServerRoomNID(roomID string) (types.RoomNID, bool)
+	StoreRoomServerRoomNID(roomID string, nid types.RoomNID)
+}
+
+func (c Caches) GetRoomServerStateKeyNID(stateKey string) (types.EventStateKeyNID, bool) {
+	val, found := c.RoomServerStateKeyNIDs.Get(stateKey)
+	if found && val != nil {
+		if stateKeyNID, ok := val.(types.EventStateKeyNID); ok {
+			return stateKeyNID, true
+		}
+	}
+	return 0, false
+}
+
+func (c Caches) StoreRoomServerStateKeyNID(stateKey string, nid types.EventStateKeyNID) {
+	c.RoomVersions.Set(stateKey, nid)
+}
+
+func (c Caches) GetRoomServerEventTypeNID(eventType string) (types.EventTypeNID, bool) {
+	val, found := c.RoomServerEventTypeNIDs.Get(eventType)
+	if found && val != nil {
+		if eventTypeNID, ok := val.(types.EventTypeNID); ok {
+			return eventTypeNID, true
+		}
+	}
+	return 0, false
+}
+
+func (c Caches) StoreRoomServerEventTypeNID(eventType string, nid types.EventTypeNID) {
+	c.RoomVersions.Set(eventType, nid)
+}
+
+func (c Caches) GetRoomServerRoomNID(roomID string) (types.RoomNID, bool) {
+	val, found := c.RoomServerRoomNIDs.Get(roomID)
+	if found && val != nil {
+		if roomNID, ok := val.(types.RoomNID); ok {
+			return roomNID, true
+		}
+	}
+	return 0, false
+}
+
+func (c Caches) StoreRoomServerRoomNID(roomID string, nid types.RoomNID) {
+	c.RoomVersions.Set(roomID, nid)
+}

--- a/internal/caching/cache_roomservernids.go
+++ b/internal/caching/cache_roomservernids.go
@@ -16,6 +16,10 @@ const (
 	RoomServerRoomNIDsCacheName       = "roomserver_room_nids"
 	RoomServerRoomNIDsCacheMaxEntries = 1024
 	RoomServerRoomNIDsCacheMutable    = false
+
+	RoomServerRoomIDsCacheName       = "roomserver_room_ids"
+	RoomServerRoomIDsCacheMaxEntries = 1024
+	RoomServerRoomIDsCacheMutable    = false
 )
 
 type RoomServerCaches interface {
@@ -34,6 +38,9 @@ type RoomServerNIDsCache interface {
 
 	GetRoomServerRoomNID(roomID string) (types.RoomNID, bool)
 	StoreRoomServerRoomNID(roomID string, nid types.RoomNID)
+
+	GetRoomServerRoomID(roomNID types.RoomNID) (string, bool)
+	StoreRoomServerRoomID(roomNID types.RoomNID, roomID string)
 }
 
 func (c Caches) GetRoomServerStateKeyNID(stateKey string) (types.EventStateKeyNID, bool) {
@@ -74,6 +81,21 @@ func (c Caches) GetRoomServerRoomNID(roomID string) (types.RoomNID, bool) {
 	return 0, false
 }
 
-func (c Caches) StoreRoomServerRoomNID(roomID string, nid types.RoomNID) {
-	c.RoomServerRoomNIDs.Set(roomID, nid)
+func (c Caches) StoreRoomServerRoomNID(roomID string, roomNID types.RoomNID) {
+	c.RoomServerRoomNIDs.Set(roomID, roomNID)
+	c.RoomServerRoomIDs.Set(string(roomNID), roomID)
+}
+
+func (c Caches) GetRoomServerRoomID(roomNID types.RoomNID) (string, bool) {
+	val, found := c.RoomServerRoomIDs.Get(string(roomNID))
+	if found && val != nil {
+		if roomID, ok := val.(string); ok {
+			return roomID, true
+		}
+	}
+	return "", false
+}
+
+func (c Caches) StoreRoomServerRoomID(roomNID types.RoomNID, roomID string) {
+	c.StoreRoomServerRoomNID(roomID, roomNID)
 }

--- a/internal/caching/cache_roomservernids.go
+++ b/internal/caching/cache_roomservernids.go
@@ -47,7 +47,7 @@ func (c Caches) GetRoomServerStateKeyNID(stateKey string) (types.EventStateKeyNI
 }
 
 func (c Caches) StoreRoomServerStateKeyNID(stateKey string, nid types.EventStateKeyNID) {
-	c.RoomVersions.Set(stateKey, nid)
+	c.RoomServerStateKeyNIDs.Set(stateKey, nid)
 }
 
 func (c Caches) GetRoomServerEventTypeNID(eventType string) (types.EventTypeNID, bool) {
@@ -61,7 +61,7 @@ func (c Caches) GetRoomServerEventTypeNID(eventType string) (types.EventTypeNID,
 }
 
 func (c Caches) StoreRoomServerEventTypeNID(eventType string, nid types.EventTypeNID) {
-	c.RoomVersions.Set(eventType, nid)
+	c.RoomServerEventTypeNIDs.Set(eventType, nid)
 }
 
 func (c Caches) GetRoomServerRoomNID(roomID string) (types.RoomNID, bool) {
@@ -75,5 +75,5 @@ func (c Caches) GetRoomServerRoomNID(roomID string) (types.RoomNID, bool) {
 }
 
 func (c Caches) StoreRoomServerRoomNID(roomID string, nid types.RoomNID) {
-	c.RoomVersions.Set(roomID, nid)
+	c.RoomServerRoomNIDs.Set(roomID, nid)
 }

--- a/internal/caching/caches.go
+++ b/internal/caching/caches.go
@@ -4,8 +4,11 @@ package caching
 // different implementations as long as they satisfy the Cache
 // interface.
 type Caches struct {
-	RoomVersions Cache // implements RoomVersionCache
-	ServerKeys   Cache // implements ServerKeyCache
+	RoomVersions            Cache // RoomVersionCache
+	ServerKeys              Cache // ServerKeyCache
+	RoomServerStateKeyNIDs  Cache // RoomServerNIDsCache
+	RoomServerEventTypeNIDs Cache // RoomServerNIDsCache
+	RoomServerRoomNIDs      Cache // RoomServerNIDsCache
 }
 
 // Cache is the interface that an implementation must satisfy.

--- a/internal/caching/caches.go
+++ b/internal/caching/caches.go
@@ -9,6 +9,7 @@ type Caches struct {
 	RoomServerStateKeyNIDs  Cache // RoomServerNIDsCache
 	RoomServerEventTypeNIDs Cache // RoomServerNIDsCache
 	RoomServerRoomNIDs      Cache // RoomServerNIDsCache
+	RoomServerRoomIDs       Cache // RoomServerNIDsCache
 }
 
 // Cache is the interface that an implementation must satisfy.

--- a/internal/caching/impl_inmemorylru.go
+++ b/internal/caching/impl_inmemorylru.go
@@ -27,9 +27,39 @@ func NewInMemoryLRUCache(enablePrometheus bool) (*Caches, error) {
 	if err != nil {
 		return nil, err
 	}
+	roomServerStateKeyNIDs, err := NewInMemoryLRUCachePartition(
+		RoomServerStateKeyNIDsCacheName,
+		RoomServerStateKeyNIDsCacheMutable,
+		RoomServerStateKeyNIDsCacheMaxEntries,
+		enablePrometheus,
+	)
+	if err != nil {
+		return nil, err
+	}
+	roomServerEventTypeNIDs, err := NewInMemoryLRUCachePartition(
+		RoomServerEventTypeNIDsCacheName,
+		RoomServerEventTypeNIDsCacheMutable,
+		RoomServerEventTypeNIDsCacheMaxEntries,
+		enablePrometheus,
+	)
+	if err != nil {
+		return nil, err
+	}
+	roomServerRoomNIDs, err := NewInMemoryLRUCachePartition(
+		RoomServerRoomNIDsCacheName,
+		RoomServerRoomNIDsCacheMutable,
+		RoomServerRoomNIDsCacheMaxEntries,
+		enablePrometheus,
+	)
+	if err != nil {
+		return nil, err
+	}
 	return &Caches{
-		RoomVersions: roomVersions,
-		ServerKeys:   serverKeys,
+		RoomVersions:            roomVersions,
+		ServerKeys:              serverKeys,
+		RoomServerStateKeyNIDs:  roomServerStateKeyNIDs,
+		RoomServerEventTypeNIDs: roomServerEventTypeNIDs,
+		RoomServerRoomNIDs:      roomServerRoomNIDs,
 	}, nil
 }
 

--- a/internal/caching/impl_inmemorylru.go
+++ b/internal/caching/impl_inmemorylru.go
@@ -54,12 +54,22 @@ func NewInMemoryLRUCache(enablePrometheus bool) (*Caches, error) {
 	if err != nil {
 		return nil, err
 	}
+	roomServerRoomIDs, err := NewInMemoryLRUCachePartition(
+		RoomServerRoomIDsCacheName,
+		RoomServerRoomIDsCacheMutable,
+		RoomServerRoomIDsCacheMaxEntries,
+		enablePrometheus,
+	)
+	if err != nil {
+		return nil, err
+	}
 	return &Caches{
 		RoomVersions:            roomVersions,
 		ServerKeys:              serverKeys,
 		RoomServerStateKeyNIDs:  roomServerStateKeyNIDs,
 		RoomServerEventTypeNIDs: roomServerEventTypeNIDs,
 		RoomServerRoomNIDs:      roomServerRoomNIDs,
+		RoomServerRoomIDs:       roomServerRoomIDs,
 	}, nil
 }
 

--- a/roomserver/internal/api.go
+++ b/roomserver/internal/api.go
@@ -16,7 +16,7 @@ type RoomserverInternalAPI struct {
 	DB                   storage.Database
 	Cfg                  *config.RoomServer
 	Producer             sarama.SyncProducer
-	Cache                caching.RoomVersionCache
+	Cache                caching.RoomServerCaches
 	ServerName           gomatrixserverlib.ServerName
 	KeyRing              gomatrixserverlib.JSONVerifier
 	FedClient            *gomatrixserverlib.FederationClient

--- a/roomserver/roomserver.go
+++ b/roomserver/roomserver.go
@@ -42,7 +42,7 @@ func NewInternalAPI(
 ) api.RoomserverInternalAPI {
 	cfg := &base.Cfg.RoomServer
 
-	roomserverDB, err := storage.Open(&cfg.Database)
+	roomserverDB, err := storage.Open(&cfg.Database, base.Caches)
 	if err != nil {
 		logrus.WithError(err).Panicf("failed to connect to room server db")
 	}

--- a/roomserver/storage/postgres/storage.go
+++ b/roomserver/storage/postgres/storage.go
@@ -18,6 +18,7 @@ package postgres
 import (
 	"database/sql"
 
+	"github.com/matrix-org/dendrite/internal/caching"
 	"github.com/matrix-org/dendrite/internal/config"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 
@@ -33,7 +34,7 @@ type Database struct {
 
 // Open a postgres database.
 // nolint: gocyclo
-func Open(dbProperties *config.DatabaseOptions) (*Database, error) {
+func Open(dbProperties *config.DatabaseOptions, cache caching.RoomServerCaches) (*Database, error) {
 	var d Database
 	var db *sql.DB
 	var err error
@@ -98,6 +99,7 @@ func Open(dbProperties *config.DatabaseOptions) (*Database, error) {
 	}
 	d.Database = shared.Database{
 		DB:                  db,
+		Cache:               cache,
 		Writer:              sqlutil.NewDummyWriter(),
 		EventTypesTable:     eventTypes,
 		EventStateKeysTable: eventStateKeys,

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -69,6 +69,7 @@ func (d *Database) EventTypeNIDs(
 		}
 		for eventType, nid := range nids {
 			result[eventType] = nid
+			d.Cache.StoreRoomServerEventTypeNID(eventType, nid)
 		}
 	}
 	return result, nil
@@ -99,6 +100,7 @@ func (d *Database) EventStateKeyNIDs(
 		}
 		for eventStateKey, nid := range nids {
 			result[eventStateKey] = nid
+			d.Cache.StoreRoomServerStateKeyNID(eventStateKey, nid)
 		}
 	}
 	return result, nil
@@ -202,6 +204,7 @@ func (d *Database) RoomNID(ctx context.Context, roomID string) (types.RoomNID, e
 	if err == sql.ErrNoRows {
 		return 0, nil
 	}
+	d.Cache.StoreRoomServerRoomNID(roomID, roomNID)
 	return roomNID, err
 }
 
@@ -213,6 +216,7 @@ func (d *Database) RoomNIDExcludingStubs(ctx context.Context, roomID string) (ro
 		if err != nil {
 			return
 		}
+		d.Cache.StoreRoomServerRoomNID(roomID, roomNID)
 	}
 	latestEvents, _, err := d.RoomsTable.SelectLatestEventNIDs(ctx, nil, roomNID)
 	if err != nil {

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -216,7 +216,6 @@ func (d *Database) RoomNIDExcludingStubs(ctx context.Context, roomID string) (ro
 		if err != nil {
 			return
 		}
-		d.Cache.StoreRoomServerRoomNID(roomID, roomNID)
 	}
 	latestEvents, _, err := d.RoomsTable.SelectLatestEventNIDs(ctx, nil, roomNID)
 	if err != nil {

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -209,13 +209,9 @@ func (d *Database) RoomNID(ctx context.Context, roomID string) (types.RoomNID, e
 }
 
 func (d *Database) RoomNIDExcludingStubs(ctx context.Context, roomID string) (roomNID types.RoomNID, err error) {
-	if nid, ok := d.Cache.GetRoomServerRoomNID(roomID); ok {
-		roomNID = nid
-	} else {
-		roomNID, err = d.RoomNID(ctx, roomID)
-		if err != nil {
-			return
-		}
+	roomNID, err = d.RoomNID(ctx, roomID)
+	if err != nil {
+		return
 	}
 	latestEvents, _, err := d.RoomsTable.SelectLatestEventNIDs(ctx, nil, roomNID)
 	if err != nil {

--- a/roomserver/storage/sqlite3/storage.go
+++ b/roomserver/storage/sqlite3/storage.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"database/sql"
 
+	"github.com/matrix-org/dendrite/internal/caching"
 	"github.com/matrix-org/dendrite/internal/config"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/roomserver/storage/shared"
@@ -46,7 +47,7 @@ type Database struct {
 
 // Open a sqlite database.
 // nolint: gocyclo
-func Open(dbProperties *config.DatabaseOptions) (*Database, error) {
+func Open(dbProperties *config.DatabaseOptions, cache caching.RoomServerCaches) (*Database, error) {
 	var d Database
 	var err error
 	if d.db, err = sqlutil.Open(dbProperties); err != nil {
@@ -120,6 +121,7 @@ func Open(dbProperties *config.DatabaseOptions) (*Database, error) {
 	}
 	d.Database = shared.Database{
 		DB:                  d.db,
+		Cache:               cache,
 		Writer:              sqlutil.NewExclusiveWriter(),
 		EventsTable:         d.events,
 		EventTypesTable:     d.eventTypes,

--- a/roomserver/storage/storage.go
+++ b/roomserver/storage/storage.go
@@ -19,18 +19,19 @@ package storage
 import (
 	"fmt"
 
+	"github.com/matrix-org/dendrite/internal/caching"
 	"github.com/matrix-org/dendrite/internal/config"
 	"github.com/matrix-org/dendrite/roomserver/storage/postgres"
 	"github.com/matrix-org/dendrite/roomserver/storage/sqlite3"
 )
 
 // Open opens a database connection.
-func Open(dbProperties *config.DatabaseOptions) (Database, error) {
+func Open(dbProperties *config.DatabaseOptions, cache caching.RoomServerCaches) (Database, error) {
 	switch {
 	case dbProperties.ConnectionString.IsSQLite():
-		return sqlite3.Open(dbProperties)
+		return sqlite3.Open(dbProperties, cache)
 	case dbProperties.ConnectionString.IsPostgres():
-		return postgres.Open(dbProperties)
+		return postgres.Open(dbProperties, cache)
 	default:
 		return nil, fmt.Errorf("unexpected database type")
 	}

--- a/roomserver/storage/storage_wasm.go
+++ b/roomserver/storage/storage_wasm.go
@@ -17,15 +17,16 @@ package storage
 import (
 	"fmt"
 
+	"github.com/matrix-org/dendrite/internal/caching"
 	"github.com/matrix-org/dendrite/internal/config"
 	"github.com/matrix-org/dendrite/roomserver/storage/sqlite3"
 )
 
 // NewPublicRoomsServerDatabase opens a database connection.
-func Open(dbProperties *config.DatabaseOptions) (Database, error) {
+func Open(dbProperties *config.DatabaseOptions, cache caching.RoomServerCaches) (Database, error) {
 	switch {
 	case dbProperties.ConnectionString.IsSQLite():
-		return sqlite3.Open(dbProperties)
+		return sqlite3.Open(dbProperties, cache)
 	case dbProperties.ConnectionString.IsPostgres():
 		return nil, fmt.Errorf("can't use Postgres implementation")
 	default:


### PR DESCRIPTION
This caches the event type, state key and room NIDs using the LRU caches.