### PR TITLE
[readability] use event.StateKeyEquals where relevant and minor for-loop refactoring

### DIFF
--- a/clientapi/routing/getevent.go
+++ b/clientapi/routing/getevent.go
@@ -104,17 +104,18 @@ func GetEvent(
 	}
 
 	for _, stateEvent := range stateResp.StateEvents {
-		if stateEvent.StateKeyEquals(r.device.UserID) {
-			membership, err := stateEvent.Membership()
-			if err != nil {
-				util.GetLogger(req.Context()).WithError(err).Error("stateEvent.Membership failed")
-				return jsonerror.InternalServerError()
-			}
-			if membership == gomatrixserverlib.Join {
-				return util.JSONResponse{
-					Code: http.StatusOK,
-					JSON: gomatrixserverlib.ToClientEvent(r.requestedEvent, gomatrixserverlib.FormatAll),
-				}
+		if !stateEvent.StateKeyEquals(device.UserID) {
+			continue
+		}
+		membership, err := stateEvent.Membership()
+		if err != nil {
+			util.GetLogger(req.Context()).WithError(err).Error("stateEvent.Membership failed")
+			return jsonerror.InternalServerError()
+		}
+		if membership == gomatrixserverlib.Join {
+			return util.JSONResponse{
+				Code: http.StatusOK,
+				JSON: gomatrixserverlib.ToClientEvent(r.requestedEvent, gomatrixserverlib.FormatAll),
 			}
 		}
 	}

--- a/clientapi/routing/membership.go
+++ b/clientapi/routing/membership.go
@@ -388,15 +388,20 @@ func checkMemberInRoom(ctx context.Context, stateAPI currentstateAPI.CurrentStat
 		e := jsonerror.InternalServerError()
 		return &e
 	}
-	ev, ok := membershipRes.StateEvents[tuple]
-	if !ok {
+	ev := membershipRes.StateEvents[tuple]
+	if ev == nil {
 		return &util.JSONResponse{
 			Code: http.StatusForbidden,
 			JSON: jsonerror.Forbidden("user does not belong to room"),
 		}
 	}
 	membership, err := ev.Membership()
-	if err != nil || membership != "join" {
+	if err != nil {
+		util.GetLogger(ctx).WithError(err).Error("Member event isn't valid")
+		e := jsonerror.InternalServerError()
+		return &e
+	}
+	if membership != gomatrixserverlib.Join {
 		return &util.JSONResponse{
 			Code: http.StatusForbidden,
 			JSON: jsonerror.Forbidden("user does not belong to room"),

--- a/currentstateserver/consumers/roomserver.go
+++ b/currentstateserver/consumers/roomserver.go
@@ -126,10 +126,8 @@ func (c *OutputRoomEventConsumer) Start() error {
 }
 
 func (c *OutputRoomEventConsumer) updateStateEvent(event gomatrixserverlib.HeaderedEvent) (gomatrixserverlib.HeaderedEvent, error) {
-	var stateKey string
-	if event.StateKey() == nil {
-		stateKey = ""
-	} else {
+	stateKey := ""
+	if event.StateKey() != nil {
 		stateKey = *event.StateKey()
 	}
 

--- a/federationapi/routing/join.go
+++ b/federationapi/routing/join.go
@@ -165,7 +165,7 @@ func SendJoin(
 	}
 
 	// Check that a state key is provided.
-	if event.StateKey() == nil || (event.StateKey() != nil && *event.StateKey() == "") {
+	if event.StateKey() == nil || event.StateKeyEquals("") {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.BadJSON(
@@ -253,11 +253,12 @@ func SendJoin(
 	// there isn't much point in sending another join event into the room.
 	alreadyJoined := false
 	for _, se := range stateAndAuthChainResponse.StateEvents {
+		if !se.StateKeyEquals(*event.StateKey()) {
+			continue
+		}
 		if membership, merr := se.Membership(); merr == nil {
-			if se.StateKey() != nil && *se.StateKey() == *event.StateKey() {
-				alreadyJoined = (membership == "join")
-				break
-			}
+			alreadyJoined = (membership == gomatrixserverlib.Join)
+			break
 		}
 	}
 

--- a/federationapi/routing/leave.go
+++ b/federationapi/routing/leave.go
@@ -81,15 +81,16 @@ func MakeLeave(
 	// event. This means that /send_leave will be a no-op, which helps
 	// to reject invites multiple times - hopefully.
 	for _, state := range queryRes.StateEvents {
-		if state.Type() == gomatrixserverlib.MRoomMember && state.StateKeyEquals(userID) {
-			if mem, merr := state.Membership(); merr == nil && mem == gomatrixserverlib.Leave {
-				return util.JSONResponse{
-					Code: http.StatusOK,
-					JSON: map[string]interface{}{
-						"room_version": event.RoomVersion,
-						"event":        state,
-					},
-				}
+		if !state.StateKeyEquals(userID) {
+			continue
+		}
+		if mem, merr := state.Membership(); merr == nil && mem == gomatrixserverlib.Leave {
+			return util.JSONResponse{
+				Code: http.StatusOK,
+				JSON: map[string]interface{}{
+					"room_version": event.RoomVersion,
+					"event":        state,
+				},
 			}
 		}
 	}

--- a/roomserver/internal/perform_backfill.go
+++ b/roomserver/internal/perform_backfill.go
@@ -104,7 +104,7 @@ func (b *backfillRequester) calculateNewStateIDs(targetEvent, prevEvent gomatrix
 			continue
 		}
 		// The state IDs BEFORE the target event are the state IDs BEFORE the prev_event PLUS the prev_event itself
-		if ev.Type() == prevEvent.Type() && ev.StateKey() != nil && *ev.StateKey() == *prevEvent.StateKey() {
+		if ev.Type() == prevEvent.Type() && ev.StateKeyEquals(*prevEvent.StateKey()) {
 			newStateIDs[i] = prevEvent.EventID()
 			foundEvent = true
 			break

--- a/roomserver/internal/perform_join.go
+++ b/roomserver/internal/perform_join.go
@@ -204,11 +204,12 @@ func (r *RoomserverInternalAPI) performJoinRoomByID(
 		// a member of the room.
 		alreadyJoined := false
 		for _, se := range buildRes.StateEvents {
+			if !se.StateKeyEquals(*event.StateKey()) {
+				continue
+			}
 			if membership, merr := se.Membership(); merr == nil {
-				if se.StateKey() != nil && *se.StateKey() == *event.StateKey() {
-					alreadyJoined = (membership == gomatrixserverlib.Join)
-					break
-				}
+				alreadyJoined = (membership == gomatrixserverlib.Join)
+				break
 			}
 		}
 

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -169,9 +169,6 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 }
 
 func (s *OutputRoomEventConsumer) notifyKeyChanges(ev *gomatrixserverlib.HeaderedEvent) {
-	if ev.Type() != gomatrixserverlib.MRoomMember || ev.StateKey() == nil {
-		return
-	}
 	membership, err := ev.Membership()
 	if err != nil {
 		return

--- a/syncapi/storage/shared/syncserver.go
+++ b/syncapi/storage/shared/syncserver.go
@@ -1216,14 +1216,14 @@ func removeDuplicates(stateEvents, recentEvents []gomatrixserverlib.HeaderedEven
 // getMembershipFromEvent returns the value of content.membership iff the event is a state event
 // with type 'm.room.member' and state_key of userID. Otherwise, an empty string is returned.
 func getMembershipFromEvent(ev *gomatrixserverlib.Event, userID string) string {
-	if ev.Type() == "m.room.member" && ev.StateKeyEquals(userID) {
-		membership, err := ev.Membership()
-		if err != nil {
-			return ""
-		}
-		return membership
+	if ev.Type() != "m.room.member" || !ev.StateKeyEquals(userID) {
+		return ""
 	}
-	return ""
+	membership, err := ev.Membership()
+	if err != nil {
+		return ""
+	}
+	return membership
 }
 
 type stateDelta struct {


### PR DESCRIPTION
I am trying to understand how membership works (leave, join & co).

I saw that `StateKeyEquals` could be used in some places and make the code more readable.
And that some for-loops could be refactored to reduce their nesting (which IMHO improves readability).