### PR TITLE
Allow join to accept server_name in query parameters

### DIFF
--- a/clientapi/routing/joinroom.go
+++ b/clientapi/routing/joinroom.go
@@ -41,6 +41,17 @@ func JoinRoomByIDOrAlias(
 	}
 	joinRes := roomserverAPI.PerformJoinResponse{}
 
+	// Check to see if any ?server_name= query parameters were
+	// given in the request.
+	if serverNames, ok := req.URL.Query()["server_name"]; ok {
+		for _, serverName := range serverNames {
+			joinReq.ServerNames = append(
+				joinReq.ServerNames,
+				gomatrixserverlib.ServerName(serverName),
+			)
+		}
+	}
+
 	// If content was provided in the request then incude that
 	// in the request. It'll get used as a part of the membership
 	// event content.


### PR DESCRIPTION
The spec states that the CS API room join endpoints can take `?server_name=`. This PR adds that to the initial RS join request.

Incidentally this implements on both `/{roomID}/join` and `/join/{roomIDOrAlias}` - see matrix-org/matrix-doc#1363.