### PR TITLE
Speed up accepting invites from remote users if we're already in the room

### DIFF
--- a/roomserver/internal/perform_join.go
+++ b/roomserver/internal/perform_join.go
@@ -161,8 +161,9 @@ func (r *RoomserverInternalAPI) performJoinRoomByID(
 	// where we might think we know about a room in the following
 	// section but don't know the latest state as all of our users
 	// have left.
+	serverInRoom, _ := r.isServerCurrentlyInRoom(ctx, r.ServerName, req.RoomIDOrAlias)
 	isInvitePending, inviteSender, _, err := r.isInvitePending(ctx, req.RoomIDOrAlias, req.UserID)
-	if err == nil && isInvitePending {
+	if err == nil && isInvitePending && !serverInRoom {
 		// Check if there's an invite pending.
 		_, inviterDomain, ierr := gomatrixserverlib.SplitID('@', inviteSender)
 		if ierr != nil {


### PR DESCRIPTION
If the remote invitee was on a different server, it looks like we tried a federated join regardless, even if we are already in the room. This should fix that and speed things up significantly. 