### PR TITLE
Fix duplicate writers

### DIFF
--- a/currentstateserver/storage/sqlite3/current_room_state_table.go
+++ b/currentstateserver/storage/sqlite3/current_room_state_table.go
@@ -83,7 +83,6 @@ const selectKnownUsersSQL = "" +
 
 type currentRoomStateStatements struct {
 	db                               *sql.DB
-	writer                           sqlutil.Writer
 	upsertRoomStateStmt              *sql.Stmt
 	deleteRoomStateByEventIDStmt     *sql.Stmt
 	selectRoomIDsWithMembershipStmt  *sql.Stmt
@@ -93,10 +92,9 @@ type currentRoomStateStatements struct {
 	selectKnownUsersStmt             *sql.Stmt
 }
 
-func NewSqliteCurrentRoomStateTable(db *sql.DB, writer sqlutil.Writer) (tables.CurrentRoomState, error) {
+func NewSqliteCurrentRoomStateTable(db *sql.DB) (tables.CurrentRoomState, error) {
 	s := &currentRoomStateStatements{
-		db:     db,
-		writer: writer,
+		db: db,
 	}
 	_, err := db.Exec(currentRoomStateSchema)
 	if err != nil {
@@ -177,11 +175,9 @@ func (s *currentRoomStateStatements) SelectRoomIDsWithMembership(
 func (s *currentRoomStateStatements) DeleteRoomStateByEventID(
 	ctx context.Context, txn *sql.Tx, eventID string,
 ) error {
-	return s.writer.Do(s.db, txn, func(txn *sql.Tx) error {
-		stmt := sqlutil.TxStmt(txn, s.deleteRoomStateByEventIDStmt)
-		_, err := stmt.ExecContext(ctx, eventID)
-		return err
-	})
+	stmt := sqlutil.TxStmt(txn, s.deleteRoomStateByEventIDStmt)
+	_, err := stmt.ExecContext(ctx, eventID)
+	return err
 }
 
 func (s *currentRoomStateStatements) UpsertRoomState(
@@ -194,20 +190,18 @@ func (s *currentRoomStateStatements) UpsertRoomState(
 	}
 
 	// upsert state event
-	return s.writer.Do(s.db, txn, func(txn *sql.Tx) error {
-		stmt := sqlutil.TxStmt(txn, s.upsertRoomStateStmt)
-		_, err = stmt.ExecContext(
-			ctx,
-			event.RoomID(),
-			event.EventID(),
-			event.Type(),
-			event.Sender(),
-			*event.StateKey(),
-			headeredJSON,
-			contentVal,
-		)
-		return err
-	})
+	stmt := sqlutil.TxStmt(txn, s.upsertRoomStateStmt)
+	_, err = stmt.ExecContext(
+		ctx,
+		event.RoomID(),
+		event.EventID(),
+		event.Type(),
+		event.Sender(),
+		*event.StateKey(),
+		headeredJSON,
+		contentVal,
+	)
+	return err
 }
 
 func (s *currentRoomStateStatements) SelectEventsWithEventIDs(

--- a/currentstateserver/storage/sqlite3/current_room_state_table.go
+++ b/currentstateserver/storage/sqlite3/current_room_state_table.go
@@ -93,10 +93,10 @@ type currentRoomStateStatements struct {
 	selectKnownUsersStmt             *sql.Stmt
 }
 
-func NewSqliteCurrentRoomStateTable(db *sql.DB) (tables.CurrentRoomState, error) {
+func NewSqliteCurrentRoomStateTable(db *sql.DB, writer sqlutil.Writer) (tables.CurrentRoomState, error) {
 	s := &currentRoomStateStatements{
 		db:     db,
-		writer: sqlutil.NewExclusiveWriter(),
+		writer: writer,
 	}
 	_, err := db.Exec(currentRoomStateSchema)
 	if err != nil {

--- a/currentstateserver/storage/sqlite3/storage.go
+++ b/currentstateserver/storage/sqlite3/storage.go
@@ -27,7 +27,7 @@ func NewDatabase(dbProperties *config.DatabaseOptions) (*Database, error) {
 	if err = d.PartitionOffsetStatements.Prepare(d.db, d.writer, "currentstate"); err != nil {
 		return nil, err
 	}
-	currRoomState, err := NewSqliteCurrentRoomStateTable(d.db)
+	currRoomState, err := NewSqliteCurrentRoomStateTable(d.db, d.writer)
 	if err != nil {
 		return nil, err
 	}

--- a/currentstateserver/storage/sqlite3/storage.go
+++ b/currentstateserver/storage/sqlite3/storage.go
@@ -27,7 +27,7 @@ func NewDatabase(dbProperties *config.DatabaseOptions) (*Database, error) {
 	if err = d.PartitionOffsetStatements.Prepare(d.db, d.writer, "currentstate"); err != nil {
 		return nil, err
 	}
-	currRoomState, err := NewSqliteCurrentRoomStateTable(d.db, d.writer)
+	currRoomState, err := NewSqliteCurrentRoomStateTable(d.db)
 	if err != nil {
 		return nil, err
 	}

--- a/roomserver/storage/sqlite3/storage.go
+++ b/roomserver/storage/sqlite3/storage.go
@@ -122,7 +122,7 @@ func Open(dbProperties *config.DatabaseOptions, cache caching.RoomServerCaches) 
 	d.Database = shared.Database{
 		DB:                  d.db,
 		Cache:               cache,
-		Writer:              sqlutil.NewExclusiveWriter(),
+		Writer:              d.writer,
 		EventsTable:         d.events,
 		EventTypesTable:     d.eventTypes,
 		EventStateKeysTable: d.eventStateKeys,

--- a/syncapi/storage/postgres/syncserver.go
+++ b/syncapi/storage/postgres/syncserver.go
@@ -80,7 +80,7 @@ func NewDatabase(dbProperties *config.DatabaseOptions) (*SyncServerDatasource, e
 	}
 	d.Database = shared.Database{
 		DB:                  d.db,
-		Writer:              sqlutil.NewDummyWriter(),
+		Writer:              d.writer,
 		Invites:             invites,
 		AccountData:         accountData,
 		OutputEvents:        events,

--- a/syncapi/storage/sqlite3/syncserver.go
+++ b/syncapi/storage/sqlite3/syncserver.go
@@ -93,7 +93,7 @@ func (d *SyncServerDatasource) prepare() (err error) {
 	}
 	d.Database = shared.Database{
 		DB:                  d.db,
-		Writer:              sqlutil.NewExclusiveWriter(),
+		Writer:              d.writer,
 		Invites:             invites,
 		AccountData:         accountData,
 		OutputEvents:        events,


### PR DESCRIPTION
This fixes a couple of places where we had duplicate `ExclusiveWriter`s, causing `database is locked` errors.