### PR TITLE
Use federation sender for backfill/getting missing events

### DIFF
--- a/build/gobind/monolith.go
+++ b/build/gobind/monolith.go
@@ -120,7 +120,7 @@ func (m *DendriteMonolith) Start() {
 	keyAPI.SetUserAPI(userAPI)
 
 	rsAPI := roomserver.NewInternalAPI(
-		base, keyRing, federation,
+		base, keyRing,
 	)
 
 	eduInputAPI := eduserver.NewInternalAPI(

--- a/cmd/dendrite-demo-libp2p/main.go
+++ b/cmd/dendrite-demo-libp2p/main.go
@@ -155,7 +155,7 @@ func main() {
 
 	stateAPI := currentstateserver.NewInternalAPI(&base.Base.Cfg.CurrentStateServer, base.Base.KafkaConsumer)
 	rsAPI := roomserver.NewInternalAPI(
-		&base.Base, keyRing, federation,
+		&base.Base, keyRing,
 	)
 	eduInputAPI := eduserver.NewInternalAPI(
 		&base.Base, cache.New(), userAPI,

--- a/cmd/dendrite-demo-yggdrasil/main.go
+++ b/cmd/dendrite-demo-yggdrasil/main.go
@@ -104,7 +104,7 @@ func main() {
 	keyAPI.SetUserAPI(userAPI)
 
 	rsComponent := roomserver.NewInternalAPI(
-		base, keyRing, federation,
+		base, keyRing,
 	)
 	rsAPI := rsComponent
 

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -81,7 +81,7 @@ func main() {
 	keyRing := serverKeyAPI.KeyRing()
 
 	rsImpl := roomserver.NewInternalAPI(
-		base, keyRing, federation,
+		base, keyRing,
 	)
 	// call functions directly on the impl unless running in HTTP mode
 	rsAPI := rsImpl

--- a/cmd/dendrite-room-server/main.go
+++ b/cmd/dendrite-room-server/main.go
@@ -23,13 +23,12 @@ func main() {
 	cfg := setup.ParseFlags(false)
 	base := setup.NewBaseDendrite(cfg, "RoomServerAPI", true)
 	defer base.Close() // nolint: errcheck
-	federation := base.CreateFederationClient()
 
 	serverKeyAPI := base.ServerKeyAPIClient()
 	keyRing := serverKeyAPI.KeyRing()
 
 	fsAPI := base.FederationSenderHTTPClient()
-	rsAPI := roomserver.NewInternalAPI(base, keyRing, federation)
+	rsAPI := roomserver.NewInternalAPI(base, keyRing)
 	rsAPI.SetFederationSenderAPI(fsAPI)
 	roomserver.AddInternalRoutes(base.InternalAPIMux, rsAPI)
 

--- a/cmd/dendritejs/main.go
+++ b/cmd/dendritejs/main.go
@@ -205,7 +205,7 @@ func main() {
 	}
 
 	stateAPI := currentstateserver.NewInternalAPI(&base.Cfg.CurrentStateServer, base.KafkaConsumer)
-	rsAPI := roomserver.NewInternalAPI(base, keyRing, federation)
+	rsAPI := roomserver.NewInternalAPI(base, keyRing)
 	eduInputAPI := eduserver.NewInternalAPI(base, cache.New(), userAPI)
 	asQuery := appservice.NewInternalAPI(
 		base, userAPI, rsAPI,

--- a/federationsender/api/api.go
+++ b/federationsender/api/api.go
@@ -14,9 +14,12 @@ import (
 // implements as proxy calls, with built-in backoff/retries/etc. Errors returned from functions in
 // this interface are of type FederationClientError
 type FederationClient interface {
+	gomatrixserverlib.BackfillClient
+	gomatrixserverlib.FederatedStateClient
 	GetUserDevices(ctx context.Context, s gomatrixserverlib.ServerName, userID string) (res gomatrixserverlib.RespUserDevices, err error)
 	ClaimKeys(ctx context.Context, s gomatrixserverlib.ServerName, oneTimeKeys map[string]map[string]string) (res gomatrixserverlib.RespClaimKeys, err error)
 	QueryKeys(ctx context.Context, s gomatrixserverlib.ServerName, keys map[string][]string) (res gomatrixserverlib.RespQueryKeys, err error)
+	GetEvent(ctx context.Context, s gomatrixserverlib.ServerName, eventID string) (res gomatrixserverlib.Transaction, err error)
 }
 
 // FederationClientError is returned from FederationClient methods in the event of a problem.

--- a/federationsender/internal/api.go
+++ b/federationsender/internal/api.go
@@ -136,3 +136,51 @@ func (a *FederationSenderInternalAPI) QueryKeys(
 	}
 	return ires.(gomatrixserverlib.RespQueryKeys), nil
 }
+
+func (a *FederationSenderInternalAPI) Backfill(
+	ctx context.Context, s gomatrixserverlib.ServerName, roomID string, limit int, eventIDs []string,
+) (res gomatrixserverlib.Transaction, err error) {
+	ires, err := a.doRequest(s, func() (interface{}, error) {
+		return a.federation.Backfill(ctx, s, roomID, limit, eventIDs)
+	})
+	if err != nil {
+		return gomatrixserverlib.Transaction{}, err
+	}
+	return ires.(gomatrixserverlib.Transaction), nil
+}
+
+func (a *FederationSenderInternalAPI) LookupState(
+	ctx context.Context, s gomatrixserverlib.ServerName, roomID, eventID string, roomVersion gomatrixserverlib.RoomVersion,
+) (res gomatrixserverlib.RespState, err error) {
+	ires, err := a.doRequest(s, func() (interface{}, error) {
+		return a.federation.LookupState(ctx, s, roomID, eventID, roomVersion)
+	})
+	if err != nil {
+		return gomatrixserverlib.RespState{}, err
+	}
+	return ires.(gomatrixserverlib.RespState), nil
+}
+
+func (a *FederationSenderInternalAPI) LookupStateIDs(
+	ctx context.Context, s gomatrixserverlib.ServerName, roomID, eventID string,
+) (res gomatrixserverlib.RespStateIDs, err error) {
+	ires, err := a.doRequest(s, func() (interface{}, error) {
+		return a.federation.LookupStateIDs(ctx, s, roomID, eventID)
+	})
+	if err != nil {
+		return gomatrixserverlib.RespStateIDs{}, err
+	}
+	return ires.(gomatrixserverlib.RespStateIDs), nil
+}
+
+func (a *FederationSenderInternalAPI) GetEvent(
+	ctx context.Context, s gomatrixserverlib.ServerName, eventID string,
+) (res gomatrixserverlib.Transaction, err error) {
+	ires, err := a.doRequest(s, func() (interface{}, error) {
+		return a.federation.GetEvent(ctx, s, eventID)
+	})
+	if err != nil {
+		return gomatrixserverlib.Transaction{}, err
+	}
+	return ires.(gomatrixserverlib.Transaction), nil
+}

--- a/federationsender/inthttp/client.go
+++ b/federationsender/inthttp/client.go
@@ -26,6 +26,10 @@ const (
 	FederationSenderGetUserDevicesPath = "/federationsender/client/getUserDevices"
 	FederationSenderClaimKeysPath      = "/federationsender/client/claimKeys"
 	FederationSenderQueryKeysPath      = "/federationsender/client/queryKeys"
+	FederationSenderBackfillPath       = "/federationsender/client/backfill"
+	FederationSenderLookupStatePath    = "/federationsender/client/lookupState"
+	FederationSenderLookupStateIDsPath = "/federationsender/client/lookupStateIDs"
+	FederationSenderGetEventPath       = "/federationsender/client/getEvent"
 )
 
 // NewFederationSenderClient creates a FederationSenderInternalAPI implemented by talking to a HTTP POST API.
@@ -225,6 +229,132 @@ func (h *httpFederationSenderInternalAPI) QueryKeys(
 	}
 	if response.Err != nil {
 		return result, response.Err
+	}
+	return *response.Res, nil
+}
+
+type backfill struct {
+	S        gomatrixserverlib.ServerName
+	RoomID   string
+	Limit    int
+	EventIDs []string
+	Res      *gomatrixserverlib.Transaction
+	Err      *api.FederationClientError
+}
+
+func (h *httpFederationSenderInternalAPI) Backfill(
+	ctx context.Context, s gomatrixserverlib.ServerName, roomID string, limit int, eventIDs []string,
+) (gomatrixserverlib.Transaction, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "Backfill")
+	defer span.Finish()
+
+	request := backfill{
+		S:        s,
+		RoomID:   roomID,
+		Limit:    limit,
+		EventIDs: eventIDs,
+	}
+	var response backfill
+	apiURL := h.federationSenderURL + FederationSenderBackfillPath
+	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, &request, &response)
+	if err != nil {
+		return gomatrixserverlib.Transaction{}, err
+	}
+	if response.Err != nil {
+		return gomatrixserverlib.Transaction{}, response.Err
+	}
+	return *response.Res, nil
+}
+
+type lookupState struct {
+	S           gomatrixserverlib.ServerName
+	RoomID      string
+	EventID     string
+	RoomVersion gomatrixserverlib.RoomVersion
+	Res         *gomatrixserverlib.RespState
+	Err         *api.FederationClientError
+}
+
+func (h *httpFederationSenderInternalAPI) LookupState(
+	ctx context.Context, s gomatrixserverlib.ServerName, roomID, eventID string, roomVersion gomatrixserverlib.RoomVersion,
+) (gomatrixserverlib.RespState, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "LookupState")
+	defer span.Finish()
+
+	request := lookupState{
+		S:           s,
+		RoomID:      roomID,
+		EventID:     eventID,
+		RoomVersion: roomVersion,
+	}
+	var response lookupState
+	apiURL := h.federationSenderURL + FederationSenderLookupStatePath
+	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, &request, &response)
+	if err != nil {
+		return gomatrixserverlib.RespState{}, err
+	}
+	if response.Err != nil {
+		return gomatrixserverlib.RespState{}, response.Err
+	}
+	return *response.Res, nil
+}
+
+type lookupStateIDs struct {
+	S       gomatrixserverlib.ServerName
+	RoomID  string
+	EventID string
+	Res     *gomatrixserverlib.RespStateIDs
+	Err     *api.FederationClientError
+}
+
+func (h *httpFederationSenderInternalAPI) LookupStateIDs(
+	ctx context.Context, s gomatrixserverlib.ServerName, roomID, eventID string,
+) (gomatrixserverlib.RespStateIDs, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "LookupStateIDs")
+	defer span.Finish()
+
+	request := lookupStateIDs{
+		S:       s,
+		RoomID:  roomID,
+		EventID: eventID,
+	}
+	var response lookupStateIDs
+	apiURL := h.federationSenderURL + FederationSenderLookupStatePath
+	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, &request, &response)
+	if err != nil {
+		return gomatrixserverlib.RespStateIDs{}, err
+	}
+	if response.Err != nil {
+		return gomatrixserverlib.RespStateIDs{}, response.Err
+	}
+	return *response.Res, nil
+}
+
+type getEvent struct {
+	S       gomatrixserverlib.ServerName
+	EventID string
+	Res     *gomatrixserverlib.Transaction
+	Err     *api.FederationClientError
+}
+
+func (h *httpFederationSenderInternalAPI) GetEvent(
+	ctx context.Context, s gomatrixserverlib.ServerName, eventID string,
+) (gomatrixserverlib.Transaction, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "GetEvent")
+	defer span.Finish()
+
+	request := getEvent{
+		S:       s,
+		EventID: eventID,
+	}
+	var response getEvent
+	apiURL := h.federationSenderURL + FederationSenderLookupStatePath
+	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, &request, &response)
+	if err != nil {
+		return gomatrixserverlib.Transaction{}, err
+	}
+	if response.Err != nil {
+		return gomatrixserverlib.Transaction{}, response.Err
 	}
 	return *response.Res, nil
 }

--- a/federationsender/inthttp/client.go
+++ b/federationsender/inthttp/client.go
@@ -319,7 +319,7 @@ func (h *httpFederationSenderInternalAPI) LookupStateIDs(
 		EventID: eventID,
 	}
 	var response lookupStateIDs
-	apiURL := h.federationSenderURL + FederationSenderLookupStatePath
+	apiURL := h.federationSenderURL + FederationSenderLookupStateIDsPath
 	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, &request, &response)
 	if err != nil {
 		return gomatrixserverlib.RespStateIDs{}, err
@@ -348,7 +348,7 @@ func (h *httpFederationSenderInternalAPI) GetEvent(
 		EventID: eventID,
 	}
 	var response getEvent
-	apiURL := h.federationSenderURL + FederationSenderLookupStatePath
+	apiURL := h.federationSenderURL + FederationSenderGetEventPath
 	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, &request, &response)
 	if err != nil {
 		return gomatrixserverlib.Transaction{}, err

--- a/federationsender/inthttp/server.go
+++ b/federationsender/inthttp/server.go
@@ -175,4 +175,26 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 			return util.JSONResponse{Code: http.StatusOK, JSON: request}
 		}),
 	)
+	internalAPIMux.Handle(
+		FederationSenderBackfillPath,
+		httputil.MakeInternalAPI("Backfill", func(req *http.Request) util.JSONResponse {
+			var request backfill
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.MessageResponse(http.StatusBadRequest, err.Error())
+			}
+			res, err := intAPI.Backfill(req.Context(), request.S, request.RoomID, request.Limit, request.EventIDs)
+			if err != nil {
+				ferr, ok := err.(*api.FederationClientError)
+				if ok {
+					request.Err = ferr
+				} else {
+					request.Err = &api.FederationClientError{
+						Err: err.Error(),
+					}
+				}
+			}
+			request.Res = &res
+			return util.JSONResponse{Code: http.StatusOK, JSON: request}
+		}),
+	)
 }

--- a/federationsender/inthttp/server.go
+++ b/federationsender/inthttp/server.go
@@ -197,4 +197,70 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 			return util.JSONResponse{Code: http.StatusOK, JSON: request}
 		}),
 	)
+	internalAPIMux.Handle(
+		FederationSenderLookupStatePath,
+		httputil.MakeInternalAPI("LookupState", func(req *http.Request) util.JSONResponse {
+			var request lookupState
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.MessageResponse(http.StatusBadRequest, err.Error())
+			}
+			res, err := intAPI.LookupState(req.Context(), request.S, request.RoomID, request.EventID, request.RoomVersion)
+			if err != nil {
+				ferr, ok := err.(*api.FederationClientError)
+				if ok {
+					request.Err = ferr
+				} else {
+					request.Err = &api.FederationClientError{
+						Err: err.Error(),
+					}
+				}
+			}
+			request.Res = &res
+			return util.JSONResponse{Code: http.StatusOK, JSON: request}
+		}),
+	)
+	internalAPIMux.Handle(
+		FederationSenderLookupStateIDsPath,
+		httputil.MakeInternalAPI("LookupStateIDs", func(req *http.Request) util.JSONResponse {
+			var request lookupStateIDs
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.MessageResponse(http.StatusBadRequest, err.Error())
+			}
+			res, err := intAPI.LookupStateIDs(req.Context(), request.S, request.RoomID, request.EventID)
+			if err != nil {
+				ferr, ok := err.(*api.FederationClientError)
+				if ok {
+					request.Err = ferr
+				} else {
+					request.Err = &api.FederationClientError{
+						Err: err.Error(),
+					}
+				}
+			}
+			request.Res = &res
+			return util.JSONResponse{Code: http.StatusOK, JSON: request}
+		}),
+	)
+	internalAPIMux.Handle(
+		FederationSenderGetEventPath,
+		httputil.MakeInternalAPI("GetEvent", func(req *http.Request) util.JSONResponse {
+			var request getEvent
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.MessageResponse(http.StatusBadRequest, err.Error())
+			}
+			res, err := intAPI.GetEvent(req.Context(), request.S, request.EventID)
+			if err != nil {
+				ferr, ok := err.(*api.FederationClientError)
+				if ok {
+					request.Err = ferr
+				} else {
+					request.Err = &api.FederationClientError{
+						Err: err.Error(),
+					}
+				}
+			}
+			request.Res = &res
+			return util.JSONResponse{Code: http.StatusOK, JSON: request}
+		}),
+	)
 }

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/matrix-org/go-http-js-libp2p v0.0.0-20200518170932-783164aeeda4
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20200522092705-bc8506ccbcf3
 	github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20200902110018-e5ddba2d6aef
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20200902135805-f7a5b5e89750
 	github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4
 	github.com/mattn/go-sqlite3 v1.14.2

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/matrix-org/go-http-js-libp2p v0.0.0-20200518170932-783164aeeda4
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20200522092705-bc8506ccbcf3
 	github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20200817100842-9d02141812f2
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20200902110018-e5ddba2d6aef
 	github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4
 	github.com/mattn/go-sqlite3 v1.14.2

--- a/go.sum
+++ b/go.sum
@@ -567,8 +567,8 @@ github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26 h1:Hr3zjRsq2bh
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
 github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd h1:xVrqJK3xHREMNjwjljkAUaadalWc0rRbmVuQatzmgwg=
 github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200902110018-e5ddba2d6aef h1:Tn7dEHaOFLzx7BHhaYUkF9TaiDzF6q7lA62MsOWDbsQ=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200902110018-e5ddba2d6aef/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200902135805-f7a5b5e89750 h1:k5vsLfpylXHOXgN51N0QNbak9i+4bT33Puk/ZJgcdDw=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200902135805-f7a5b5e89750/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
 github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91 h1:HJ6U3S3ljJqNffYMcIeAncp5qT/i+ZMiJ2JC2F0aXP4=
 github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91/go.mod h1:sjyPyRxKM5uw1nD2cJ6O2OxI6GOqyVBfNXqKjBZTBZE=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7 h1:ntrLa/8xVzeSs8vHFHK25k0C+NV74sYMJnNSg5NoSRo=

--- a/go.sum
+++ b/go.sum
@@ -567,8 +567,8 @@ github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26 h1:Hr3zjRsq2bh
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
 github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd h1:xVrqJK3xHREMNjwjljkAUaadalWc0rRbmVuQatzmgwg=
 github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200817100842-9d02141812f2 h1:9wKwfd5KDcXuqZ7/kAaYe0QM4DGM+2awjjvXQtrDa6k=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200817100842-9d02141812f2/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200902110018-e5ddba2d6aef h1:Tn7dEHaOFLzx7BHhaYUkF9TaiDzF6q7lA62MsOWDbsQ=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200902110018-e5ddba2d6aef/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
 github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91 h1:HJ6U3S3ljJqNffYMcIeAncp5qT/i+ZMiJ2JC2F0aXP4=
 github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91/go.mod h1:sjyPyRxKM5uw1nD2cJ6O2OxI6GOqyVBfNXqKjBZTBZE=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7 h1:ntrLa/8xVzeSs8vHFHK25k0C+NV74sYMJnNSg5NoSRo=

--- a/roomserver/internal/api.go
+++ b/roomserver/internal/api.go
@@ -19,8 +19,7 @@ type RoomserverInternalAPI struct {
 	Cache                caching.RoomServerCaches
 	ServerName           gomatrixserverlib.ServerName
 	KeyRing              gomatrixserverlib.JSONVerifier
-	FedClient            *gomatrixserverlib.FederationClient
+	fsAPI                fsAPI.FederationSenderInternalAPI
 	OutputRoomEventTopic string   // Kafka topic for new output room events
 	mutexes              sync.Map // room ID -> *sync.Mutex, protects calls to processRoomEvent
-	fsAPI                fsAPI.FederationSenderInternalAPI
 }

--- a/roomserver/internal/query.go
+++ b/roomserver/internal/query.go
@@ -512,7 +512,7 @@ func (r *RoomserverInternalAPI) backfillViaFederation(ctx context.Context, req *
 	if err != nil {
 		return fmt.Errorf("backfillViaFederation: unknown room version for room %s : %w", req.RoomID, err)
 	}
-	requester := newBackfillRequester(r.DB, r.FedClient, r.ServerName, req.BackwardsExtremities)
+	requester := newBackfillRequester(r.DB, r.fsAPI, r.ServerName, req.BackwardsExtremities)
 	// Request 100 items regardless of what the query asks for.
 	// We don't want to go much higher than this.
 	// We can't honour exactly the limit as some sytests rely on requesting more for tests to pass
@@ -622,7 +622,7 @@ func (r *RoomserverInternalAPI) fetchAndStoreMissingEvents(ctx context.Context, 
 				continue // already found
 			}
 			logger := util.GetLogger(ctx).WithField("server", srv).WithField("event_id", id)
-			res, err := r.FedClient.GetEvent(ctx, srv, id)
+			res, err := r.fsAPI.GetEvent(ctx, srv, id)
 			if err != nil {
 				logger.WithError(err).Warn("failed to get event from server")
 				continue

--- a/roomserver/roomserver.go
+++ b/roomserver/roomserver.go
@@ -38,7 +38,6 @@ func AddInternalRoutes(router *mux.Router, intAPI api.RoomserverInternalAPI) {
 func NewInternalAPI(
 	base *setup.BaseDendrite,
 	keyRing gomatrixserverlib.JSONVerifier,
-	fedClient *gomatrixserverlib.FederationClient,
 ) api.RoomserverInternalAPI {
 	cfg := &base.Cfg.RoomServer
 
@@ -54,7 +53,6 @@ func NewInternalAPI(
 		OutputRoomEventTopic: string(cfg.Matrix.Kafka.TopicFor(config.TopicOutputRoomEvent)),
 		Cache:                base.Caches,
 		ServerName:           cfg.Matrix.ServerName,
-		FedClient:            fedClient,
 		KeyRing:              keyRing,
 	}
 }

--- a/roomserver/roomserver_test.go
+++ b/roomserver/roomserver_test.go
@@ -112,7 +112,7 @@ func mustSendEvents(t *testing.T, ver gomatrixserverlib.RoomVersion, events []js
 		Cfg:           cfg,
 	}
 
-	rsAPI := NewInternalAPI(base, &test.NopJSONVerifier{}, nil)
+	rsAPI := NewInternalAPI(base, &test.NopJSONVerifier{})
 	hevents := mustLoadEvents(t, ver, events)
 	_, err = api.SendEvents(ctx, rsAPI, hevents, testOrigin, nil)
 	if err != nil {


### PR DESCRIPTION
This is an attempt to use the federation sender for backfill/getting missing events rather than using a federation client directly.