### PR TITLE
Add Queryer and Inputer and factor out more RSAPI stuff

### DIFF
--- a/clientapi/routing/membership.go
+++ b/clientapi/routing/membership.go
@@ -270,7 +270,7 @@ func buildMembershipEvent(
 		return nil, err
 	}
 
-	return eventutil.BuildEvent(ctx, &builder, cfg.Matrix, evTime, rsAPI, nil)
+	return eventutil.QueryAndBuildEvent(ctx, &builder, cfg.Matrix, evTime, rsAPI, nil)
 }
 
 // loadProfile lookups the profile of a given user from the database and returns

--- a/clientapi/routing/profile.go
+++ b/clientapi/routing/profile.go
@@ -375,7 +375,7 @@ func buildMembershipEvents(
 			return nil, err
 		}
 
-		event, err := eventutil.BuildEvent(ctx, &builder, cfg.Matrix, evTime, rsAPI, nil)
+		event, err := eventutil.QueryAndBuildEvent(ctx, &builder, cfg.Matrix, evTime, rsAPI, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/clientapi/routing/redaction.go
+++ b/clientapi/routing/redaction.go
@@ -115,7 +115,7 @@ func SendRedaction(
 	}
 
 	var queryRes api.QueryLatestEventsAndStateResponse
-	e, err := eventutil.BuildEvent(req.Context(), &builder, cfg.Matrix, time.Now(), rsAPI, &queryRes)
+	e, err := eventutil.QueryAndBuildEvent(req.Context(), &builder, cfg.Matrix, time.Now(), rsAPI, &queryRes)
 	if err == eventutil.ErrRoomNoExists {
 		return util.JSONResponse{
 			Code: http.StatusNotFound,

--- a/clientapi/routing/sendevent.go
+++ b/clientapi/routing/sendevent.go
@@ -158,7 +158,7 @@ func generateSendEvent(
 	}
 
 	var queryRes api.QueryLatestEventsAndStateResponse
-	e, err := eventutil.BuildEvent(req.Context(), &builder, cfg.Matrix, evTime, rsAPI, &queryRes)
+	e, err := eventutil.QueryAndBuildEvent(req.Context(), &builder, cfg.Matrix, evTime, rsAPI, &queryRes)
 	if err == eventutil.ErrRoomNoExists {
 		return nil, &util.JSONResponse{
 			Code: http.StatusNotFound,

--- a/clientapi/threepid/invites.go
+++ b/clientapi/threepid/invites.go
@@ -354,7 +354,7 @@ func emit3PIDInviteEvent(
 	}
 
 	queryRes := api.QueryLatestEventsAndStateResponse{}
-	event, err := eventutil.BuildEvent(ctx, builder, cfg.Matrix, evTime, rsAPI, &queryRes)
+	event, err := eventutil.QueryAndBuildEvent(ctx, builder, cfg.Matrix, evTime, rsAPI, &queryRes)
 	if err != nil {
 		return err
 	}

--- a/federationapi/routing/join.go
+++ b/federationapi/routing/join.go
@@ -95,7 +95,7 @@ func MakeJoin(
 	queryRes := api.QueryLatestEventsAndStateResponse{
 		RoomVersion: verRes.RoomVersion,
 	}
-	event, err := eventutil.BuildEvent(httpReq.Context(), &builder, cfg.Matrix, time.Now(), rsAPI, &queryRes)
+	event, err := eventutil.QueryAndBuildEvent(httpReq.Context(), &builder, cfg.Matrix, time.Now(), rsAPI, &queryRes)
 	if err == eventutil.ErrRoomNoExists {
 		return util.JSONResponse{
 			Code: http.StatusNotFound,

--- a/federationapi/routing/leave.go
+++ b/federationapi/routing/leave.go
@@ -61,7 +61,7 @@ func MakeLeave(
 	}
 
 	var queryRes api.QueryLatestEventsAndStateResponse
-	event, err := eventutil.BuildEvent(httpReq.Context(), &builder, cfg.Matrix, time.Now(), rsAPI, &queryRes)
+	event, err := eventutil.QueryAndBuildEvent(httpReq.Context(), &builder, cfg.Matrix, time.Now(), rsAPI, &queryRes)
 	if err == eventutil.ErrRoomNoExists {
 		return util.JSONResponse{
 			Code: http.StatusNotFound,

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package input
 
 import (
 	"context"
@@ -36,7 +36,7 @@ import (
 // state deltas when sending to kafka streams
 // TODO: Break up function - we should probably do transaction ID checks before calling this.
 // nolint:gocyclo
-func (r *RoomserverInternalAPI) processRoomEvent(
+func (r *Inputer) processRoomEvent(
 	ctx context.Context,
 	input api.InputRoomEvent,
 ) (eventID string, err error) {
@@ -141,7 +141,7 @@ func (r *RoomserverInternalAPI) processRoomEvent(
 	return event.EventID(), nil
 }
 
-func (r *RoomserverInternalAPI) calculateAndSetState(
+func (r *Inputer) calculateAndSetState(
 	ctx context.Context,
 	input api.InputRoomEvent,
 	roomInfo types.RoomInfo,

--- a/roomserver/internal/input/input_latest_events.go
+++ b/roomserver/internal/input/input_latest_events.go
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package input
 
 import (
 	"bytes"
@@ -47,7 +47,7 @@ import (
 //      7 <----- latest
 //
 // Can only be called once at a time
-func (r *RoomserverInternalAPI) updateLatestEvents(
+func (r *Inputer) updateLatestEvents(
 	ctx context.Context,
 	roomInfo *types.RoomInfo,
 	stateAtEvent types.StateAtEvent,
@@ -87,7 +87,7 @@ func (r *RoomserverInternalAPI) updateLatestEvents(
 // when there are so many variables to pass around.
 type latestEventsUpdater struct {
 	ctx           context.Context
-	api           *RoomserverInternalAPI
+	api           *Inputer
 	updater       *shared.LatestEventsUpdater
 	roomInfo      *types.RoomInfo
 	stateAtEvent  types.StateAtEvent

--- a/roomserver/internal/input/input_membership.go
+++ b/roomserver/internal/input/input_membership.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package input
 
 import (
 	"context"
@@ -29,7 +29,7 @@ import (
 // user affected by a change in the current state of the room.
 // Returns a list of output events to write to the kafka log to inform the
 // consumers about the invites added or retired by the change in current state.
-func (r *RoomserverInternalAPI) updateMemberships(
+func (r *Inputer) updateMemberships(
 	ctx context.Context,
 	updater *shared.LatestEventsUpdater,
 	removed, added []types.StateEntry,
@@ -78,7 +78,7 @@ func (r *RoomserverInternalAPI) updateMemberships(
 	return updates, nil
 }
 
-func (r *RoomserverInternalAPI) updateMembership(
+func (r *Inputer) updateMembership(
 	updater *shared.LatestEventsUpdater,
 	targetUserNID types.EventStateKeyNID,
 	remove, add *gomatrixserverlib.Event,
@@ -133,11 +133,11 @@ func (r *RoomserverInternalAPI) updateMembership(
 	}
 }
 
-func (r *RoomserverInternalAPI) isLocalTarget(event *gomatrixserverlib.Event) bool {
+func (r *Inputer) isLocalTarget(event *gomatrixserverlib.Event) bool {
 	isTargetLocalUser := false
 	if statekey := event.StateKey(); statekey != nil {
 		_, domain, _ := gomatrixserverlib.SplitID('@', *statekey)
-		isTargetLocalUser = domain == r.Cfg.Matrix.ServerName
+		isTargetLocalUser = domain == r.ServerName
 	}
 	return isTargetLocalUser
 }

--- a/roomserver/internal/perform/perform_backfill.go
+++ b/roomserver/internal/perform/perform_backfill.go
@@ -1,3 +1,17 @@
+// Copyright 2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package perform
 
 import (

--- a/roomserver/internal/perform/perform_invite.go
+++ b/roomserver/internal/perform/perform_invite.go
@@ -1,3 +1,17 @@
+// Copyright 2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package perform
 
 import (

--- a/roomserver/internal/perform/perform_invite.go
+++ b/roomserver/internal/perform/perform_invite.go
@@ -22,6 +22,7 @@ import (
 	"github.com/matrix-org/dendrite/internal/config"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/roomserver/internal/helpers"
+	"github.com/matrix-org/dendrite/roomserver/internal/input"
 	"github.com/matrix-org/dendrite/roomserver/state"
 	"github.com/matrix-org/dendrite/roomserver/storage"
 	"github.com/matrix-org/dendrite/roomserver/types"
@@ -30,12 +31,10 @@ import (
 )
 
 type Inviter struct {
-	DB    storage.Database
-	Cfg   *config.RoomServer
-	FSAPI federationSenderAPI.FederationSenderInternalAPI
-
-	// TODO FIXME: Remove this
-	RSAPI api.RoomserverInternalAPI
+	DB      storage.Database
+	Cfg     *config.RoomServer
+	FSAPI   federationSenderAPI.FederationSenderInternalAPI
+	Inputer *input.Inputer
 }
 
 // nolint:gocyclo
@@ -184,7 +183,7 @@ func (r *Inviter) PerformInvite(
 			},
 		}
 		inputRes := &api.InputRoomEventsResponse{}
-		if err = r.RSAPI.InputRoomEvents(context.Background(), inputReq, inputRes); err != nil {
+		if err = r.Inputer.InputRoomEvents(context.Background(), inputReq, inputRes); err != nil {
 			return nil, fmt.Errorf("r.InputRoomEvents: %w", err)
 		}
 	} else {

--- a/roomserver/internal/perform/perform_join.go
+++ b/roomserver/internal/perform/perform_join.go
@@ -1,3 +1,17 @@
+// Copyright 2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package perform
 
 import (

--- a/roomserver/internal/perform/perform_join.go
+++ b/roomserver/internal/perform/perform_join.go
@@ -26,6 +26,7 @@ import (
 	"github.com/matrix-org/dendrite/internal/eventutil"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/roomserver/internal/helpers"
+	"github.com/matrix-org/dendrite/roomserver/internal/input"
 	"github.com/matrix-org/dendrite/roomserver/storage"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/sirupsen/logrus"
@@ -37,8 +38,7 @@ type Joiner struct {
 	FSAPI      fsAPI.FederationSenderInternalAPI
 	DB         storage.Database
 
-	// TODO FIXME: Remove this
-	RSAPI api.RoomserverInternalAPI
+	Inputer *input.Inputer
 }
 
 // PerformJoin handles joining matrix rooms, including over federation by talking to the federationsender.
@@ -215,15 +215,7 @@ func (r *Joiner) performJoinRoomByID(
 	// locally on the homeserver.
 	// TODO: Check what happens if the room exists on the server
 	// but everyone has since left. I suspect it does the wrong thing.
-	buildRes := api.QueryLatestEventsAndStateResponse{}
-	event, err := eventutil.BuildEvent(
-		ctx,          // the request context
-		&eb,          // the template join event
-		r.Cfg.Matrix, // the server configuration
-		time.Now(),   // the event timestamp to use
-		r.RSAPI,      // the roomserver API to use
-		&buildRes,    // the query response
-	)
+	event, buildRes, err := buildEvent(ctx, r.DB, r.Cfg.Matrix, &eb)
 
 	switch err {
 	case nil:
@@ -255,7 +247,7 @@ func (r *Joiner) performJoinRoomByID(
 				},
 			}
 			inputRes := api.InputRoomEventsResponse{}
-			if err = r.RSAPI.InputRoomEvents(ctx, &inputReq, &inputRes); err != nil {
+			if err = r.Inputer.InputRoomEvents(ctx, &inputReq, &inputRes); err != nil {
 				var notAllowed *gomatrixserverlib.NotAllowed
 				if errors.As(err, &notAllowed) {
 					return "", &api.PerformError{
@@ -319,4 +311,32 @@ func (r *Joiner) performFederatedJoinRoomByID(
 		}
 	}
 	return nil
+}
+
+func buildEvent(
+	ctx context.Context, db storage.Database, cfg *config.Global, builder *gomatrixserverlib.EventBuilder,
+) (*gomatrixserverlib.HeaderedEvent, *api.QueryLatestEventsAndStateResponse, error) {
+	eventsNeeded, err := gomatrixserverlib.StateNeededForEventBuilder(builder)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gomatrixserverlib.StateNeededForEventBuilder: %w", err)
+	}
+
+	if len(eventsNeeded.Tuples()) == 0 {
+		return nil, nil, errors.New("expecting state tuples for event builder, got none")
+	}
+
+	var queryRes api.QueryLatestEventsAndStateResponse
+	err = helpers.QueryLatestEventsAndState(ctx, db, &api.QueryLatestEventsAndStateRequest{
+		RoomID:       builder.RoomID,
+		StateToFetch: eventsNeeded.Tuples(),
+	}, &queryRes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("QueryLatestEventsAndState: %w", err)
+	}
+
+	ev, err := eventutil.BuildEvent(ctx, builder, cfg, time.Now(), &eventsNeeded, &queryRes)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ev, &queryRes, nil
 }

--- a/roomserver/internal/perform/perform_leave.go
+++ b/roomserver/internal/perform/perform_leave.go
@@ -1,3 +1,17 @@
+// Copyright 2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package perform
 
 import (

--- a/roomserver/internal/perform/perform_publish.go
+++ b/roomserver/internal/perform/perform_publish.go
@@ -1,3 +1,17 @@
+// Copyright 2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package perform
 
 import (

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -1,6 +1,4 @@
-// Copyright 2017 Vector Creations Ltd
-// Copyright 2018 New Vector Ltd
-// Copyright 2019-2020 The Matrix.org Foundation C.I.C.
+// Copyright 2020 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,15 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package query
 
 import (
 	"context"
 	"fmt"
 
+	"github.com/matrix-org/dendrite/internal/caching"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/roomserver/internal/helpers"
 	"github.com/matrix-org/dendrite/roomserver/state"
+	"github.com/matrix-org/dendrite/roomserver/storage"
 	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/roomserver/version"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -30,8 +30,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type Queryer struct {
+	DB    storage.Database
+	Cache caching.RoomServerCaches
+}
+
 // QueryLatestEventsAndState implements api.RoomserverInternalAPI
-func (r *RoomserverInternalAPI) QueryLatestEventsAndState(
+func (r *Queryer) QueryLatestEventsAndState(
 	ctx context.Context,
 	request *api.QueryLatestEventsAndStateRequest,
 	response *api.QueryLatestEventsAndStateResponse,
@@ -85,7 +90,7 @@ func (r *RoomserverInternalAPI) QueryLatestEventsAndState(
 }
 
 // QueryStateAfterEvents implements api.RoomserverInternalAPI
-func (r *RoomserverInternalAPI) QueryStateAfterEvents(
+func (r *Queryer) QueryStateAfterEvents(
 	ctx context.Context,
 	request *api.QueryStateAfterEventsRequest,
 	response *api.QueryStateAfterEventsResponse,
@@ -134,7 +139,7 @@ func (r *RoomserverInternalAPI) QueryStateAfterEvents(
 }
 
 // QueryEventsByID implements api.RoomserverInternalAPI
-func (r *RoomserverInternalAPI) QueryEventsByID(
+func (r *Queryer) QueryEventsByID(
 	ctx context.Context,
 	request *api.QueryEventsByIDRequest,
 	response *api.QueryEventsByIDResponse,
@@ -167,7 +172,7 @@ func (r *RoomserverInternalAPI) QueryEventsByID(
 }
 
 // QueryMembershipForUser implements api.RoomserverInternalAPI
-func (r *RoomserverInternalAPI) QueryMembershipForUser(
+func (r *Queryer) QueryMembershipForUser(
 	ctx context.Context,
 	request *api.QueryMembershipForUserRequest,
 	response *api.QueryMembershipForUserResponse,
@@ -204,7 +209,7 @@ func (r *RoomserverInternalAPI) QueryMembershipForUser(
 }
 
 // QueryMembershipsForRoom implements api.RoomserverInternalAPI
-func (r *RoomserverInternalAPI) QueryMembershipsForRoom(
+func (r *Queryer) QueryMembershipsForRoom(
 	ctx context.Context,
 	request *api.QueryMembershipsForRoomRequest,
 	response *api.QueryMembershipsForRoomResponse,
@@ -260,7 +265,7 @@ func (r *RoomserverInternalAPI) QueryMembershipsForRoom(
 }
 
 // QueryServerAllowedToSeeEvent implements api.RoomserverInternalAPI
-func (r *RoomserverInternalAPI) QueryServerAllowedToSeeEvent(
+func (r *Queryer) QueryServerAllowedToSeeEvent(
 	ctx context.Context,
 	request *api.QueryServerAllowedToSeeEventRequest,
 	response *api.QueryServerAllowedToSeeEventResponse,
@@ -293,7 +298,7 @@ func (r *RoomserverInternalAPI) QueryServerAllowedToSeeEvent(
 
 // QueryMissingEvents implements api.RoomserverInternalAPI
 // nolint:gocyclo
-func (r *RoomserverInternalAPI) QueryMissingEvents(
+func (r *Queryer) QueryMissingEvents(
 	ctx context.Context,
 	request *api.QueryMissingEventsRequest,
 	response *api.QueryMissingEventsResponse,
@@ -352,7 +357,7 @@ func (r *RoomserverInternalAPI) QueryMissingEvents(
 }
 
 // QueryStateAndAuthChain implements api.RoomserverInternalAPI
-func (r *RoomserverInternalAPI) QueryStateAndAuthChain(
+func (r *Queryer) QueryStateAndAuthChain(
 	ctx context.Context,
 	request *api.QueryStateAndAuthChainRequest,
 	response *api.QueryStateAndAuthChainResponse,
@@ -405,7 +410,7 @@ func (r *RoomserverInternalAPI) QueryStateAndAuthChain(
 	return err
 }
 
-func (r *RoomserverInternalAPI) loadStateAtEventIDs(ctx context.Context, roomInfo types.RoomInfo, eventIDs []string) ([]gomatrixserverlib.Event, error) {
+func (r *Queryer) loadStateAtEventIDs(ctx context.Context, roomInfo types.RoomInfo, eventIDs []string) ([]gomatrixserverlib.Event, error) {
 	roomState := state.NewStateResolution(r.DB, roomInfo)
 	prevStates, err := r.DB.StateAtEventIDs(ctx, eventIDs)
 	if err != nil {
@@ -482,7 +487,7 @@ func getAuthChain(
 }
 
 // QueryRoomVersionCapabilities implements api.RoomserverInternalAPI
-func (r *RoomserverInternalAPI) QueryRoomVersionCapabilities(
+func (r *Queryer) QueryRoomVersionCapabilities(
 	ctx context.Context,
 	request *api.QueryRoomVersionCapabilitiesRequest,
 	response *api.QueryRoomVersionCapabilitiesResponse,
@@ -500,7 +505,7 @@ func (r *RoomserverInternalAPI) QueryRoomVersionCapabilities(
 }
 
 // QueryRoomVersionCapabilities implements api.RoomserverInternalAPI
-func (r *RoomserverInternalAPI) QueryRoomVersionForRoom(
+func (r *Queryer) QueryRoomVersionForRoom(
 	ctx context.Context,
 	request *api.QueryRoomVersionForRoomRequest,
 	response *api.QueryRoomVersionForRoomResponse,
@@ -522,7 +527,7 @@ func (r *RoomserverInternalAPI) QueryRoomVersionForRoom(
 	return nil
 }
 
-func (r *RoomserverInternalAPI) roomVersion(roomID string) (gomatrixserverlib.RoomVersion, error) {
+func (r *Queryer) roomVersion(roomID string) (gomatrixserverlib.RoomVersion, error) {
 	var res api.QueryRoomVersionForRoomResponse
 	err := r.QueryRoomVersionForRoom(context.Background(), &api.QueryRoomVersionForRoomRequest{
 		RoomID: roomID,
@@ -530,7 +535,7 @@ func (r *RoomserverInternalAPI) roomVersion(roomID string) (gomatrixserverlib.Ro
 	return res.RoomVersion, err
 }
 
-func (r *RoomserverInternalAPI) QueryPublishedRooms(
+func (r *Queryer) QueryPublishedRooms(
 	ctx context.Context,
 	req *api.QueryPublishedRoomsRequest,
 	res *api.QueryPublishedRoomsResponse,

--- a/roomserver/internal/query/query_test.go
+++ b/roomserver/internal/query/query_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Vector Creations Ltd
+// Copyright 2020 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package query
 
 import (
 	"context"


### PR DESCRIPTION
This neatly splits up the RS API based on the functionality it provides,
whilst providing a useful place for code sharing via the `helpers` package.

This reduces the overall internal surface of RSAPI considerably. 

What remains to be done:
 - There's a lot of "helper" functions which aren't exactly optimised, and grown organically. Helpers are used in at least two distinct RSAPI areas (e.g query and perform), and they tend to be wrappers around storage API calls to map between different types.