### PR TITLE
Remove QueryRoomsForUser from current state server

### DIFF
--- a/build/gobind/monolith.go
+++ b/build/gobind/monolith.go
@@ -130,7 +130,7 @@ func (m *DendriteMonolith) Start() {
 	asAPI := appservice.NewInternalAPI(base, userAPI, rsAPI)
 	stateAPI := currentstateserver.NewInternalAPI(&base.Cfg.CurrentStateServer, base.KafkaConsumer)
 	fsAPI := federationsender.NewInternalAPI(
-		base, federation, rsAPI, stateAPI, keyRing,
+		base, federation, rsAPI, keyRing,
 	)
 
 	ygg.SetSessionFunc(func(address string) {

--- a/clientapi/routing/memberships.go
+++ b/clientapi/routing/memberships.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
-	currentstateAPI "github.com/matrix-org/dendrite/currentstateserver/api"
 	"github.com/matrix-org/dendrite/internal/config"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
@@ -94,10 +93,10 @@ func GetMemberships(
 func GetJoinedRooms(
 	req *http.Request,
 	device *userapi.Device,
-	stateAPI currentstateAPI.CurrentStateInternalAPI,
+	rsAPI api.RoomserverInternalAPI,
 ) util.JSONResponse {
-	var res currentstateAPI.QueryRoomsForUserResponse
-	err := stateAPI.QueryRoomsForUser(req.Context(), &currentstateAPI.QueryRoomsForUserRequest{
+	var res api.QueryRoomsForUserResponse
+	err := rsAPI.QueryRoomsForUser(req.Context(), &api.QueryRoomsForUserRequest{
 		UserID:         device.UserID,
 		WantMembership: "join",
 	}, &res)

--- a/clientapi/routing/profile.go
+++ b/clientapi/routing/profile.go
@@ -140,8 +140,8 @@ func SetAvatarURL(
 		return jsonerror.InternalServerError()
 	}
 
-	var res currentstateAPI.QueryRoomsForUserResponse
-	err = stateAPI.QueryRoomsForUser(req.Context(), &currentstateAPI.QueryRoomsForUserRequest{
+	var res api.QueryRoomsForUserResponse
+	err = rsAPI.QueryRoomsForUser(req.Context(), &api.QueryRoomsForUserRequest{
 		UserID:         device.UserID,
 		WantMembership: "join",
 	}, &res)
@@ -258,8 +258,8 @@ func SetDisplayName(
 		return jsonerror.InternalServerError()
 	}
 
-	var res currentstateAPI.QueryRoomsForUserResponse
-	err = stateAPI.QueryRoomsForUser(req.Context(), &currentstateAPI.QueryRoomsForUserRequest{
+	var res api.QueryRoomsForUserResponse
+	err = rsAPI.QueryRoomsForUser(req.Context(), &api.QueryRoomsForUserRequest{
 		UserID:         device.UserID,
 		WantMembership: "join",
 	}, &res)

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -107,7 +107,7 @@ func Setup(
 	).Methods(http.MethodPost, http.MethodOptions)
 	r0mux.Handle("/joined_rooms",
 		httputil.MakeAuthAPI("joined_rooms", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			return GetJoinedRooms(req, device, stateAPI)
+			return GetJoinedRooms(req, device, rsAPI)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 	r0mux.Handle("/rooms/{roomID}/join",

--- a/cmd/dendrite-demo-libp2p/main.go
+++ b/cmd/dendrite-demo-libp2p/main.go
@@ -162,7 +162,7 @@ func main() {
 	)
 	asAPI := appservice.NewInternalAPI(&base.Base, userAPI, rsAPI)
 	fsAPI := federationsender.NewInternalAPI(
-		&base.Base, federation, rsAPI, stateAPI, keyRing,
+		&base.Base, federation, rsAPI, keyRing,
 	)
 	rsAPI.SetFederationSenderAPI(fsAPI)
 	provider := newPublicRoomsProvider(base.LibP2PPubsub, rsAPI, stateAPI)

--- a/cmd/dendrite-demo-yggdrasil/main.go
+++ b/cmd/dendrite-demo-yggdrasil/main.go
@@ -115,7 +115,7 @@ func main() {
 	asAPI := appservice.NewInternalAPI(base, userAPI, rsAPI)
 	stateAPI := currentstateserver.NewInternalAPI(&base.Cfg.CurrentStateServer, base.KafkaConsumer)
 	fsAPI := federationsender.NewInternalAPI(
-		base, federation, rsAPI, stateAPI, keyRing,
+		base, federation, rsAPI, keyRing,
 	)
 
 	ygg.SetSessionFunc(func(address string) {

--- a/cmd/dendrite-federation-sender-server/main.go
+++ b/cmd/dendrite-federation-sender-server/main.go
@@ -31,7 +31,7 @@ func main() {
 
 	rsAPI := base.RoomserverHTTPClient()
 	fsAPI := federationsender.NewInternalAPI(
-		base, federation, rsAPI, base.CurrentStateAPIClient(), keyRing,
+		base, federation, rsAPI, keyRing,
 	)
 	federationsender.AddInternalRoutes(base.InternalAPIMux, fsAPI)
 

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -98,7 +98,7 @@ func main() {
 	stateAPI := currentstateserver.NewInternalAPI(&base.Cfg.CurrentStateServer, base.KafkaConsumer)
 
 	fsAPI := federationsender.NewInternalAPI(
-		base, federation, rsAPI, stateAPI, keyRing,
+		base, federation, rsAPI, keyRing,
 	)
 	if base.UseHTTPAPIs {
 		federationsender.AddInternalRoutes(base.InternalAPIMux, fsAPI)

--- a/cmd/dendritejs/main.go
+++ b/cmd/dendritejs/main.go
@@ -210,7 +210,7 @@ func main() {
 	asQuery := appservice.NewInternalAPI(
 		base, userAPI, rsAPI,
 	)
-	fedSenderAPI := federationsender.NewInternalAPI(base, federation, rsAPI, stateAPI, &keyRing)
+	fedSenderAPI := federationsender.NewInternalAPI(base, federation, rsAPI, &keyRing)
 	rsAPI.SetFederationSenderAPI(fedSenderAPI)
 	p2pPublicRoomProvider := NewLibP2PPublicRoomsProvider(node, fedSenderAPI, federation)
 

--- a/currentstateserver/api/api.go
+++ b/currentstateserver/api/api.go
@@ -21,20 +21,8 @@ import (
 )
 
 type CurrentStateInternalAPI interface {
-	// QueryRoomsForUser retrieves a list of room IDs matching the given query.
-	QueryRoomsForUser(ctx context.Context, req *QueryRoomsForUserRequest, res *QueryRoomsForUserResponse) error
 	// QueryBulkStateContent does a bulk query for state event content in the given rooms.
 	QueryBulkStateContent(ctx context.Context, req *QueryBulkStateContentRequest, res *QueryBulkStateContentResponse) error
-}
-
-type QueryRoomsForUserRequest struct {
-	UserID string
-	// The desired membership of the user. If this is the empty string then no rooms are returned.
-	WantMembership string
-}
-
-type QueryRoomsForUserResponse struct {
-	RoomIDs []string
 }
 
 type QueryBulkStateContentRequest struct {

--- a/currentstateserver/internal/api.go
+++ b/currentstateserver/internal/api.go
@@ -26,15 +26,6 @@ type CurrentStateInternalAPI struct {
 	DB storage.Database
 }
 
-func (a *CurrentStateInternalAPI) QueryRoomsForUser(ctx context.Context, req *api.QueryRoomsForUserRequest, res *api.QueryRoomsForUserResponse) error {
-	roomIDs, err := a.DB.GetRoomsByMembership(ctx, req.UserID, req.WantMembership)
-	if err != nil {
-		return err
-	}
-	res.RoomIDs = roomIDs
-	return nil
-}
-
 func (a *CurrentStateInternalAPI) QueryBulkStateContent(ctx context.Context, req *api.QueryBulkStateContentRequest, res *api.QueryBulkStateContentResponse) error {
 	events, err := a.DB.GetBulkStateContent(ctx, req.RoomIDs, req.StateTuples, req.AllowWildcards)
 	if err != nil {

--- a/currentstateserver/inthttp/client.go
+++ b/currentstateserver/inthttp/client.go
@@ -50,18 +50,6 @@ type httpCurrentStateInternalAPI struct {
 	httpClient *http.Client
 }
 
-func (h *httpCurrentStateInternalAPI) QueryRoomsForUser(
-	ctx context.Context,
-	request *api.QueryRoomsForUserRequest,
-	response *api.QueryRoomsForUserResponse,
-) error {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "QueryRoomsForUser")
-	defer span.Finish()
-
-	apiURL := h.apiURL + QueryRoomsForUserPath
-	return httputil.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
-}
-
 func (h *httpCurrentStateInternalAPI) QueryBulkStateContent(
 	ctx context.Context,
 	request *api.QueryBulkStateContentRequest,

--- a/currentstateserver/inthttp/server.go
+++ b/currentstateserver/inthttp/server.go
@@ -25,19 +25,6 @@ import (
 )
 
 func AddRoutes(internalAPIMux *mux.Router, intAPI api.CurrentStateInternalAPI) {
-	internalAPIMux.Handle(QueryRoomsForUserPath,
-		httputil.MakeInternalAPI("queryRoomsForUser", func(req *http.Request) util.JSONResponse {
-			request := api.QueryRoomsForUserRequest{}
-			response := api.QueryRoomsForUserResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
-				return util.MessageResponse(http.StatusBadRequest, err.Error())
-			}
-			if err := intAPI.QueryRoomsForUser(req.Context(), &request, &response); err != nil {
-				return util.ErrorResponse(err)
-			}
-			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
-		}),
-	)
 	internalAPIMux.Handle(QueryBulkStateContentPath,
 		httputil.MakeInternalAPI("queryBulkStateContent", func(req *http.Request) util.JSONResponse {
 			request := api.QueryBulkStateContentRequest{}

--- a/federationsender/consumers/keychange.go
+++ b/federationsender/consumers/keychange.go
@@ -20,12 +20,12 @@ import (
 	"fmt"
 
 	"github.com/Shopify/sarama"
-	stateapi "github.com/matrix-org/dendrite/currentstateserver/api"
 	"github.com/matrix-org/dendrite/federationsender/queue"
 	"github.com/matrix-org/dendrite/federationsender/storage"
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/config"
 	"github.com/matrix-org/dendrite/keyserver/api"
+	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
 	log "github.com/sirupsen/logrus"
 )
@@ -36,7 +36,7 @@ type KeyChangeConsumer struct {
 	db         storage.Database
 	queues     *queue.OutgoingQueues
 	serverName gomatrixserverlib.ServerName
-	stateAPI   stateapi.CurrentStateInternalAPI
+	rsAPI      roomserverAPI.RoomserverInternalAPI
 }
 
 // NewKeyChangeConsumer creates a new KeyChangeConsumer. Call Start() to begin consuming from key servers.
@@ -45,7 +45,7 @@ func NewKeyChangeConsumer(
 	kafkaConsumer sarama.Consumer,
 	queues *queue.OutgoingQueues,
 	store storage.Database,
-	stateAPI stateapi.CurrentStateInternalAPI,
+	rsAPI roomserverAPI.RoomserverInternalAPI,
 ) *KeyChangeConsumer {
 	c := &KeyChangeConsumer{
 		consumer: &internal.ContinualConsumer{
@@ -57,7 +57,7 @@ func NewKeyChangeConsumer(
 		queues:     queues,
 		db:         store,
 		serverName: cfg.Matrix.ServerName,
-		stateAPI:   stateAPI,
+		rsAPI:      rsAPI,
 	}
 	c.consumer.ProcessMessage = c.onMessage
 
@@ -92,8 +92,8 @@ func (t *KeyChangeConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 		return nil
 	}
 
-	var queryRes stateapi.QueryRoomsForUserResponse
-	err = t.stateAPI.QueryRoomsForUser(context.Background(), &stateapi.QueryRoomsForUserRequest{
+	var queryRes roomserverAPI.QueryRoomsForUserResponse
+	err = t.rsAPI.QueryRoomsForUser(context.Background(), &roomserverAPI.QueryRoomsForUserRequest{
 		UserID:         m.UserID,
 		WantMembership: "join",
 	}, &queryRes)

--- a/federationsender/federationsender.go
+++ b/federationsender/federationsender.go
@@ -16,7 +16,6 @@ package federationsender
 
 import (
 	"github.com/gorilla/mux"
-	stateapi "github.com/matrix-org/dendrite/currentstateserver/api"
 	"github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/dendrite/federationsender/consumers"
 	"github.com/matrix-org/dendrite/federationsender/internal"
@@ -42,7 +41,6 @@ func NewInternalAPI(
 	base *setup.BaseDendrite,
 	federation *gomatrixserverlib.FederationClient,
 	rsAPI roomserverAPI.RoomserverInternalAPI,
-	stateAPI stateapi.CurrentStateInternalAPI,
 	keyRing *gomatrixserverlib.KeyRing,
 ) api.FederationSenderInternalAPI {
 	cfg := &base.Cfg.FederationSender
@@ -82,7 +80,7 @@ func NewInternalAPI(
 		logrus.WithError(err).Panic("failed to start typing server consumer")
 	}
 	keyConsumer := consumers.NewKeyChangeConsumer(
-		&base.Cfg.KeyServer, base.KafkaConsumer, queues, federationSenderDB, stateAPI,
+		&base.Cfg.KeyServer, base.KafkaConsumer, queues, federationSenderDB, rsAPI,
 	)
 	if err := keyConsumer.Start(); err != nil {
 		logrus.WithError(err).Panic("failed to start key server consumer")

--- a/syncapi/internal/keychange_test.go
+++ b/syncapi/internal/keychange_test.go
@@ -112,11 +112,6 @@ type mockStateAPI struct {
 	rsAPI *mockRoomserverAPI
 }
 
-// QueryRoomsForUser retrieves a list of room IDs matching the given query.
-func (s *mockStateAPI) QueryRoomsForUser(ctx context.Context, req *stateapi.QueryRoomsForUserRequest, res *stateapi.QueryRoomsForUserResponse) error {
-	return nil
-}
-
 // QueryBulkStateContent does a bulk query for state event content in the given rooms.
 func (s *mockStateAPI) QueryBulkStateContent(ctx context.Context, req *stateapi.QueryBulkStateContentRequest, res *stateapi.QueryBulkStateContentResponse) error {
 	var res2 api.QueryBulkStateContentResponse


### PR DESCRIPTION
This leaves `QueryBulkStateContent` which needs DB impl as well, then I can remove the current-state-server entirely.