### PR TITLE
Ignore state events with invalid signatures when joining rooms

### DIFF
--- a/federationsender/internal/perform.go
+++ b/federationsender/internal/perform.go
@@ -192,17 +192,6 @@ func (r *FederationSenderInternalAPI) performJoinUsingServer(
 		return fmt.Errorf("joinCtx.CheckSendJoinResponse: %w", err)
 	}
 
-	// Work out which events were not returned from checking the
-	// send_join response. We'll include these in a map so that we
-	// don't generate input events for them.
-	var invalidEventIDs map[string]bool
-	if invalid := respState.InvalidEventIDs(); len(invalid) > 0 {
-		invalidEventIDs = make(map[string]bool)
-		for _, eventID := range invalid {
-			invalidEventIDs[eventID] = true
-		}
-	}
-
 	// If we successfully performed a send_join above then the other
 	// server now thinks we're a part of the room. Send the newly
 	// returned state to the roomserver to update our local view.
@@ -210,7 +199,7 @@ func (r *FederationSenderInternalAPI) performJoinUsingServer(
 		ctx, r.rsAPI,
 		respState,
 		event.Headered(respMakeJoin.RoomVersion),
-		invalidEventIDs,
+		nil,
 	); err != nil {
 		return fmt.Errorf("r.producer.SendEventWithState: %w", err)
 	}

--- a/federationsender/internal/perform.go
+++ b/federationsender/internal/perform.go
@@ -185,19 +185,19 @@ func (r *FederationSenderInternalAPI) performJoinUsingServer(
 
 	// Check that the send_join response was valid.
 	joinCtx := perform.JoinContext(r.federation, r.keyRing)
-	if err = joinCtx.CheckSendJoinResponse(
+	respState, err := joinCtx.CheckSendJoinResponse(
 		ctx, event, serverName, respMakeJoin, respSendJoin,
-	); err != nil {
+	)
+	if err != nil {
 		return fmt.Errorf("joinCtx.CheckSendJoinResponse: %w", err)
 	}
 
 	// If we successfully performed a send_join above then the other
 	// server now thinks we're a part of the room. Send the newly
 	// returned state to the roomserver to update our local view.
-	respState := respSendJoin.ToRespState()
 	if err = roomserverAPI.SendEventWithState(
 		ctx, r.rsAPI,
-		&respState,
+		respState,
 		event.Headered(respMakeJoin.RoomVersion), nil,
 	); err != nil {
 		return fmt.Errorf("r.producer.SendEventWithState: %w", err)

--- a/federationsender/internal/perform/join.go
+++ b/federationsender/internal/perform/join.go
@@ -30,7 +30,7 @@ func (r joinContext) CheckSendJoinResponse(
 	server gomatrixserverlib.ServerName,
 	respMakeJoin gomatrixserverlib.RespMakeJoin,
 	respSendJoin gomatrixserverlib.RespSendJoin,
-) error {
+) (*gomatrixserverlib.RespState, error) {
 	// A list of events that we have retried, if they were not included in
 	// the auth events supplied in the send_join.
 	retries := map[string][]gomatrixserverlib.Event{}
@@ -97,8 +97,9 @@ func (r joinContext) CheckSendJoinResponse(
 
 	// TODO: Can we expand Check here to return a list of missing auth
 	// events rather than failing one at a time?
-	if err := respSendJoin.Check(ctx, r.keyRing, event, missingAuth); err != nil {
-		return fmt.Errorf("respSendJoin: %w", err)
+	rs, err := respSendJoin.Check(ctx, r.keyRing, event, missingAuth)
+	if err != nil {
+		return nil, fmt.Errorf("respSendJoin: %w", err)
 	}
-	return nil
+	return rs, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/matrix-org/go-http-js-libp2p v0.0.0-20200518170932-783164aeeda4
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20200522092705-bc8506ccbcf3
 	github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20200907140345-a4851252e384
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20200907143659-4b5669b82c8d
 	github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4
 	github.com/mattn/go-sqlite3 v1.14.2

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/matrix-org/go-http-js-libp2p v0.0.0-20200518170932-783164aeeda4
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20200522092705-bc8506ccbcf3
 	github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20200907133812-66753e24bdff
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20200907140345-a4851252e384
 	github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4
 	github.com/mattn/go-sqlite3 v1.14.2

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/matrix-org/go-http-js-libp2p v0.0.0-20200518170932-783164aeeda4
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20200522092705-bc8506ccbcf3
 	github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20200907150740-f193ad89f824
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20200907151926-38f437f2b2a6
 	github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4
 	github.com/mattn/go-sqlite3 v1.14.2

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/matrix-org/go-http-js-libp2p v0.0.0-20200518170932-783164aeeda4
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20200522092705-bc8506ccbcf3
 	github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20200907143659-4b5669b82c8d
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20200907150041-ff7f57818c81
 	github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4
 	github.com/mattn/go-sqlite3 v1.14.2

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/matrix-org/go-http-js-libp2p v0.0.0-20200518170932-783164aeeda4
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20200522092705-bc8506ccbcf3
 	github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20200907150041-ff7f57818c81
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20200907150740-f193ad89f824
 	github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4
 	github.com/mattn/go-sqlite3 v1.14.2

--- a/go.sum
+++ b/go.sum
@@ -567,8 +567,8 @@ github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26 h1:Hr3zjRsq2bh
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
 github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd h1:xVrqJK3xHREMNjwjljkAUaadalWc0rRbmVuQatzmgwg=
 github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200907150041-ff7f57818c81 h1:UGjwRtWVmc13iWOPCIJDJ8e5DxUGBsIrZ1p2LDKMEhM=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200907150041-ff7f57818c81/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200907150740-f193ad89f824 h1:zQFO+B6wsXzLgFw98KRK+URVP07YS1pF0rv/ay4LhGo=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200907150740-f193ad89f824/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
 github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91 h1:HJ6U3S3ljJqNffYMcIeAncp5qT/i+ZMiJ2JC2F0aXP4=
 github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91/go.mod h1:sjyPyRxKM5uw1nD2cJ6O2OxI6GOqyVBfNXqKjBZTBZE=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7 h1:ntrLa/8xVzeSs8vHFHK25k0C+NV74sYMJnNSg5NoSRo=

--- a/go.sum
+++ b/go.sum
@@ -567,8 +567,8 @@ github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26 h1:Hr3zjRsq2bh
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
 github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd h1:xVrqJK3xHREMNjwjljkAUaadalWc0rRbmVuQatzmgwg=
 github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200907133812-66753e24bdff h1:XSQSvCTLnohO5q4g11ezrUwd4sxPbcs27SqWKg/UhA0=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200907133812-66753e24bdff/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200907140345-a4851252e384 h1:ShZMM8Yh3mWtMUc7MubTrFM+3K/RYg36uXP7LnocxoM=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200907140345-a4851252e384/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
 github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91 h1:HJ6U3S3ljJqNffYMcIeAncp5qT/i+ZMiJ2JC2F0aXP4=
 github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91/go.mod h1:sjyPyRxKM5uw1nD2cJ6O2OxI6GOqyVBfNXqKjBZTBZE=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7 h1:ntrLa/8xVzeSs8vHFHK25k0C+NV74sYMJnNSg5NoSRo=

--- a/go.sum
+++ b/go.sum
@@ -567,8 +567,8 @@ github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26 h1:Hr3zjRsq2bh
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
 github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd h1:xVrqJK3xHREMNjwjljkAUaadalWc0rRbmVuQatzmgwg=
 github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200907143659-4b5669b82c8d h1:nHCJnv2QxP1eQzVhIl9Iwkc5wGaWTzOhcT7wfSpmRl8=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200907143659-4b5669b82c8d/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200907150041-ff7f57818c81 h1:UGjwRtWVmc13iWOPCIJDJ8e5DxUGBsIrZ1p2LDKMEhM=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200907150041-ff7f57818c81/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
 github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91 h1:HJ6U3S3ljJqNffYMcIeAncp5qT/i+ZMiJ2JC2F0aXP4=
 github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91/go.mod h1:sjyPyRxKM5uw1nD2cJ6O2OxI6GOqyVBfNXqKjBZTBZE=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7 h1:ntrLa/8xVzeSs8vHFHK25k0C+NV74sYMJnNSg5NoSRo=

--- a/go.sum
+++ b/go.sum
@@ -567,8 +567,8 @@ github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26 h1:Hr3zjRsq2bh
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
 github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd h1:xVrqJK3xHREMNjwjljkAUaadalWc0rRbmVuQatzmgwg=
 github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200907140345-a4851252e384 h1:ShZMM8Yh3mWtMUc7MubTrFM+3K/RYg36uXP7LnocxoM=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200907140345-a4851252e384/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200907143659-4b5669b82c8d h1:nHCJnv2QxP1eQzVhIl9Iwkc5wGaWTzOhcT7wfSpmRl8=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200907143659-4b5669b82c8d/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
 github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91 h1:HJ6U3S3ljJqNffYMcIeAncp5qT/i+ZMiJ2JC2F0aXP4=
 github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91/go.mod h1:sjyPyRxKM5uw1nD2cJ6O2OxI6GOqyVBfNXqKjBZTBZE=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7 h1:ntrLa/8xVzeSs8vHFHK25k0C+NV74sYMJnNSg5NoSRo=

--- a/go.sum
+++ b/go.sum
@@ -567,8 +567,8 @@ github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26 h1:Hr3zjRsq2bh
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
 github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd h1:xVrqJK3xHREMNjwjljkAUaadalWc0rRbmVuQatzmgwg=
 github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200907150740-f193ad89f824 h1:zQFO+B6wsXzLgFw98KRK+URVP07YS1pF0rv/ay4LhGo=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200907150740-f193ad89f824/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200907151926-38f437f2b2a6 h1:43gla6bLt4opWY1mQkAasF/LUCipZl7x2d44TY0wf40=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200907151926-38f437f2b2a6/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
 github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91 h1:HJ6U3S3ljJqNffYMcIeAncp5qT/i+ZMiJ2JC2F0aXP4=
 github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91/go.mod h1:sjyPyRxKM5uw1nD2cJ6O2OxI6GOqyVBfNXqKjBZTBZE=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7 h1:ntrLa/8xVzeSs8vHFHK25k0C+NV74sYMJnNSg5NoSRo=


### PR DESCRIPTION
This fixes the problem whereby an invalid signature on a single state event in a room would prevent you from being able to join the room by ensuring that we use the mutated `RespState`.

Closes #1401.