### PR TITLE
Backoff for 401s

### DIFF
--- a/federationsender/api/api.go
+++ b/federationsender/api/api.go
@@ -30,7 +30,7 @@ type FederationClientError struct {
 }
 
 func (e *FederationClientError) Error() string {
-	return fmt.Sprintf("%s - (retry_after=%d, blacklisted=%v)", e.Err, e.RetryAfter, e.Blacklisted)
+	return fmt.Sprintf("%s - (retry_after=%s, blacklisted=%v)", e.Err, e.RetryAfter.String(), e.Blacklisted)
 }
 
 // FederationSenderInternalAPI is used to query information from the federation sender.

--- a/federationsender/internal/api.go
+++ b/federationsender/internal/api.go
@@ -70,7 +70,10 @@ func failBlacklistableError(err error, stats *statistics.ServerStatistics) (unti
 	if !ok {
 		return stats.Failure()
 	}
-	if mxerr.Code >= 500 && mxerr.Code < 600 {
+	if mxerr.Code == 401 { // invalid signature in X-Matrix header
+		return stats.Failure()
+	}
+	if mxerr.Code >= 500 && mxerr.Code < 600 { // internal server errors
 		return stats.Failure()
 	}
 	return


### PR DESCRIPTION
This adds HTTP 401 to the list of backoff-inducing return codes, since it seems to be standard for the remote server to return a 401 if they can't validate our `X-Matrix` header.