### PR TITLE
Optional transactional isolation in Sync API

### DIFF
--- a/syncapi/storage/postgres/syncserver.go
+++ b/syncapi/storage/postgres/syncserver.go
@@ -79,17 +79,18 @@ func NewDatabase(dbProperties *config.DatabaseOptions) (*SyncServerDatasource, e
 		return nil, err
 	}
 	d.Database = shared.Database{
-		DB:                  d.db,
-		Writer:              d.writer,
-		Invites:             invites,
-		AccountData:         accountData,
-		OutputEvents:        events,
-		Topology:            topology,
-		CurrentRoomState:    currState,
-		BackwardExtremities: backwardExtremities,
-		Filter:              filter,
-		SendToDevice:        sendToDevice,
-		EDUCache:            cache.New(),
+		DB:                     d.db,
+		TransactionalIsolation: true,
+		Writer:                 d.writer,
+		Invites:                invites,
+		AccountData:            accountData,
+		OutputEvents:           events,
+		Topology:               topology,
+		CurrentRoomState:       currState,
+		BackwardExtremities:    backwardExtremities,
+		Filter:                 filter,
+		SendToDevice:           sendToDevice,
+		EDUCache:               cache.New(),
 	}
 	return &d, nil
 }

--- a/syncapi/storage/shared/syncserver.go
+++ b/syncapi/storage/shared/syncserver.go
@@ -429,7 +429,8 @@ func (d *Database) addPDUDeltaToResponse(
 	succeeded := false
 	defer func() {
 		_ = d.Writer.Do(d.DB, txn, func(txn *sql.Tx) error {
-			return sqlutil.EndTransactionWithCheck(txn, &succeeded, &err)
+			sqlutil.EndTransactionWithCheck(txn, &succeeded, &err)
+			return nil
 		})
 	}()
 
@@ -626,7 +627,8 @@ func (d *Database) getResponseWithPDUsForCompleteSync(
 	succeeded := false
 	defer func() {
 		_ = d.Writer.Do(d.DB, txn, func(txn *sql.Tx) error {
-			return sqlutil.EndTransactionWithCheck(txn, &succeeded, &err)
+			sqlutil.EndTransactionWithCheck(txn, &succeeded, &err)
+			return nil
 		})
 	}()
 

--- a/syncapi/storage/shared/syncserver.go
+++ b/syncapi/storage/shared/syncserver.go
@@ -427,7 +427,11 @@ func (d *Database) addPDUDeltaToResponse(
 		return nil, err
 	}
 	succeeded := false
-	defer sqlutil.EndTransactionWithCheck(txn, &succeeded, &err)
+	defer func() {
+		_ = d.Writer.Do(d.DB, txn, func(txn *sql.Tx) error {
+			return sqlutil.EndTransactionWithCheck(txn, &succeeded, &err)
+		})
+	}()
 
 	stateFilter := gomatrixserverlib.DefaultStateFilter() // TODO: use filter provided in request
 
@@ -620,7 +624,11 @@ func (d *Database) getResponseWithPDUsForCompleteSync(
 		return
 	}
 	succeeded := false
-	defer sqlutil.EndTransactionWithCheck(txn, &succeeded, &err)
+	defer func() {
+		_ = d.Writer.Do(d.DB, txn, func(txn *sql.Tx) error {
+			return sqlutil.EndTransactionWithCheck(txn, &succeeded, &err)
+		})
+	}()
 
 	// Get the current sync position which we will base the sync response on.
 	toPos, err = d.syncPositionTx(ctx, txn)

--- a/syncapi/storage/sqlite3/account_data_table.go
+++ b/syncapi/storage/sqlite3/account_data_table.go
@@ -20,6 +20,7 @@ import (
 	"database/sql"
 
 	"github.com/matrix-org/dendrite/internal"
+	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/syncapi/storage/tables"
 	"github.com/matrix-org/dendrite/syncapi/types"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -85,7 +86,7 @@ func (s *accountDataStatements) InsertAccountData(
 	if err != nil {
 		return
 	}
-	_, err = txn.Stmt(s.insertAccountDataStmt).ExecContext(ctx, pos, userID, roomID, dataType)
+	_, err = sqlutil.TxStmt(txn, s.insertAccountDataStmt).ExecContext(ctx, pos, userID, roomID, dataType)
 	return
 }
 
@@ -147,7 +148,7 @@ func (s *accountDataStatements) SelectMaxAccountDataID(
 	ctx context.Context, txn *sql.Tx,
 ) (id int64, err error) {
 	var nullableID sql.NullInt64
-	err = txn.Stmt(s.selectMaxAccountDataIDStmt).QueryRowContext(ctx).Scan(&nullableID)
+	err = sqlutil.TxStmt(txn, s.selectMaxAccountDataIDStmt).QueryRowContext(ctx).Scan(&nullableID)
 	if nullableID.Valid {
 		id = nullableID.Int64
 	}

--- a/syncapi/storage/sqlite3/syncserver.go
+++ b/syncapi/storage/sqlite3/syncserver.go
@@ -92,17 +92,18 @@ func (d *SyncServerDatasource) prepare() (err error) {
 		return err
 	}
 	d.Database = shared.Database{
-		DB:                  d.db,
-		Writer:              d.writer,
-		Invites:             invites,
-		AccountData:         accountData,
-		OutputEvents:        events,
-		BackwardExtremities: bwExtrem,
-		CurrentRoomState:    roomState,
-		Topology:            topology,
-		Filter:              filter,
-		SendToDevice:        sendToDevice,
-		EDUCache:            cache.New(),
+		DB:                     d.db,
+		TransactionalIsolation: false,
+		Writer:                 d.writer,
+		Invites:                invites,
+		AccountData:            accountData,
+		OutputEvents:           events,
+		BackwardExtremities:    bwExtrem,
+		CurrentRoomState:       roomState,
+		Topology:               topology,
+		Filter:                 filter,
+		SendToDevice:           sendToDevice,
+		EDUCache:               cache.New(),
 	}
 	return nil
 }


### PR DESCRIPTION
I suspect that the transaction that we open in the sync API may be causing `database is locked` errors. This disables it for SQLite.