### PR TITLE
Handle state with input event as new events

### DIFF
--- a/federationsender/consumers/roomserver.go
+++ b/federationsender/consumers/roomserver.go
@@ -139,7 +139,7 @@ func (s *OutputRoomEventConsumer) processMessage(ore api.OutputNewRoomEvent) err
 		return nil
 	}
 
-	if ore.SendAsServer == api.DoNotSendToOtherServers || ore.Type == api.OutputRoomState {
+	if ore.SendAsServer == api.DoNotSendToOtherServers {
 		// Ignore event that we don't need to send anywhere.
 		return nil
 	}

--- a/federationsender/consumers/roomserver.go
+++ b/federationsender/consumers/roomserver.go
@@ -110,9 +110,6 @@ func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 // processMessage updates the list of currently joined hosts in the room
 // and then sends the event to the hosts that were joined before the event.
 func (s *OutputRoomEventConsumer) processMessage(ore api.OutputNewRoomEvent) error {
-	if ore.Historical {
-		return nil
-	}
 
 	addsJoinedHosts, err := joinedHostsFromEvents(gomatrixserverlib.UnwrapEventHeaders(ore.AddsState()))
 	if err != nil {
@@ -143,7 +140,7 @@ func (s *OutputRoomEventConsumer) processMessage(ore api.OutputNewRoomEvent) err
 		return nil
 	}
 
-	if ore.SendAsServer == api.DoNotSendToOtherServers {
+	if ore.SendAsServer == api.DoNotSendToOtherServers || ore.Type == api.OutputRoomState {
 		// Ignore event that we don't need to send anywhere.
 		return nil
 	}

--- a/federationsender/consumers/roomserver.go
+++ b/federationsender/consumers/roomserver.go
@@ -110,7 +110,6 @@ func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 // processMessage updates the list of currently joined hosts in the room
 // and then sends the event to the hosts that were joined before the event.
 func (s *OutputRoomEventConsumer) processMessage(ore api.OutputNewRoomEvent) error {
-
 	addsJoinedHosts, err := joinedHostsFromEvents(gomatrixserverlib.UnwrapEventHeaders(ore.AddsState()))
 	if err != nil {
 		return err

--- a/federationsender/consumers/roomserver.go
+++ b/federationsender/consumers/roomserver.go
@@ -110,6 +110,10 @@ func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 // processMessage updates the list of currently joined hosts in the room
 // and then sends the event to the hosts that were joined before the event.
 func (s *OutputRoomEventConsumer) processMessage(ore api.OutputNewRoomEvent) error {
+	if ore.Historical {
+		return nil
+	}
+
 	addsJoinedHosts, err := joinedHostsFromEvents(gomatrixserverlib.UnwrapEventHeaders(ore.AddsState()))
 	if err != nil {
 		return err

--- a/federationsender/internal/perform.go
+++ b/federationsender/internal/perform.go
@@ -98,7 +98,10 @@ func (r *FederationSenderInternalAPI) PerformJoin(
 		response.LastError = &gomatrix.HTTPError{
 			Code:         0,
 			WrappedError: nil,
-			Message:      lastErr.Error(),
+			Message:      "Unknown HTTP error",
+		}
+		if lastErr != nil {
+			response.LastError.Message = lastErr.Error()
 		}
 	}
 

--- a/federationsender/internal/perform.go
+++ b/federationsender/internal/perform.go
@@ -108,6 +108,7 @@ func (r *FederationSenderInternalAPI) PerformJoin(
 	)
 }
 
+// nolint:gocyclo
 func (r *FederationSenderInternalAPI) performJoinUsingServer(
 	ctx context.Context,
 	roomID, userID string,
@@ -190,6 +191,19 @@ func (r *FederationSenderInternalAPI) performJoinUsingServer(
 	)
 	if err != nil {
 		return fmt.Errorf("joinCtx.CheckSendJoinResponse: %w", err)
+	}
+
+	// It's possible that the remote server has included our new
+	// membership event in the room state in the send_join response,
+	// but if that's the case, then we'll get a duplicate state block
+	// error if we try to send that along with our own copy of the
+	// event. The simple way around this is just to prune the event
+	// from the state if we find it.
+	for i, ev := range respState.StateEvents {
+		if ev.Type() == gomatrixserverlib.MRoomMember && ev.StateKeyEquals(userID) {
+			respState.StateEvents = append(respState.StateEvents[i:], respState.StateEvents[:i+1]...)
+			break
+		}
 	}
 
 	// If we successfully performed a send_join above then the other

--- a/federationsender/internal/perform.go
+++ b/federationsender/internal/perform.go
@@ -193,19 +193,6 @@ func (r *FederationSenderInternalAPI) performJoinUsingServer(
 		return fmt.Errorf("joinCtx.CheckSendJoinResponse: %w", err)
 	}
 
-	// It's possible that the remote server has included our new
-	// membership event in the room state in the send_join response,
-	// but if that's the case, then we'll get a duplicate state block
-	// error if we try to send that along with our own copy of the
-	// event. The simple way around this is just to prune the event
-	// from the state if we find it.
-	for i, ev := range respState.StateEvents {
-		if ev.Type() == gomatrixserverlib.MRoomMember && ev.StateKeyEquals(userID) {
-			respState.StateEvents = append(respState.StateEvents[i:], respState.StateEvents[:i+1]...)
-			break
-		}
-	}
-
 	// If we successfully performed a send_join above then the other
 	// server now thinks we're a part of the room. Send the newly
 	// returned state to the roomserver to update our local view.

--- a/federationsender/internal/perform.go
+++ b/federationsender/internal/perform.go
@@ -108,7 +108,6 @@ func (r *FederationSenderInternalAPI) PerformJoin(
 	)
 }
 
-// nolint:gocyclo
 func (r *FederationSenderInternalAPI) performJoinUsingServer(
 	ctx context.Context,
 	roomID, userID string,

--- a/federationsender/internal/perform.go
+++ b/federationsender/internal/perform.go
@@ -198,7 +198,7 @@ func (r *FederationSenderInternalAPI) performJoinUsingServer(
 	// If we successfully performed a send_join above then the other
 	// server now thinks we're a part of the room. Send the newly
 	// returned state to the roomserver to update our local view.
-	if err = roomserverAPI.SendEventWithState(
+	if err = roomserverAPI.SendEventWithRewrite(
 		ctx, r.rsAPI,
 		respState,
 		event.Headered(respMakeJoin.RoomVersion),

--- a/roomserver/api/input.go
+++ b/roomserver/api/input.go
@@ -33,6 +33,10 @@ const (
 	// KindBackfill event extend the contiguous graph going backwards.
 	// They always have state.
 	KindBackfill = 3
+	// KindRewrite events are used to rewrite the head of the graph.
+	// They are used in state, forward extremity and membership updates
+	// but are not sent as output events.
+	KindRewrite = 4
 )
 
 // DoNotSendToOtherServers tells us not to send the event to other matrix

--- a/roomserver/api/input.go
+++ b/roomserver/api/input.go
@@ -33,9 +33,9 @@ const (
 	// KindBackfill event extend the contiguous graph going backwards.
 	// They always have state.
 	KindBackfill = 3
-	// KindRewrite events are used to rewrite the head of the graph.
-	// They are used in state, forward extremity and membership updates
-	// but are not sent as output events.
+	// KindRewrite events are used when rewriting the head of the room
+	// graph with entirely new state. The output events generated will
+	// be state events rather than timeline events.
 	KindRewrite = 4
 )
 

--- a/roomserver/api/output.go
+++ b/roomserver/api/output.go
@@ -75,6 +75,9 @@ type OutputEvent struct {
 type OutputNewRoomEvent struct {
 	// The Event.
 	Event gomatrixserverlib.HeaderedEvent `json:"event"`
+	// Is the event historical? If so, then downstream components should not treat the
+	// event as if it just arrived.
+	Historical bool `json:"historical"`
 	// The latest events in the room after this event.
 	// This can be used to set the prev events for new events in the room.
 	// This also can be used to get the full current state after this event.

--- a/roomserver/api/output.go
+++ b/roomserver/api/output.go
@@ -63,6 +63,17 @@ type OutputEvent struct {
 	RedactedEvent *OutputRedactedEvent `json:"redacted_event,omitempty"`
 }
 
+// Type of the OutputNewRoomEvent.
+type OutputRoomEventType int
+
+const (
+	// The event is a timeline event and likely just happened.
+	OutputRoomTimeline OutputRoomEventType = iota
+
+	// The event is a state event and quite possibly happened in the past.
+	OutputRoomState
+)
+
 // An OutputNewRoomEvent is written when the roomserver receives a new event.
 // It contains the full matrix room event and enough information for a
 // consumer to construct the current state of the room and the state before the
@@ -75,9 +86,9 @@ type OutputEvent struct {
 type OutputNewRoomEvent struct {
 	// The Event.
 	Event gomatrixserverlib.HeaderedEvent `json:"event"`
-	// Is the event historical? If so, then downstream components should not treat the
-	// event as if it just arrived.
-	Historical bool `json:"historical"`
+	// Is the event a timeline event or a state event? Defaults to timeline
+	// if not specified.
+	Type OutputRoomEventType `json:"type"`
 	// The latest events in the room after this event.
 	// This can be used to set the prev events for new events in the room.
 	// This also can be used to get the full current state after this event.

--- a/roomserver/api/output.go
+++ b/roomserver/api/output.go
@@ -86,9 +86,9 @@ const (
 type OutputNewRoomEvent struct {
 	// The Event.
 	Event gomatrixserverlib.HeaderedEvent `json:"event"`
-	// Is the event a timeline event or a state event? Defaults to timeline
-	// if not specified.
-	Type OutputRoomEventType `json:"type"`
+	// Does the event completely rewrite the room state? If so, then AddsStateEventIDs
+	// will contain the entire room state.
+	RewritesState bool `json:"rewrites_state"`
 	// The latest events in the room after this event.
 	// This can be used to set the prev events for new events in the room.
 	// This also can be used to get the full current state after this event.

--- a/roomserver/api/wrapper.go
+++ b/roomserver/api/wrapper.go
@@ -53,15 +53,20 @@ func SendEventWithState(
 	}
 
 	var ires []InputRoomEvent
+	var stateIDs []string
+
 	for _, outlier := range outliers {
 		if haveEventIDs[outlier.EventID()] {
 			continue
 		}
 		ires = append(ires, InputRoomEvent{
-			Kind:         KindOutlier,
-			Event:        outlier.Headered(event.RoomVersion),
-			AuthEventIDs: outlier.AuthEventIDs(),
+			Kind:          KindNew,
+			Event:         outlier.Headered(event.RoomVersion),
+			AuthEventIDs:  outlier.AuthEventIDs(),
+			HasState:      true,
+			StateEventIDs: stateIDs,
 		})
+		stateIDs = append(stateIDs, outlier.EventID())
 	}
 
 	stateEventIDs := make([]string, len(state.StateEvents))

--- a/roomserver/api/wrapper.go
+++ b/roomserver/api/wrapper.go
@@ -69,17 +69,12 @@ func SendEventWithState(
 		stateIDs = append(stateIDs, outlier.EventID())
 	}
 
-	stateEventIDs := make([]string, len(state.StateEvents))
-	for i := range state.StateEvents {
-		stateEventIDs[i] = state.StateEvents[i].EventID()
-	}
-
 	ires = append(ires, InputRoomEvent{
 		Kind:          KindNew,
 		Event:         event,
 		AuthEventIDs:  event.AuthEventIDs(),
 		HasState:      true,
-		StateEventIDs: stateEventIDs,
+		StateEventIDs: stateIDs,
 	})
 
 	return SendInputRoomEvents(ctx, rsAPI, ires)

--- a/roomserver/api/wrapper.go
+++ b/roomserver/api/wrapper.go
@@ -76,7 +76,7 @@ func SendEventWithState(
 			continue
 		}
 		ires = append(ires, InputRoomEvent{
-			Kind:          KindNew,
+			Kind:          KindRewrite,
 			Event:         stateEvent.Headered(event.RoomVersion),
 			AuthEventIDs:  stateEvent.AuthEventIDs(),
 			HasState:      true,

--- a/roomserver/internal/helpers/auth.go
+++ b/roomserver/internal/helpers/auth.go
@@ -36,7 +36,7 @@ func CheckAuthEvents(
 	if err != nil {
 		return nil, err
 	}
-	// TODO: check for duplicate state keys here.
+	authStateEntries = types.DeduplicateStateEntries(authStateEntries)
 
 	// Work out which of the state events we actually need.
 	stateNeeded := gomatrixserverlib.StateNeededForAuth([]gomatrixserverlib.Event{event.Unwrap()})

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -108,12 +108,13 @@ func (r *Inputer) processRoomEvent(
 	}
 
 	if err = r.updateLatestEvents(
-		ctx,                 // context
-		roomInfo,            // room info for the room being updated
-		stateAtEvent,        // state at event (below)
-		event,               // event
-		input.SendAsServer,  // send as server
-		input.TransactionID, // transaction ID
+		ctx,                       // context
+		roomInfo,                  // room info for the room being updated
+		stateAtEvent,              // state at event (below)
+		event,                     // event
+		input.SendAsServer,        // send as server
+		input.TransactionID,       // transaction ID
+		input.Kind == api.KindNew, // should we send output events?
 	); err != nil {
 		return "", fmt.Errorf("r.updateLatestEvents: %w", err)
 	}

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -86,7 +86,7 @@ func (r *Inputer) processRoomEvent(
 			"event_id": event.EventID(),
 			"type":     event.Type(),
 			"room":     event.RoomID(),
-		}).Info("Stored outlier")
+		}).Debug("Stored outlier")
 		return event.EventID(), nil
 	}
 
@@ -107,14 +107,23 @@ func (r *Inputer) processRoomEvent(
 		}
 	}
 
+	if input.Kind == api.KindRewrite {
+		logrus.WithFields(logrus.Fields{
+			"event_id": event.EventID(),
+			"type":     event.Type(),
+			"room":     event.RoomID(),
+		}).Debug("Stored rewrite")
+		return event.EventID(), nil
+	}
+
 	if err = r.updateLatestEvents(
-		ctx,                           // context
-		roomInfo,                      // room info for the room being updated
-		stateAtEvent,                  // state at event (below)
-		event,                         // event
-		input.SendAsServer,            // send as server
-		input.TransactionID,           // transaction ID
-		input.Kind == api.KindRewrite, // historical
+		ctx,                 // context
+		roomInfo,            // room info for the room being updated
+		stateAtEvent,        // state at event (below)
+		event,               // event
+		input.SendAsServer,  // send as server
+		input.TransactionID, // transaction ID
+		input.HasState,      // rewrites state?
 	); err != nil {
 		return "", fmt.Errorf("r.updateLatestEvents: %w", err)
 	}

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -170,6 +170,7 @@ func (r *Inputer) calculateAndSetState(
 		if entries, err = r.DB.StateEntriesForEventIDs(ctx, input.StateEventIDs); err != nil {
 			return fmt.Errorf("r.DB.StateEntriesForEventIDs: %w", err)
 		}
+		entries = types.DeduplicateStateEntries(entries)
 
 		if stateAtEvent.BeforeStateSnapshotNID, err = r.DB.AddState(ctx, roomInfo.RoomNID, nil, entries); err != nil {
 			return fmt.Errorf("r.DB.AddState: %w", err)

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -108,13 +108,13 @@ func (r *Inputer) processRoomEvent(
 	}
 
 	if err = r.updateLatestEvents(
-		ctx,                       // context
-		roomInfo,                  // room info for the room being updated
-		stateAtEvent,              // state at event (below)
-		event,                     // event
-		input.SendAsServer,        // send as server
-		input.TransactionID,       // transaction ID
-		input.Kind == api.KindNew, // should we send output events?
+		ctx,                           // context
+		roomInfo,                      // room info for the room being updated
+		stateAtEvent,                  // state at event (below)
+		event,                         // event
+		input.SendAsServer,            // send as server
+		input.TransactionID,           // transaction ID
+		input.Kind != api.KindRewrite, // should we send output events?
 	); err != nil {
 		return "", fmt.Errorf("r.updateLatestEvents: %w", err)
 	}

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -167,19 +167,24 @@ func (r *Inputer) calculateAndSetState(
 		// Check that those state events are in the database and store the state.
 		var entries []types.StateEntry
 		if entries, err = r.DB.StateEntriesForEventIDs(ctx, input.StateEventIDs); err != nil {
-			return err
+			return fmt.Errorf("r.DB.StateEntriesForEventIDs: %w", err)
 		}
 
 		if stateAtEvent.BeforeStateSnapshotNID, err = r.DB.AddState(ctx, roomInfo.RoomNID, nil, entries); err != nil {
-			return err
+			return fmt.Errorf("r.DB.AddState: %w", err)
 		}
 	} else {
 		stateAtEvent.Overwrite = false
 
 		// We haven't been told what the state at the event is so we need to calculate it from the prev_events
 		if stateAtEvent.BeforeStateSnapshotNID, err = roomState.CalculateAndStoreStateBeforeEvent(ctx, event); err != nil {
-			return err
+			return fmt.Errorf("roomState.CalculateAndStoreStateBeforeEvent: %w", err)
 		}
 	}
-	return r.DB.SetState(ctx, stateAtEvent.EventNID, stateAtEvent.BeforeStateSnapshotNID)
+
+	err = r.DB.SetState(ctx, stateAtEvent.EventNID, stateAtEvent.BeforeStateSnapshotNID)
+	if err != nil {
+		return fmt.Errorf("r.DB.SetState: %w", err)
+	}
+	return nil
 }

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -114,7 +114,7 @@ func (r *Inputer) processRoomEvent(
 		event,                         // event
 		input.SendAsServer,            // send as server
 		input.TransactionID,           // transaction ID
-		input.Kind != api.KindRewrite, // should we send output events?
+		input.Kind == api.KindRewrite, // historical
 	); err != nil {
 		return "", fmt.Errorf("r.updateLatestEvents: %w", err)
 	}

--- a/roomserver/internal/input/input_latest_events.go
+++ b/roomserver/internal/input/input_latest_events.go
@@ -54,6 +54,7 @@ func (r *Inputer) updateLatestEvents(
 	event gomatrixserverlib.Event,
 	sendAsServer string,
 	transactionID *api.TransactionID,
+	sendOutput bool,
 ) (err error) {
 	updater, err := r.DB.GetLatestEventsForUpdate(ctx, *roomInfo)
 	if err != nil {
@@ -71,6 +72,7 @@ func (r *Inputer) updateLatestEvents(
 		event:         event,
 		sendAsServer:  sendAsServer,
 		transactionID: transactionID,
+		sendOutput:    sendOutput,
 	}
 
 	if err = u.doUpdateLatestEvents(); err != nil {
@@ -93,6 +95,7 @@ type latestEventsUpdater struct {
 	stateAtEvent  types.StateAtEvent
 	event         gomatrixserverlib.Event
 	transactionID *api.TransactionID
+	sendOutput    bool
 	// Which server to send this event as.
 	sendAsServer string
 	// The eventID of the event that was processed before this one.
@@ -178,30 +181,35 @@ func (u *latestEventsUpdater) doUpdateLatestEvents() error {
 		return fmt.Errorf("u.api.updateMemberships: %w", err)
 	}
 
-	update, err := u.makeOutputNewRoomEvent()
-	if err != nil {
-		return fmt.Errorf("u.makeOutputNewRoomEvent: %w", err)
-	}
-	updates = append(updates, *update)
+	if u.sendOutput {
+		var update *api.OutputEvent
+		update, err = u.makeOutputNewRoomEvent()
+		if err != nil {
+			return fmt.Errorf("u.makeOutputNewRoomEvent: %w", err)
+		}
+		updates = append(updates, *update)
 
-	// Send the event to the output logs.
-	// We do this inside the database transaction to ensure that we only mark an event as sent if we sent it.
-	// (n.b. this means that it's possible that the same event will be sent twice if the transaction fails but
-	//  the write to the output log succeeds)
-	// TODO: This assumes that writing the event to the output log is synchronous. It should be possible to
-	// send the event asynchronously but we would need to ensure that 1) the events are written to the log in
-	// the correct order, 2) that pending writes are resent across restarts. In order to avoid writing all the
-	// necessary bookkeeping we'll keep the event sending synchronous for now.
-	if err = u.api.WriteOutputEvents(u.event.RoomID(), updates); err != nil {
-		return fmt.Errorf("u.api.WriteOutputEvents: %w", err)
+		// Send the event to the output logs.
+		// We do this inside the database transaction to ensure that we only mark an event as sent if we sent it.
+		// (n.b. this means that it's possible that the same event will be sent twice if the transaction fails but
+		//  the write to the output log succeeds)
+		// TODO: This assumes that writing the event to the output log is synchronous. It should be possible to
+		// send the event asynchronously but we would need to ensure that 1) the events are written to the log in
+		// the correct order, 2) that pending writes are resent across restarts. In order to avoid writing all the
+		// necessary bookkeeping we'll keep the event sending synchronous for now.
+		if err = u.api.WriteOutputEvents(u.event.RoomID(), updates); err != nil {
+			return fmt.Errorf("u.api.WriteOutputEvents: %w", err)
+		}
 	}
 
 	if err = u.updater.SetLatestEvents(u.roomInfo.RoomNID, u.latest, u.stateAtEvent.EventNID, u.newStateNID); err != nil {
 		return fmt.Errorf("u.updater.SetLatestEvents: %w", err)
 	}
 
-	if err = u.updater.MarkEventAsSent(u.stateAtEvent.EventNID); err != nil {
-		return fmt.Errorf("u.updater.MarkEventAsSent: %w", err)
+	if u.sendOutput {
+		if err = u.updater.MarkEventAsSent(u.stateAtEvent.EventNID); err != nil {
+			return fmt.Errorf("u.updater.MarkEventAsSent: %w", err)
+		}
 	}
 
 	return nil

--- a/roomserver/internal/input/input_latest_events.go
+++ b/roomserver/internal/input/input_latest_events.go
@@ -307,9 +307,14 @@ func (u *latestEventsUpdater) makeOutputNewRoomEvent() (*api.OutputEvent, error)
 		latestEventIDs[i] = u.latest[i].EventID
 	}
 
+	var outputType api.OutputRoomEventType
+	if u.isHistorical {
+		outputType = api.OutputRoomState
+	}
+
 	ore := api.OutputNewRoomEvent{
 		Event:           u.event.Headered(u.roomInfo.RoomVersion),
-		Historical:      u.isHistorical,
+		Type:            outputType,
 		LastSentEventID: u.lastEventIDSent,
 		LatestEventIDs:  latestEventIDs,
 		TransactionID:   u.transactionID,

--- a/roomserver/internal/input/input_latest_events.go
+++ b/roomserver/internal/input/input_latest_events.go
@@ -54,7 +54,7 @@ func (r *Inputer) updateLatestEvents(
 	event gomatrixserverlib.Event,
 	sendAsServer string,
 	transactionID *api.TransactionID,
-	sendOutput bool,
+	isHistorical bool,
 ) (err error) {
 	updater, err := r.DB.GetLatestEventsForUpdate(ctx, *roomInfo)
 	if err != nil {
@@ -72,7 +72,7 @@ func (r *Inputer) updateLatestEvents(
 		event:         event,
 		sendAsServer:  sendAsServer,
 		transactionID: transactionID,
-		isHistorical:  sendOutput,
+		isHistorical:  isHistorical,
 	}
 
 	if err = u.doUpdateLatestEvents(); err != nil {

--- a/roomserver/internal/input/input_latest_events.go
+++ b/roomserver/internal/input/input_latest_events.go
@@ -342,6 +342,11 @@ func (u *latestEventsUpdater) makeOutputNewRoomEvent() (*api.OutputEvent, error)
 			return nil, fmt.Errorf("failed to load add_state_events from db: %w", err)
 		}
 	}
+	// State is rewritten if the input room event HasState and we actually produced a delta on state events.
+	// Without this check, /get_missing_events which produce events with associated (but not complete) state
+	// will incorrectly purge the room and set it to no state. TODO: This is likely flakey, as if /gme produced
+	// a state conflict res which just so happens to include 2+ events we might purge the room state downstream.
+	ore.RewritesState = len(ore.AddsStateEventIDs) > 1
 
 	return &api.OutputEvent{
 		Type:         api.OutputTypeNewRoomEvent,

--- a/roomserver/internal/perform/perform_join.go
+++ b/roomserver/internal/perform/perform_join.go
@@ -192,7 +192,6 @@ func (r *Joiner) performJoinRoomByID(
 	// and we aren't in the room.
 	isInvitePending, inviteSender, _, err := helpers.IsInvitePending(ctx, r.DB, req.RoomIDOrAlias, req.UserID)
 	if err == nil && isInvitePending {
-		forceFederatedJoin = true
 		_, inviterDomain, ierr := gomatrixserverlib.SplitID('@', inviteSender)
 		if ierr != nil {
 			return "", fmt.Errorf("gomatrixserverlib.SplitID: %w", err)
@@ -202,6 +201,7 @@ func (r *Joiner) performJoinRoomByID(
 		// assume they are in the room so we can join via them.
 		if inviterDomain != r.Cfg.Matrix.ServerName {
 			req.ServerNames = append(req.ServerNames, inviterDomain)
+			forceFederatedJoin = true
 		}
 	}
 

--- a/roomserver/internal/perform/perform_join.go
+++ b/roomserver/internal/perform/perform_join.go
@@ -25,7 +25,6 @@ import (
 	"github.com/matrix-org/dendrite/internal/config"
 	"github.com/matrix-org/dendrite/internal/eventutil"
 	"github.com/matrix-org/dendrite/roomserver/api"
-	"github.com/matrix-org/dendrite/roomserver/auth"
 	"github.com/matrix-org/dendrite/roomserver/internal/helpers"
 	"github.com/matrix-org/dendrite/roomserver/internal/input"
 	"github.com/matrix-org/dendrite/roomserver/storage"
@@ -333,20 +332,6 @@ func buildEvent(
 	}, &queryRes)
 	if err != nil {
 		return nil, nil, fmt.Errorf("QueryLatestEventsAndState: %w", err)
-	}
-
-	// If we know about any membership events in this room, check and see
-	// if we still believe any of our users to be in the room. If not, then
-	// returning that the room doesn't exist will kick the room join over
-	// to a federated join. If we don't know about any of the membership
-	// events then it's probably a new local room so do nothing.
-	for _, ev := range queryRes.StateEvents {
-		if ev.Type() == gomatrixserverlib.MRoomMember {
-			if !auth.IsAnyUserOnServerWithMembership(cfg.ServerName, gomatrixserverlib.UnwrapEventHeaders(queryRes.StateEvents), "join") {
-				return nil, nil, eventutil.ErrRoomNoExists
-			}
-			break
-		}
 	}
 
 	ev, err := eventutil.BuildEvent(ctx, builder, cfg, time.Now(), &eventsNeeded, &queryRes)

--- a/roomserver/internal/perform/perform_join.go
+++ b/roomserver/internal/perform/perform_join.go
@@ -192,7 +192,7 @@ func (r *Joiner) performJoinRoomByID(
 	serverInRoom, _ := helpers.IsServerCurrentlyInRoom(ctx, r.DB, r.ServerName, req.RoomIDOrAlias)
 	isInvitePending, inviteSender, _, err := helpers.IsInvitePending(ctx, r.DB, req.RoomIDOrAlias, req.UserID)
 	if !serverInRoom || (err == nil && isInvitePending) {
-		if inviteSender != "" {
+		if err == nil && inviteSender != "" {
 			// Check if there's an invite pending.
 			_, inviterDomain, ierr := gomatrixserverlib.SplitID('@', inviteSender)
 			if ierr != nil {

--- a/roomserver/internal/perform/perform_join.go
+++ b/roomserver/internal/perform/perform_join.go
@@ -25,6 +25,7 @@ import (
 	"github.com/matrix-org/dendrite/internal/config"
 	"github.com/matrix-org/dendrite/internal/eventutil"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/auth"
 	"github.com/matrix-org/dendrite/roomserver/internal/helpers"
 	"github.com/matrix-org/dendrite/roomserver/internal/input"
 	"github.com/matrix-org/dendrite/roomserver/storage"
@@ -332,6 +333,10 @@ func buildEvent(
 	}, &queryRes)
 	if err != nil {
 		return nil, nil, fmt.Errorf("QueryLatestEventsAndState: %w", err)
+	}
+
+	if !auth.IsAnyUserOnServerWithMembership(cfg.ServerName, gomatrixserverlib.UnwrapEventHeaders(queryRes.StateEvents), "join") {
+		return nil, nil, eventutil.ErrRoomNoExists
 	}
 
 	ev, err := eventutil.BuildEvent(ctx, builder, cfg, time.Now(), &eventsNeeded, &queryRes)

--- a/roomserver/roomserver_test.go
+++ b/roomserver/roomserver_test.go
@@ -1,12 +1,15 @@
 package roomserver
 
 import (
+	"bytes"
 	"context"
+	"crypto/ed25519"
 	"encoding/json"
 	"fmt"
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/Shopify/sarama"
 	"github.com/matrix-org/dendrite/internal/caching"
@@ -80,7 +83,73 @@ func deleteDatabase() {
 	}
 }
 
-func mustLoadEvents(t *testing.T, ver gomatrixserverlib.RoomVersion, events []json.RawMessage) []gomatrixserverlib.HeaderedEvent {
+type fledglingEvent struct {
+	Type     string
+	StateKey *string
+	Content  interface{}
+	Sender   string
+	RoomID   string
+}
+
+func mustCreateEvents(t *testing.T, roomVer gomatrixserverlib.RoomVersion, events []fledglingEvent) (result []gomatrixserverlib.HeaderedEvent) {
+	t.Helper()
+	depth := int64(1)
+	seed := make([]byte, ed25519.SeedSize) // zero seed
+	key := ed25519.NewKeyFromSeed(seed)
+	var prevs []string
+	roomState := make(map[gomatrixserverlib.StateKeyTuple]string) // state -> event ID
+	for _, ev := range events {
+		eb := gomatrixserverlib.EventBuilder{
+			Sender:     ev.Sender,
+			Depth:      depth,
+			Type:       ev.Type,
+			StateKey:   ev.StateKey,
+			RoomID:     ev.RoomID,
+			PrevEvents: prevs,
+		}
+		err := eb.SetContent(ev.Content)
+		if err != nil {
+			t.Fatalf("mustCreateEvent: failed to marshal event content %+v", ev.Content)
+		}
+		stateNeeded, err := gomatrixserverlib.StateNeededForEventBuilder(&eb)
+		if err != nil {
+			t.Fatalf("mustCreateEvent: failed to work out auth_events : %s", err)
+		}
+		var authEvents []string
+		for _, tuple := range stateNeeded.Tuples() {
+			eventID := roomState[tuple]
+			if eventID != "" {
+				authEvents = append(authEvents, eventID)
+			}
+		}
+		eb.AuthEvents = authEvents
+		signedEvent, err := eb.Build(time.Now(), testOrigin, "ed25519:test", key, roomVer)
+		if err != nil {
+			t.Fatalf("mustCreateEvent: failed to sign event: %s", err)
+		}
+		depth++
+		prevs = []string{signedEvent.EventID()}
+		if ev.StateKey != nil {
+			roomState[gomatrixserverlib.StateKeyTuple{
+				EventType: ev.Type,
+				StateKey:  *ev.StateKey,
+			}] = signedEvent.EventID()
+		}
+		result = append(result, signedEvent.Headered(roomVer))
+	}
+	return
+}
+
+func eventsJSON(events []gomatrixserverlib.Event) []json.RawMessage {
+	result := make([]json.RawMessage, len(events))
+	for i := range events {
+		result[i] = events[i].JSON()
+	}
+	return result
+}
+
+func mustLoadRawEvents(t *testing.T, ver gomatrixserverlib.RoomVersion, events []json.RawMessage) []gomatrixserverlib.HeaderedEvent {
+	t.Helper()
 	hs := make([]gomatrixserverlib.HeaderedEvent, len(events))
 	for i := range events {
 		e, err := gomatrixserverlib.NewEventFromTrustedJSON(events[i], false, ver)
@@ -93,7 +162,8 @@ func mustLoadEvents(t *testing.T, ver gomatrixserverlib.RoomVersion, events []js
 	return hs
 }
 
-func mustSendEvents(t *testing.T, ver gomatrixserverlib.RoomVersion, events []json.RawMessage) (api.RoomserverInternalAPI, *dummyProducer, []gomatrixserverlib.HeaderedEvent) {
+func mustCreateRoomserverAPI(t *testing.T) (api.RoomserverInternalAPI, *dummyProducer) {
+	t.Helper()
 	cfg := &config.Dendrite{}
 	cfg.Defaults()
 	cfg.Global.ServerName = testOrigin
@@ -112,9 +182,14 @@ func mustSendEvents(t *testing.T, ver gomatrixserverlib.RoomVersion, events []js
 		Cfg:           cfg,
 	}
 
-	rsAPI := NewInternalAPI(base, &test.NopJSONVerifier{})
-	hevents := mustLoadEvents(t, ver, events)
-	if err = api.SendEvents(ctx, rsAPI, hevents, testOrigin, nil); err != nil {
+	return NewInternalAPI(base, &test.NopJSONVerifier{}), dp
+}
+
+func mustSendEvents(t *testing.T, ver gomatrixserverlib.RoomVersion, events []json.RawMessage) (api.RoomserverInternalAPI, *dummyProducer, []gomatrixserverlib.HeaderedEvent) {
+	t.Helper()
+	rsAPI, dp := mustCreateRoomserverAPI(t)
+	hevents := mustLoadRawEvents(t, ver, events)
+	if err := api.SendEvents(ctx, rsAPI, hevents, testOrigin, nil); err != nil {
 		t.Errorf("failed to SendEvents: %s", err)
 	}
 	return rsAPI, dp, hevents
@@ -168,5 +243,165 @@ func TestOutputRedactedEvent(t *testing.T) {
 		if !reflect.DeepEqual(*redactedOutputs[i].RedactedEvent, *wantRedactedOutputs[i].RedactedEvent) {
 			t.Errorf("OutputRedactionEvent %d: wrong event got:\n%+v want:\n%+v", i+1, redactedOutputs[i].RedactedEvent, wantRedactedOutputs[i].RedactedEvent)
 		}
+	}
+}
+
+// This tests that rewriting state via KindRewrite works correctly.
+// This creates a small room with a create/join/name state, then replays it
+// with a new room name. We expect the output events to contain the original events,
+// followed by a single OutputNewRoomEvent with RewritesState set to true with the
+// rewritten state events (with the 2nd room name).
+func TestOutputRewritesState(t *testing.T) {
+	roomID := "!foo:" + string(testOrigin)
+	alice := "@alice:" + string(testOrigin)
+	emptyKey := ""
+	originalEvents := mustCreateEvents(t, gomatrixserverlib.RoomVersionV6, []fledglingEvent{
+		{
+			RoomID: roomID,
+			Sender: alice,
+			Content: map[string]interface{}{
+				"creator":      alice,
+				"room_version": "6",
+			},
+			StateKey: &emptyKey,
+			Type:     gomatrixserverlib.MRoomCreate,
+		},
+		{
+			RoomID: roomID,
+			Sender: alice,
+			Content: map[string]interface{}{
+				"membership": "join",
+			},
+			StateKey: &alice,
+			Type:     gomatrixserverlib.MRoomMember,
+		},
+		{
+			RoomID: roomID,
+			Sender: alice,
+			Content: map[string]interface{}{
+				"body": "hello world",
+			},
+			StateKey: nil,
+			Type:     "m.room.message",
+		},
+		{
+			RoomID: roomID,
+			Sender: alice,
+			Content: map[string]interface{}{
+				"name": "Room Name",
+			},
+			StateKey: &emptyKey,
+			Type:     "m.room.name",
+		},
+	})
+	rewriteEvents := mustCreateEvents(t, gomatrixserverlib.RoomVersionV6, []fledglingEvent{
+		{
+			RoomID: roomID,
+			Sender: alice,
+			Content: map[string]interface{}{
+				"creator": alice,
+			},
+			StateKey: &emptyKey,
+			Type:     gomatrixserverlib.MRoomCreate,
+		},
+		{
+			RoomID: roomID,
+			Sender: alice,
+			Content: map[string]interface{}{
+				"membership": "join",
+			},
+			StateKey: &alice,
+			Type:     gomatrixserverlib.MRoomMember,
+		},
+		{
+			RoomID: roomID,
+			Sender: alice,
+			Content: map[string]interface{}{
+				"name": "Room Name 2",
+			},
+			StateKey: &emptyKey,
+			Type:     "m.room.name",
+		},
+		{
+			RoomID: roomID,
+			Sender: alice,
+			Content: map[string]interface{}{
+				"body": "hello world 2",
+			},
+			StateKey: nil,
+			Type:     "m.room.message",
+		},
+	})
+	deleteDatabase()
+	rsAPI, producer := mustCreateRoomserverAPI(t)
+	defer deleteDatabase()
+	err := api.SendEvents(context.Background(), rsAPI, originalEvents, testOrigin, nil)
+	if err != nil {
+		t.Fatalf("failed to send original events: %s", err)
+	}
+	// assert we got them produced, this is just a sanity check and isn't the intention of this test
+	if len(producer.producedMessages) != len(originalEvents) {
+		t.Fatalf("SendEvents didn't result in same number of produced output events: got %d want %d", len(producer.producedMessages), len(originalEvents))
+	}
+	producer.producedMessages = nil // we aren't actually interested in these events, just the rewrite ones
+
+	var inputEvents []api.InputRoomEvent
+	// slowly build up the state IDs again, we're basically telling the roomserver what to store as a snapshot
+	var stateIDs []string
+	// skip the last event, we'll use this to tie together the rewrite as the KindNew event
+	for i := 0; i < len(rewriteEvents)-1; i++ {
+		ev := rewriteEvents[i]
+		inputEvents = append(inputEvents, api.InputRoomEvent{
+			Kind:          api.KindRewrite,
+			Event:         ev,
+			AuthEventIDs:  ev.AuthEventIDs(),
+			HasState:      true,
+			StateEventIDs: stateIDs,
+		})
+		if ev.StateKey() != nil {
+			stateIDs = append(stateIDs, ev.EventID())
+		}
+	}
+	lastEv := rewriteEvents[len(rewriteEvents)-1]
+	inputEvents = append(inputEvents, api.InputRoomEvent{
+		Kind:          api.KindNew,
+		Event:         lastEv,
+		AuthEventIDs:  lastEv.AuthEventIDs(),
+		HasState:      true,
+		StateEventIDs: stateIDs,
+	})
+	if err := api.SendInputRoomEvents(context.Background(), rsAPI, inputEvents); err != nil {
+		t.Fatalf("SendInputRoomEvents returned error for rewrite events: %s", err)
+	}
+	// we should just have one output event with the entire state of the room in it
+	if len(producer.producedMessages) != 1 {
+		t.Fatalf("Rewritten events got output, want only 1 got %d", len(producer.producedMessages))
+	}
+	outputEvent := producer.producedMessages[0]
+	if !outputEvent.NewRoomEvent.RewritesState {
+		t.Errorf("RewritesState flag not set on output event")
+	}
+	if !reflect.DeepEqual(stateIDs, outputEvent.NewRoomEvent.AddsStateEventIDs) {
+		t.Errorf("Output event is missing room state event IDs, got %v want %v", outputEvent.NewRoomEvent.AddsStateEventIDs, stateIDs)
+	}
+	if !bytes.Equal(outputEvent.NewRoomEvent.Event.JSON(), lastEv.JSON()) {
+		t.Errorf(
+			"Output event isn't the latest KindNew event:\ngot  %s\nwant %s",
+			string(outputEvent.NewRoomEvent.Event.JSON()),
+			string(lastEv.JSON()),
+		)
+	}
+	if len(outputEvent.NewRoomEvent.AddStateEvents) != len(stateIDs) {
+		t.Errorf("Output event is missing room state events themselves, got %d want %d", len(outputEvent.NewRoomEvent.AddStateEvents), len(stateIDs))
+	}
+	// make sure the state got overwritten, check the room name
+	hasRoomName := false
+	for _, ev := range outputEvent.NewRoomEvent.AddStateEvents {
+		if ev.Type() == "m.room.name" {
+			hasRoomName = string(ev.Content()) == `{"name":"Room Name 2"}`
+		}
+	}
+	if !hasRoomName {
+		t.Errorf("Output event did not overwrite room state")
 	}
 }

--- a/roomserver/types/types.go
+++ b/roomserver/types/types.go
@@ -16,6 +16,8 @@
 package types
 
 import (
+	"sort"
+
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
@@ -70,6 +72,24 @@ func (a StateEntry) LessThan(b StateEntry) bool {
 		return a.StateKeyTuple.LessThan(b.StateKeyTuple)
 	}
 	return a.EventNID < b.EventNID
+}
+
+// Deduplicate ensures that the latest NIDs are always presented in the case of duplicates.
+func DeduplicateStateEntries(a []StateEntry) []StateEntry {
+	result := a
+	if len(a) < 2 {
+		return a
+	}
+	sort.SliceStable(a, func(i, j int) bool {
+		return a[i].LessThan(a[j])
+	})
+	for i := 0; i < len(result)-1; i++ {
+		if result[i].StateKeyTuple == result[i+1].StateKeyTuple {
+			result = append(result[:i], result[i+1:]...)
+			i--
+		}
+	}
+	return result
 }
 
 // StateAtEvent is the state before and after a matrix event.

--- a/roomserver/types/types.go
+++ b/roomserver/types/types.go
@@ -74,22 +74,23 @@ func (a StateEntry) LessThan(b StateEntry) bool {
 	return a.EventNID < b.EventNID
 }
 
-// Deduplicate ensures that the latest NIDs are always presented in the case of duplicates.
+// Deduplicate takes a set of state entries and ensures that there are no
+// duplicate (event type, state key) tuples. If there are then we dedupe
+// them, making sure that the latest/highest NIDs are always chosen.
 func DeduplicateStateEntries(a []StateEntry) []StateEntry {
-	result := a
 	if len(a) < 2 {
 		return a
 	}
 	sort.SliceStable(a, func(i, j int) bool {
 		return a[i].LessThan(a[j])
 	})
-	for i := 0; i < len(result)-1; i++ {
-		if result[i].StateKeyTuple == result[i+1].StateKeyTuple {
-			result = append(result[:i], result[i+1:]...)
+	for i := 0; i < len(a)-1; i++ {
+		if a[i].StateKeyTuple == a[i+1].StateKeyTuple {
+			a = append(a[:i], a[i+1:]...)
 			i--
 		}
 	}
-	return result
+	return a
 }
 
 // StateAtEvent is the state before and after a matrix event.

--- a/roomserver/types/types_test.go
+++ b/roomserver/types/types_test.go
@@ -1,0 +1,26 @@
+package types
+
+import (
+	"testing"
+)
+
+func TestDeduplicateStateEntries(t *testing.T) {
+	entries := []StateEntry{
+		{StateKeyTuple{1, 1}, 1},
+		{StateKeyTuple{1, 1}, 2},
+		{StateKeyTuple{1, 1}, 3},
+		{StateKeyTuple{2, 2}, 4},
+		{StateKeyTuple{2, 3}, 5},
+		{StateKeyTuple{3, 3}, 6},
+	}
+	expected := []EventNID{3, 4, 5, 6}
+	entries = DeduplicateStateEntries(entries)
+	if len(entries) != 4 {
+		t.Fatalf("Expected 4 entries, got %d entries", len(entries))
+	}
+	for i, v := range entries {
+		if v.EventNID != expected[i] {
+			t.Fatalf("Expected position %d to be %d but got %d", i, expected[i], v.EventNID)
+		}
+	}
+}

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -129,6 +129,11 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 	ctx context.Context, msg api.OutputNewRoomEvent,
 ) error {
 	ev := msg.Event
+	if msg.Type == api.OutputRoomState {
+		s.notifyKeyChanges(&ev)
+		return nil
+	}
+
 	addsStateEvents := msg.AddsState()
 
 	ev, err := s.updateStateEvent(ev)
@@ -150,7 +155,7 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 		msg.AddsStateEventIDs,
 		msg.RemovesStateEventIDs,
 		msg.TransactionID,
-		msg.Type == api.OutputRoomState,
+		false,
 	)
 	if err != nil {
 		// panic rather than continue with an inconsistent database

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -150,7 +150,7 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 		msg.AddsStateEventIDs,
 		msg.RemovesStateEventIDs,
 		msg.TransactionID,
-		msg.SendAsServer == "", // TODO: this helps us to spot backfilled/historical events but there must be a better way
+		false,
 	)
 	if err != nil {
 		// panic rather than continue with an inconsistent database

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -145,15 +145,8 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 	}
 
 	if msg.RewritesState {
-		err = s.db.RewriteState(
-			ctx,
-			&ev,
-			addsStateEvents,
-			msg.AddsStateEventIDs,
-			msg.TransactionID,
-		)
-		if err != nil {
-			return fmt.Errorf("s.db.RewriteState: %w", err)
+		if err = s.db.PurgeRoom(ctx, ev.RoomID()); err != nil {
+			return fmt.Errorf("s.db.PurgeRoom: %w", err)
 		}
 	}
 

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -150,7 +150,7 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 		msg.AddsStateEventIDs,
 		msg.RemovesStateEventIDs,
 		msg.TransactionID,
-		false,
+		msg.SendAsServer == "", // TODO: this helps us to spot backfilled/historical events but there must be a better way
 	)
 	if err != nil {
 		// panic rather than continue with an inconsistent database

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -143,6 +143,10 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 		}
 	}
 
+	if msg.Historical {
+		return nil
+	}
+
 	pduPos, err := s.db.WriteEvent(
 		ctx,
 		&ev,

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -143,7 +143,7 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 		}
 	}
 
-	if msg.Historical {
+	if msg.Type == api.OutputRoomState {
 		return nil
 	}
 

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -143,11 +143,6 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 		}
 	}
 
-	if msg.Type == api.OutputRoomState {
-		s.notifyKeyChanges(&ev)
-		return nil
-	}
-
 	pduPos, err := s.db.WriteEvent(
 		ctx,
 		&ev,
@@ -155,7 +150,7 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 		msg.AddsStateEventIDs,
 		msg.RemovesStateEventIDs,
 		msg.TransactionID,
-		false,
+		msg.Type == api.OutputRoomState,
 	)
 	if err != nil {
 		// panic rather than continue with an inconsistent database

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -144,7 +144,7 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 		}
 	}
 
-	if msg.Type == api.OutputRoomState {
+	if msg.RewritesState {
 		err = s.db.RewriteState(
 			ctx,
 			&ev,
@@ -155,7 +155,6 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 		if err != nil {
 			return fmt.Errorf("s.db.RewriteState: %w", err)
 		}
-		return nil
 	}
 
 	pduPos, err := s.db.WriteEvent(

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -129,11 +129,6 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 	ctx context.Context, msg api.OutputNewRoomEvent,
 ) error {
 	ev := msg.Event
-	if msg.Type == api.OutputRoomState {
-		s.notifyKeyChanges(&ev)
-		return nil
-	}
-
 	addsStateEvents := msg.AddsState()
 
 	ev, err := s.updateStateEvent(ev)
@@ -155,7 +150,7 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 		msg.AddsStateEventIDs,
 		msg.RemovesStateEventIDs,
 		msg.TransactionID,
-		false,
+		msg.Type == api.OutputRoomState,
 	)
 	if err != nil {
 		// panic rather than continue with an inconsistent database

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -144,6 +144,7 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 	}
 
 	if msg.Type == api.OutputRoomState {
+		s.notifyKeyChanges(&ev)
 		return nil
 	}
 

--- a/syncapi/routing/messages.go
+++ b/syncapi/routing/messages.go
@@ -417,7 +417,7 @@ func (r *messagesReq) backfill(roomID string, backwardsExtremities map[string][]
 			[]gomatrixserverlib.HeaderedEvent{},
 			[]string{},
 			[]string{},
-			nil, true,
+			nil, false,
 		)
 		if err != nil {
 			return nil, err

--- a/syncapi/routing/messages.go
+++ b/syncapi/routing/messages.go
@@ -417,7 +417,7 @@ func (r *messagesReq) backfill(roomID string, backwardsExtremities map[string][]
 			[]gomatrixserverlib.HeaderedEvent{},
 			[]string{},
 			[]string{},
-			nil, false,
+			nil, true,
 		)
 		if err != nil {
 			return nil, err

--- a/syncapi/storage/interface.go
+++ b/syncapi/storage/interface.go
@@ -41,6 +41,9 @@ type Database interface {
 	// Returns an error if there was a problem inserting this event.
 	WriteEvent(ctx context.Context, ev *gomatrixserverlib.HeaderedEvent, addStateEvents []gomatrixserverlib.HeaderedEvent,
 		addStateEventIDs []string, removeStateEventIDs []string, transactionID *api.TransactionID, excludeFromSync bool) (types.StreamPosition, error)
+	// RewriteState rewrites a current room state event. If the state event is a create event then all existing
+	// state in the room will be deleted before rewriting the event.
+	RewriteState(ctx context.Context, ev *gomatrixserverlib.HeaderedEvent, addStateEvents []gomatrixserverlib.HeaderedEvent, addStateEventIDs []string, transactionID *api.TransactionID) error
 	// GetStateEvent returns the Matrix state event of a given type for a given room with a given state key
 	// If no event could be found, returns nil
 	// If there was an issue during the retrieval, returns an error

--- a/syncapi/storage/interface.go
+++ b/syncapi/storage/interface.go
@@ -41,9 +41,9 @@ type Database interface {
 	// Returns an error if there was a problem inserting this event.
 	WriteEvent(ctx context.Context, ev *gomatrixserverlib.HeaderedEvent, addStateEvents []gomatrixserverlib.HeaderedEvent,
 		addStateEventIDs []string, removeStateEventIDs []string, transactionID *api.TransactionID, excludeFromSync bool) (types.StreamPosition, error)
-	// RewriteState rewrites a current room state event. If the state event is a create event then all existing
-	// state in the room will be deleted before rewriting the event.
-	RewriteState(ctx context.Context, ev *gomatrixserverlib.HeaderedEvent, addStateEvents []gomatrixserverlib.HeaderedEvent, addStateEventIDs []string, transactionID *api.TransactionID) error
+	// PurgeRoom completely purges room state from the sync API. This is done when
+	// receiving an output event that completely resets the state.
+	PurgeRoom(ctx context.Context, roomID string) error
 	// GetStateEvent returns the Matrix state event of a given type for a given room with a given state key
 	// If no event could be found, returns nil
 	// If there was an issue during the retrieval, returns an error

--- a/syncapi/storage/postgres/current_room_state_table.go
+++ b/syncapi/storage/postgres/current_room_state_table.go
@@ -69,6 +69,9 @@ const upsertRoomStateSQL = "" +
 const deleteRoomStateByEventIDSQL = "" +
 	"DELETE FROM syncapi_current_room_state WHERE event_id = $1"
 
+const deleteRoomStateByRoomIDSQL = "" +
+	"DELETE FROM syncapi_current_room_state WHERE event_id = $1"
+
 const selectRoomIDsWithMembershipSQL = "" +
 	"SELECT DISTINCT room_id FROM syncapi_current_room_state WHERE type = 'm.room.member' AND state_key = $1 AND membership = $2"
 
@@ -98,6 +101,7 @@ const selectEventsWithEventIDsSQL = "" +
 type currentRoomStateStatements struct {
 	upsertRoomStateStmt             *sql.Stmt
 	deleteRoomStateByEventIDStmt    *sql.Stmt
+	deleteRoomStateByRoomIDStmt     *sql.Stmt
 	selectRoomIDsWithMembershipStmt *sql.Stmt
 	selectCurrentStateStmt          *sql.Stmt
 	selectJoinedUsersStmt           *sql.Stmt
@@ -115,6 +119,9 @@ func NewPostgresCurrentRoomStateTable(db *sql.DB) (tables.CurrentRoomState, erro
 		return nil, err
 	}
 	if s.deleteRoomStateByEventIDStmt, err = db.Prepare(deleteRoomStateByEventIDSQL); err != nil {
+		return nil, err
+	}
+	if s.deleteRoomStateByRoomIDStmt, err = db.Prepare(deleteRoomStateByRoomIDSQL); err != nil {
 		return nil, err
 	}
 	if s.selectRoomIDsWithMembershipStmt, err = db.Prepare(selectRoomIDsWithMembershipSQL); err != nil {
@@ -211,6 +218,14 @@ func (s *currentRoomStateStatements) DeleteRoomStateByEventID(
 ) error {
 	stmt := sqlutil.TxStmt(txn, s.deleteRoomStateByEventIDStmt)
 	_, err := stmt.ExecContext(ctx, eventID)
+	return err
+}
+
+func (s *currentRoomStateStatements) DeleteRoomStateByRoomID(
+	ctx context.Context, txn *sql.Tx, roomID string,
+) error {
+	stmt := sqlutil.TxStmt(txn, s.deleteRoomStateByRoomIDStmt)
+	_, err := stmt.ExecContext(ctx, roomID)
 	return err
 }
 

--- a/syncapi/storage/postgres/current_room_state_table.go
+++ b/syncapi/storage/postgres/current_room_state_table.go
@@ -69,7 +69,7 @@ const upsertRoomStateSQL = "" +
 const deleteRoomStateByEventIDSQL = "" +
 	"DELETE FROM syncapi_current_room_state WHERE event_id = $1"
 
-const deleteRoomStateByRoomIDSQL = "" +
+const DeleteRoomStateForRoomSQL = "" +
 	"DELETE FROM syncapi_current_room_state WHERE event_id = $1"
 
 const selectRoomIDsWithMembershipSQL = "" +
@@ -101,7 +101,7 @@ const selectEventsWithEventIDsSQL = "" +
 type currentRoomStateStatements struct {
 	upsertRoomStateStmt             *sql.Stmt
 	deleteRoomStateByEventIDStmt    *sql.Stmt
-	deleteRoomStateByRoomIDStmt     *sql.Stmt
+	DeleteRoomStateForRoomStmt      *sql.Stmt
 	selectRoomIDsWithMembershipStmt *sql.Stmt
 	selectCurrentStateStmt          *sql.Stmt
 	selectJoinedUsersStmt           *sql.Stmt
@@ -121,7 +121,7 @@ func NewPostgresCurrentRoomStateTable(db *sql.DB) (tables.CurrentRoomState, erro
 	if s.deleteRoomStateByEventIDStmt, err = db.Prepare(deleteRoomStateByEventIDSQL); err != nil {
 		return nil, err
 	}
-	if s.deleteRoomStateByRoomIDStmt, err = db.Prepare(deleteRoomStateByRoomIDSQL); err != nil {
+	if s.DeleteRoomStateForRoomStmt, err = db.Prepare(DeleteRoomStateForRoomSQL); err != nil {
 		return nil, err
 	}
 	if s.selectRoomIDsWithMembershipStmt, err = db.Prepare(selectRoomIDsWithMembershipSQL); err != nil {
@@ -221,10 +221,10 @@ func (s *currentRoomStateStatements) DeleteRoomStateByEventID(
 	return err
 }
 
-func (s *currentRoomStateStatements) DeleteRoomStateByRoomID(
+func (s *currentRoomStateStatements) DeleteRoomStateForRoom(
 	ctx context.Context, txn *sql.Tx, roomID string,
 ) error {
-	stmt := sqlutil.TxStmt(txn, s.deleteRoomStateByRoomIDStmt)
+	stmt := sqlutil.TxStmt(txn, s.DeleteRoomStateForRoomStmt)
 	_, err := stmt.ExecContext(ctx, roomID)
 	return err
 }

--- a/syncapi/storage/shared/syncserver.go
+++ b/syncapi/storage/shared/syncserver.go
@@ -258,6 +258,7 @@ func (d *Database) RewriteState(
 			}
 		}
 
+		// TODO: is there something better here that we can do instead of giving stream position 0?
 		return d.updateRoomState(ctx, txn, []string{}, addStateEvents, types.StreamPosition(0))
 	})
 }

--- a/syncapi/storage/shared/syncserver.go
+++ b/syncapi/storage/shared/syncserver.go
@@ -267,12 +267,14 @@ func (d *Database) RewriteState(
 			}
 		}
 
-		if err := d.handleBackwardExtremities(ctx, txn, ev); err != nil {
-			return fmt.Errorf("d.handleBackwardExtremities: %w", err)
-		}
-
+		/*
+			if err := d.handleBackwardExtremities(ctx, txn, ev); err != nil {
+				return fmt.Errorf("d.handleBackwardExtremities: %w", err)
+			}
+		*/
 		// TODO: is there something better here that we can do instead of giving stream position 0?
-		return d.updateRoomState(ctx, txn, []string{}, addStateEvents, types.StreamPosition(0))
+		//return d.updateRoomState(ctx, txn, []string{}, addStateEvents, types.StreamPosition(0))
+		return nil
 	})
 }
 

--- a/syncapi/storage/shared/syncserver.go
+++ b/syncapi/storage/shared/syncserver.go
@@ -241,39 +241,25 @@ func (d *Database) handleBackwardExtremities(ctx context.Context, txn *sql.Tx, e
 	return nil
 }
 
-func (d *Database) RewriteState(
-	ctx context.Context,
-	ev *gomatrixserverlib.HeaderedEvent,
-	addStateEvents []gomatrixserverlib.HeaderedEvent,
-	addStateEventIDs []string,
-	transactionID *api.TransactionID,
+func (d *Database) PurgeRoom(
+	ctx context.Context, roomID string,
 ) error {
 	return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
 		// If the event is a create event then we'll delete all of the existing
 		// data for the room. The only reason that a create event would be replayed
 		// to us in this way is if we're about to receive the entire room state.
-		if ev.Type() == gomatrixserverlib.MRoomCreate {
-			if err := d.CurrentRoomState.DeleteRoomStateForRoom(ctx, txn, ev.RoomID()); err != nil {
-				return fmt.Errorf("d.CurrentRoomState.DeleteRoomStateForRoom: %w", err)
-			}
-			if err := d.OutputEvents.DeleteEventsForRoom(ctx, txn, ev.RoomID()); err != nil {
-				return fmt.Errorf("d.Events.DeleteEventsForRoom: %w", err)
-			}
-			if err := d.Topology.DeleteTopologyForRoom(ctx, txn, ev.RoomID()); err != nil {
-				return fmt.Errorf("d.Topology.DeleteTopologyForRoom: %w", err)
-			}
-			if err := d.BackwardExtremities.DeleteBackwardExtremitiesForRoom(ctx, txn, ev.RoomID()); err != nil {
-				return fmt.Errorf("d.BackwardExtremities.DeleteBackwardExtremitiesForRoom: %w", err)
-			}
+		if err := d.CurrentRoomState.DeleteRoomStateForRoom(ctx, txn, roomID); err != nil {
+			return fmt.Errorf("d.CurrentRoomState.DeleteRoomStateForRoom: %w", err)
 		}
-
-		/*
-			if err := d.handleBackwardExtremities(ctx, txn, ev); err != nil {
-				return fmt.Errorf("d.handleBackwardExtremities: %w", err)
-			}
-		*/
-		// TODO: is there something better here that we can do instead of giving stream position 0?
-		//return d.updateRoomState(ctx, txn, []string{}, addStateEvents, types.StreamPosition(0))
+		if err := d.OutputEvents.DeleteEventsForRoom(ctx, txn, roomID); err != nil {
+			return fmt.Errorf("d.Events.DeleteEventsForRoom: %w", err)
+		}
+		if err := d.Topology.DeleteTopologyForRoom(ctx, txn, roomID); err != nil {
+			return fmt.Errorf("d.Topology.DeleteTopologyForRoom: %w", err)
+		}
+		if err := d.BackwardExtremities.DeleteBackwardExtremitiesForRoom(ctx, txn, roomID); err != nil {
+			return fmt.Errorf("d.BackwardExtremities.DeleteBackwardExtremitiesForRoom: %w", err)
+		}
 		return nil
 	})
 }

--- a/syncapi/storage/sqlite3/current_room_state_table.go
+++ b/syncapi/storage/sqlite3/current_room_state_table.go
@@ -57,6 +57,9 @@ const upsertRoomStateSQL = "" +
 const deleteRoomStateByEventIDSQL = "" +
 	"DELETE FROM syncapi_current_room_state WHERE event_id = $1"
 
+const deleteRoomStateByRoomIDSQL = "" +
+	"DELETE FROM syncapi_current_room_state WHERE event_id = $1"
+
 const selectRoomIDsWithMembershipSQL = "" +
 	"SELECT DISTINCT room_id FROM syncapi_current_room_state WHERE type = 'm.room.member' AND state_key = $1 AND membership = $2"
 
@@ -88,6 +91,7 @@ type currentRoomStateStatements struct {
 	streamIDStatements              *streamIDStatements
 	upsertRoomStateStmt             *sql.Stmt
 	deleteRoomStateByEventIDStmt    *sql.Stmt
+	deleteRoomStateByRoomIDStmt     *sql.Stmt
 	selectRoomIDsWithMembershipStmt *sql.Stmt
 	selectCurrentStateStmt          *sql.Stmt
 	selectJoinedUsersStmt           *sql.Stmt
@@ -107,6 +111,9 @@ func NewSqliteCurrentRoomStateTable(db *sql.DB, streamID *streamIDStatements) (t
 		return nil, err
 	}
 	if s.deleteRoomStateByEventIDStmt, err = db.Prepare(deleteRoomStateByEventIDSQL); err != nil {
+		return nil, err
+	}
+	if s.deleteRoomStateByRoomIDStmt, err = db.Prepare(deleteRoomStateByRoomIDSQL); err != nil {
 		return nil, err
 	}
 	if s.selectRoomIDsWithMembershipStmt, err = db.Prepare(selectRoomIDsWithMembershipSQL); err != nil {
@@ -200,6 +207,14 @@ func (s *currentRoomStateStatements) DeleteRoomStateByEventID(
 ) error {
 	stmt := sqlutil.TxStmt(txn, s.deleteRoomStateByEventIDStmt)
 	_, err := stmt.ExecContext(ctx, eventID)
+	return err
+}
+
+func (s *currentRoomStateStatements) DeleteRoomStateByRoomID(
+	ctx context.Context, txn *sql.Tx, roomID string,
+) error {
+	stmt := sqlutil.TxStmt(txn, s.deleteRoomStateByRoomIDStmt)
+	_, err := stmt.ExecContext(ctx, roomID)
 	return err
 }
 

--- a/syncapi/storage/sqlite3/current_room_state_table.go
+++ b/syncapi/storage/sqlite3/current_room_state_table.go
@@ -57,7 +57,7 @@ const upsertRoomStateSQL = "" +
 const deleteRoomStateByEventIDSQL = "" +
 	"DELETE FROM syncapi_current_room_state WHERE event_id = $1"
 
-const deleteRoomStateByRoomIDSQL = "" +
+const DeleteRoomStateForRoomSQL = "" +
 	"DELETE FROM syncapi_current_room_state WHERE event_id = $1"
 
 const selectRoomIDsWithMembershipSQL = "" +
@@ -91,7 +91,7 @@ type currentRoomStateStatements struct {
 	streamIDStatements              *streamIDStatements
 	upsertRoomStateStmt             *sql.Stmt
 	deleteRoomStateByEventIDStmt    *sql.Stmt
-	deleteRoomStateByRoomIDStmt     *sql.Stmt
+	DeleteRoomStateForRoomStmt      *sql.Stmt
 	selectRoomIDsWithMembershipStmt *sql.Stmt
 	selectCurrentStateStmt          *sql.Stmt
 	selectJoinedUsersStmt           *sql.Stmt
@@ -113,7 +113,7 @@ func NewSqliteCurrentRoomStateTable(db *sql.DB, streamID *streamIDStatements) (t
 	if s.deleteRoomStateByEventIDStmt, err = db.Prepare(deleteRoomStateByEventIDSQL); err != nil {
 		return nil, err
 	}
-	if s.deleteRoomStateByRoomIDStmt, err = db.Prepare(deleteRoomStateByRoomIDSQL); err != nil {
+	if s.DeleteRoomStateForRoomStmt, err = db.Prepare(DeleteRoomStateForRoomSQL); err != nil {
 		return nil, err
 	}
 	if s.selectRoomIDsWithMembershipStmt, err = db.Prepare(selectRoomIDsWithMembershipSQL); err != nil {
@@ -210,10 +210,10 @@ func (s *currentRoomStateStatements) DeleteRoomStateByEventID(
 	return err
 }
 
-func (s *currentRoomStateStatements) DeleteRoomStateByRoomID(
+func (s *currentRoomStateStatements) DeleteRoomStateForRoom(
 	ctx context.Context, txn *sql.Tx, roomID string,
 ) error {
-	stmt := sqlutil.TxStmt(txn, s.deleteRoomStateByRoomIDStmt)
+	stmt := sqlutil.TxStmt(txn, s.DeleteRoomStateForRoomStmt)
 	_, err := stmt.ExecContext(ctx, roomID)
 	return err
 }

--- a/syncapi/storage/sqlite3/current_room_state_table.go
+++ b/syncapi/storage/sqlite3/current_room_state_table.go
@@ -51,7 +51,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS syncapi_event_id_idx ON syncapi_current_room_s
 const upsertRoomStateSQL = "" +
 	"INSERT INTO syncapi_current_room_state (room_id, event_id, type, sender, contains_url, state_key, headered_event_json, membership, added_at)" +
 	" VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)" +
-	" ON CONFLICT (event_id, room_id, type, sender, contains_url)" +
+	" ON CONFLICT (room_id, type, state_key)" +
 	" DO UPDATE SET event_id = $2, sender=$4, contains_url=$5, headered_event_json = $7, membership = $8, added_at = $9"
 
 const deleteRoomStateByEventIDSQL = "" +

--- a/syncapi/storage/tables/interface.go
+++ b/syncapi/storage/tables/interface.go
@@ -75,6 +75,7 @@ type CurrentRoomState interface {
 	SelectEventsWithEventIDs(ctx context.Context, txn *sql.Tx, eventIDs []string) ([]types.StreamEvent, error)
 	UpsertRoomState(ctx context.Context, txn *sql.Tx, event gomatrixserverlib.HeaderedEvent, membership *string, addedAt types.StreamPosition) error
 	DeleteRoomStateByEventID(ctx context.Context, txn *sql.Tx, eventID string) error
+	DeleteRoomStateByRoomID(ctx context.Context, txn *sql.Tx, roomID string) error
 	// SelectCurrentState returns all the current state events for the given room.
 	SelectCurrentState(ctx context.Context, txn *sql.Tx, roomID string, stateFilter *gomatrixserverlib.StateFilter) ([]gomatrixserverlib.HeaderedEvent, error)
 	// SelectRoomIDsWithMembership returns the list of room IDs which have the given user in the given membership state.

--- a/syncapi/storage/tables/interface.go
+++ b/syncapi/storage/tables/interface.go
@@ -51,6 +51,8 @@ type Events interface {
 	SelectEarlyEvents(ctx context.Context, txn *sql.Tx, roomID string, r types.Range, limit int) ([]types.StreamEvent, error)
 	SelectEvents(ctx context.Context, txn *sql.Tx, eventIDs []string) ([]types.StreamEvent, error)
 	UpdateEventJSON(ctx context.Context, event *gomatrixserverlib.HeaderedEvent) error
+	// DeleteEventsForRoom removes all event information for a room. This should only be done when removing the room entirely.
+	DeleteEventsForRoom(ctx context.Context, txn *sql.Tx, roomID string) (err error)
 }
 
 // Topology keeps track of the depths and stream positions for all events.
@@ -68,6 +70,8 @@ type Topology interface {
 	SelectPositionInTopology(ctx context.Context, txn *sql.Tx, eventID string) (depth, spos types.StreamPosition, err error)
 	// SelectMaxPositionInTopology returns the event which has the highest depth, and if there are multiple, the event with the highest stream position.
 	SelectMaxPositionInTopology(ctx context.Context, txn *sql.Tx, roomID string) (depth types.StreamPosition, spos types.StreamPosition, err error)
+	// DeleteTopologyForRoom removes all topological information for a room. This should only be done when removing the room entirely.
+	DeleteTopologyForRoom(ctx context.Context, txn *sql.Tx, roomID string) (err error)
 }
 
 type CurrentRoomState interface {
@@ -75,7 +79,7 @@ type CurrentRoomState interface {
 	SelectEventsWithEventIDs(ctx context.Context, txn *sql.Tx, eventIDs []string) ([]types.StreamEvent, error)
 	UpsertRoomState(ctx context.Context, txn *sql.Tx, event gomatrixserverlib.HeaderedEvent, membership *string, addedAt types.StreamPosition) error
 	DeleteRoomStateByEventID(ctx context.Context, txn *sql.Tx, eventID string) error
-	DeleteRoomStateByRoomID(ctx context.Context, txn *sql.Tx, roomID string) error
+	DeleteRoomStateForRoom(ctx context.Context, txn *sql.Tx, roomID string) error
 	// SelectCurrentState returns all the current state events for the given room.
 	SelectCurrentState(ctx context.Context, txn *sql.Tx, roomID string, stateFilter *gomatrixserverlib.StateFilter) ([]gomatrixserverlib.HeaderedEvent, error)
 	// SelectRoomIDsWithMembership returns the list of room IDs which have the given user in the given membership state.
@@ -110,6 +114,8 @@ type BackwardsExtremities interface {
 	SelectBackwardExtremitiesForRoom(ctx context.Context, roomID string) (bwExtrems map[string][]string, err error)
 	// DeleteBackwardExtremity removes a backwards extremity for a room, if one existed.
 	DeleteBackwardExtremity(ctx context.Context, txn *sql.Tx, roomID, knownEventID string) (err error)
+	// DeleteBackwardExtremitiesFoorRoomID removes all backward extremities for a room. This should only be done when removing the room entirely.
+	DeleteBackwardExtremitiesForRoom(ctx context.Context, txn *sql.Tx, roomID string) (err error)
 }
 
 // SendToDevice tracks send-to-device messages which are sent to individual


### PR DESCRIPTION
This has some side-effects:

- The roomserver will generate state snapshots for each of the state events when joining a room over federation (previously they did not have one)
- The latest events updater will run for each of these events, resetting the forward extremities when joining a room over federation
- Output events from the roomserver are generated, notifying the sync API and other components about these events inline

However, this should make it possible to start implementing soft-failed events without breaking federated joins.