### PR TITLE
Process federated joins in background context

### DIFF
--- a/federationsender/internal/api.go
+++ b/federationsender/internal/api.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/matrix-org/dendrite/federationsender/api"
@@ -23,6 +24,7 @@ type FederationSenderInternalAPI struct {
 	federation *gomatrixserverlib.FederationClient
 	keyRing    *gomatrixserverlib.KeyRing
 	queues     *queue.OutgoingQueues
+	joins      sync.Map // joins currently in progress
 }
 
 func NewFederationSenderInternalAPI(


### PR DESCRIPTION
This updates federated room joins so that, if the client gives up waiting, the federated room join continues to verify state in the background so that the work is not wasted. It also stops multiple concurrent joins to the same room being started by the same user.