### PR TITLE
Set default room version to v6

### DIFF
--- a/roomserver/version/version.go
+++ b/roomserver/version/version.go
@@ -23,7 +23,7 @@ import (
 // DefaultRoomVersion contains the room version that will, by
 // default, be used to create new rooms on this server.
 func DefaultRoomVersion() gomatrixserverlib.RoomVersion {
-	return gomatrixserverlib.RoomVersionV5
+	return gomatrixserverlib.RoomVersionV6
 }
 
 // RoomVersions returns a map of all known room versions to this


### PR DESCRIPTION
Following matrix-org/matrix-doc#2788.

Related: matrix-org/synapse#7646.