### PR TITLE
Return the correct error codes for v6 invite JSON violations

### DIFF
--- a/federationapi/routing/invite.go
+++ b/federationapi/routing/invite.go
@@ -39,7 +39,15 @@ func InviteV2(
 	keys gomatrixserverlib.JSONVerifier,
 ) util.JSONResponse {
 	inviteReq := gomatrixserverlib.InviteV2Request{}
-	if err := json.Unmarshal(request.Content(), &inviteReq); err != nil {
+	err := json.Unmarshal(request.Content(), &inviteReq)
+	switch err.(type) {
+	case gomatrixserverlib.BadJSONError:
+		return util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.BadJSON(err.Error()),
+		}
+	case nil:
+	default:
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.NotJSON("The request body could not be decoded into an invite request. " + err.Error()),
@@ -63,10 +71,17 @@ func InviteV1(
 	roomVer := gomatrixserverlib.RoomVersionV1
 	body := request.Content()
 	event, err := gomatrixserverlib.NewEventFromTrustedJSON(body, false, roomVer)
-	if err != nil {
+	switch err.(type) {
+	case gomatrixserverlib.BadJSONError:
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
-			JSON: jsonerror.NotJSON("The request body could not be decoded into an invite v1 request: " + err.Error()),
+			JSON: jsonerror.BadJSON(err.Error()),
+		}
+	case nil:
+	default:
+		return util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.NotJSON("The request body could not be decoded into an invite v1 request. " + err.Error()),
 		}
 	}
 	var strippedState []gomatrixserverlib.InviteV2StrippedState

--- a/federationapi/routing/leave.go
+++ b/federationapi/routing/leave.go
@@ -138,7 +138,14 @@ func SendLeave(
 
 	// Decode the event JSON from the request.
 	event, err := gomatrixserverlib.NewEventFromUntrustedJSON(request.Content(), verRes.RoomVersion)
-	if err != nil {
+	switch err.(type) {
+	case gomatrixserverlib.BadJSONError:
+		return util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.BadJSON(err.Error()),
+		}
+	case nil:
+	default:
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.NotJSON("The request body could not be decoded into valid JSON. " + err.Error()),

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -478,3 +478,5 @@ Inbound federation accepts a second soft-failed event
 Federation key API can act as a notary server via a POST request
 Federation key API can act as a notary server via a GET request
 Inbound /make_join rejects attempts to join rooms where all users have left
+Inbound federation rejects invites which include invalid JSON for room version 6
+Inbound federation rejects invite rejections which include invalid JSON for room version 6


### PR DESCRIPTION
As per #1313, this fixes a couple of cases where we incorrectly returned `M_NOT_JSON` instead of `M_BAD_JSON` when dealing with invalid JSON in room version 6.

This therefore fixes the following tests:
```
Inbound federation rejects invites which include invalid JSON for room version 6
Inbound federation rejects invite rejections which include invalid JSON for room version 6
```

There is still a failing test:
```
Outbound federation rejects invite response which include invalid JSON for room version 6
```
... which is again down to the error returned, as we are instead returning `{"errcode":"M_FORBIDDEN","error":"r.federation.SendInviteV2: gomatrixserverlib: bad JSON: value is outside of safe range"}`.

We will need to fix the horrible mess that is error handling across API boundaries before we can resolve that one.