### PR TITLE
Allow configuring old verify keys

### DIFF
--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -42,9 +42,9 @@ global:
   # to old signing private keys that were formerly in use on this domain. These
   # keys will not be used for federation request or event signing, but will be
   # provided to any other homeserver that asks when trying to verify old events.
-  old_private_keys:
-  - private_key: old_matrix_key.pem
-    expired_at: 1601024554498
+  # old_private_keys:
+  # - private_key: old_matrix_key.pem
+  #   expired_at: 1601024554498
 
   # How long a remote server can cache our server signing key before requesting it
   # again. Increasing this number will reduce the number of requests made by other

--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -38,6 +38,14 @@ global:
   # The path to the signing private key file, used to sign requests and events.
   private_key: matrix_key.pem
 
+  # The paths and expiry timestamps (as a UNIX timestamp in millisecond precision)
+  # to old signing private keys that were formerly in use on this domain. These
+  # keys will not be used for federation request or event signing, but will be
+  # provided to any other homeserver that asks when trying to verify old events.
+  old_private_keys:
+  - private_key: old_matrix_key.pem
+    expired_at: 1601024554498
+
   # How long a remote server can cache our server signing key before requesting it
   # again. Increasing this number will reduce the number of requests made by other
   # servers for our key but increases the period that a compromised key will be

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -232,6 +232,20 @@ func loadConfig(
 		return nil, err
 	}
 
+	for _, oldPrivateKey := range c.Global.OldVerifyKeys {
+		var oldPrivateKeyData []byte
+
+		oldPrivateKeyPath := absPath(basePath, oldPrivateKey.PrivateKeyPath)
+		oldPrivateKeyData, err = readFile(oldPrivateKeyPath)
+		if err != nil {
+			return nil, err
+		}
+
+		if oldPrivateKey.KeyID, oldPrivateKey.PrivateKey, err = readKeyPEM(oldPrivateKeyPath, oldPrivateKeyData); err != nil {
+			return nil, err
+		}
+	}
+
 	for _, certPath := range c.FederationAPI.FederationCertificatePaths {
 		absCertPath := absPath(basePath, certPath)
 		var pemData []byte

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -241,7 +241,7 @@ func loadConfig(
 			return nil, err
 		}
 
-		// NOTSPEC: Ordinarily we should force key ID formatting, but since there are
+		// NOTSPEC: Ordinarily we should enforce key ID formatting, but since there are
 		// a number of private keys out there with non-compatible symbols in them due
 		// to lack of validation in Synapse, we won't enforce that for old verify keys.
 		keyID, privateKey, perr := readKeyPEM(oldPrivateKeyPath, oldPrivateKeyData, false)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -232,7 +232,7 @@ func loadConfig(
 		return nil, err
 	}
 
-	for _, oldPrivateKey := range c.Global.OldVerifyKeys {
+	for i, oldPrivateKey := range c.Global.OldVerifyKeys {
 		var oldPrivateKeyData []byte
 
 		oldPrivateKeyPath := absPath(basePath, oldPrivateKey.PrivateKeyPath)
@@ -241,7 +241,7 @@ func loadConfig(
 			return nil, err
 		}
 
-		if oldPrivateKey.KeyID, oldPrivateKey.PrivateKey, err = readKeyPEM(oldPrivateKeyPath, oldPrivateKeyData); err != nil {
+		if c.Global.OldVerifyKeys[i].KeyID, c.Global.OldVerifyKeys[i].PrivateKey, err = readKeyPEM(oldPrivateKeyPath, oldPrivateKeyData); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -228,7 +228,7 @@ func loadConfig(
 		return nil, err
 	}
 
-	if c.Global.KeyID, c.Global.PrivateKey, err = readKeyPEM(privateKeyPath, privateKeyData); err != nil {
+	if c.Global.KeyID, c.Global.PrivateKey, err = readKeyPEM(privateKeyPath, privateKeyData, true); err != nil {
 		return nil, err
 	}
 
@@ -241,9 +241,15 @@ func loadConfig(
 			return nil, err
 		}
 
-		if c.Global.OldVerifyKeys[i].KeyID, c.Global.OldVerifyKeys[i].PrivateKey, err = readKeyPEM(oldPrivateKeyPath, oldPrivateKeyData); err != nil {
-			return nil, err
+		// NOTSPEC: Ordinarily we should force key ID formatting, but since there are
+		// a number of private keys out there with non-compatible symbols in them due
+		// to lack of validation in Synapse, we won't enforce that for old verify keys.
+		keyID, privateKey, perr := readKeyPEM(oldPrivateKeyPath, oldPrivateKeyData, false)
+		if perr != nil {
+			return nil, perr
 		}
+
+		c.Global.OldVerifyKeys[i].KeyID, c.Global.OldVerifyKeys[i].PrivateKey = keyID, privateKey
 	}
 
 	for _, certPath := range c.FederationAPI.FederationCertificatePaths {
@@ -458,7 +464,7 @@ func absPath(dir string, path Path) string {
 	return filepath.Join(dir, string(path))
 }
 
-func readKeyPEM(path string, data []byte) (gomatrixserverlib.KeyID, ed25519.PrivateKey, error) {
+func readKeyPEM(path string, data []byte, enforceKeyIDFormat bool) (gomatrixserverlib.KeyID, ed25519.PrivateKey, error) {
 	for {
 		var keyBlock *pem.Block
 		keyBlock, data = pem.Decode(data)
@@ -476,7 +482,7 @@ func readKeyPEM(path string, data []byte) (gomatrixserverlib.KeyID, ed25519.Priv
 			if !strings.HasPrefix(keyID, "ed25519:") {
 				return "", nil, fmt.Errorf("key ID %q doesn't start with \"ed25519:\" in %q", keyID, path)
 			}
-			if !keyIDRegexp.MatchString(keyID) {
+			if enforceKeyIDFormat && !keyIDRegexp.MatchString(keyID) {
 				return "", nil, fmt.Errorf("key ID %q in %q contains illegal characters (use a-z, A-Z, 0-9 and _ only)", keyID, path)
 			}
 			_, privKey, err := ed25519.GenerateKey(bytes.NewReader(keyBlock.Bytes))

--- a/internal/config/config_global.go
+++ b/internal/config/config_global.go
@@ -22,6 +22,11 @@ type Global struct {
 	// prefix "ed25519:".
 	KeyID gomatrixserverlib.KeyID `yaml:"-"`
 
+	// Information about old private keys that used to be used to sign requests and
+	// events on this domain. They will not be used but will be advertised to other
+	// servers that ask for them to help verify old events.
+	OldVerifyKeys []OldVerifyKeys `yaml:"old_private_keys"`
+
 	// How long a remote server can cache our server key for before requesting it again.
 	// Increasing this number will reduce the number of requests made by remote servers
 	// for our key, but increases the period a compromised key will be considered valid
@@ -58,6 +63,21 @@ func (c *Global) Verify(configErrs *ConfigErrors, isMonolith bool) {
 
 	c.Kafka.Verify(configErrs, isMonolith)
 	c.Metrics.Verify(configErrs, isMonolith)
+}
+
+type OldVerifyKeys struct {
+	// Path to the private key.
+	PrivateKeyPath Path `yaml:"private_key"`
+
+	// The private key itself.
+	PrivateKey ed25519.PrivateKey `yaml:"-"`
+
+	// The key ID of the private key.
+	KeyID gomatrixserverlib.KeyID `yaml:"-"`
+
+	// When the private key was designed as "expired", as a UNIX timestamp
+	// in millisecond precision.
+	ExpiredAt gomatrixserverlib.Timestamp `yaml:"expired_at"`
 }
 
 // The configuration to use for Prometheus metrics

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -234,7 +234,7 @@ func (m mockReadFile) readFile(path string) ([]byte, error) {
 }
 
 func TestReadKey(t *testing.T) {
-	keyID, _, err := readKeyPEM("path/to/key", []byte(testKey))
+	keyID, _, err := readKeyPEM("path/to/key", []byte(testKey), true)
 	if err != nil {
 		t.Error("failed to load private key:", err)
 	}


### PR DESCRIPTION
This allows configuring `old_verify_keys` in the Dendrite config.

Fixes #1442.