### PR TITLE
Hint where AuthChainProvider should retrieve events from

### DIFF
--- a/federationsender/internal/perform/join.go
+++ b/federationsender/internal/perform/join.go
@@ -38,7 +38,7 @@ func (r joinContext) CheckSendJoinResponse(
 	// Define a function which we can pass to Check to retrieve missing
 	// auth events inline. This greatly increases our chances of not having
 	// to repeat the entire set of checks just for a missing event or two.
-	missingAuth := func(roomVersion gomatrixserverlib.RoomVersion, eventIDs []string) ([]gomatrixserverlib.Event, error) {
+	missingAuth := func(roomVersion gomatrixserverlib.RoomVersion, eventIDs []string, serverName gomatrixserverlib.ServerName) ([]gomatrixserverlib.Event, error) {
 		returning := []gomatrixserverlib.Event{}
 
 		// See if we have retry entries for each of the supplied event IDs.
@@ -59,7 +59,7 @@ func (r joinContext) CheckSendJoinResponse(
 
 			// Try to retrieve the event from the server that sent us the send
 			// join response.
-			tx, txerr := r.federation.GetEvent(ctx, server, eventID)
+			tx, txerr := r.federation.GetEvent(ctx, serverName, eventID)
 			if txerr != nil {
 				return nil, fmt.Errorf("missingAuth r.federation.GetEvent: %w", txerr)
 			}

--- a/federationsender/internal/perform/join.go
+++ b/federationsender/internal/perform/join.go
@@ -59,9 +59,15 @@ func (r joinContext) CheckSendJoinResponse(
 
 			// Try to retrieve the event from the server that sent us the send
 			// join response.
-			tx, txerr := r.federation.GetEvent(ctx, serverName, eventID)
+			tx, txerr := r.federation.GetEvent(ctx, server, eventID)
 			if txerr != nil {
-				return nil, fmt.Errorf("missingAuth r.federation.GetEvent: %w", txerr)
+				if server == serverName {
+					return nil, fmt.Errorf("missingAuth r.federation.GetEvent via %q: %w", server, txerr)
+				}
+				tx, txerr = r.federation.GetEvent(ctx, serverName, eventID)
+				if txerr != nil {
+					return nil, fmt.Errorf("missingAuth r.federation.GetEvent via %q and %q: %w", server, serverName, txerr)
+				}
 			}
 
 			// For each event returned, add it to the set of return events. We

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/matrix-org/go-http-js-libp2p v0.0.0-20200518170932-783164aeeda4
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20200522092705-bc8506ccbcf3
 	github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20200923114637-d0bf7a3c8b02
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20200925144332-ab41ac3396b1
 	github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4
 	github.com/mattn/go-sqlite3 v1.14.2

--- a/go.sum
+++ b/go.sum
@@ -569,8 +569,8 @@ github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26 h1:Hr3zjRsq2bh
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
 github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd h1:xVrqJK3xHREMNjwjljkAUaadalWc0rRbmVuQatzmgwg=
 github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200923114637-d0bf7a3c8b02 h1:oos5KSWybuqmDKsiedQYBPFTzLLYaI3m2iisL0wB4yw=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20200923114637-d0bf7a3c8b02/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200925144332-ab41ac3396b1 h1:FLNL4rAJPeurtVUP4e7kL8y2zbSknDhQJ9IByGAa6r8=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20200925144332-ab41ac3396b1/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
 github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91 h1:HJ6U3S3ljJqNffYMcIeAncp5qT/i+ZMiJ2JC2F0aXP4=
 github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91/go.mod h1:sjyPyRxKM5uw1nD2cJ6O2OxI6GOqyVBfNXqKjBZTBZE=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7 h1:ntrLa/8xVzeSs8vHFHK25k0C+NV74sYMJnNSg5NoSRo=

--- a/roomserver/internal/perform/perform_backfill.go
+++ b/roomserver/internal/perform/perform_backfill.go
@@ -329,7 +329,7 @@ func (b *backfillRequester) StateBeforeEvent(ctx context.Context, roomVer gomatr
 	event gomatrixserverlib.HeaderedEvent, eventIDs []string) (map[string]*gomatrixserverlib.Event, error) {
 
 	// try to fetch the events from the database first
-	events, err := b.ProvideEvents(roomVer, eventIDs)
+	events, err := b.ProvideEvents(roomVer, eventIDs, "")
 	if err != nil {
 		// non-fatal, fallthrough
 		logrus.WithError(err).Info("Failed to fetch events")
@@ -451,7 +451,7 @@ func (b *backfillRequester) Backfill(ctx context.Context, server gomatrixserverl
 	return tx, err
 }
 
-func (b *backfillRequester) ProvideEvents(roomVer gomatrixserverlib.RoomVersion, eventIDs []string) ([]gomatrixserverlib.Event, error) {
+func (b *backfillRequester) ProvideEvents(roomVer gomatrixserverlib.RoomVersion, eventIDs []string, _ gomatrixserverlib.ServerName) ([]gomatrixserverlib.Event, error) {
 	ctx := context.Background()
 	nidMap, err := b.db.EventNIDs(ctx, eventIDs)
 	if err != nil {


### PR DESCRIPTION
This matches matrix-org/gomatrixserverlib#224 by hinting where to retrieve events from.

This has one particular side effect: that when doing `/send_join`, we will try to find missing auth events *both* from the server we try to join via, and also by the `origin` of the event that refers to the missing auth event.