### PR TITLE
Finish implementing the capabilities endpoint

### DIFF
--- a/clientapi/routing/capabilities.go
+++ b/clientapi/routing/capabilities.go
@@ -23,8 +23,8 @@ import (
 	"github.com/matrix-org/util"
 )
 
-// SendMembership implements PUT /rooms/{roomID}/(join|kick|ban|unban|leave|invite)
-// by building a m.room.member event then sending it to the room server
+// GetCapabilities returns information about the server's supported feature set
+// and other relevant capabilities to an authenticated user.
 func GetCapabilities(
 	req *http.Request, rsAPI roomserverAPI.RoomserverInternalAPI,
 ) util.JSONResponse {
@@ -41,6 +41,9 @@ func GetCapabilities(
 
 	response := map[string]interface{}{
 		"capabilities": map[string]interface{}{
+			"m.change_password": map[string]bool{
+				"enabled": true,
+			},
 			"m.room_versions": roomVersionsQueryRes,
 		},
 	}

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -480,3 +480,4 @@ Federation key API can act as a notary server via a GET request
 Inbound /make_join rejects attempts to join rooms where all users have left
 Inbound federation rejects invites which include invalid JSON for room version 6
 Inbound federation rejects invite rejections which include invalid JSON for room version 6
+GET /capabilities is present and well formed for registered user 


### PR DESCRIPTION
Closes #1310

I added the `m.change_password` capability to the endpoint and whitelisted the sytest test for the /capabilities endpoint.

The password change capability is just hardcoded for now. If there's a better way to read out the password change capability instead of just hardcoding it, I'd appreciate it if someone could nudge me into the right direction :)

Signed-off-by: Benjamin Nater <me@bn4t.me>

### Pull Request Checklist
* [x] I have added any new tests that need to pass to `testfile` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)
