### PR TITLE
Fetch missing auth events, implement QueryMissingAuthPrevEvents, try other servers in room for /event and /get_missing_events

### DIFF
--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -17,7 +17,6 @@ package routing
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -208,7 +207,7 @@ func (t *txnReq) processTransaction(ctx context.Context) (*gomatrixserverlib.Res
 			} else {
 				// Auth errors mean the event is 'rejected' which have to be silent to appease sytest
 				errMsg := ""
-				rejected := errors.Is(err, &gomatrixserverlib.NotAllowed{})
+				_, rejected := err.(*gomatrixserverlib.NotAllowed)
 				if !rejected {
 					errMsg = err.Error()
 				}
@@ -371,7 +370,7 @@ func (t *txnReq) processEvent(ctx context.Context, e gomatrixserverlib.Event, is
 	}
 
 	if len(stateResp.MissingAuthEventIDs) > 0 {
-		logger.Infof("%d missing auth_events", len(stateResp.MissingAuthEventIDs))
+		logger.Infof("Event refers to %d unknown auth_events", len(stateResp.MissingAuthEventIDs))
 
 		servers := []gomatrixserverlib.ServerName{t.Origin}
 		serverReq := &api.QueryServerJoinedToRoomRequest{
@@ -416,7 +415,7 @@ func (t *txnReq) processEvent(ctx context.Context, e gomatrixserverlib.Event, is
 	}
 
 	if len(stateResp.MissingPrevEventIDs) > 0 {
-		logger.Infof("%d missing prev_events", len(stateResp.MissingAuthEventIDs))
+		logger.Infof("Event refers to %d unknown prev_events", len(stateResp.MissingPrevEventIDs))
 		return t.processEventWithMissingState(ctx, e, stateResp.RoomVersion, isInboundTxn)
 	}
 

--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -17,6 +17,7 @@ package routing
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sync"
@@ -206,10 +207,10 @@ func (t *txnReq) processTransaction(ctx context.Context) (*gomatrixserverlib.Res
 				return nil, &jsonErr
 			} else {
 				// Auth errors mean the event is 'rejected' which have to be silent to appease sytest
-				_, rejected := err.(*gomatrixserverlib.NotAllowed)
-				errMsg := err.Error()
-				if rejected {
-					errMsg = ""
+				errMsg := ""
+				rejected := errors.Is(err, &gomatrixserverlib.NotAllowed{})
+				if !rejected {
+					errMsg = err.Error()
 				}
 				util.GetLogger(ctx).WithError(err).WithField("event_id", e.EventID()).WithField("rejected", rejected).Warn(
 					"Failed to process incoming federation event, skipping",

--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -375,17 +375,8 @@ func (t *txnReq) processEvent(ctx context.Context, e gomatrixserverlib.Event, is
 				logrus.WithError(err).Warnf("Failed to unmarshal auth event %d", missingAuthEventID)
 				continue
 			}
-			err = api.SendEvents(
-				context.Background(),
-				t.rsAPI,
-				[]gomatrixserverlib.HeaderedEvent{
-					ev.Headered(stateResp.RoomVersion),
-				},
-				api.DoNotSendToOtherServers,
-				nil,
-			)
-			if err != nil {
-				logrus.WithError(err).Warnf("Failed to submit auth event %d to roomserver", missingAuthEventID)
+			if err = t.processEvent(ctx, ev, false); err != nil {
+				logrus.WithError(err).Warnf("Failed to process auth event %d", missingAuthEventID)
 			}
 		}
 	}

--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -370,6 +370,8 @@ func (t *txnReq) processEvent(ctx context.Context, e gomatrixserverlib.Event, is
 	}
 
 	if len(stateResp.MissingAuthEventIDs) > 0 {
+		logger.Infof("%d missing auth_events", len(stateResp.MissingAuthEventIDs))
+
 		servers := []gomatrixserverlib.ServerName{t.Origin}
 		serverReq := &api.QueryServerJoinedToRoomRequest{
 			RoomID: e.RoomID(),
@@ -413,6 +415,7 @@ func (t *txnReq) processEvent(ctx context.Context, e gomatrixserverlib.Event, is
 	}
 
 	if len(stateResp.MissingPrevEventIDs) > 0 {
+		logger.Infof("%d missing prev_events", len(stateResp.MissingAuthEventIDs))
 		return t.processEventWithMissingState(ctx, e, stateResp.RoomVersion, isInboundTxn)
 	}
 

--- a/federationapi/routing/send_test.go
+++ b/federationapi/routing/send_test.go
@@ -77,11 +77,10 @@ func (p *testEDUProducer) InputSendToDeviceEvent(
 }
 
 type testRoomserverAPI struct {
-	inputRoomEvents            []api.InputRoomEvent
-	queryMissingAuthPrevEvents func(*api.QueryMissingAuthPrevEventsRequest) api.QueryMissingAuthPrevEventsResponse
-	queryStateAfterEvents      func(*api.QueryStateAfterEventsRequest) api.QueryStateAfterEventsResponse
-	queryEventsByID            func(req *api.QueryEventsByIDRequest) api.QueryEventsByIDResponse
-	queryLatestEventsAndState  func(*api.QueryLatestEventsAndStateRequest) api.QueryLatestEventsAndStateResponse
+	inputRoomEvents           []api.InputRoomEvent
+	queryStateAfterEvents     func(*api.QueryStateAfterEventsRequest) api.QueryStateAfterEventsResponse
+	queryEventsByID           func(req *api.QueryEventsByIDRequest) api.QueryEventsByIDResponse
+	queryLatestEventsAndState func(*api.QueryLatestEventsAndStateRequest) api.QueryLatestEventsAndStateResponse
 }
 
 func (t *testRoomserverAPI) SetFederationSenderAPI(fsAPI fsAPI.FederationSenderInternalAPI) {}
@@ -160,20 +159,6 @@ func (t *testRoomserverAPI) QueryStateAfterEvents(
 	response.PrevEventsExist = res.PrevEventsExist
 	response.RoomExists = res.RoomExists
 	response.StateEvents = res.StateEvents
-	return nil
-}
-
-// Query the state after a list of events in a room from the room server.
-func (t *testRoomserverAPI) QueryMissingAuthPrevEvents(
-	ctx context.Context,
-	request *api.QueryMissingAuthPrevEventsRequest,
-	response *api.QueryMissingAuthPrevEventsResponse,
-) error {
-	response.RoomVersion = testRoomVersion
-	res := t.queryMissingAuthPrevEvents(request)
-	response.RoomExists = res.RoomExists
-	response.MissingAuthEventIDs = res.MissingAuthEventIDs
-	response.MissingPrevEventIDs = res.MissingPrevEventIDs
 	return nil
 }
 
@@ -468,11 +453,11 @@ func assertInputRoomEvents(t *testing.T, got []api.InputRoomEvent, want []gomatr
 // to the roomserver. It's the most basic test possible.
 func TestBasicTransaction(t *testing.T) {
 	rsAPI := &testRoomserverAPI{
-		queryMissingAuthPrevEvents: func(req *api.QueryMissingAuthPrevEventsRequest) api.QueryMissingAuthPrevEventsResponse {
-			return api.QueryMissingAuthPrevEventsResponse{
-				RoomExists:          true,
-				MissingAuthEventIDs: []string{},
-				MissingPrevEventIDs: []string{},
+		queryStateAfterEvents: func(req *api.QueryStateAfterEventsRequest) api.QueryStateAfterEventsResponse {
+			return api.QueryStateAfterEventsResponse{
+				PrevEventsExist: true,
+				RoomExists:      true,
+				StateEvents:     fromStateTuples(req.StateToFetch, nil),
 			}
 		},
 	}
@@ -488,11 +473,14 @@ func TestBasicTransaction(t *testing.T) {
 // as it does the auth check.
 func TestTransactionFailAuthChecks(t *testing.T) {
 	rsAPI := &testRoomserverAPI{
-		queryMissingAuthPrevEvents: func(req *api.QueryMissingAuthPrevEventsRequest) api.QueryMissingAuthPrevEventsResponse {
-			return api.QueryMissingAuthPrevEventsResponse{
-				RoomExists:          true,
-				MissingAuthEventIDs: []string{"create_event"},
-				MissingPrevEventIDs: []string{},
+		queryStateAfterEvents: func(req *api.QueryStateAfterEventsRequest) api.QueryStateAfterEventsResponse {
+			return api.QueryStateAfterEventsResponse{
+				PrevEventsExist: true,
+				RoomExists:      true,
+				// omit the create event so auth checks fail
+				StateEvents: fromStateTuples(req.StateToFetch, []gomatrixserverlib.StateKeyTuple{
+					{EventType: gomatrixserverlib.MRoomCreate, StateKey: ""},
+				}),
 			}
 		},
 	}
@@ -516,6 +504,30 @@ func TestTransactionFetchMissingPrevEvents(t *testing.T) {
 
 	var rsAPI *testRoomserverAPI // ref here so we can refer to inputRoomEvents inside these functions
 	rsAPI = &testRoomserverAPI{
+		queryStateAfterEvents: func(req *api.QueryStateAfterEventsRequest) api.QueryStateAfterEventsResponse {
+			// we expect this to be called three times:
+			// - first with input event to realise there's a gap
+			// - second with the prevEvent to realise there is no gap
+			// - third with the input event to realise there is no longer a gap
+			prevEventsExist := false
+			if len(req.PrevEventIDs) == 1 {
+				switch req.PrevEventIDs[0] {
+				case haveEvent.EventID():
+					prevEventsExist = true
+				case prevEvent.EventID():
+					// we only have this event if we've been send prevEvent
+					if len(rsAPI.inputRoomEvents) == 1 && rsAPI.inputRoomEvents[0].Event.EventID() == prevEvent.EventID() {
+						prevEventsExist = true
+					}
+				}
+			}
+
+			return api.QueryStateAfterEventsResponse{
+				PrevEventsExist: prevEventsExist,
+				RoomExists:      true,
+				StateEvents:     fromStateTuples(req.StateToFetch, nil),
+			}
+		},
 		queryLatestEventsAndState: func(req *api.QueryLatestEventsAndStateRequest) api.QueryLatestEventsAndStateResponse {
 			return api.QueryLatestEventsAndStateResponse{
 				RoomExists: true,
@@ -524,30 +536,6 @@ func TestTransactionFetchMissingPrevEvents(t *testing.T) {
 					haveEvent.EventReference(),
 				},
 				StateEvents: fromStateTuples(req.StateToFetch, nil),
-			}
-		},
-		queryMissingAuthPrevEvents: func(req *api.QueryMissingAuthPrevEventsRequest) api.QueryMissingAuthPrevEventsResponse {
-			// we expect this to be called three times:
-			// - first with input event to realise there's a gap
-			// - second with the prevEvent to realise there is no gap
-			// - third with the input event to realise there is no longer a gap
-			missingPrevEvent := []string{"missing_prev_event"}
-			if len(req.PrevEventIDs) == 1 {
-				switch req.PrevEventIDs[0] {
-				case haveEvent.EventID():
-					missingPrevEvent = []string{}
-				case prevEvent.EventID():
-					// we only have this event if we've been send prevEvent
-					if len(rsAPI.inputRoomEvents) == 1 && rsAPI.inputRoomEvents[0].Event.EventID() == prevEvent.EventID() {
-						missingPrevEvent = []string{}
-					}
-				}
-			}
-
-			return api.QueryMissingAuthPrevEventsResponse{
-				RoomExists:          true,
-				MissingAuthEventIDs: []string{},
-				MissingPrevEventIDs: missingPrevEvent,
 			}
 		},
 	}
@@ -588,9 +576,6 @@ func TestTransactionFetchMissingPrevEvents(t *testing.T) {
 // - /state_ids?event=B is requested, then /event/B to get the state AFTER B. B is a state event.
 // - state resolution is done to check C is allowed.
 // This results in B being sent as an outlier FIRST, then C,D.
-/*
-TODO: Fix this test!
-
 func TestTransactionFetchMissingStateByStateIDs(t *testing.T) {
 	eventA := testEvents[len(testEvents)-5]
 	// this is also len(testEvents)-4
@@ -652,21 +637,6 @@ func TestTransactionFetchMissingStateByStateIDs(t *testing.T) {
 					eventA.EventReference(),
 				},
 				StateEvents: fromStateTuples(req.StateToFetch, omitTuples),
-			}
-		},
-		queryMissingAuthPrevEvents: func(req *api.QueryMissingAuthPrevEventsRequest) api.QueryMissingAuthPrevEventsResponse {
-			askingForEvent := req.PrevEventIDs[0]
-			missingPrevEvents := []string{"missing_prev_event"}
-			if askingForEvent == eventC.EventID() {
-				missingPrevEvents = []string{}
-			} else if askingForEvent == eventB.EventID() {
-				missingPrevEvents = []string{}
-			}
-
-			return api.QueryMissingAuthPrevEventsResponse{
-				RoomExists:          true,
-				MissingAuthEventIDs: []string{},
-				MissingPrevEventIDs: missingPrevEvents,
 			}
 		},
 		queryEventsByID: func(req *api.QueryEventsByIDRequest) api.QueryEventsByIDResponse {
@@ -746,4 +716,3 @@ func TestTransactionFetchMissingStateByStateIDs(t *testing.T) {
 	mustProcessTransaction(t, txn, nil)
 	assertInputRoomEvents(t, rsAPI.inputRoomEvents, []gomatrixserverlib.HeaderedEvent{eventB, eventC, eventD})
 }
-*/

--- a/roomserver/api/api.go
+++ b/roomserver/api/api.go
@@ -68,6 +68,13 @@ type RoomserverInternalAPI interface {
 		response *QueryStateAfterEventsResponse,
 	) error
 
+	// Query whether the roomserver is missing any auth or prev events.
+	QueryMissingAuthPrevEvents(
+		ctx context.Context,
+		request *QueryMissingAuthPrevEventsRequest,
+		response *QueryMissingAuthPrevEventsResponse,
+	) error
+
 	// Query a list of events by event ID.
 	QueryEventsByID(
 		ctx context.Context,

--- a/roomserver/api/api_trace.go
+++ b/roomserver/api/api_trace.go
@@ -104,6 +104,16 @@ func (t *RoomserverInternalAPITrace) QueryStateAfterEvents(
 	return err
 }
 
+func (t *RoomserverInternalAPITrace) QueryMissingAuthPrevEvents(
+	ctx context.Context,
+	req *QueryMissingAuthPrevEventsRequest,
+	res *QueryMissingAuthPrevEventsResponse,
+) error {
+	err := t.Impl.QueryMissingAuthPrevEvents(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("QueryMissingAuthPrevEvents req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
 func (t *RoomserverInternalAPITrace) QueryEventsByID(
 	ctx context.Context,
 	req *QueryEventsByIDRequest,

--- a/roomserver/api/query.go
+++ b/roomserver/api/query.go
@@ -82,6 +82,27 @@ type QueryStateAfterEventsResponse struct {
 	StateEvents []gomatrixserverlib.HeaderedEvent `json:"state_events"`
 }
 
+type QueryMissingAuthPrevEventsRequest struct {
+	// The room ID to query the state in.
+	RoomID string `json:"room_id"`
+	// The list of auth events to check the existence of.
+	AuthEventIDs []string `json:"auth_event_ids"`
+	// The list of previous events to check the existence of.
+	PrevEventIDs []string `json:"prev_event_ids"`
+}
+
+type QueryMissingAuthPrevEventsResponse struct {
+	// Does the room exist on this roomserver?
+	// If the room doesn't exist all other fields will be empty.
+	RoomExists bool `json:"room_exists"`
+	// The room version of the room.
+	RoomVersion gomatrixserverlib.RoomVersion `json:"room_version"`
+	// The event IDs of the auth events that we don't know locally.
+	MissingAuthEventIDs []string `json:"missing_auth_event_ids"`
+	// The event IDs of the previous events that we don't know locally.
+	MissingPrevEventIDs []string `json:"missing_prev_event_ids"`
+}
+
 // QueryEventsByIDRequest is a request to QueryEventsByID
 type QueryEventsByIDRequest struct {
 	// The event IDs to look up.

--- a/roomserver/api/query.go
+++ b/roomserver/api/query.go
@@ -154,6 +154,8 @@ type QueryServerJoinedToRoomResponse struct {
 	RoomExists bool `json:"room_exists"`
 	// True if we still believe that we are participating in the room
 	IsInRoom bool `json:"is_in_room"`
+	// List of servers that are also in the room
+	ServerNames []gomatrixserverlib.ServerName `json:"server_names"`
 }
 
 // QueryServerAllowedToSeeEventRequest is a request to QueryServerAllowedToSeeEvent

--- a/roomserver/internal/helpers/auth.go
+++ b/roomserver/internal/helpers/auth.go
@@ -83,7 +83,7 @@ func CheckForSoftFail(
 	// Check if the event is allowed.
 	if err = gomatrixserverlib.Allowed(event.Event, &authEvents); err != nil {
 		// return true, nil
-		return true, fmt.Errorf("gomatrixserverlib.Allowed: %w", err)
+		return true, err
 	}
 	return false, nil
 }
@@ -114,7 +114,7 @@ func CheckAuthEvents(
 
 	// Check if the event is allowed.
 	if err = gomatrixserverlib.Allowed(event.Event, &authEvents); err != nil {
-		return nil, fmt.Errorf("gomatrixserverlib.Allowed: %w", err)
+		return nil, err
 	}
 
 	// Return the numeric IDs for the auth events.

--- a/roomserver/internal/helpers/auth.go
+++ b/roomserver/internal/helpers/auth.go
@@ -99,7 +99,7 @@ func CheckAuthEvents(
 	// Grab the numeric IDs for the supplied auth state events from the database.
 	authStateEntries, err := db.StateEntriesForEventIDs(ctx, authEventIDs)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("db.StateEntriesForEventIDs: %w", err)
 	}
 	authStateEntries = types.DeduplicateStateEntries(authStateEntries)
 
@@ -109,12 +109,12 @@ func CheckAuthEvents(
 	// Load the actual auth events from the database.
 	authEvents, err := loadAuthEvents(ctx, db, stateNeeded, authStateEntries)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("loadAuthEvents: %w", err)
 	}
 
 	// Check if the event is allowed.
 	if err = gomatrixserverlib.Allowed(event.Event, &authEvents); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("gomatrixserverlib.Allowed: %w", err)
 	}
 
 	// Return the numeric IDs for the auth events.

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -49,7 +49,7 @@ func (r *Inputer) processRoomEvent(
 	isRejected := false
 	authEventNIDs, rejectionErr := helpers.CheckAuthEvents(ctx, r.DB, headered, input.AuthEventIDs)
 	if rejectionErr != nil {
-		logrus.WithError(rejectionErr).WithField("event_id", event.EventID()).WithField("auth_event_ids", input.AuthEventIDs).Error("processRoomEvent.checkAuthEvents failed for event, rejecting event")
+		logrus.WithError(rejectionErr).WithField("event_id", event.EventID()).WithField("auth_event_ids", input.AuthEventIDs).Error("helpers.CheckAuthEvents failed for event, rejecting event")
 		isRejected = true
 	}
 

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -133,7 +133,7 @@ func (r *Inputer) processRoomEvent(
 			"soft_fail": softfail,
 			"sender":    event.Sender(),
 		}).Debug("Stored rejected event")
-		return event.EventID(), rejectionErr
+		return event.EventID(), nil
 	}
 
 	if input.Kind == api.KindRewrite {

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -133,7 +133,7 @@ func (r *Inputer) processRoomEvent(
 			"soft_fail": softfail,
 			"sender":    event.Sender(),
 		}).Debug("Stored rejected event")
-		return event.EventID(), nil
+		return event.EventID(), rejectionErr
 	}
 
 	if input.Kind == api.KindRewrite {

--- a/roomserver/internal/perform/perform_join.go
+++ b/roomserver/internal/perform/perform_join.go
@@ -249,14 +249,10 @@ func (r *Joiner) performJoinRoomByID(
 			inputRes := api.InputRoomEventsResponse{}
 			r.Inputer.InputRoomEvents(ctx, &inputReq, &inputRes)
 			if err = inputRes.Err(); err != nil {
-				var notAllowed *gomatrixserverlib.NotAllowed
-				if errors.As(err, &notAllowed) {
-					return "", &api.PerformError{
-						Code: api.PerformErrorNotAllowed,
-						Msg:  fmt.Sprintf("InputRoomEvents auth failed: %s", err),
-					}
+				return "", &api.PerformError{
+					Code: api.PerformErrorNotAllowed,
+					Msg:  fmt.Sprintf("InputRoomEvents auth failed: %s", err),
 				}
-				return "", fmt.Errorf("r.InputRoomEvents: %w", err)
 			}
 		}
 

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -116,13 +116,13 @@ func (r *Queryer) QueryMissingAuthPrevEvents(
 	response.RoomVersion = info.RoomVersion
 
 	for _, authEventID := range request.AuthEventIDs {
-		if _, err := r.DB.EventNIDs(ctx, []string{authEventID}); err != nil {
+		if nids, err := r.DB.EventNIDs(ctx, []string{authEventID}); err != nil || len(nids) != 1 {
 			response.MissingAuthEventIDs = append(response.MissingAuthEventIDs, authEventID)
 		}
 	}
 
 	for _, prevEventID := range request.PrevEventIDs {
-		if _, err := r.DB.EventNIDs(ctx, []string{prevEventID}); err != nil {
+		if nids, err := r.DB.EventNIDs(ctx, []string{prevEventID}); err != nil || len(nids) != 1 {
 			response.MissingPrevEventIDs = append(response.MissingPrevEventIDs, prevEventID)
 		}
 	}

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -108,11 +108,11 @@ func (r *Queryer) QueryMissingAuthPrevEvents(
 	if err != nil {
 		return err
 	}
-	if info == nil || info.IsStub {
+	if info == nil {
 		return errors.New("room doesn't exist")
 	}
 
-	response.RoomExists = true
+	response.RoomExists = !info.IsStub
 	response.RoomVersion = info.RoomVersion
 
 	for _, authEventID := range request.AuthEventIDs {

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -116,13 +116,13 @@ func (r *Queryer) QueryMissingAuthPrevEvents(
 	response.RoomVersion = info.RoomVersion
 
 	for _, authEventID := range request.AuthEventIDs {
-		if nids, err := r.DB.EventNIDs(ctx, []string{authEventID}); err != nil || len(nids) != 1 {
+		if nids, err := r.DB.EventNIDs(ctx, []string{authEventID}); err != nil || len(nids) == 0 {
 			response.MissingAuthEventIDs = append(response.MissingAuthEventIDs, authEventID)
 		}
 	}
 
 	for _, prevEventID := range request.PrevEventIDs {
-		if nids, err := r.DB.EventNIDs(ctx, []string{prevEventID}); err != nil || len(nids) != 1 {
+		if nids, err := r.DB.EventNIDs(ctx, []string{prevEventID}); err != nil || len(nids) == 0 {
 			response.MissingPrevEventIDs = append(response.MissingPrevEventIDs, prevEventID)
 		}
 	}

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -255,17 +255,22 @@ func (r *Queryer) QueryServerJoinedToRoom(
 		return fmt.Errorf("r.DB.Events: %w", err)
 	}
 
+	servers := map[gomatrixserverlib.ServerName]struct{}{}
 	for _, e := range events {
 		if e.Type() == gomatrixserverlib.MRoomMember && e.StateKey() != nil {
 			_, serverName, err := gomatrixserverlib.SplitID('@', *e.StateKey())
 			if err != nil {
 				continue
 			}
+			servers[serverName] = struct{}{}
 			if serverName == request.ServerName {
 				response.IsInRoom = true
-				break
 			}
 		}
+	}
+
+	for server := range servers {
+		response.ServerNames = append(response.ServerNames, server)
 	}
 
 	return nil

--- a/roomserver/inthttp/client.go
+++ b/roomserver/inthttp/client.go
@@ -35,6 +35,7 @@ const (
 	// Query operations
 	RoomserverQueryLatestEventsAndStatePath    = "/roomserver/queryLatestEventsAndState"
 	RoomserverQueryStateAfterEventsPath        = "/roomserver/queryStateAfterEvents"
+	RoomserverQueryMissingAuthPrevEventsPath   = "/roomserver/queryMissingAuthPrevEvents"
 	RoomserverQueryEventsByIDPath              = "/roomserver/queryEventsByID"
 	RoomserverQueryMembershipForUserPath       = "/roomserver/queryMembershipForUser"
 	RoomserverQueryMembershipsForRoomPath      = "/roomserver/queryMembershipsForRoom"
@@ -259,6 +260,19 @@ func (h *httpRoomserverInternalAPI) QueryStateAfterEvents(
 	defer span.Finish()
 
 	apiURL := h.roomserverURL + RoomserverQueryStateAfterEventsPath
+	return httputil.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+}
+
+// QueryStateAfterEvents implements RoomserverQueryAPI
+func (h *httpRoomserverInternalAPI) QueryMissingAuthPrevEvents(
+	ctx context.Context,
+	request *api.QueryMissingAuthPrevEventsRequest,
+	response *api.QueryMissingAuthPrevEventsResponse,
+) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "QueryMissingAuthPrevEvents")
+	defer span.Finish()
+
+	apiURL := h.roomserverURL + RoomserverQueryMissingAuthPrevEventsPath
 	return httputil.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }
 

--- a/roomserver/inthttp/server.go
+++ b/roomserver/inthttp/server.go
@@ -126,6 +126,20 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		}),
 	)
 	internalAPIMux.Handle(
+		RoomserverQueryMissingAuthPrevEventsPath,
+		httputil.MakeInternalAPI("queryMissingAuthPrevEvents", func(req *http.Request) util.JSONResponse {
+			var request api.QueryMissingAuthPrevEventsRequest
+			var response api.QueryMissingAuthPrevEventsResponse
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.ErrorResponse(err)
+			}
+			if err := r.QueryMissingAuthPrevEvents(req.Context(), &request, &response); err != nil {
+				return util.ErrorResponse(err)
+			}
+			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
+		}),
+	)
+	internalAPIMux.Handle(
 		RoomserverQueryEventsByIDPath,
 		httputil.MakeInternalAPI("queryEventsByID", func(req *http.Request) util.JSONResponse {
 			var request api.QueryEventsByIDRequest


### PR DESCRIPTION
This PR makes a few changes:

- Implements `QueryMissingAuthPrevEvents` so that:
  - the federation `/send` endpoint can call that to work out if auth or prev events referred to in the event are not known to us
  - we don't waste roomserver effort calculating state when we don't care about the result
- Try to fetch missing auth events
- Include known server names in `QueryServerJoinedToRoom`, since we are processing them anyway it's useful to know them
- Try to use other servers when doing `/event` (to retrieve missing auth events) or `/get_missing_events` (to retrieve missing prev events)