### PR TITLE
Fix bug in error handling in SQLite InsertPreviousEvent

### DIFF
--- a/roomserver/storage/sqlite3/previous_events_table.go
+++ b/roomserver/storage/sqlite3/previous_events_table.go
@@ -98,7 +98,7 @@ func (s *previousEventStatements) InsertPreviousEvent(
 	eventNIDAsString := fmt.Sprintf("%d", eventNID)
 	selectStmt := sqlutil.TxStmt(txn, s.selectPreviousEventExistsStmt)
 	err := selectStmt.QueryRowContext(ctx, previousEventID, previousEventReferenceSHA256).Scan(&eventNIDs)
-	if err != sql.ErrNoRows {
+	if err != nil && err != sql.ErrNoRows {
 		return fmt.Errorf("selectStmt.QueryRowContext.Scan: %w", err)
 	}
 	var nids []string


### PR DESCRIPTION
This fixes a case where we might accidentally handle a `nil` error as if it were a returnable offence. 