### PR TITLE
Update version imprinting

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,10 +3,16 @@
 # Put installed packages into ./bin
 export GOBIN=$PWD/`dirname $0`/bin
 
-export BRANCH=`(git symbolic-ref --short HEAD | cut -d'/' -f 3 )|| ""`
-export BUILD=`git rev-parse --short HEAD || ""`
+if [ -d ".git" ] 
+then
+    export BUILD=`git rev-parse --short HEAD || ""`
+    export BRANCH=`(git symbolic-ref --short HEAD | tr -d \/ ) || ""`
+    [[ $BRANCH == "master" ]] && export BRANCH=""
 
-export FLAGS="-X github.com/matrix-org/dendrite/internal.branch=$BRANCH -X github.com/matrix-org/dendrite/internal.build=$BUILD"
+    export FLAGS="-X github.com/matrix-org/dendrite/internal.branch=$BRANCH -X github.com/matrix-org/dendrite/internal.build=$BUILD"
+else
+    export FLAGS=""
+fi
 
 go install -trimpath -ldflags "$FLAGS" -v $PWD/`dirname $0`/cmd/...
 

--- a/internal/version.go
+++ b/internal/version.go
@@ -12,10 +12,11 @@ const (
 	VersionMajor = 0
 	VersionMinor = 0
 	VersionPatch = 0
+	VersionTag   = "" // example: "rc1"
 )
 
 func VersionString() string {
-	version := fmt.Sprintf("%d.%d.%d", VersionMajor, VersionMinor, VersionPatch)
+	version := fmt.Sprintf("%d.%d.%d%s", VersionMajor, VersionMinor, VersionPatch, VersionTag)
 	if branch != "" {
 		version += fmt.Sprintf("-%s", branch)
 	}


### PR DESCRIPTION
This makes a couple of minor tweaks:

- We'll now only try to get the build commit ID and branch if `.git` exists (this won't be true when downloading the `.tar.gz`/`.zip` from the GitHub Releases/tags)
- We won't include the `master` branch in the imprint, as it seems a bit unnecessary
- Adds a `VersionTag` for release candidate tags