### PR TITLE
Add history visibility guards

### DIFF
--- a/syncapi/routing/messages.go
+++ b/syncapi/routing/messages.go
@@ -259,6 +259,7 @@ func (r *messagesReq) retrieveEvents() (
 	return clientEvents, start, end, err
 }
 
+// nolint:gocyclo
 func (r *messagesReq) filterHistoryVisible(events []gomatrixserverlib.HeaderedEvent) []gomatrixserverlib.HeaderedEvent {
 	// TODO FIXME: We don't fully implement history visibility yet. To avoid leaking events which the
 	// user shouldn't see, we check the recent events and remove any prior to the join event of the user
@@ -302,10 +303,6 @@ func (r *messagesReq) filterHistoryVisible(events []gomatrixserverlib.HeaderedEv
 			},
 		}, &queryRes)
 		if err != nil {
-			wasJoined = false
-			break
-		}
-		if len(queryRes.StateEvents) == 0 {
 			wasJoined = false
 			break
 		}

--- a/syncapi/routing/messages.go
+++ b/syncapi/routing/messages.go
@@ -318,16 +318,16 @@ func (r *messagesReq) filterHistoryVisible(events []gomatrixserverlib.HeaderedEv
 				hisVisEvent = &queryRes.StateEvents[i]
 			}
 		}
-		if membershipEvent == nil {
-			wasJoined = false
-			break
-		}
 		if hisVisEvent == nil {
 			return events // apply no filtering as it defaults to Shared.
 		}
 		hisVis, _ := hisVisEvent.HistoryVisibility()
 		if hisVis == "shared" {
 			return events // apply no filtering
+		}
+		if membershipEvent == nil {
+			wasJoined = false
+			break
 		}
 		membership, err := membershipEvent.Membership()
 		if err != nil {

--- a/syncapi/routing/routing.go
+++ b/syncapi/routing/routing.go
@@ -51,7 +51,7 @@ func Setup(
 		if err != nil {
 			return util.ErrorResponse(err)
 		}
-		return OnIncomingMessagesRequest(req, syncDB, vars["roomID"], federation, rsAPI, cfg)
+		return OnIncomingMessagesRequest(req, syncDB, vars["roomID"], device, federation, rsAPI, cfg)
 	})).Methods(http.MethodGet, http.MethodOptions)
 
 	r0mux.Handle("/user/{userId}/filter",

--- a/syncapi/storage/storage_test.go
+++ b/syncapi/storage/storage_test.go
@@ -689,6 +689,7 @@ func assertInvitedToRooms(t *testing.T, res *types.Response, roomIDs []string) {
 }
 
 func assertEventsEqual(t *testing.T, msg string, checkRoomID bool, gots []gomatrixserverlib.ClientEvent, wants []gomatrixserverlib.HeaderedEvent) {
+	t.Helper()
 	if len(gots) != len(wants) {
 		t.Fatalf("%s response returned %d events, want %d", msg, len(gots), len(wants))
 	}

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -90,8 +90,6 @@ Real non-joined users can get state for world_readable rooms
 Real non-joined users can get individual state for world_readable rooms
 #Real non-joined users can get individual state for world_readable rooms after leaving
 Real non-joined users cannot send messages to guest_access rooms if not joined
-Real users can sync from world_readable guest_access rooms if joined
-Real users can sync from default guest_access rooms if joined
 Can't forget room you're still in
 Can get rooms/{roomId}/members
 Can create filter
@@ -236,13 +234,11 @@ Outbound federation can query v2 /send_join
 Inbound federation can receive v2 /send_join
 Message history can be paginated
 Getting messages going forward is limited for a departed room (SPEC-216)
-m.room.history_visibility == "world_readable" allows/forbids appropriately for Real users
 Backfill works correctly with history visibility set to joined
 Guest user cannot call /events globally
 Guest users can join guest_access rooms
 Guest user can set display names
 Guest user cannot upgrade other users
-m.room.history_visibility == "world_readable" allows/forbids appropriately for Guest users
 Guest non-joined user cannot call /events on shared room
 Guest non-joined user cannot call /events on invited room
 Guest non-joined user cannot call /events on joined room
@@ -252,8 +248,6 @@ Guest non-joined users can get individual state for world_readable rooms
 Guest non-joined users cannot room initalSync for non-world_readable rooms
 Guest non-joined users can get individual state for world_readable rooms after leaving
 Guest non-joined users cannot send messages to guest_access rooms if not joined
-Guest users can sync from world_readable guest_access rooms if joined
-Guest users can sync from default guest_access rooms if joined
 Real non-joined users cannot room initalSync for non-world_readable rooms
 Push rules come down in an initial /sync
 Regular users can add and delete aliases in the default room configuration
@@ -479,3 +473,5 @@ Inbound /make_join rejects attempts to join rooms where all users have left
 Inbound federation rejects invites which include invalid JSON for room version 6
 Inbound federation rejects invite rejections which include invalid JSON for room version 6
 GET /capabilities is present and well formed for registered user 
+m.room.history_visibility == "joined" allows/forbids appropriately for Guest users
+m.room.history_visibility == "joined" allows/forbids appropriately for Real users


### PR DESCRIPTION
Default to 'joined' visibility to avoid leaking events, until we get
around to implementing history visibility completely. Related #617
