### PR TITLE
Don't use request context for backfill event persistence

### DIFF
--- a/syncapi/routing/messages.go
+++ b/syncapi/routing/messages.go
@@ -412,7 +412,7 @@ func (r *messagesReq) backfill(roomID string, backwardsExtremities map[string][]
 	// up in responses to sync requests.
 	for i := range res.Events {
 		_, err = r.db.WriteEvent(
-			r.ctx,
+			context.Background(),
 			&res.Events[i],
 			[]gomatrixserverlib.HeaderedEvent{},
 			[]string{},


### PR DESCRIPTION
This PR makes some tweaks to backfill (re. #1477).