### PR TITLE
Don't give up if we fail to fetch a key

### DIFF
--- a/cmd/furl/main.go
+++ b/cmd/furl/main.go
@@ -20,6 +20,7 @@ var requestFrom = flag.String("from", "", "the server name that the request shou
 var requestKey = flag.String("key", "matrix_key.pem", "the private key to use when signing the request")
 var requestPost = flag.Bool("post", false, "send a POST request instead of GET (pipe input into stdin or type followed by Ctrl-D)")
 
+// nolint:gocyclo
 func main() {
 	flag.Parse()
 

--- a/roomserver/internal/perform/perform_backfill.go
+++ b/roomserver/internal/perform/perform_backfill.go
@@ -195,7 +195,7 @@ func (r *Backfiller) fetchAndStoreMissingEvents(ctx context.Context, roomVer gom
 			logger.Infof("returned %d PDUs which made events %+v", len(res.PDUs), result)
 			for _, res := range result {
 				if res.Error != nil {
-					logger.WithError(err).Warn("event failed PDU checks")
+					logger.WithError(res.Error).Warn("event failed PDU checks")
 					continue
 				}
 				missingMap[id] = res.Event

--- a/serverkeyapi/internal/api.go
+++ b/serverkeyapi/internal/api.go
@@ -98,10 +98,6 @@ func (s *ServerKeyAPI) FetchKeys(
 			// we've failed to satisfy it from local keys, database keys or from
 			// all of the fetchers. Report an error.
 			logrus.Warnf("Failed to retrieve key %q for server %q", req.KeyID, req.ServerName)
-			return results, fmt.Errorf(
-				"server key API failed to satisfy key request for server %q key ID %q",
-				req.ServerName, req.KeyID,
-			)
 		}
 	}
 


### PR DESCRIPTION
If we fail to fetch specific keys, we shouldn't just give up - gomatrixserverlib may well be happy to carry on ignoring specific auth/state events if they aren't important to anything else.