### PR TITLE
Update monolith -api behaviour

### DIFF
--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -46,10 +46,11 @@ func main() {
 	cfg := setup.ParseFlags(true)
 	httpAddr := config.HTTPAddress("http://" + *httpBindAddr)
 	httpsAddr := config.HTTPAddress("https://" + *httpsBindAddr)
-	httpAPIAddr := config.HTTPAddress("https://" + *apiBindAddr)
+	httpAPIAddr := httpAddr
 
 	if *enableHTTPAPIs {
 		logrus.Warnf("DANGER! The -api option is enabled, exposing internal APIs on %q!", *apiBindAddr)
+		httpAPIAddr = config.HTTPAddress("http://" + *apiBindAddr)
 		// If the HTTP APIs are enabled then we need to update the Listen
 		// statements in the configuration so that we know where to find
 		// the API endpoints. They'll listen on the same port as the monolith

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -29,11 +29,13 @@ import (
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/serverkeyapi"
 	"github.com/matrix-org/dendrite/userapi"
+	"github.com/sirupsen/logrus"
 )
 
 var (
 	httpBindAddr   = flag.String("http-bind-address", ":8008", "The HTTP listening port for the server")
 	httpsBindAddr  = flag.String("https-bind-address", ":8448", "The HTTPS listening port for the server")
+	apiBindAddr    = flag.String("api-bind-address", "localhost:18008", "The HTTP listening port for the internal HTTP APIs (if -api is enabled)")
 	certFile       = flag.String("tls-cert", "", "The PEM formatted X509 certificate to use for TLS")
 	keyFile        = flag.String("tls-key", "", "The PEM private key to use for TLS")
 	enableHTTPAPIs = flag.Bool("api", false, "Use HTTP APIs instead of short-circuiting (warning: exposes API endpoints!)")
@@ -44,22 +46,24 @@ func main() {
 	cfg := setup.ParseFlags(true)
 	httpAddr := config.HTTPAddress("http://" + *httpBindAddr)
 	httpsAddr := config.HTTPAddress("https://" + *httpsBindAddr)
+	httpAPIAddr := config.HTTPAddress("https://" + *apiBindAddr)
 
 	if *enableHTTPAPIs {
+		logrus.Warnf("DANGER! The -api option is enabled, exposing internal APIs on %q!", *apiBindAddr)
 		// If the HTTP APIs are enabled then we need to update the Listen
 		// statements in the configuration so that we know where to find
 		// the API endpoints. They'll listen on the same port as the monolith
 		// itself.
-		cfg.AppServiceAPI.InternalAPI.Connect = httpAddr
-		cfg.ClientAPI.InternalAPI.Connect = httpAddr
-		cfg.EDUServer.InternalAPI.Connect = httpAddr
-		cfg.FederationAPI.InternalAPI.Connect = httpAddr
-		cfg.FederationSender.InternalAPI.Connect = httpAddr
-		cfg.KeyServer.InternalAPI.Connect = httpAddr
-		cfg.MediaAPI.InternalAPI.Connect = httpAddr
-		cfg.RoomServer.InternalAPI.Connect = httpAddr
-		cfg.ServerKeyAPI.InternalAPI.Connect = httpAddr
-		cfg.SyncAPI.InternalAPI.Connect = httpAddr
+		cfg.AppServiceAPI.InternalAPI.Connect = httpAPIAddr
+		cfg.ClientAPI.InternalAPI.Connect = httpAPIAddr
+		cfg.EDUServer.InternalAPI.Connect = httpAPIAddr
+		cfg.FederationAPI.InternalAPI.Connect = httpAPIAddr
+		cfg.FederationSender.InternalAPI.Connect = httpAPIAddr
+		cfg.KeyServer.InternalAPI.Connect = httpAPIAddr
+		cfg.MediaAPI.InternalAPI.Connect = httpAPIAddr
+		cfg.RoomServer.InternalAPI.Connect = httpAPIAddr
+		cfg.ServerKeyAPI.InternalAPI.Connect = httpAPIAddr
+		cfg.SyncAPI.InternalAPI.Connect = httpAPIAddr
 	}
 
 	base := setup.NewBaseDendrite(cfg, "Monolith", *enableHTTPAPIs)
@@ -148,18 +152,18 @@ func main() {
 	// Expose the matrix APIs directly rather than putting them under a /api path.
 	go func() {
 		base.SetupAndServeHTTP(
-			config.HTTPAddress(httpAddr), // internal API
-			config.HTTPAddress(httpAddr), // external API
-			nil, nil,                     // TLS settings
+			httpAPIAddr, // internal API
+			httpAddr,    // external API
+			nil, nil,    // TLS settings
 		)
 	}()
 	// Handle HTTPS if certificate and key are provided
 	if *certFile != "" && *keyFile != "" {
 		go func() {
 			base.SetupAndServeHTTP(
-				config.HTTPAddress(httpsAddr), // internal API
-				config.HTTPAddress(httpsAddr), // external API
-				certFile, keyFile,             // TLS settings
+				setup.NoInternalListener, // internal API
+				httpsAddr,                // external API
+				certFile, keyFile,        // TLS settings
 			)
 		}()
 	}

--- a/internal/setup/base.go
+++ b/internal/setup/base.go
@@ -300,35 +300,35 @@ func (b *BaseDendrite) SetupAndServeHTTP(
 	externalRouter.PathPrefix(httputil.PublicFederationPathPrefix).Handler(b.PublicFederationAPIMux)
 	externalRouter.PathPrefix(httputil.PublicMediaPathPrefix).Handler(b.PublicMediaAPIMux)
 
-	go func() {
-		logrus.Infof("Starting %s listener on %s", b.componentName, internalServ.Addr)
-		if certFile != nil && keyFile != nil {
-			if err := internalServ.ListenAndServeTLS(*certFile, *keyFile); err != nil {
-				logrus.WithError(err).Fatal("failed to serve HTTPS")
-			}
-		} else {
-			if err := internalServ.ListenAndServe(); err != nil {
-				logrus.WithError(err).Fatal("failed to serve HTTP")
-			}
-		}
-		logrus.Infof("Stopped %s listener on %s", b.componentName, internalServ.Addr)
-	}()
-
 	if internalAddr != NoInternalListener && internalAddr != externalAddr {
 		go func() {
-			logrus.Infof("Starting %s listener on %s", b.componentName, externalServ.Addr)
+			logrus.Infof("Starting %s listener on %s", b.componentName, internalServ.Addr)
 			if certFile != nil && keyFile != nil {
-				if err := externalServ.ListenAndServeTLS(*certFile, *keyFile); err != nil {
+				if err := internalServ.ListenAndServeTLS(*certFile, *keyFile); err != nil {
 					logrus.WithError(err).Fatal("failed to serve HTTPS")
 				}
 			} else {
-				if err := externalServ.ListenAndServe(); err != nil {
+				if err := internalServ.ListenAndServe(); err != nil {
 					logrus.WithError(err).Fatal("failed to serve HTTP")
 				}
 			}
-			logrus.Infof("Stopped %s listener on %s", b.componentName, externalServ.Addr)
+			logrus.Infof("Stopped %s listener on %s", b.componentName, internalServ.Addr)
 		}()
 	}
+
+	go func() {
+		logrus.Infof("Starting %s listener on %s", b.componentName, externalServ.Addr)
+		if certFile != nil && keyFile != nil {
+			if err := externalServ.ListenAndServeTLS(*certFile, *keyFile); err != nil {
+				logrus.WithError(err).Fatal("failed to serve HTTPS")
+			}
+		} else {
+			if err := externalServ.ListenAndServe(); err != nil {
+				logrus.WithError(err).Fatal("failed to serve HTTP")
+			}
+		}
+		logrus.Infof("Stopped %s listener on %s", b.componentName, externalServ.Addr)
+	}()
 
 	select {}
 }

--- a/internal/setup/base.go
+++ b/internal/setup/base.go
@@ -314,7 +314,7 @@ func (b *BaseDendrite) SetupAndServeHTTP(
 		logrus.Infof("Stopped %s listener on %s", b.componentName, internalServ.Addr)
 	}()
 
-	if externalAddr != NoInternalListener && internalAddr != externalAddr {
+	if internalAddr != NoInternalListener && internalAddr != externalAddr {
 		go func() {
 			logrus.Infof("Starting %s listener on %s", b.componentName, externalServ.Addr)
 			if certFile != nil && keyFile != nil {


### PR DESCRIPTION
This makes some changes to the monolith `-api` behaviour:

- The monolith internal listener is now on `localhost:18008` by default when `-api` is enabled
- Adds `-api-bind-address` for overriding the above
- The setup package now prefers setting up the external listener over the internal one, which ultimately makes more sense because that's where the majority of useful HTTP routing goes