### PR TITLE
Don't return 500s on checking if allowed to see event

### DIFF
--- a/roomserver/internal/helpers/helpers.go
+++ b/roomserver/internal/helpers/helpers.go
@@ -2,6 +2,8 @@ package helpers
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 
 	"github.com/matrix-org/dendrite/roomserver/api"
@@ -217,6 +219,9 @@ func CheckServerAllowedToSeeEvent(
 	roomState := state.NewStateResolution(db, info)
 	stateEntries, err := roomState.LoadStateAtEvent(ctx, eventID)
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
 		return false, err
 	}
 


### PR DESCRIPTION
`CheckServerAllowedToSeeEvent` was returning `sql.ErrNoRows` which was causing us to return 500s.