### PR TITLE
Update invite stripped state in sync API

### DIFF
--- a/syncapi/types/types.go
+++ b/syncapi/types/types.go
@@ -466,17 +466,31 @@ func NewJoinResponse() *JoinResponse {
 // InviteResponse represents a /sync response for a room which is under the 'invite' key.
 type InviteResponse struct {
 	InviteState struct {
-		Events json.RawMessage `json:"events"`
+		Events []json.RawMessage `json:"events"`
 	} `json:"invite_state"`
 }
 
 // NewInviteResponse creates an empty response with initialised arrays.
 func NewInviteResponse(event gomatrixserverlib.HeaderedEvent) *InviteResponse {
 	res := InviteResponse{}
-	res.InviteState.Events = json.RawMessage{'[', ']'}
+	res.InviteState.Events = []json.RawMessage{}
+
+	// First see if there's invite_room_state in the unsigned key of the invite.
+	// If there is then unmarshal it into the response. This will contain the
+	// partial room state such as join rules, room name etc.
 	if inviteRoomState := gjson.GetBytes(event.Unsigned(), "invite_room_state"); inviteRoomState.Exists() {
-		res.InviteState.Events = json.RawMessage(inviteRoomState.Raw)
+		_ = json.Unmarshal([]byte(inviteRoomState.Raw), &res.InviteState.Events)
 	}
+
+	// Then we'll see if we can create a partial of the invite event itself.
+	// This is needed for clients to work out *who* sent the invite.
+	format, _ := event.RoomVersion.EventFormat()
+	inviteEvent := gomatrixserverlib.ToClientEvent(event.Unwrap(), format)
+	inviteEvent.Unsigned = nil
+	if ev, err := json.Marshal(inviteEvent); err == nil {
+		res.InviteState.Events = append(res.InviteState.Events, ev)
+	}
+
 	return &res
 }
 

--- a/syncapi/types/types_test.go
+++ b/syncapi/types/types_test.go
@@ -1,8 +1,11 @@
 package types
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
+
+	"github.com/matrix-org/gomatrixserverlib"
 )
 
 func TestNewSyncTokenWithLogs(t *testing.T) {
@@ -85,5 +88,25 @@ func TestNewSyncTokenFromString(t *testing.T) {
 		if _, _, err := newSyncTokenFromString(test); err == nil {
 			t.Errorf("input '%v' should have errored but didn't", test)
 		}
+	}
+}
+
+func TestNewInviteResponse(t *testing.T) {
+	event := `{"auth_events":["$SbSsh09j26UAXnjd3RZqf2lyA3Kw2sY_VZJVZQAV9yA","$EwL53onrLwQ5gL8Dv3VrOOCvHiueXu2ovLdzqkNi3lo","$l2wGmz9iAwevBDGpHT_xXLUA5O8BhORxWIGU1cGi1ZM","$GsWFJLXgdlF5HpZeyWkP72tzXYWW3uQ9X28HBuTztHE"],"content":{"avatar_url":"","displayname":"neilalexander","membership":"invite"},"depth":9,"hashes":{"sha256":"8p+Ur4f8vLFX6mkIXhxI0kegPG7X3tWy56QmvBkExAg"},"origin":"matrix.org","origin_server_ts":1602087113066,"prev_events":["$1v-O6tNwhOZcA8bvCYY-Dnj1V2ZDE58lLPxtlV97S28"],"prev_state":[],"room_id":"!XbeXirGWSPXbEaGokF:matrix.org","sender":"@neilalexander:matrix.org","signatures":{"dendrite.neilalexander.dev":{"ed25519:BMJi":"05KQ5lPw0cSFsE4A0x1z7vi/3cc8bG4WHUsFWYkhxvk/XkXMGIYAYkpNThIvSeLfdcHlbm/k10AsBSKH8Uq4DA"},"matrix.org":{"ed25519:a_RXGa":"jeovuHr9E/x0sHbFkdfxDDYV/EyoeLi98douZYqZ02iYddtKhfB7R3WLay/a+D3V3V7IW0FUmPh/A404x5sYCw"}},"state_key":"@neilalexander:dendrite.neilalexander.dev","type":"m.room.member","unsigned":{"age":2512,"invite_room_state":[{"content":{"join_rule":"invite"},"sender":"@neilalexander:matrix.org","state_key":"","type":"m.room.join_rules"},{"content":{"avatar_url":"mxc://matrix.org/BpDaozLwgLnlNStxDxvLzhPr","displayname":"neilalexander","membership":"join"},"sender":"@neilalexander:matrix.org","state_key":"@neilalexander:matrix.org","type":"m.room.member"},{"content":{"name":"Test room"},"sender":"@neilalexander:matrix.org","state_key":"","type":"m.room.name"}]},"_room_version":"5"}`
+	expected := `{"invite_state":{"events":[{"content":{"join_rule":"invite"},"sender":"@neilalexander:matrix.org","state_key":"","type":"m.room.join_rules"},{"content":{"avatar_url":"mxc://matrix.org/BpDaozLwgLnlNStxDxvLzhPr","displayname":"neilalexander","membership":"join"},"sender":"@neilalexander:matrix.org","state_key":"@neilalexander:matrix.org","type":"m.room.member"},{"content":{"name":"Test room"},"sender":"@neilalexander:matrix.org","state_key":"","type":"m.room.name"},{"content":{"avatar_url":"","displayname":"neilalexander","membership":"invite"},"event_id":"$GQmw8e8-26CQv1QuFoHBHpKF1hQj61Flg3kvv_v_XWs","origin_server_ts":1602087113066,"sender":"@neilalexander:matrix.org","state_key":"@neilalexander:dendrite.neilalexander.dev","type":"m.room.member"}]}}`
+
+	ev, err := gomatrixserverlib.NewEventFromTrustedJSON([]byte(event), false, gomatrixserverlib.RoomVersionV5)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := NewInviteResponse(ev.Headered(gomatrixserverlib.RoomVersionV5))
+	j, err := json.Marshal(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(j) != expected {
+		t.Fatalf("Invite response didn't contain correct info")
 	}
 }


### PR DESCRIPTION
It will now include a stripped version of the invite itself, on a best effort basis, to help clients work out *who* actually sent the invite. This seems to fix the display of invites in Element Web.