### PR TITLE
Return a non-fatal error to the federation API on a state regression

### DIFF
--- a/roomserver/internal/input/input_latest_events.go
+++ b/roomserver/internal/input/input_latest_events.go
@@ -236,10 +236,12 @@ func (u *latestEventsUpdater) latestState() error {
 	if len(u.removed) > len(u.added) {
 		// This really shouldn't happen.
 		// TODO: What is ultimately the best way to handle this situation?
-		return fmt.Errorf(
-			"invalid state delta wants to remove %d state but only add %d state (between state snapshots %d and %d)",
-			len(u.removed), len(u.added), u.oldStateNID, u.newStateNID,
-		)
+		return &gomatrixserverlib.NotAllowed{
+			Message: fmt.Sprintf(
+				"invalid state delta wants to remove %d state but only add %d state (between state snapshots %d and %d)",
+				len(u.removed), len(u.added), u.oldStateNID, u.newStateNID,
+			),
+		}
 	}
 
 	// Also work out the state before the event removes and the event

--- a/roomserver/internal/input/input_latest_events.go
+++ b/roomserver/internal/input/input_latest_events.go
@@ -236,12 +236,13 @@ func (u *latestEventsUpdater) latestState() error {
 	if len(u.removed) > len(u.added) {
 		// This really shouldn't happen.
 		// TODO: What is ultimately the best way to handle this situation?
-		return &gomatrixserverlib.NotAllowed{
-			Message: fmt.Sprintf(
-				"invalid state delta wants to remove %d state but only add %d state (between state snapshots %d and %d)",
-				len(u.removed), len(u.added), u.oldStateNID, u.newStateNID,
-			),
-		}
+		logrus.Errorf(
+			"Invalid state delta on event %q wants to remove %d state but only add %d state (between state snapshots %d and %d)",
+			u.event.EventID(), len(u.removed), len(u.added), u.oldStateNID, u.newStateNID,
+		)
+		u.added = u.added[:0]
+		u.removed = u.removed[:0]
+		return nil
 	}
 
 	// Also work out the state before the event removes and the event


### PR DESCRIPTION
This stops us from returning a 500 and killing the entire transaction.