### PR TITLE
Return what we have when we encounter missing events when servicing backfill/gme

### DIFF
--- a/roomserver/internal/helpers/helpers.go
+++ b/roomserver/internal/helpers/helpers.go
@@ -309,7 +309,9 @@ BFSLoop:
 						util.GetLogger(ctx).WithField("server", serverName).WithField("event_id", pre).WithError(err).Error(
 							"Error checking if allowed to see event",
 						)
-						return resultNIDs, err
+						// drop the error, as we will often error at the DB level if we don't have the prev_event itself. Let's
+						// just return what we have.
+						return resultNIDs, nil
 					}
 
 					// If the event hasn't been seen before and the HS


### PR DESCRIPTION
We expect to have missing events as we walk back in the DAG over federation
as we didn't always create the room. When checking if the server is allowed
to see those events, just give up and stop rather than fail the request.
