### PR TITLE
use jsoniter instead of encoding/json

### DIFF
--- a/appservice/consumers/roomserver.go
+++ b/appservice/consumers/roomserver.go
@@ -16,7 +16,7 @@ package consumers
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/appservice/storage"
 	"github.com/matrix-org/dendrite/appservice/types"
@@ -75,7 +75,7 @@ func (s *OutputRoomEventConsumer) Start() error {
 func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	// Parse out the event JSON
 	var output api.OutputEvent
-	if err := json.Unmarshal(msg.Value, &output); err != nil {
+	if err := jsoniter.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Errorf("roomserver output log: message parse failure")
 		return nil

--- a/appservice/consumers/roomserver.go
+++ b/appservice/consumers/roomserver.go
@@ -16,6 +16,7 @@ package consumers
 
 import (
 	"context"
+
 	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/appservice/storage"

--- a/appservice/consumers/roomserver.go
+++ b/appservice/consumers/roomserver.go
@@ -16,7 +16,7 @@ package consumers
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/appservice/storage"
 	"github.com/matrix-org/dendrite/appservice/types"
@@ -75,7 +75,7 @@ func (s *OutputRoomEventConsumer) Start() error {
 func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	// Parse out the event JSON
 	var output api.OutputEvent
-	if err := jsoniter.Unmarshal(msg.Value, &output); err != nil {
+	if err := json.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Errorf("roomserver output log: message parse failure")
 		return nil

--- a/appservice/consumers/roomserver.go
+++ b/appservice/consumers/roomserver.go
@@ -76,7 +76,7 @@ func (s *OutputRoomEventConsumer) Start() error {
 func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	// Parse out the event JSON
 	var output api.OutputEvent
-	if err := json.Unmarshal(msg.Value, &output); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Errorf("roomserver output log: message parse failure")
 		return nil

--- a/appservice/inthttp/server.go
+++ b/appservice/inthttp/server.go
@@ -1,7 +1,7 @@
 package inthttp
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -17,7 +17,7 @@ func AddRoutes(a api.AppServiceQueryAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("appserviceRoomAliasExists", func(req *http.Request) util.JSONResponse {
 			var request api.RoomAliasExistsRequest
 			var response api.RoomAliasExistsResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := a.RoomAliasExists(req.Context(), &request, &response); err != nil {
@@ -31,7 +31,7 @@ func AddRoutes(a api.AppServiceQueryAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("appserviceUserIDExists", func(req *http.Request) util.JSONResponse {
 			var request api.UserIDExistsRequest
 			var response api.UserIDExistsResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := a.UserIDExists(req.Context(), &request, &response); err != nil {

--- a/appservice/inthttp/server.go
+++ b/appservice/inthttp/server.go
@@ -1,7 +1,7 @@
 package inthttp
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -17,7 +17,7 @@ func AddRoutes(a api.AppServiceQueryAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("appserviceRoomAliasExists", func(req *http.Request) util.JSONResponse {
 			var request api.RoomAliasExistsRequest
 			var response api.RoomAliasExistsResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := a.RoomAliasExists(req.Context(), &request, &response); err != nil {
@@ -31,7 +31,7 @@ func AddRoutes(a api.AppServiceQueryAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("appserviceUserIDExists", func(req *http.Request) util.JSONResponse {
 			var request api.UserIDExistsRequest
 			var response api.UserIDExistsResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := a.UserIDExists(req.Context(), &request, &response); err != nil {

--- a/appservice/inthttp/server.go
+++ b/appservice/inthttp/server.go
@@ -1,8 +1,9 @@
 package inthttp
 
 import (
-	json "github.com/json-iterator/go"
 	"net/http"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/appservice/api"

--- a/appservice/storage/postgres/appservice_events_table.go
+++ b/appservice/storage/postgres/appservice_events_table.go
@@ -18,7 +18,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"time"
 
 	"github.com/matrix-org/gomatrixserverlib"
@@ -161,7 +161,7 @@ func retrieveEvents(eventRows *sql.Rows, limit int) (events []gomatrixserverlib.
 		}
 
 		// Unmarshal eventJSON
-		if err = json.Unmarshal(eventJSON, &event); err != nil {
+		if err = jsoniter.Unmarshal(eventJSON, &event); err != nil {
 			return nil, 0, 0, false, err
 		}
 
@@ -219,7 +219,7 @@ func (s *eventsStatements) insertEvent(
 	event *gomatrixserverlib.HeaderedEvent,
 ) (err error) {
 	// Convert event to JSON before inserting
-	eventJSON, err := json.Marshal(event)
+	eventJSON, err := jsoniter.Marshal(event)
 	if err != nil {
 		return err
 	}

--- a/appservice/storage/postgres/appservice_events_table.go
+++ b/appservice/storage/postgres/appservice_events_table.go
@@ -162,7 +162,7 @@ func retrieveEvents(eventRows *sql.Rows, limit int) (events []gomatrixserverlib.
 		}
 
 		// Unmarshal eventJSON
-		if err = json.Unmarshal(eventJSON, &event); err != nil {
+		if err = json.ConfigCompatibleWithStandardLibrary.Unmarshal(eventJSON, &event); err != nil {
 			return nil, 0, 0, false, err
 		}
 
@@ -220,7 +220,7 @@ func (s *eventsStatements) insertEvent(
 	event *gomatrixserverlib.HeaderedEvent,
 ) (err error) {
 	// Convert event to JSON before inserting
-	eventJSON, err := json.Marshal(event)
+	eventJSON, err := json.ConfigCompatibleWithStandardLibrary.Marshal(event)
 	if err != nil {
 		return err
 	}

--- a/appservice/storage/postgres/appservice_events_table.go
+++ b/appservice/storage/postgres/appservice_events_table.go
@@ -18,8 +18,9 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	json "github.com/json-iterator/go"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/gomatrixserverlib"
 	log "github.com/sirupsen/logrus"

--- a/appservice/storage/postgres/appservice_events_table.go
+++ b/appservice/storage/postgres/appservice_events_table.go
@@ -18,7 +18,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"time"
 
 	"github.com/matrix-org/gomatrixserverlib"
@@ -161,7 +161,7 @@ func retrieveEvents(eventRows *sql.Rows, limit int) (events []gomatrixserverlib.
 		}
 
 		// Unmarshal eventJSON
-		if err = jsoniter.Unmarshal(eventJSON, &event); err != nil {
+		if err = json.Unmarshal(eventJSON, &event); err != nil {
 			return nil, 0, 0, false, err
 		}
 
@@ -219,7 +219,7 @@ func (s *eventsStatements) insertEvent(
 	event *gomatrixserverlib.HeaderedEvent,
 ) (err error) {
 	// Convert event to JSON before inserting
-	eventJSON, err := jsoniter.Marshal(event)
+	eventJSON, err := json.Marshal(event)
 	if err != nil {
 		return err
 	}

--- a/appservice/storage/sqlite3/appservice_events_table.go
+++ b/appservice/storage/sqlite3/appservice_events_table.go
@@ -18,7 +18,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"time"
 
 	"github.com/matrix-org/dendrite/internal/sqlutil"
@@ -166,7 +166,7 @@ func retrieveEvents(eventRows *sql.Rows, limit int) (events []gomatrixserverlib.
 		}
 
 		// Unmarshal eventJSON
-		if err = json.Unmarshal(eventJSON, &event); err != nil {
+		if err = jsoniter.Unmarshal(eventJSON, &event); err != nil {
 			return nil, 0, 0, false, err
 		}
 
@@ -224,7 +224,7 @@ func (s *eventsStatements) insertEvent(
 	event *gomatrixserverlib.HeaderedEvent,
 ) (err error) {
 	// Convert event to JSON before inserting
-	eventJSON, err := json.Marshal(event)
+	eventJSON, err := jsoniter.Marshal(event)
 	if err != nil {
 		return err
 	}

--- a/appservice/storage/sqlite3/appservice_events_table.go
+++ b/appservice/storage/sqlite3/appservice_events_table.go
@@ -167,7 +167,7 @@ func retrieveEvents(eventRows *sql.Rows, limit int) (events []gomatrixserverlib.
 		}
 
 		// Unmarshal eventJSON
-		if err = json.Unmarshal(eventJSON, &event); err != nil {
+		if err = json.ConfigCompatibleWithStandardLibrary.Unmarshal(eventJSON, &event); err != nil {
 			return nil, 0, 0, false, err
 		}
 
@@ -225,7 +225,7 @@ func (s *eventsStatements) insertEvent(
 	event *gomatrixserverlib.HeaderedEvent,
 ) (err error) {
 	// Convert event to JSON before inserting
-	eventJSON, err := json.Marshal(event)
+	eventJSON, err := json.ConfigCompatibleWithStandardLibrary.Marshal(event)
 	if err != nil {
 		return err
 	}

--- a/appservice/storage/sqlite3/appservice_events_table.go
+++ b/appservice/storage/sqlite3/appservice_events_table.go
@@ -18,8 +18,9 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	json "github.com/json-iterator/go"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/gomatrixserverlib"

--- a/appservice/storage/sqlite3/appservice_events_table.go
+++ b/appservice/storage/sqlite3/appservice_events_table.go
@@ -18,7 +18,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"time"
 
 	"github.com/matrix-org/dendrite/internal/sqlutil"
@@ -166,7 +166,7 @@ func retrieveEvents(eventRows *sql.Rows, limit int) (events []gomatrixserverlib.
 		}
 
 		// Unmarshal eventJSON
-		if err = jsoniter.Unmarshal(eventJSON, &event); err != nil {
+		if err = json.Unmarshal(eventJSON, &event); err != nil {
 			return nil, 0, 0, false, err
 		}
 
@@ -224,7 +224,7 @@ func (s *eventsStatements) insertEvent(
 	event *gomatrixserverlib.HeaderedEvent,
 ) (err error) {
 	// Convert event to JSON before inserting
-	eventJSON, err := jsoniter.Marshal(event)
+	eventJSON, err := json.Marshal(event)
 	if err != nil {
 		return err
 	}

--- a/appservice/workers/transaction_scheduler.go
+++ b/appservice/workers/transaction_scheduler.go
@@ -17,7 +17,7 @@ package workers
 import (
 	"bytes"
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"math"
 	"net/http"
@@ -195,7 +195,7 @@ func createTransaction(
 		Events: ev,
 	}
 
-	transactionJSON, err = json.Marshal(transaction)
+	transactionJSON, err = jsoniter.Marshal(transaction)
 	if err != nil {
 		return
 	}

--- a/appservice/workers/transaction_scheduler.go
+++ b/appservice/workers/transaction_scheduler.go
@@ -17,7 +17,7 @@ package workers
 import (
 	"bytes"
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"math"
 	"net/http"
@@ -195,7 +195,7 @@ func createTransaction(
 		Events: ev,
 	}
 
-	transactionJSON, err = jsoniter.Marshal(transaction)
+	transactionJSON, err = json.Marshal(transaction)
 	if err != nil {
 		return
 	}

--- a/appservice/workers/transaction_scheduler.go
+++ b/appservice/workers/transaction_scheduler.go
@@ -17,12 +17,13 @@ package workers
 import (
 	"bytes"
 	"context"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"math"
 	"net/http"
 	"net/url"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/appservice/storage"
 	"github.com/matrix-org/dendrite/appservice/types"

--- a/appservice/workers/transaction_scheduler.go
+++ b/appservice/workers/transaction_scheduler.go
@@ -196,7 +196,7 @@ func createTransaction(
 		Events: ev,
 	}
 
-	transactionJSON, err = json.Marshal(transaction)
+	transactionJSON, err = json.ConfigCompatibleWithStandardLibrary.Marshal(transaction)
 	if err != nil {
 		return
 	}

--- a/clientapi/auth/user_interactive.go
+++ b/clientapi/auth/user_interactive.go
@@ -16,7 +16,7 @@ package auth
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
@@ -181,19 +181,19 @@ func (u *UserInteractive) NewSession() *util.JSONResponse {
 // standard challenge response.
 func (u *UserInteractive) ResponseWithChallenge(sessionID string, response interface{}) *util.JSONResponse {
 	mixedObjects := make(map[string]interface{})
-	b, err := jsoniter.Marshal(response)
+	b, err := json.Marshal(response)
 	if err != nil {
 		ise := jsonerror.InternalServerError()
 		return &ise
 	}
-	_ = jsoniter.Unmarshal(b, &mixedObjects)
+	_ = json.Unmarshal(b, &mixedObjects)
 	challenge := u.Challenge(sessionID)
-	b, err = jsoniter.Marshal(challenge.JSON)
+	b, err = json.Marshal(challenge.JSON)
 	if err != nil {
 		ise := jsonerror.InternalServerError()
 		return &ise
 	}
-	_ = jsoniter.Unmarshal(b, &mixedObjects)
+	_ = json.Unmarshal(b, &mixedObjects)
 
 	return &util.JSONResponse{
 		Code: 401,
@@ -237,7 +237,7 @@ func (u *UserInteractive) Verify(ctx context.Context, bodyBytes []byte, device *
 	}
 
 	r := loginType.Request()
-	if err := jsoniter.Unmarshal([]byte(gjson.GetBytes(bodyBytes, "auth").Raw), r); err != nil {
+	if err := json.Unmarshal([]byte(gjson.GetBytes(bodyBytes, "auth").Raw), r); err != nil {
 		return nil, &util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.BadJSON("The request body could not be decoded into valid JSON. " + err.Error()),

--- a/clientapi/auth/user_interactive.go
+++ b/clientapi/auth/user_interactive.go
@@ -16,8 +16,9 @@ package auth
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"net/http"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/internal/config"

--- a/clientapi/auth/user_interactive.go
+++ b/clientapi/auth/user_interactive.go
@@ -182,19 +182,19 @@ func (u *UserInteractive) NewSession() *util.JSONResponse {
 // standard challenge response.
 func (u *UserInteractive) ResponseWithChallenge(sessionID string, response interface{}) *util.JSONResponse {
 	mixedObjects := make(map[string]interface{})
-	b, err := json.Marshal(response)
+	b, err := json.ConfigCompatibleWithStandardLibrary.Marshal(response)
 	if err != nil {
 		ise := jsonerror.InternalServerError()
 		return &ise
 	}
-	_ = json.Unmarshal(b, &mixedObjects)
+	_ = json.ConfigCompatibleWithStandardLibrary.Unmarshal(b, &mixedObjects)
 	challenge := u.Challenge(sessionID)
-	b, err = json.Marshal(challenge.JSON)
+	b, err = json.ConfigCompatibleWithStandardLibrary.Marshal(challenge.JSON)
 	if err != nil {
 		ise := jsonerror.InternalServerError()
 		return &ise
 	}
-	_ = json.Unmarshal(b, &mixedObjects)
+	_ = json.ConfigCompatibleWithStandardLibrary.Unmarshal(b, &mixedObjects)
 
 	return &util.JSONResponse{
 		Code: 401,
@@ -238,7 +238,7 @@ func (u *UserInteractive) Verify(ctx context.Context, bodyBytes []byte, device *
 	}
 
 	r := loginType.Request()
-	if err := json.Unmarshal([]byte(gjson.GetBytes(bodyBytes, "auth").Raw), r); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(gjson.GetBytes(bodyBytes, "auth").Raw), r); err != nil {
 		return nil, &util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.BadJSON("The request body could not be decoded into valid JSON. " + err.Error()),

--- a/clientapi/auth/user_interactive.go
+++ b/clientapi/auth/user_interactive.go
@@ -16,7 +16,7 @@ package auth
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
@@ -181,19 +181,19 @@ func (u *UserInteractive) NewSession() *util.JSONResponse {
 // standard challenge response.
 func (u *UserInteractive) ResponseWithChallenge(sessionID string, response interface{}) *util.JSONResponse {
 	mixedObjects := make(map[string]interface{})
-	b, err := json.Marshal(response)
+	b, err := jsoniter.Marshal(response)
 	if err != nil {
 		ise := jsonerror.InternalServerError()
 		return &ise
 	}
-	_ = json.Unmarshal(b, &mixedObjects)
+	_ = jsoniter.Unmarshal(b, &mixedObjects)
 	challenge := u.Challenge(sessionID)
-	b, err = json.Marshal(challenge.JSON)
+	b, err = jsoniter.Marshal(challenge.JSON)
 	if err != nil {
 		ise := jsonerror.InternalServerError()
 		return &ise
 	}
-	_ = json.Unmarshal(b, &mixedObjects)
+	_ = jsoniter.Unmarshal(b, &mixedObjects)
 
 	return &util.JSONResponse{
 		Code: 401,
@@ -237,7 +237,7 @@ func (u *UserInteractive) Verify(ctx context.Context, bodyBytes []byte, device *
 	}
 
 	r := loginType.Request()
-	if err := json.Unmarshal([]byte(gjson.GetBytes(bodyBytes, "auth").Raw), r); err != nil {
+	if err := jsoniter.Unmarshal([]byte(gjson.GetBytes(bodyBytes, "auth").Raw), r); err != nil {
 		return nil, &util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.BadJSON("The request body could not be decoded into valid JSON. " + err.Error()),

--- a/clientapi/auth/user_interactive_test.go
+++ b/clientapi/auth/user_interactive_test.go
@@ -2,9 +2,10 @@ package auth
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"testing"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal/config"
 	"github.com/matrix-org/dendrite/userapi/api"

--- a/clientapi/auth/user_interactive_test.go
+++ b/clientapi/auth/user_interactive_test.go
@@ -2,7 +2,7 @@ package auth
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"testing"
 
@@ -62,7 +62,7 @@ func TestUserInteractivePasswordLogin(t *testing.T) {
 		UserID:     fmt.Sprintf("@alice:%s", serverName),
 	}
 	// valid password requests
-	testCases := []json.RawMessage{
+	testCases := []jsoniter.RawMessage{
 		// deprecated form
 		[]byte(`{
 			"auth": {
@@ -101,7 +101,7 @@ func TestUserInteractivePasswordBadLogin(t *testing.T) {
 	}
 	// invalid password requests
 	testCases := []struct {
-		body    json.RawMessage
+		body    jsoniter.RawMessage
 		wantRes util.JSONResponse
 	}{
 		{

--- a/clientapi/auth/user_interactive_test.go
+++ b/clientapi/auth/user_interactive_test.go
@@ -2,7 +2,7 @@ package auth
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"testing"
 
@@ -62,7 +62,7 @@ func TestUserInteractivePasswordLogin(t *testing.T) {
 		UserID:     fmt.Sprintf("@alice:%s", serverName),
 	}
 	// valid password requests
-	testCases := []jsoniter.RawMessage{
+	testCases := []json.RawMessage{
 		// deprecated form
 		[]byte(`{
 			"auth": {
@@ -101,7 +101,7 @@ func TestUserInteractivePasswordBadLogin(t *testing.T) {
 	}
 	// invalid password requests
 	testCases := []struct {
-		body    jsoniter.RawMessage
+		body    json.RawMessage
 		wantRes util.JSONResponse
 	}{
 		{

--- a/clientapi/httputil/httputil.go
+++ b/clientapi/httputil/httputil.go
@@ -15,7 +15,7 @@
 package httputil
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"io/ioutil"
 	"net/http"
 	"unicode/utf8"
@@ -43,7 +43,7 @@ func UnmarshalJSONRequest(req *http.Request, iface interface{}) *util.JSONRespon
 		}
 	}
 
-	if err := json.Unmarshal(body, iface); err != nil {
+	if err := jsoniter.Unmarshal(body, iface); err != nil {
 		// TODO: We may want to suppress the Error() return in production? It's useful when
 		// debugging because an error will be produced for both invalid/malformed JSON AND
 		// valid JSON with incorrect types for values.

--- a/clientapi/httputil/httputil.go
+++ b/clientapi/httputil/httputil.go
@@ -15,7 +15,7 @@
 package httputil
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"io/ioutil"
 	"net/http"
 	"unicode/utf8"
@@ -43,7 +43,7 @@ func UnmarshalJSONRequest(req *http.Request, iface interface{}) *util.JSONRespon
 		}
 	}
 
-	if err := jsoniter.Unmarshal(body, iface); err != nil {
+	if err := json.Unmarshal(body, iface); err != nil {
 		// TODO: We may want to suppress the Error() return in production? It's useful when
 		// debugging because an error will be produced for both invalid/malformed JSON AND
 		// valid JSON with incorrect types for values.

--- a/clientapi/httputil/httputil.go
+++ b/clientapi/httputil/httputil.go
@@ -15,10 +15,11 @@
 package httputil
 
 import (
-	json "github.com/json-iterator/go"
 	"io/ioutil"
 	"net/http"
 	"unicode/utf8"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/util"

--- a/clientapi/httputil/httputil.go
+++ b/clientapi/httputil/httputil.go
@@ -44,7 +44,7 @@ func UnmarshalJSONRequest(req *http.Request, iface interface{}) *util.JSONRespon
 		}
 	}
 
-	if err := json.Unmarshal(body, iface); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(body, iface); err != nil {
 		// TODO: We may want to suppress the Error() return in production? It's useful when
 		// debugging because an error will be produced for both invalid/malformed JSON AND
 		// valid JSON with incorrect types for values.

--- a/clientapi/jsonerror/jsonerror_test.go
+++ b/clientapi/jsonerror/jsonerror_test.go
@@ -15,13 +15,13 @@
 package jsonerror
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"testing"
 )
 
 func TestLimitExceeded(t *testing.T) {
 	e := LimitExceeded("too fast", 5000)
-	jsonBytes, err := jsoniter.Marshal(&e)
+	jsonBytes, err := json.Marshal(&e)
 	if err != nil {
 		t.Fatalf("TestLimitExceeded: Failed to marshal LimitExceeded error. %s", err.Error())
 	}
@@ -33,7 +33,7 @@ func TestLimitExceeded(t *testing.T) {
 
 func TestForbidden(t *testing.T) {
 	e := Forbidden("you shall not pass")
-	jsonBytes, err := jsoniter.Marshal(&e)
+	jsonBytes, err := json.Marshal(&e)
 	if err != nil {
 		t.Fatalf("TestForbidden: Failed to marshal Forbidden error. %s", err.Error())
 	}

--- a/clientapi/jsonerror/jsonerror_test.go
+++ b/clientapi/jsonerror/jsonerror_test.go
@@ -15,13 +15,13 @@
 package jsonerror
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"testing"
 )
 
 func TestLimitExceeded(t *testing.T) {
 	e := LimitExceeded("too fast", 5000)
-	jsonBytes, err := json.Marshal(&e)
+	jsonBytes, err := jsoniter.Marshal(&e)
 	if err != nil {
 		t.Fatalf("TestLimitExceeded: Failed to marshal LimitExceeded error. %s", err.Error())
 	}
@@ -33,7 +33,7 @@ func TestLimitExceeded(t *testing.T) {
 
 func TestForbidden(t *testing.T) {
 	e := Forbidden("you shall not pass")
-	jsonBytes, err := json.Marshal(&e)
+	jsonBytes, err := jsoniter.Marshal(&e)
 	if err != nil {
 		t.Fatalf("TestForbidden: Failed to marshal Forbidden error. %s", err.Error())
 	}

--- a/clientapi/jsonerror/jsonerror_test.go
+++ b/clientapi/jsonerror/jsonerror_test.go
@@ -15,8 +15,9 @@
 package jsonerror
 
 import (
-	json "github.com/json-iterator/go"
 	"testing"
+
+	json "github.com/json-iterator/go"
 )
 
 func TestLimitExceeded(t *testing.T) {

--- a/clientapi/jsonerror/jsonerror_test.go
+++ b/clientapi/jsonerror/jsonerror_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestLimitExceeded(t *testing.T) {
 	e := LimitExceeded("too fast", 5000)
-	jsonBytes, err := json.Marshal(&e)
+	jsonBytes, err := json.ConfigCompatibleWithStandardLibrary.Marshal(&e)
 	if err != nil {
 		t.Fatalf("TestLimitExceeded: Failed to marshal LimitExceeded error. %s", err.Error())
 	}
@@ -34,7 +34,7 @@ func TestLimitExceeded(t *testing.T) {
 
 func TestForbidden(t *testing.T) {
 	e := Forbidden("you shall not pass")
-	jsonBytes, err := json.Marshal(&e)
+	jsonBytes, err := json.ConfigCompatibleWithStandardLibrary.Marshal(&e)
 	if err != nil {
 		t.Fatalf("TestForbidden: Failed to marshal Forbidden error. %s", err.Error())
 	}

--- a/clientapi/producers/syncapi.go
+++ b/clientapi/producers/syncapi.go
@@ -15,7 +15,7 @@
 package producers
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"
 	"github.com/matrix-org/dendrite/internal/eventutil"
@@ -36,7 +36,7 @@ func (p *SyncAPIProducer) SendData(userID string, roomID string, dataType string
 		RoomID: roomID,
 		Type:   dataType,
 	}
-	value, err := jsoniter.Marshal(data)
+	value, err := json.Marshal(data)
 	if err != nil {
 		return err
 	}

--- a/clientapi/producers/syncapi.go
+++ b/clientapi/producers/syncapi.go
@@ -15,7 +15,7 @@
 package producers
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"
 	"github.com/matrix-org/dendrite/internal/eventutil"
@@ -36,7 +36,7 @@ func (p *SyncAPIProducer) SendData(userID string, roomID string, dataType string
 		RoomID: roomID,
 		Type:   dataType,
 	}
-	value, err := json.Marshal(data)
+	value, err := jsoniter.Marshal(data)
 	if err != nil {
 		return err
 	}

--- a/clientapi/producers/syncapi.go
+++ b/clientapi/producers/syncapi.go
@@ -36,7 +36,7 @@ func (p *SyncAPIProducer) SendData(userID string, roomID string, dataType string
 		RoomID: roomID,
 		Type:   dataType,
 	}
-	value, err := json.Marshal(data)
+	value, err := json.ConfigCompatibleWithStandardLibrary.Marshal(data)
 	if err != nil {
 		return err
 	}

--- a/clientapi/routing/account_data.go
+++ b/clientapi/routing/account_data.go
@@ -15,8 +15,8 @@
 package routing
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/json-iterator/go"
 	"io/ioutil"
 	"net/http"
 
@@ -52,7 +52,7 @@ func GetAccountData(
 		return util.ErrorResponse(fmt.Errorf("userAPI.QueryAccountData: %w", err))
 	}
 
-	var data json.RawMessage
+	var data jsoniter.RawMessage
 	var ok bool
 	if roomID != "" {
 		data, ok = dataRes.RoomAccountData[roomID][dataType]
@@ -106,7 +106,7 @@ func SaveAccountData(
 		return jsonerror.InternalServerError()
 	}
 
-	if !json.Valid(body) {
+	if !jsoniter.Valid(body) {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.BadJSON("Bad JSON content"),
@@ -117,7 +117,7 @@ func SaveAccountData(
 		UserID:      userID,
 		DataType:    dataType,
 		RoomID:      roomID,
-		AccountData: json.RawMessage(body),
+		AccountData: jsoniter.RawMessage(body),
 	}
 	dataRes := api.InputAccountDataResponse{}
 	if err := userAPI.InputAccountData(req.Context(), &dataReq, &dataRes); err != nil {
@@ -170,7 +170,7 @@ func SaveReadMarker(
 		}
 	}
 
-	data, err := json.Marshal(fullyReadEvent{EventID: r.FullyRead})
+	data, err := jsoniter.Marshal(fullyReadEvent{EventID: r.FullyRead})
 	if err != nil {
 		return jsonerror.InternalServerError()
 	}

--- a/clientapi/routing/account_data.go
+++ b/clientapi/routing/account_data.go
@@ -16,9 +16,10 @@ package routing
 
 import (
 	"fmt"
-	json "github.com/json-iterator/go"
 	"io/ioutil"
 	"net/http"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"

--- a/clientapi/routing/account_data.go
+++ b/clientapi/routing/account_data.go
@@ -16,7 +16,7 @@ package routing
 
 import (
 	"fmt"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"io/ioutil"
 	"net/http"
 
@@ -52,7 +52,7 @@ func GetAccountData(
 		return util.ErrorResponse(fmt.Errorf("userAPI.QueryAccountData: %w", err))
 	}
 
-	var data jsoniter.RawMessage
+	var data json.RawMessage
 	var ok bool
 	if roomID != "" {
 		data, ok = dataRes.RoomAccountData[roomID][dataType]
@@ -106,7 +106,7 @@ func SaveAccountData(
 		return jsonerror.InternalServerError()
 	}
 
-	if !jsoniter.Valid(body) {
+	if !json.Valid(body) {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.BadJSON("Bad JSON content"),
@@ -117,7 +117,7 @@ func SaveAccountData(
 		UserID:      userID,
 		DataType:    dataType,
 		RoomID:      roomID,
-		AccountData: jsoniter.RawMessage(body),
+		AccountData: json.RawMessage(body),
 	}
 	dataRes := api.InputAccountDataResponse{}
 	if err := userAPI.InputAccountData(req.Context(), &dataReq, &dataRes); err != nil {
@@ -170,7 +170,7 @@ func SaveReadMarker(
 		}
 	}
 
-	data, err := jsoniter.Marshal(fullyReadEvent{EventID: r.FullyRead})
+	data, err := json.Marshal(fullyReadEvent{EventID: r.FullyRead})
 	if err != nil {
 		return jsonerror.InternalServerError()
 	}

--- a/clientapi/routing/account_data.go
+++ b/clientapi/routing/account_data.go
@@ -171,7 +171,7 @@ func SaveReadMarker(
 		}
 	}
 
-	data, err := json.Marshal(fullyReadEvent{EventID: r.FullyRead})
+	data, err := json.ConfigCompatibleWithStandardLibrary.Marshal(fullyReadEvent{EventID: r.FullyRead})
 	if err != nil {
 		return jsonerror.InternalServerError()
 	}

--- a/clientapi/routing/createroom.go
+++ b/clientapi/routing/createroom.go
@@ -15,11 +15,12 @@
 package routing
 
 import (
-	json "github.com/json-iterator/go"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"
 	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"

--- a/clientapi/routing/createroom.go
+++ b/clientapi/routing/createroom.go
@@ -15,7 +15,7 @@
 package routing
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"net/http"
 	"strings"
@@ -99,7 +99,7 @@ func (r createRoomRequest) Validate() *util.JSONResponse {
 	// creation_content map into bytes and then unmarshalling the bytes into
 	// eventutil.CreateContent.
 
-	creationContentBytes, err := jsoniter.Marshal(r.CreationContent)
+	creationContentBytes, err := json.Marshal(r.CreationContent)
 	if err != nil {
 		return &util.JSONResponse{
 			Code: http.StatusBadRequest,
@@ -108,7 +108,7 @@ func (r createRoomRequest) Validate() *util.JSONResponse {
 	}
 
 	var CreationContent gomatrixserverlib.CreateContent
-	err = jsoniter.Unmarshal(creationContentBytes, &CreationContent)
+	err = json.Unmarshal(creationContentBytes, &CreationContent)
 	if err != nil {
 		return &util.JSONResponse{
 			Code: http.StatusBadRequest,

--- a/clientapi/routing/createroom.go
+++ b/clientapi/routing/createroom.go
@@ -15,7 +15,7 @@
 package routing
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"net/http"
 	"strings"
@@ -99,7 +99,7 @@ func (r createRoomRequest) Validate() *util.JSONResponse {
 	// creation_content map into bytes and then unmarshalling the bytes into
 	// eventutil.CreateContent.
 
-	creationContentBytes, err := json.Marshal(r.CreationContent)
+	creationContentBytes, err := jsoniter.Marshal(r.CreationContent)
 	if err != nil {
 		return &util.JSONResponse{
 			Code: http.StatusBadRequest,
@@ -108,7 +108,7 @@ func (r createRoomRequest) Validate() *util.JSONResponse {
 	}
 
 	var CreationContent gomatrixserverlib.CreateContent
-	err = json.Unmarshal(creationContentBytes, &CreationContent)
+	err = jsoniter.Unmarshal(creationContentBytes, &CreationContent)
 	if err != nil {
 		return &util.JSONResponse{
 			Code: http.StatusBadRequest,

--- a/clientapi/routing/createroom.go
+++ b/clientapi/routing/createroom.go
@@ -100,7 +100,7 @@ func (r createRoomRequest) Validate() *util.JSONResponse {
 	// creation_content map into bytes and then unmarshalling the bytes into
 	// eventutil.CreateContent.
 
-	creationContentBytes, err := json.Marshal(r.CreationContent)
+	creationContentBytes, err := json.ConfigCompatibleWithStandardLibrary.Marshal(r.CreationContent)
 	if err != nil {
 		return &util.JSONResponse{
 			Code: http.StatusBadRequest,
@@ -109,7 +109,7 @@ func (r createRoomRequest) Validate() *util.JSONResponse {
 	}
 
 	var CreationContent gomatrixserverlib.CreateContent
-	err = json.Unmarshal(creationContentBytes, &CreationContent)
+	err = json.ConfigCompatibleWithStandardLibrary.Unmarshal(creationContentBytes, &CreationContent)
 	if err != nil {
 		return &util.JSONResponse{
 			Code: http.StatusBadRequest,

--- a/clientapi/routing/keys.go
+++ b/clientapi/routing/keys.go
@@ -15,9 +15,10 @@
 package routing
 
 import (
-	json "github.com/json-iterator/go"
 	"net/http"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"

--- a/clientapi/routing/keys.go
+++ b/clientapi/routing/keys.go
@@ -15,7 +15,7 @@
 package routing
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"net/http"
 	"time"
 
@@ -27,8 +27,8 @@ import (
 )
 
 type uploadKeysRequest struct {
-	DeviceKeys  json.RawMessage            `json:"device_keys"`
-	OneTimeKeys map[string]json.RawMessage `json:"one_time_keys"`
+	DeviceKeys  jsoniter.RawMessage            `json:"device_keys"`
+	OneTimeKeys map[string]jsoniter.RawMessage `json:"one_time_keys"`
 }
 
 func UploadKeys(req *http.Request, keyAPI api.KeyInternalAPI, device *userapi.Device) util.JSONResponse {

--- a/clientapi/routing/keys.go
+++ b/clientapi/routing/keys.go
@@ -15,7 +15,7 @@
 package routing
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"net/http"
 	"time"
 
@@ -27,8 +27,8 @@ import (
 )
 
 type uploadKeysRequest struct {
-	DeviceKeys  jsoniter.RawMessage            `json:"device_keys"`
-	OneTimeKeys map[string]jsoniter.RawMessage `json:"one_time_keys"`
+	DeviceKeys  json.RawMessage            `json:"device_keys"`
+	OneTimeKeys map[string]json.RawMessage `json:"one_time_keys"`
 }
 
 func UploadKeys(req *http.Request, keyAPI api.KeyInternalAPI, device *userapi.Device) util.JSONResponse {

--- a/clientapi/routing/login.go
+++ b/clientapi/routing/login.go
@@ -79,7 +79,7 @@ func Login(
 			return *authErr
 		}
 		// make a device/access token
-		return completeAuth(req.Context(), cfg.Matrix.ServerName, userAPI, login)
+		return completeAuth(req.Context(), cfg.Matrix.ServerName, userAPI, login, req.RemoteAddr, req.UserAgent())
 	}
 	return util.JSONResponse{
 		Code: http.StatusMethodNotAllowed,
@@ -89,6 +89,7 @@ func Login(
 
 func completeAuth(
 	ctx context.Context, serverName gomatrixserverlib.ServerName, userAPI userapi.UserInternalAPI, login *auth.Login,
+	ipAddr, userAgent string,
 ) util.JSONResponse {
 	token, err := auth.GenerateAccessToken()
 	if err != nil {
@@ -108,6 +109,8 @@ func completeAuth(
 		DeviceID:          login.DeviceID,
 		AccessToken:       token,
 		Localpart:         localpart,
+		IPAddr:            ipAddr,
+		UserAgent:         userAgent,
 	}, &performRes)
 	if err != nil {
 		return util.JSONResponse{

--- a/clientapi/routing/memberships.go
+++ b/clientapi/routing/memberships.go
@@ -15,8 +15,9 @@
 package routing
 
 import (
-	json "github.com/json-iterator/go"
 	"net/http"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/internal/config"

--- a/clientapi/routing/memberships.go
+++ b/clientapi/routing/memberships.go
@@ -74,7 +74,7 @@ func GetMemberships(
 		res.Joined = make(map[string]joinedMember)
 		for _, ev := range queryRes.JoinEvents {
 			var content joinedMember
-			if err := json.Unmarshal(ev.Content, &content); err != nil {
+			if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(ev.Content, &content); err != nil {
 				util.GetLogger(req.Context()).WithError(err).Error("failed to unmarshal event content")
 				return jsonerror.InternalServerError()
 			}

--- a/clientapi/routing/memberships.go
+++ b/clientapi/routing/memberships.go
@@ -15,7 +15,7 @@
 package routing
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
@@ -73,7 +73,7 @@ func GetMemberships(
 		res.Joined = make(map[string]joinedMember)
 		for _, ev := range queryRes.JoinEvents {
 			var content joinedMember
-			if err := jsoniter.Unmarshal(ev.Content, &content); err != nil {
+			if err := json.Unmarshal(ev.Content, &content); err != nil {
 				util.GetLogger(req.Context()).WithError(err).Error("failed to unmarshal event content")
 				return jsonerror.InternalServerError()
 			}

--- a/clientapi/routing/memberships.go
+++ b/clientapi/routing/memberships.go
@@ -15,7 +15,7 @@
 package routing
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
@@ -73,7 +73,7 @@ func GetMemberships(
 		res.Joined = make(map[string]joinedMember)
 		for _, ev := range queryRes.JoinEvents {
 			var content joinedMember
-			if err := json.Unmarshal(ev.Content, &content); err != nil {
+			if err := jsoniter.Unmarshal(ev.Content, &content); err != nil {
 				util.GetLogger(req.Context()).WithError(err).Error("failed to unmarshal event content")
 				return jsonerror.InternalServerError()
 			}

--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -543,6 +543,8 @@ func handleGuestRegistration(
 		Localpart:         res.Account.Localpart,
 		DeviceDisplayName: r.InitialDisplayName,
 		AccessToken:       token,
+		IPAddr:            req.RemoteAddr,
+		UserAgent:         req.UserAgent(),
 	}, &devRes)
 	if err != nil {
 		return util.JSONResponse{
@@ -691,7 +693,7 @@ func handleApplicationServiceRegistration(
 	// Don't need to worry about appending to registration stages as
 	// application service registration is entirely separate.
 	return completeRegistration(
-		req.Context(), userAPI, r.Username, "", appserviceID,
+		req.Context(), userAPI, r.Username, "", appserviceID, req.RemoteAddr, req.UserAgent(),
 		r.InhibitLogin, r.InitialDisplayName, r.DeviceID,
 	)
 }
@@ -710,7 +712,7 @@ func checkAndCompleteFlow(
 	if checkFlowCompleted(flow, cfg.Derived.Registration.Flows) {
 		// This flow was completed, registration can continue
 		return completeRegistration(
-			req.Context(), userAPI, r.Username, r.Password, "",
+			req.Context(), userAPI, r.Username, r.Password, "", req.RemoteAddr, req.UserAgent(),
 			r.InhibitLogin, r.InitialDisplayName, r.DeviceID,
 		)
 	}
@@ -762,10 +764,10 @@ func LegacyRegister(
 			return util.MessageResponse(http.StatusForbidden, "HMAC incorrect")
 		}
 
-		return completeRegistration(req.Context(), userAPI, r.Username, r.Password, "", false, nil, nil)
+		return completeRegistration(req.Context(), userAPI, r.Username, r.Password, "", req.RemoteAddr, req.UserAgent(), false, nil, nil)
 	case authtypes.LoginTypeDummy:
 		// there is nothing to do
-		return completeRegistration(req.Context(), userAPI, r.Username, r.Password, "", false, nil, nil)
+		return completeRegistration(req.Context(), userAPI, r.Username, r.Password, "", req.RemoteAddr, req.UserAgent(), false, nil, nil)
 	default:
 		return util.JSONResponse{
 			Code: http.StatusNotImplemented,
@@ -812,7 +814,7 @@ func parseAndValidateLegacyLogin(req *http.Request, r *legacyRegisterRequest) *u
 func completeRegistration(
 	ctx context.Context,
 	userAPI userapi.UserInternalAPI,
-	username, password, appserviceID string,
+	username, password, appserviceID, ipAddr, userAgent string,
 	inhibitLogin eventutil.WeakBoolean,
 	displayName, deviceID *string,
 ) util.JSONResponse {
@@ -880,6 +882,8 @@ func completeRegistration(
 		AccessToken:       token,
 		DeviceDisplayName: displayName,
 		DeviceID:          deviceID,
+		IPAddr:            ipAddr,
+		UserAgent:         userAgent,
 	}, &devRes)
 	if err != nil {
 		return util.JSONResponse{

--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -302,7 +302,7 @@ func validateRecaptcha(
 			JSON: jsonerror.Unknown("Error in contacting captcha server" + err.Error()),
 		}
 	}
-	err = json.Unmarshal(body, &r)
+	err = json.ConfigCompatibleWithStandardLibrary.Unmarshal(body, &r)
 	if err != nil {
 		return &util.JSONResponse{
 			Code: http.StatusInternalServerError,

--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha1"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -301,7 +301,7 @@ func validateRecaptcha(
 			JSON: jsonerror.Unknown("Error in contacting captcha server" + err.Error()),
 		}
 	}
-	err = json.Unmarshal(body, &r)
+	err = jsoniter.Unmarshal(body, &r)
 	if err != nil {
 		return &util.JSONResponse{
 			Code: http.StatusInternalServerError,

--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha1"
-	json "github.com/json-iterator/go"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -31,6 +30,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal/config"
 	"github.com/matrix-org/dendrite/internal/eventutil"

--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha1"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -301,7 +301,7 @@ func validateRecaptcha(
 			JSON: jsonerror.Unknown("Error in contacting captcha server" + err.Error()),
 		}
 	}
-	err = jsoniter.Unmarshal(body, &r)
+	err = json.Unmarshal(body, &r)
 	if err != nil {
 		return &util.JSONResponse{
 			Code: http.StatusInternalServerError,

--- a/clientapi/routing/room_tagging.go
+++ b/clientapi/routing/room_tagging.go
@@ -15,7 +15,7 @@
 package routing
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
@@ -183,7 +183,7 @@ func obtainSavedTags(
 	if !ok {
 		return
 	}
-	if err = jsoniter.Unmarshal(data, &tags); err != nil {
+	if err = json.Unmarshal(data, &tags); err != nil {
 		return
 	}
 	return tags, nil
@@ -197,7 +197,7 @@ func saveTagData(
 	userAPI api.UserInternalAPI,
 	Tag gomatrix.TagContent,
 ) error {
-	newTagData, err := jsoniter.Marshal(Tag)
+	newTagData, err := json.Marshal(Tag)
 	if err != nil {
 		return err
 	}
@@ -205,7 +205,7 @@ func saveTagData(
 		UserID:      userID,
 		RoomID:      roomID,
 		DataType:    "m.tag",
-		AccountData: jsoniter.RawMessage(newTagData),
+		AccountData: json.RawMessage(newTagData),
 	}
 	dataRes := api.InputAccountDataResponse{}
 	return userAPI.InputAccountData(req.Context(), &dataReq, &dataRes)

--- a/clientapi/routing/room_tagging.go
+++ b/clientapi/routing/room_tagging.go
@@ -15,8 +15,9 @@
 package routing
 
 import (
-	json "github.com/json-iterator/go"
 	"net/http"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/sirupsen/logrus"
 

--- a/clientapi/routing/room_tagging.go
+++ b/clientapi/routing/room_tagging.go
@@ -184,7 +184,7 @@ func obtainSavedTags(
 	if !ok {
 		return
 	}
-	if err = json.Unmarshal(data, &tags); err != nil {
+	if err = json.ConfigCompatibleWithStandardLibrary.Unmarshal(data, &tags); err != nil {
 		return
 	}
 	return tags, nil
@@ -198,7 +198,7 @@ func saveTagData(
 	userAPI api.UserInternalAPI,
 	Tag gomatrix.TagContent,
 ) error {
-	newTagData, err := json.Marshal(Tag)
+	newTagData, err := json.ConfigCompatibleWithStandardLibrary.Marshal(Tag)
 	if err != nil {
 		return err
 	}

--- a/clientapi/routing/room_tagging.go
+++ b/clientapi/routing/room_tagging.go
@@ -15,7 +15,7 @@
 package routing
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
@@ -183,7 +183,7 @@ func obtainSavedTags(
 	if !ok {
 		return
 	}
-	if err = json.Unmarshal(data, &tags); err != nil {
+	if err = jsoniter.Unmarshal(data, &tags); err != nil {
 		return
 	}
 	return tags, nil
@@ -197,7 +197,7 @@ func saveTagData(
 	userAPI api.UserInternalAPI,
 	Tag gomatrix.TagContent,
 ) error {
-	newTagData, err := json.Marshal(Tag)
+	newTagData, err := jsoniter.Marshal(Tag)
 	if err != nil {
 		return err
 	}
@@ -205,7 +205,7 @@ func saveTagData(
 		UserID:      userID,
 		RoomID:      roomID,
 		DataType:    "m.tag",
-		AccountData: json.RawMessage(newTagData),
+		AccountData: jsoniter.RawMessage(newTagData),
 	}
 	dataRes := api.InputAccountDataResponse{}
 	return userAPI.InputAccountData(req.Context(), &dataReq, &dataRes)

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -15,7 +15,7 @@
 package routing
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"net/http"
 	"strings"
 
@@ -466,7 +466,7 @@ func Setup(
 	r0mux.Handle("/pushrules/",
 		httputil.MakeExternalAPI("push_rules", func(req *http.Request) util.JSONResponse {
 			// TODO: Implement push rules API
-			res := json.RawMessage(`{
+			res := jsoniter.RawMessage(`{
 					"global": {
 						"content": [],
 						"override": [],

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -15,7 +15,7 @@
 package routing
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"net/http"
 	"strings"
 
@@ -466,7 +466,7 @@ func Setup(
 	r0mux.Handle("/pushrules/",
 		httputil.MakeExternalAPI("push_rules", func(req *http.Request) util.JSONResponse {
 			// TODO: Implement push rules API
-			res := jsoniter.RawMessage(`{
+			res := json.RawMessage(`{
 					"global": {
 						"content": [],
 						"override": [],

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -15,9 +15,10 @@
 package routing
 
 import (
-	json "github.com/json-iterator/go"
 	"net/http"
 	"strings"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/gorilla/mux"
 	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"

--- a/clientapi/routing/sendtodevice.go
+++ b/clientapi/routing/sendtodevice.go
@@ -13,7 +13,7 @@
 package routing
 
 import (
-	"encoding/json"
+	jsoniter "github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/matrix-org/dendrite/clientapi/httputil"
@@ -39,7 +39,7 @@ func SendToDevice(
 	}
 
 	var httpReq struct {
-		Messages map[string]map[string]json.RawMessage `json:"messages"`
+		Messages map[string]map[string]jsoniter.RawMessage `json:"messages"`
 	}
 	resErr := httputil.UnmarshalJSONRequest(req, &httpReq)
 	if resErr != nil {

--- a/clientapi/routing/sendtodevice.go
+++ b/clientapi/routing/sendtodevice.go
@@ -13,7 +13,7 @@
 package routing
 
 import (
-	jsoniter "github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/matrix-org/dendrite/clientapi/httputil"
@@ -39,7 +39,7 @@ func SendToDevice(
 	}
 
 	var httpReq struct {
-		Messages map[string]map[string]jsoniter.RawMessage `json:"messages"`
+		Messages map[string]map[string]json.RawMessage `json:"messages"`
 	}
 	resErr := httputil.UnmarshalJSONRequest(req, &httpReq)
 	if resErr != nil {

--- a/clientapi/routing/sendtodevice.go
+++ b/clientapi/routing/sendtodevice.go
@@ -13,8 +13,9 @@
 package routing
 
 import (
-	json "github.com/json-iterator/go"
 	"net/http"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"

--- a/clientapi/routing/state.go
+++ b/clientapi/routing/state.go
@@ -64,7 +64,7 @@ func OnIncomingStateRequest(ctx context.Context, device *userapi.Device, rsAPI a
 	for _, ev := range stateRes.StateEvents {
 		if ev.Type() == gomatrixserverlib.MRoomHistoryVisibility {
 			content := map[string]string{}
-			if err := json.Unmarshal(ev.Content(), &content); err != nil {
+			if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(ev.Content(), &content); err != nil {
 				util.GetLogger(ctx).WithError(err).Error("json.Unmarshal for history visibility failed")
 				return jsonerror.InternalServerError()
 			}
@@ -205,7 +205,7 @@ func OnIncomingStateTypeRequest(
 	for _, ev := range stateRes.StateEvents {
 		if ev.Type() == gomatrixserverlib.MRoomHistoryVisibility {
 			content := map[string]string{}
-			if err := json.Unmarshal(ev.Content(), &content); err != nil {
+			if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(ev.Content(), &content); err != nil {
 				util.GetLogger(ctx).WithError(err).Error("json.Unmarshal for history visibility failed")
 				return jsonerror.InternalServerError()
 			}

--- a/clientapi/routing/state.go
+++ b/clientapi/routing/state.go
@@ -16,7 +16,7 @@ package routing
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"net/http"
 
@@ -30,7 +30,7 @@ import (
 
 type stateEventInStateResp struct {
 	gomatrixserverlib.ClientEvent
-	PrevContent   jsoniter.RawMessage `json:"prev_content,omitempty"`
+	PrevContent   json.RawMessage `json:"prev_content,omitempty"`
 	ReplacesState string          `json:"replaces_state,omitempty"`
 }
 
@@ -63,7 +63,7 @@ func OnIncomingStateRequest(ctx context.Context, device *userapi.Device, rsAPI a
 	for _, ev := range stateRes.StateEvents {
 		if ev.Type() == gomatrixserverlib.MRoomHistoryVisibility {
 			content := map[string]string{}
-			if err := jsoniter.Unmarshal(ev.Content(), &content); err != nil {
+			if err := json.Unmarshal(ev.Content(), &content); err != nil {
 				util.GetLogger(ctx).WithError(err).Error("json.Unmarshal for history visibility failed")
 				return jsonerror.InternalServerError()
 			}
@@ -204,7 +204,7 @@ func OnIncomingStateTypeRequest(
 	for _, ev := range stateRes.StateEvents {
 		if ev.Type() == gomatrixserverlib.MRoomHistoryVisibility {
 			content := map[string]string{}
-			if err := jsoniter.Unmarshal(ev.Content(), &content); err != nil {
+			if err := json.Unmarshal(ev.Content(), &content); err != nil {
 				util.GetLogger(ctx).WithError(err).Error("json.Unmarshal for history visibility failed")
 				return jsonerror.InternalServerError()
 			}

--- a/clientapi/routing/state.go
+++ b/clientapi/routing/state.go
@@ -16,7 +16,7 @@ package routing
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"net/http"
 
@@ -30,7 +30,7 @@ import (
 
 type stateEventInStateResp struct {
 	gomatrixserverlib.ClientEvent
-	PrevContent   json.RawMessage `json:"prev_content,omitempty"`
+	PrevContent   jsoniter.RawMessage `json:"prev_content,omitempty"`
 	ReplacesState string          `json:"replaces_state,omitempty"`
 }
 
@@ -63,7 +63,7 @@ func OnIncomingStateRequest(ctx context.Context, device *userapi.Device, rsAPI a
 	for _, ev := range stateRes.StateEvents {
 		if ev.Type() == gomatrixserverlib.MRoomHistoryVisibility {
 			content := map[string]string{}
-			if err := json.Unmarshal(ev.Content(), &content); err != nil {
+			if err := jsoniter.Unmarshal(ev.Content(), &content); err != nil {
 				util.GetLogger(ctx).WithError(err).Error("json.Unmarshal for history visibility failed")
 				return jsonerror.InternalServerError()
 			}
@@ -204,7 +204,7 @@ func OnIncomingStateTypeRequest(
 	for _, ev := range stateRes.StateEvents {
 		if ev.Type() == gomatrixserverlib.MRoomHistoryVisibility {
 			content := map[string]string{}
-			if err := json.Unmarshal(ev.Content(), &content); err != nil {
+			if err := jsoniter.Unmarshal(ev.Content(), &content); err != nil {
 				util.GetLogger(ctx).WithError(err).Error("json.Unmarshal for history visibility failed")
 				return jsonerror.InternalServerError()
 			}

--- a/clientapi/routing/state.go
+++ b/clientapi/routing/state.go
@@ -16,9 +16,10 @@ package routing
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"net/http"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/roomserver/api"

--- a/clientapi/threepid/invites.go
+++ b/clientapi/threepid/invites.go
@@ -16,7 +16,7 @@ package threepid
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"errors"
 	"fmt"
 	"net/http"
@@ -197,7 +197,7 @@ func queryIDServerLookup(ctx context.Context, body *MembershipRequest) (*idServe
 	}
 
 	var res idServerLookupResponse
-	err = json.NewDecoder(resp.Body).Decode(&res)
+	err = jsoniter.NewDecoder(resp.Body).Decode(&res)
 	return &res, err
 }
 
@@ -258,7 +258,7 @@ func queryIDServerStoreInvite(
 	}
 
 	var idResp idServerStoreInviteResponse
-	err = json.NewDecoder(resp.Body).Decode(&idResp)
+	err = jsoniter.NewDecoder(resp.Body).Decode(&idResp)
 	return &idResp, err
 }
 
@@ -287,7 +287,7 @@ func queryIDServerPubKey(ctx context.Context, idServerName string, keyID string)
 		return nil, errors.New(errMsg)
 	}
 
-	err = json.NewDecoder(resp.Body).Decode(&pubKeyRes)
+	err = jsoniter.NewDecoder(resp.Body).Decode(&pubKeyRes)
 	return pubKeyRes.PublicKey, err
 }
 
@@ -302,7 +302,7 @@ func checkIDServerSignatures(
 	ctx context.Context, body *MembershipRequest, res *idServerLookupResponse,
 ) error {
 	// Mashall the body so we can give it to VerifyJSON
-	marshalledBody, err := json.Marshal(*res)
+	marshalledBody, err := jsoniter.Marshal(*res)
 	if err != nil {
 		return err
 	}

--- a/clientapi/threepid/invites.go
+++ b/clientapi/threepid/invites.go
@@ -303,7 +303,7 @@ func checkIDServerSignatures(
 	ctx context.Context, body *MembershipRequest, res *idServerLookupResponse,
 ) error {
 	// Mashall the body so we can give it to VerifyJSON
-	marshalledBody, err := json.Marshal(*res)
+	marshalledBody, err := json.ConfigCompatibleWithStandardLibrary.Marshal(*res)
 	if err != nil {
 		return err
 	}

--- a/clientapi/threepid/invites.go
+++ b/clientapi/threepid/invites.go
@@ -16,13 +16,14 @@ package threepid
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/internal/config"

--- a/clientapi/threepid/invites.go
+++ b/clientapi/threepid/invites.go
@@ -16,7 +16,7 @@ package threepid
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"errors"
 	"fmt"
 	"net/http"
@@ -197,7 +197,7 @@ func queryIDServerLookup(ctx context.Context, body *MembershipRequest) (*idServe
 	}
 
 	var res idServerLookupResponse
-	err = jsoniter.NewDecoder(resp.Body).Decode(&res)
+	err = json.NewDecoder(resp.Body).Decode(&res)
 	return &res, err
 }
 
@@ -258,7 +258,7 @@ func queryIDServerStoreInvite(
 	}
 
 	var idResp idServerStoreInviteResponse
-	err = jsoniter.NewDecoder(resp.Body).Decode(&idResp)
+	err = json.NewDecoder(resp.Body).Decode(&idResp)
 	return &idResp, err
 }
 
@@ -287,7 +287,7 @@ func queryIDServerPubKey(ctx context.Context, idServerName string, keyID string)
 		return nil, errors.New(errMsg)
 	}
 
-	err = jsoniter.NewDecoder(resp.Body).Decode(&pubKeyRes)
+	err = json.NewDecoder(resp.Body).Decode(&pubKeyRes)
 	return pubKeyRes.PublicKey, err
 }
 
@@ -302,7 +302,7 @@ func checkIDServerSignatures(
 	ctx context.Context, body *MembershipRequest, res *idServerLookupResponse,
 ) error {
 	// Mashall the body so we can give it to VerifyJSON
-	marshalledBody, err := jsoniter.Marshal(*res)
+	marshalledBody, err := json.Marshal(*res)
 	if err != nil {
 		return err
 	}

--- a/clientapi/threepid/threepid.go
+++ b/clientapi/threepid/threepid.go
@@ -16,13 +16,14 @@ package threepid
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal/config"
 )

--- a/clientapi/threepid/threepid.go
+++ b/clientapi/threepid/threepid.go
@@ -16,7 +16,7 @@ package threepid
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"errors"
 	"fmt"
 	"net/http"
@@ -88,7 +88,7 @@ func CreateSession(
 	var sid struct {
 		SID string `json:"sid"`
 	}
-	err = jsoniter.NewDecoder(resp.Body).Decode(&sid)
+	err = json.NewDecoder(resp.Body).Decode(&sid)
 
 	return sid.SID, err
 }
@@ -125,7 +125,7 @@ func CheckAssociation(
 		Error       string `json:"error"`
 	}
 
-	if err = jsoniter.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+	if err = json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
 		return false, "", "", err
 	}
 

--- a/clientapi/threepid/threepid.go
+++ b/clientapi/threepid/threepid.go
@@ -16,7 +16,7 @@ package threepid
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"errors"
 	"fmt"
 	"net/http"
@@ -88,7 +88,7 @@ func CreateSession(
 	var sid struct {
 		SID string `json:"sid"`
 	}
-	err = json.NewDecoder(resp.Body).Decode(&sid)
+	err = jsoniter.NewDecoder(resp.Body).Decode(&sid)
 
 	return sid.SID, err
 }
@@ -125,7 +125,7 @@ func CheckAssociation(
 		Error       string `json:"error"`
 	}
 
-	if err = json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+	if err = jsoniter.NewDecoder(resp.Body).Decode(&respBody); err != nil {
 		return false, "", "", err
 	}
 

--- a/cmd/create-account/main.go
+++ b/cmd/create-account/main.go
@@ -92,7 +92,7 @@ func main() {
 	}
 
 	device, err := deviceDB.CreateDevice(
-		context.Background(), *username, nil, *accessToken, nil,
+		context.Background(), *username, nil, *accessToken, nil, "127.0.0.1", "",
 	)
 	if err != nil {
 		fmt.Println(err.Error())

--- a/cmd/create-room-events/main.go
+++ b/cmd/create-room-events/main.go
@@ -18,12 +18,13 @@ package main
 
 import (
 	"encoding/base64"
-	json "github.com/json-iterator/go"
 	"flag"
 	"fmt"
 	"os"
 	"strings"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"

--- a/cmd/create-room-events/main.go
+++ b/cmd/create-room-events/main.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"encoding/base64"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"flag"
 	"fmt"
 	"os"
@@ -124,7 +124,7 @@ func buildAndOutput() gomatrixserverlib.EventReference {
 
 // Write an event to the output.
 func writeEvent(event gomatrixserverlib.Event) {
-	encoder := jsoniter.NewEncoder(os.Stdout)
+	encoder := json.NewEncoder(os.Stdout)
 	if *format == "InputRoomEvent" {
 		var ire api.InputRoomEvent
 		ire.Kind = api.KindNew

--- a/cmd/create-room-events/main.go
+++ b/cmd/create-room-events/main.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"encoding/base64"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"flag"
 	"fmt"
 	"os"
@@ -124,7 +124,7 @@ func buildAndOutput() gomatrixserverlib.EventReference {
 
 // Write an event to the output.
 func writeEvent(event gomatrixserverlib.Event) {
-	encoder := json.NewEncoder(os.Stdout)
+	encoder := jsoniter.NewEncoder(os.Stdout)
 	if *format == "InputRoomEvent" {
 		var ire api.InputRoomEvent
 		ire.Kind = api.KindNew

--- a/cmd/dendrite-demo-libp2p/publicrooms.go
+++ b/cmd/dendrite-demo-libp2p/publicrooms.go
@@ -16,11 +16,12 @@ package main
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
 

--- a/cmd/dendrite-demo-libp2p/publicrooms.go
+++ b/cmd/dendrite-demo-libp2p/publicrooms.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -110,7 +110,7 @@ func (p *publicRoomsProvider) AdvertiseRooms() error {
 	}
 	advertised := 0
 	for _, room := range ourRooms {
-		if j, err := json.Marshal(room); err == nil {
+		if j, err := jsoniter.Marshal(room); err == nil {
 			if err := p.topic.Publish(context.TODO(), j); err != nil {
 				fmt.Println("Failed to publish public room:", err)
 			} else {
@@ -132,7 +132,7 @@ func (p *publicRoomsProvider) FindRooms() {
 		received := discoveredRoom{
 			time: time.Now(),
 		}
-		if err := json.Unmarshal(msg.Data, &received.room); err != nil {
+		if err := jsoniter.Unmarshal(msg.Data, &received.room); err != nil {
 			fmt.Println("Unmarshal error:", err)
 			continue
 		}

--- a/cmd/dendrite-demo-libp2p/publicrooms.go
+++ b/cmd/dendrite-demo-libp2p/publicrooms.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -110,7 +110,7 @@ func (p *publicRoomsProvider) AdvertiseRooms() error {
 	}
 	advertised := 0
 	for _, room := range ourRooms {
-		if j, err := jsoniter.Marshal(room); err == nil {
+		if j, err := json.Marshal(room); err == nil {
 			if err := p.topic.Publish(context.TODO(), j); err != nil {
 				fmt.Println("Failed to publish public room:", err)
 			} else {
@@ -132,7 +132,7 @@ func (p *publicRoomsProvider) FindRooms() {
 		received := discoveredRoom{
 			time: time.Now(),
 		}
-		if err := jsoniter.Unmarshal(msg.Data, &received.room); err != nil {
+		if err := json.Unmarshal(msg.Data, &received.room); err != nil {
 			fmt.Println("Unmarshal error:", err)
 			continue
 		}

--- a/cmd/dendrite-demo-libp2p/publicrooms.go
+++ b/cmd/dendrite-demo-libp2p/publicrooms.go
@@ -111,7 +111,7 @@ func (p *publicRoomsProvider) AdvertiseRooms() error {
 	}
 	advertised := 0
 	for _, room := range ourRooms {
-		if j, err := json.Marshal(room); err == nil {
+		if j, err := json.ConfigCompatibleWithStandardLibrary.Marshal(room); err == nil {
 			if err := p.topic.Publish(context.TODO(), j); err != nil {
 				fmt.Println("Failed to publish public room:", err)
 			} else {
@@ -133,7 +133,7 @@ func (p *publicRoomsProvider) FindRooms() {
 		received := discoveredRoom{
 			time: time.Now(),
 		}
-		if err := json.Unmarshal(msg.Data, &received.room); err != nil {
+		if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(msg.Data, &received.room); err != nil {
 			fmt.Println("Unmarshal error:", err)
 			continue
 		}

--- a/cmd/dendrite-demo-yggdrasil/yggconn/node.go
+++ b/cmd/dendrite-demo-yggdrasil/yggconn/node.go
@@ -19,7 +19,7 @@ import (
 	"crypto/ed25519"
 	"crypto/tls"
 	"encoding/hex"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -89,7 +89,7 @@ func Setup(instanceName, storageDirectory string) (*Node, error) {
 		if e != nil {
 			panic(err)
 		}
-		if err := json.Unmarshal([]byte(yggconf), &n.config); err != nil {
+		if err := jsoniter.Unmarshal([]byte(yggconf), &n.config); err != nil {
 			panic(err)
 		}
 	}
@@ -113,7 +113,7 @@ func Setup(instanceName, storageDirectory string) (*Node, error) {
 	n.config.EncryptionPrivateKey = hex.EncodeToString(n.EncryptionPrivateKey())
 	n.config.EncryptionPublicKey = hex.EncodeToString(n.EncryptionPublicKey())
 
-	j, err := json.MarshalIndent(n.config, "", "  ")
+	j, err := jsoniter.MarshalIndent(n.config, "", "  ")
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/dendrite-demo-yggdrasil/yggconn/node.go
+++ b/cmd/dendrite-demo-yggdrasil/yggconn/node.go
@@ -90,7 +90,7 @@ func Setup(instanceName, storageDirectory string) (*Node, error) {
 		if e != nil {
 			panic(err)
 		}
-		if err := json.Unmarshal([]byte(yggconf), &n.config); err != nil {
+		if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(yggconf), &n.config); err != nil {
 			panic(err)
 		}
 	}

--- a/cmd/dendrite-demo-yggdrasil/yggconn/node.go
+++ b/cmd/dendrite-demo-yggdrasil/yggconn/node.go
@@ -19,7 +19,6 @@ import (
 	"crypto/ed25519"
 	"crypto/tls"
 	"encoding/hex"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -28,6 +27,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/lucas-clemente/quic-go"
 	"github.com/matrix-org/dendrite/cmd/dendrite-demo-yggdrasil/convert"

--- a/cmd/dendrite-demo-yggdrasil/yggconn/node.go
+++ b/cmd/dendrite-demo-yggdrasil/yggconn/node.go
@@ -19,7 +19,7 @@ import (
 	"crypto/ed25519"
 	"crypto/tls"
 	"encoding/hex"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -89,7 +89,7 @@ func Setup(instanceName, storageDirectory string) (*Node, error) {
 		if e != nil {
 			panic(err)
 		}
-		if err := jsoniter.Unmarshal([]byte(yggconf), &n.config); err != nil {
+		if err := json.Unmarshal([]byte(yggconf), &n.config); err != nil {
 			panic(err)
 		}
 	}
@@ -113,7 +113,7 @@ func Setup(instanceName, storageDirectory string) (*Node, error) {
 	n.config.EncryptionPrivateKey = hex.EncodeToString(n.EncryptionPrivateKey())
 	n.config.EncryptionPublicKey = hex.EncodeToString(n.EncryptionPublicKey())
 
-	j, err := jsoniter.MarshalIndent(n.config, "", "  ")
+	j, err := json.MarshalIndent(n.config, "", "  ")
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/furl/main.go
+++ b/cmd/furl/main.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"encoding/pem"
 	"flag"
 	"fmt"
@@ -75,7 +75,7 @@ func main() {
 			bodyBytes = append(bodyBytes, bytes...)
 		}
 		fmt.Println("Done!")
-		if err = jsoniter.Unmarshal(bodyBytes, &bodyObj); err != nil {
+		if err = json.Unmarshal(bodyBytes, &bodyObj); err != nil {
 			panic(err)
 		}
 	}
@@ -115,7 +115,7 @@ func main() {
 		panic(err)
 	}
 
-	j, err := jsoniter.MarshalIndent(res, "", "  ")
+	j, err := json.MarshalIndent(res, "", "  ")
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/furl/main.go
+++ b/cmd/furl/main.go
@@ -76,7 +76,7 @@ func main() {
 			bodyBytes = append(bodyBytes, bytes...)
 		}
 		fmt.Println("Done!")
-		if err = json.Unmarshal(bodyBytes, &bodyObj); err != nil {
+		if err = json.ConfigCompatibleWithStandardLibrary.Unmarshal(bodyBytes, &bodyObj); err != nil {
 			panic(err)
 		}
 	}

--- a/cmd/furl/main.go
+++ b/cmd/furl/main.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"encoding/pem"
 	"flag"
 	"fmt"
@@ -75,7 +75,7 @@ func main() {
 			bodyBytes = append(bodyBytes, bytes...)
 		}
 		fmt.Println("Done!")
-		if err = json.Unmarshal(bodyBytes, &bodyObj); err != nil {
+		if err = jsoniter.Unmarshal(bodyBytes, &bodyObj); err != nil {
 			panic(err)
 		}
 	}
@@ -115,7 +115,7 @@ func main() {
 		panic(err)
 	}
 
-	j, err := json.MarshalIndent(res, "", "  ")
+	j, err := jsoniter.MarshalIndent(res, "", "  ")
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/furl/main.go
+++ b/cmd/furl/main.go
@@ -5,13 +5,14 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
-	json "github.com/json-iterator/go"
 	"encoding/pem"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"net/url"
 	"os"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/gomatrixserverlib"
 )

--- a/cmd/roomserver-integration-tests/main.go
+++ b/cmd/roomserver-integration-tests/main.go
@@ -207,7 +207,7 @@ func writeToRoomServer(input []string, roomserverURL string) error {
 	var err error
 	request.InputRoomEvents = make([]api.InputRoomEvent, len(input))
 	for i := range input {
-		if err = json.Unmarshal([]byte(input[i]), &request.InputRoomEvents[i]); err != nil {
+		if err = json.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(input[i]), &request.InputRoomEvents[i]); err != nil {
 			return err
 		}
 	}

--- a/cmd/roomserver-integration-tests/main.go
+++ b/cmd/roomserver-integration-tests/main.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"encoding/json"
+	"github.com/json-iterator/go"
 
 	"net/http"
 
@@ -207,7 +207,7 @@ func writeToRoomServer(input []string, roomserverURL string) error {
 	var err error
 	request.InputRoomEvents = make([]api.InputRoomEvent, len(input))
 	for i := range input {
-		if err = json.Unmarshal([]byte(input[i]), &request.InputRoomEvents[i]); err != nil {
+		if err = jsoniter.Unmarshal([]byte(input[i]), &request.InputRoomEvents[i]); err != nil {
 			return err
 		}
 	}

--- a/cmd/roomserver-integration-tests/main.go
+++ b/cmd/roomserver-integration-tests/main.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 
 	"net/http"
 
@@ -207,7 +207,7 @@ func writeToRoomServer(input []string, roomserverURL string) error {
 	var err error
 	request.InputRoomEvents = make([]api.InputRoomEvent, len(input))
 	for i := range input {
-		if err = jsoniter.Unmarshal([]byte(input[i]), &request.InputRoomEvents[i]); err != nil {
+		if err = json.Unmarshal([]byte(input[i]), &request.InputRoomEvents[i]); err != nil {
 			return err
 		}
 	}

--- a/cmd/syncserver-integration-tests/main.go
+++ b/cmd/syncserver-integration-tests/main.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -100,13 +100,13 @@ func createTestUser(database, username, token string) error {
 // Panics if there are any problems.
 func clientEventJSONForOutputRoomEvent(outputRoomEvent string) string {
 	var out api.OutputEvent
-	if err := jsoniter.Unmarshal([]byte(outputRoomEvent), &out); err != nil {
+	if err := json.Unmarshal([]byte(outputRoomEvent), &out); err != nil {
 		panic("failed to unmarshal output room event: " + err.Error())
 	}
 	clientEvs := gomatrixserverlib.ToClientEvents([]gomatrixserverlib.Event{
 		out.NewRoomEvent.Event.Event,
 	}, gomatrixserverlib.FormatSync)
-	b, err := jsoniter.Marshal(clientEvs[0])
+	b, err := json.Marshal(clientEvs[0])
 	if err != nil {
 		panic("failed to marshal client event as json: " + err.Error())
 	}

--- a/cmd/syncserver-integration-tests/main.go
+++ b/cmd/syncserver-integration-tests/main.go
@@ -101,13 +101,13 @@ func createTestUser(database, username, token string) error {
 // Panics if there are any problems.
 func clientEventJSONForOutputRoomEvent(outputRoomEvent string) string {
 	var out api.OutputEvent
-	if err := json.Unmarshal([]byte(outputRoomEvent), &out); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(outputRoomEvent), &out); err != nil {
 		panic("failed to unmarshal output room event: " + err.Error())
 	}
 	clientEvs := gomatrixserverlib.ToClientEvents([]gomatrixserverlib.Event{
 		out.NewRoomEvent.Event.Event,
 	}, gomatrixserverlib.FormatSync)
-	b, err := json.Marshal(clientEvs[0])
+	b, err := json.ConfigCompatibleWithStandardLibrary.Marshal(clientEvs[0])
 	if err != nil {
 		panic("failed to marshal client event as json: " + err.Error())
 	}

--- a/cmd/syncserver-integration-tests/main.go
+++ b/cmd/syncserver-integration-tests/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	json "github.com/json-iterator/go"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -23,6 +22,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal/config"
 	"github.com/matrix-org/dendrite/internal/test"

--- a/cmd/syncserver-integration-tests/main.go
+++ b/cmd/syncserver-integration-tests/main.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -100,13 +100,13 @@ func createTestUser(database, username, token string) error {
 // Panics if there are any problems.
 func clientEventJSONForOutputRoomEvent(outputRoomEvent string) string {
 	var out api.OutputEvent
-	if err := json.Unmarshal([]byte(outputRoomEvent), &out); err != nil {
+	if err := jsoniter.Unmarshal([]byte(outputRoomEvent), &out); err != nil {
 		panic("failed to unmarshal output room event: " + err.Error())
 	}
 	clientEvs := gomatrixserverlib.ToClientEvents([]gomatrixserverlib.Event{
 		out.NewRoomEvent.Event.Event,
 	}, gomatrixserverlib.FormatSync)
-	b, err := json.Marshal(clientEvs[0])
+	b, err := jsoniter.Marshal(clientEvs[0])
 	if err != nil {
 		panic("failed to marshal client event as json: " + err.Error())
 	}

--- a/eduserver/api/wrapper.go
+++ b/eduserver/api/wrapper.go
@@ -16,8 +16,9 @@ package api
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/gomatrixserverlib"
 )

--- a/eduserver/api/wrapper.go
+++ b/eduserver/api/wrapper.go
@@ -49,7 +49,7 @@ func SendToDevice(
 	ctx context.Context, eduAPI EDUServerInputAPI, sender, userID, deviceID, eventType string,
 	message interface{},
 ) error {
-	js, err := json.Marshal(message)
+	js, err := json.ConfigCompatibleWithStandardLibrary.Marshal(message)
 	if err != nil {
 		return err
 	}

--- a/eduserver/api/wrapper.go
+++ b/eduserver/api/wrapper.go
@@ -16,7 +16,7 @@ package api
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"time"
 
 	"github.com/matrix-org/gomatrixserverlib"
@@ -48,7 +48,7 @@ func SendToDevice(
 	ctx context.Context, eduAPI EDUServerInputAPI, sender, userID, deviceID, eventType string,
 	message interface{},
 ) error {
-	js, err := json.Marshal(message)
+	js, err := jsoniter.Marshal(message)
 	if err != nil {
 		return err
 	}

--- a/eduserver/api/wrapper.go
+++ b/eduserver/api/wrapper.go
@@ -16,7 +16,7 @@ package api
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"time"
 
 	"github.com/matrix-org/gomatrixserverlib"
@@ -48,7 +48,7 @@ func SendToDevice(
 	ctx context.Context, eduAPI EDUServerInputAPI, sender, userID, deviceID, eventType string,
 	message interface{},
 ) error {
-	js, err := jsoniter.Marshal(message)
+	js, err := json.Marshal(message)
 	if err != nil {
 		return err
 	}

--- a/eduserver/input/input.go
+++ b/eduserver/input/input.go
@@ -18,7 +18,7 @@ package input
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"time"
 
 	"github.com/Shopify/sarama"
@@ -93,7 +93,7 @@ func (t *EDUServerInputAPI) sendTypingEvent(ite *api.InputTypingEvent) error {
 		ote.ExpireTime = &expireTime
 	}
 
-	eventJSON, err := jsoniter.Marshal(ote)
+	eventJSON, err := json.Marshal(ote)
 	if err != nil {
 		return err
 	}
@@ -152,9 +152,9 @@ func (t *EDUServerInputAPI) sendToDeviceEvent(ise *api.InputSendToDeviceEvent) e
 			SendToDeviceEvent: ise.SendToDeviceEvent,
 		}
 
-		eventJSON, err := jsoniter.Marshal(ote)
+		eventJSON, err := json.Marshal(ote)
 		if err != nil {
-			logrus.WithError(err).Error("sendToDevice failed jsoniter.Marshal")
+			logrus.WithError(err).Error("sendToDevice failed json.Marshal")
 			return err
 		}
 

--- a/eduserver/input/input.go
+++ b/eduserver/input/input.go
@@ -18,8 +18,9 @@ package input
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"
 	"github.com/matrix-org/dendrite/eduserver/api"

--- a/eduserver/input/input.go
+++ b/eduserver/input/input.go
@@ -18,7 +18,7 @@ package input
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"time"
 
 	"github.com/Shopify/sarama"
@@ -93,7 +93,7 @@ func (t *EDUServerInputAPI) sendTypingEvent(ite *api.InputTypingEvent) error {
 		ote.ExpireTime = &expireTime
 	}
 
-	eventJSON, err := json.Marshal(ote)
+	eventJSON, err := jsoniter.Marshal(ote)
 	if err != nil {
 		return err
 	}
@@ -152,9 +152,9 @@ func (t *EDUServerInputAPI) sendToDeviceEvent(ise *api.InputSendToDeviceEvent) e
 			SendToDeviceEvent: ise.SendToDeviceEvent,
 		}
 
-		eventJSON, err := json.Marshal(ote)
+		eventJSON, err := jsoniter.Marshal(ote)
 		if err != nil {
-			logrus.WithError(err).Error("sendToDevice failed json.Marshal")
+			logrus.WithError(err).Error("sendToDevice failed jsoniter.Marshal")
 			return err
 		}
 

--- a/eduserver/input/input.go
+++ b/eduserver/input/input.go
@@ -94,7 +94,7 @@ func (t *EDUServerInputAPI) sendTypingEvent(ite *api.InputTypingEvent) error {
 		ote.ExpireTime = &expireTime
 	}
 
-	eventJSON, err := json.Marshal(ote)
+	eventJSON, err := json.ConfigCompatibleWithStandardLibrary.Marshal(ote)
 	if err != nil {
 		return err
 	}
@@ -153,7 +153,7 @@ func (t *EDUServerInputAPI) sendToDeviceEvent(ise *api.InputSendToDeviceEvent) e
 			SendToDeviceEvent: ise.SendToDeviceEvent,
 		}
 
-		eventJSON, err := json.Marshal(ote)
+		eventJSON, err := json.ConfigCompatibleWithStandardLibrary.Marshal(ote)
 		if err != nil {
 			logrus.WithError(err).Error("sendToDevice failed json.Marshal")
 			return err

--- a/eduserver/inthttp/server.go
+++ b/eduserver/inthttp/server.go
@@ -1,7 +1,7 @@
 package inthttp
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -16,7 +16,7 @@ func AddRoutes(t api.EDUServerInputAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("inputTypingEvents", func(req *http.Request) util.JSONResponse {
 			var request api.InputTypingEventRequest
 			var response api.InputTypingEventResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := t.InputTypingEvent(req.Context(), &request, &response); err != nil {
@@ -29,7 +29,7 @@ func AddRoutes(t api.EDUServerInputAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("inputSendToDeviceEvents", func(req *http.Request) util.JSONResponse {
 			var request api.InputSendToDeviceEventRequest
 			var response api.InputSendToDeviceEventResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := t.InputSendToDeviceEvent(req.Context(), &request, &response); err != nil {

--- a/eduserver/inthttp/server.go
+++ b/eduserver/inthttp/server.go
@@ -1,8 +1,9 @@
 package inthttp
 
 import (
-	json "github.com/json-iterator/go"
 	"net/http"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/eduserver/api"

--- a/eduserver/inthttp/server.go
+++ b/eduserver/inthttp/server.go
@@ -1,7 +1,7 @@
 package inthttp
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -16,7 +16,7 @@ func AddRoutes(t api.EDUServerInputAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("inputTypingEvents", func(req *http.Request) util.JSONResponse {
 			var request api.InputTypingEventRequest
 			var response api.InputTypingEventResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := t.InputTypingEvent(req.Context(), &request, &response); err != nil {
@@ -29,7 +29,7 @@ func AddRoutes(t api.EDUServerInputAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("inputSendToDeviceEvents", func(req *http.Request) util.JSONResponse {
 			var request api.InputSendToDeviceEventRequest
 			var response api.InputSendToDeviceEventResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := t.InputSendToDeviceEvent(req.Context(), &request, &response); err != nil {

--- a/federationapi/routing/backfill.go
+++ b/federationapi/routing/backfill.go
@@ -102,7 +102,7 @@ func Backfill(
 		}
 	}
 
-	eventJSONs := []json.RawMessage{}
+	var eventJSONs []json.RawMessage
 	for _, e := range gomatrixserverlib.ReverseTopologicalOrdering(
 		evs,
 		gomatrixserverlib.TopologicalOrderByPrevEvents,

--- a/federationapi/routing/backfill.go
+++ b/federationapi/routing/backfill.go
@@ -15,11 +15,12 @@
 package routing
 
 import (
-	json "github.com/json-iterator/go"
 	"fmt"
 	"net/http"
 	"strconv"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/internal/config"

--- a/federationapi/routing/backfill.go
+++ b/federationapi/routing/backfill.go
@@ -15,7 +15,7 @@
 package routing
 
 import (
-	"encoding/json"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"net/http"
 	"strconv"

--- a/federationapi/routing/devices.go
+++ b/federationapi/routing/devices.go
@@ -46,7 +46,7 @@ func GetUserDevices(
 
 	for _, dev := range res.Devices {
 		var key gomatrixserverlib.RespUserDeviceKeys
-		err := json.Unmarshal(dev.DeviceKeys.KeyJSON, &key)
+		err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(dev.DeviceKeys.KeyJSON, &key)
 		if err != nil {
 			util.GetLogger(req.Context()).WithError(err).Warnf("malformed device key: %s", string(dev.DeviceKeys.KeyJSON))
 			continue

--- a/federationapi/routing/devices.go
+++ b/federationapi/routing/devices.go
@@ -13,8 +13,9 @@
 package routing
 
 import (
-	json "github.com/json-iterator/go"
 	"net/http"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	keyapi "github.com/matrix-org/dendrite/keyserver/api"

--- a/federationapi/routing/devices.go
+++ b/federationapi/routing/devices.go
@@ -13,7 +13,7 @@
 package routing
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
@@ -45,7 +45,7 @@ func GetUserDevices(
 
 	for _, dev := range res.Devices {
 		var key gomatrixserverlib.RespUserDeviceKeys
-		err := json.Unmarshal(dev.DeviceKeys.KeyJSON, &key)
+		err := jsoniter.Unmarshal(dev.DeviceKeys.KeyJSON, &key)
 		if err != nil {
 			util.GetLogger(req.Context()).WithError(err).Warnf("malformed device key: %s", string(dev.DeviceKeys.KeyJSON))
 			continue

--- a/federationapi/routing/devices.go
+++ b/federationapi/routing/devices.go
@@ -13,7 +13,7 @@
 package routing
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
@@ -45,7 +45,7 @@ func GetUserDevices(
 
 	for _, dev := range res.Devices {
 		var key gomatrixserverlib.RespUserDeviceKeys
-		err := jsoniter.Unmarshal(dev.DeviceKeys.KeyJSON, &key)
+		err := json.Unmarshal(dev.DeviceKeys.KeyJSON, &key)
 		if err != nil {
 			util.GetLogger(req.Context()).WithError(err).Warnf("malformed device key: %s", string(dev.DeviceKeys.KeyJSON))
 			continue

--- a/federationapi/routing/events.go
+++ b/federationapi/routing/events.go
@@ -16,9 +16,10 @@ package routing
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"net/http"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"

--- a/federationapi/routing/events.go
+++ b/federationapi/routing/events.go
@@ -16,7 +16,7 @@ package routing
 
 import (
 	"context"
-	"encoding/json"
+	json "github.com/json-iterator/go"
 	"net/http"
 	"time"
 

--- a/federationapi/routing/invite.go
+++ b/federationapi/routing/invite.go
@@ -40,7 +40,7 @@ func InviteV2(
 	keys gomatrixserverlib.JSONVerifier,
 ) util.JSONResponse {
 	inviteReq := gomatrixserverlib.InviteV2Request{}
-	err := json.Unmarshal(request.Content(), &inviteReq)
+	err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(request.Content(), &inviteReq)
 	switch err.(type) {
 	case gomatrixserverlib.BadJSONError:
 		return util.JSONResponse{
@@ -86,7 +86,7 @@ func InviteV1(
 		}
 	}
 	var strippedState []gomatrixserverlib.InviteV2StrippedState
-	if err := json.Unmarshal(event.Unsigned(), &strippedState); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(event.Unsigned(), &strippedState); err != nil {
 		// just warn, they may not have added any.
 		util.GetLogger(httpReq.Context()).Warnf("failed to extract stripped state from invite event")
 	}

--- a/federationapi/routing/invite.go
+++ b/federationapi/routing/invite.go
@@ -16,9 +16,10 @@ package routing
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"net/http"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/internal/config"

--- a/federationapi/routing/invite.go
+++ b/federationapi/routing/invite.go
@@ -16,7 +16,7 @@ package routing
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"net/http"
 
@@ -39,7 +39,7 @@ func InviteV2(
 	keys gomatrixserverlib.JSONVerifier,
 ) util.JSONResponse {
 	inviteReq := gomatrixserverlib.InviteV2Request{}
-	err := jsoniter.Unmarshal(request.Content(), &inviteReq)
+	err := json.Unmarshal(request.Content(), &inviteReq)
 	switch err.(type) {
 	case gomatrixserverlib.BadJSONError:
 		return util.JSONResponse{
@@ -85,7 +85,7 @@ func InviteV1(
 		}
 	}
 	var strippedState []gomatrixserverlib.InviteV2StrippedState
-	if err := jsoniter.Unmarshal(event.Unsigned(), &strippedState); err != nil {
+	if err := json.Unmarshal(event.Unsigned(), &strippedState); err != nil {
 		// just warn, they may not have added any.
 		util.GetLogger(httpReq.Context()).Warnf("failed to extract stripped state from invite event")
 	}

--- a/federationapi/routing/invite.go
+++ b/federationapi/routing/invite.go
@@ -16,7 +16,7 @@ package routing
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"net/http"
 
@@ -39,7 +39,7 @@ func InviteV2(
 	keys gomatrixserverlib.JSONVerifier,
 ) util.JSONResponse {
 	inviteReq := gomatrixserverlib.InviteV2Request{}
-	err := json.Unmarshal(request.Content(), &inviteReq)
+	err := jsoniter.Unmarshal(request.Content(), &inviteReq)
 	switch err.(type) {
 	case gomatrixserverlib.BadJSONError:
 		return util.JSONResponse{
@@ -85,7 +85,7 @@ func InviteV1(
 		}
 	}
 	var strippedState []gomatrixserverlib.InviteV2StrippedState
-	if err := json.Unmarshal(event.Unsigned(), &strippedState); err != nil {
+	if err := jsoniter.Unmarshal(event.Unsigned(), &strippedState); err != nil {
 		// just warn, they may not have added any.
 		util.GetLogger(httpReq.Context()).Warnf("failed to extract stripped state from invite event")
 	}

--- a/federationapi/routing/keys.go
+++ b/federationapi/routing/keys.go
@@ -15,7 +15,7 @@
 package routing
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"net/http"
 	"time"
 
@@ -40,7 +40,7 @@ func QueryDeviceKeys(
 	httpReq *http.Request, request *gomatrixserverlib.FederationRequest, keyAPI api.KeyInternalAPI, thisServer gomatrixserverlib.ServerName,
 ) util.JSONResponse {
 	var qkr queryKeysRequest
-	err := jsoniter.Unmarshal(request.Content(), &qkr)
+	err := json.Unmarshal(request.Content(), &qkr)
 	if err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
@@ -86,7 +86,7 @@ func ClaimOneTimeKeys(
 	httpReq *http.Request, request *gomatrixserverlib.FederationRequest, keyAPI api.KeyInternalAPI, thisServer gomatrixserverlib.ServerName,
 ) util.JSONResponse {
 	var cor claimOTKsRequest
-	err := jsoniter.Unmarshal(request.Content(), &cor)
+	err := json.Unmarshal(request.Content(), &cor)
 	if err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
@@ -156,7 +156,7 @@ func localKeys(cfg *config.FederationAPI, validUntil time.Time) (*gomatrixserver
 		}
 	}
 
-	toSign, err := jsoniter.Marshal(keys.ServerKeyFields)
+	toSign, err := json.Marshal(keys.ServerKeyFields)
 	if err != nil {
 		return nil, err
 	}
@@ -184,9 +184,9 @@ func NotaryKeys(
 	}
 
 	var response struct {
-		ServerKeys []jsoniter.RawMessage `json:"server_keys"`
+		ServerKeys []json.RawMessage `json:"server_keys"`
 	}
-	response.ServerKeys = []jsoniter.RawMessage{}
+	response.ServerKeys = []json.RawMessage{}
 
 	for serverName := range req.ServerKeys {
 		var keys *gomatrixserverlib.ServerKeys
@@ -207,7 +207,7 @@ func NotaryKeys(
 			continue
 		}
 
-		j, err := jsoniter.Marshal(keys)
+		j, err := json.Marshal(keys)
 		if err != nil {
 			logrus.WithError(err).Errorf("Failed to marshal %q response", serverName)
 			return jsonerror.InternalServerError()

--- a/federationapi/routing/keys.go
+++ b/federationapi/routing/keys.go
@@ -15,9 +15,10 @@
 package routing
 
 import (
-	json "github.com/json-iterator/go"
 	"net/http"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"

--- a/federationapi/routing/keys.go
+++ b/federationapi/routing/keys.go
@@ -15,7 +15,7 @@
 package routing
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"net/http"
 	"time"
 
@@ -40,7 +40,7 @@ func QueryDeviceKeys(
 	httpReq *http.Request, request *gomatrixserverlib.FederationRequest, keyAPI api.KeyInternalAPI, thisServer gomatrixserverlib.ServerName,
 ) util.JSONResponse {
 	var qkr queryKeysRequest
-	err := json.Unmarshal(request.Content(), &qkr)
+	err := jsoniter.Unmarshal(request.Content(), &qkr)
 	if err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
@@ -86,7 +86,7 @@ func ClaimOneTimeKeys(
 	httpReq *http.Request, request *gomatrixserverlib.FederationRequest, keyAPI api.KeyInternalAPI, thisServer gomatrixserverlib.ServerName,
 ) util.JSONResponse {
 	var cor claimOTKsRequest
-	err := json.Unmarshal(request.Content(), &cor)
+	err := jsoniter.Unmarshal(request.Content(), &cor)
 	if err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
@@ -156,7 +156,7 @@ func localKeys(cfg *config.FederationAPI, validUntil time.Time) (*gomatrixserver
 		}
 	}
 
-	toSign, err := json.Marshal(keys.ServerKeyFields)
+	toSign, err := jsoniter.Marshal(keys.ServerKeyFields)
 	if err != nil {
 		return nil, err
 	}
@@ -184,9 +184,9 @@ func NotaryKeys(
 	}
 
 	var response struct {
-		ServerKeys []json.RawMessage `json:"server_keys"`
+		ServerKeys []jsoniter.RawMessage `json:"server_keys"`
 	}
-	response.ServerKeys = []json.RawMessage{}
+	response.ServerKeys = []jsoniter.RawMessage{}
 
 	for serverName := range req.ServerKeys {
 		var keys *gomatrixserverlib.ServerKeys
@@ -207,7 +207,7 @@ func NotaryKeys(
 			continue
 		}
 
-		j, err := json.Marshal(keys)
+		j, err := jsoniter.Marshal(keys)
 		if err != nil {
 			logrus.WithError(err).Errorf("Failed to marshal %q response", serverName)
 			return jsonerror.InternalServerError()

--- a/federationapi/routing/keys.go
+++ b/federationapi/routing/keys.go
@@ -41,7 +41,7 @@ func QueryDeviceKeys(
 	httpReq *http.Request, request *gomatrixserverlib.FederationRequest, keyAPI api.KeyInternalAPI, thisServer gomatrixserverlib.ServerName,
 ) util.JSONResponse {
 	var qkr queryKeysRequest
-	err := json.Unmarshal(request.Content(), &qkr)
+	err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(request.Content(), &qkr)
 	if err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
@@ -87,7 +87,7 @@ func ClaimOneTimeKeys(
 	httpReq *http.Request, request *gomatrixserverlib.FederationRequest, keyAPI api.KeyInternalAPI, thisServer gomatrixserverlib.ServerName,
 ) util.JSONResponse {
 	var cor claimOTKsRequest
-	err := json.Unmarshal(request.Content(), &cor)
+	err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(request.Content(), &cor)
 	if err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
@@ -157,7 +157,7 @@ func localKeys(cfg *config.FederationAPI, validUntil time.Time) (*gomatrixserver
 		}
 	}
 
-	toSign, err := json.Marshal(keys.ServerKeyFields)
+	toSign, err := json.ConfigCompatibleWithStandardLibrary.Marshal(keys.ServerKeyFields)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +208,7 @@ func NotaryKeys(
 			continue
 		}
 
-		j, err := json.Marshal(keys)
+		j, err := json.ConfigCompatibleWithStandardLibrary.Marshal(keys)
 		if err != nil {
 			logrus.WithError(err).Errorf("Failed to marshal %q response", serverName)
 			return jsonerror.InternalServerError()

--- a/federationapi/routing/missingevents.go
+++ b/federationapi/routing/missingevents.go
@@ -13,7 +13,7 @@
 package routing
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
@@ -38,7 +38,7 @@ func GetMissingEvents(
 	roomID string,
 ) util.JSONResponse {
 	var gme getMissingEventRequest
-	if err := json.Unmarshal(request.Content(), &gme); err != nil {
+	if err := jsoniter.Unmarshal(request.Content(), &gme); err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.NotJSON("The request body could not be decoded into valid JSON. " + err.Error()),

--- a/federationapi/routing/missingevents.go
+++ b/federationapi/routing/missingevents.go
@@ -13,7 +13,7 @@
 package routing
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
@@ -38,7 +38,7 @@ func GetMissingEvents(
 	roomID string,
 ) util.JSONResponse {
 	var gme getMissingEventRequest
-	if err := jsoniter.Unmarshal(request.Content(), &gme); err != nil {
+	if err := json.Unmarshal(request.Content(), &gme); err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.NotJSON("The request body could not be decoded into valid JSON. " + err.Error()),

--- a/federationapi/routing/missingevents.go
+++ b/federationapi/routing/missingevents.go
@@ -13,8 +13,9 @@
 package routing
 
 import (
-	json "github.com/json-iterator/go"
 	"net/http"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/roomserver/api"

--- a/federationapi/routing/missingevents.go
+++ b/federationapi/routing/missingevents.go
@@ -39,7 +39,7 @@ func GetMissingEvents(
 	roomID string,
 ) util.JSONResponse {
 	var gme getMissingEventRequest
-	if err := json.Unmarshal(request.Content(), &gme); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(request.Content(), &gme); err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.NotJSON("The request body could not be decoded into valid JSON. " + err.Error()),

--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -17,6 +17,7 @@ package routing
 import (
 	"context"
 	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"net/http"
 	"sync"
@@ -59,7 +60,7 @@ func Send(
 		EDUs []gomatrixserverlib.EDU `json:"edus"`
 	}
 
-	if err := json.Unmarshal(request.Content(), &txnEvents); err != nil {
+	if err := jsoniter.Unmarshal(request.Content(), &txnEvents); err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.NotJSON("The request body could not be decoded into valid JSON. " + err.Error()),
@@ -132,7 +133,7 @@ func (t *txnReq) processTransaction(ctx context.Context) (*gomatrixserverlib.Res
 		var header struct {
 			RoomID string `json:"room_id"`
 		}
-		if err := json.Unmarshal(pdu, &header); err != nil {
+		if err := jsoniter.Unmarshal(pdu, &header); err != nil {
 			util.GetLogger(ctx).WithError(err).Warn("Transaction: Failed to extract room ID from event")
 			// We don't know the event ID at this point so we can't return the
 			// failure in the PDU results
@@ -295,7 +296,7 @@ func (t *txnReq) processEDUs(ctx context.Context) {
 				UserID string `json:"user_id"`
 				Typing bool   `json:"typing"`
 			}
-			if err := json.Unmarshal(e.Content, &typingPayload); err != nil {
+			if err := jsoniter.Unmarshal(e.Content, &typingPayload); err != nil {
 				util.GetLogger(ctx).WithError(err).Error("Failed to unmarshal typing event")
 				continue
 			}
@@ -305,7 +306,7 @@ func (t *txnReq) processEDUs(ctx context.Context) {
 		case gomatrixserverlib.MDirectToDevice:
 			// https://matrix.org/docs/spec/server_server/r0.1.3#m-direct-to-device-schema
 			var directPayload gomatrixserverlib.ToDeviceMessage
-			if err := json.Unmarshal(e.Content, &directPayload); err != nil {
+			if err := jsoniter.Unmarshal(e.Content, &directPayload); err != nil {
 				util.GetLogger(ctx).WithError(err).Error("Failed to unmarshal send-to-device events")
 				continue
 			}
@@ -331,7 +332,7 @@ func (t *txnReq) processEDUs(ctx context.Context) {
 
 func (t *txnReq) processDeviceListUpdate(ctx context.Context, e gomatrixserverlib.EDU) {
 	var payload gomatrixserverlib.DeviceListUpdateEvent
-	if err := json.Unmarshal(e.Content, &payload); err != nil {
+	if err := jsoniter.Unmarshal(e.Content, &payload); err != nil {
 		util.GetLogger(ctx).WithError(err).Error("Failed to unmarshal device list update event")
 		return
 	}

--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -18,10 +18,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	json "github.com/json-iterator/go"
 	"net/http"
 	"sync"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	eduserverAPI "github.com/matrix-org/dendrite/eduserver/api"

--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -16,7 +16,6 @@ package routing
 
 import (
 	"context"
-	stdjson "encoding/json"
 	"fmt"
 	json "github.com/json-iterator/go"
 	"net/http"
@@ -56,7 +55,7 @@ func Send(
 	}
 
 	var txnEvents struct {
-		PDUs []stdjson.RawMessage       `json:"pdus"`
+		PDUs []json.RawMessage       `json:"pdus"`
 		EDUs []gomatrixserverlib.EDU `json:"edus"`
 	}
 

--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -16,9 +16,9 @@ package routing
 
 import (
 	"context"
-	"encoding/json"
-	"github.com/json-iterator/go"
+	stdjson "encoding/json"
 	"fmt"
+	json "github.com/json-iterator/go"
 	"net/http"
 	"sync"
 	"time"
@@ -56,11 +56,11 @@ func Send(
 	}
 
 	var txnEvents struct {
-		PDUs []json.RawMessage       `json:"pdus"`
+		PDUs []stdjson.RawMessage       `json:"pdus"`
 		EDUs []gomatrixserverlib.EDU `json:"edus"`
 	}
 
-	if err := jsoniter.Unmarshal(request.Content(), &txnEvents); err != nil {
+	if err := json.Unmarshal(request.Content(), &txnEvents); err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.NotJSON("The request body could not be decoded into valid JSON. " + err.Error()),
@@ -133,7 +133,7 @@ func (t *txnReq) processTransaction(ctx context.Context) (*gomatrixserverlib.Res
 		var header struct {
 			RoomID string `json:"room_id"`
 		}
-		if err := jsoniter.Unmarshal(pdu, &header); err != nil {
+		if err := json.Unmarshal(pdu, &header); err != nil {
 			util.GetLogger(ctx).WithError(err).Warn("Transaction: Failed to extract room ID from event")
 			// We don't know the event ID at this point so we can't return the
 			// failure in the PDU results
@@ -296,7 +296,7 @@ func (t *txnReq) processEDUs(ctx context.Context) {
 				UserID string `json:"user_id"`
 				Typing bool   `json:"typing"`
 			}
-			if err := jsoniter.Unmarshal(e.Content, &typingPayload); err != nil {
+			if err := json.Unmarshal(e.Content, &typingPayload); err != nil {
 				util.GetLogger(ctx).WithError(err).Error("Failed to unmarshal typing event")
 				continue
 			}
@@ -306,7 +306,7 @@ func (t *txnReq) processEDUs(ctx context.Context) {
 		case gomatrixserverlib.MDirectToDevice:
 			// https://matrix.org/docs/spec/server_server/r0.1.3#m-direct-to-device-schema
 			var directPayload gomatrixserverlib.ToDeviceMessage
-			if err := jsoniter.Unmarshal(e.Content, &directPayload); err != nil {
+			if err := json.Unmarshal(e.Content, &directPayload); err != nil {
 				util.GetLogger(ctx).WithError(err).Error("Failed to unmarshal send-to-device events")
 				continue
 			}
@@ -332,7 +332,7 @@ func (t *txnReq) processEDUs(ctx context.Context) {
 
 func (t *txnReq) processDeviceListUpdate(ctx context.Context, e gomatrixserverlib.EDU) {
 	var payload gomatrixserverlib.DeviceListUpdateEvent
-	if err := jsoniter.Unmarshal(e.Content, &payload); err != nil {
+	if err := json.Unmarshal(e.Content, &payload); err != nil {
 		util.GetLogger(ctx).WithError(err).Error("Failed to unmarshal device list update event")
 		return
 	}

--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -61,7 +61,7 @@ func Send(
 		EDUs []gomatrixserverlib.EDU `json:"edus"`
 	}
 
-	if err := json.Unmarshal(request.Content(), &txnEvents); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(request.Content(), &txnEvents); err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.NotJSON("The request body could not be decoded into valid JSON. " + err.Error()),
@@ -134,7 +134,7 @@ func (t *txnReq) processTransaction(ctx context.Context) (*gomatrixserverlib.Res
 		var header struct {
 			RoomID string `json:"room_id"`
 		}
-		if err := json.Unmarshal(pdu, &header); err != nil {
+		if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(pdu, &header); err != nil {
 			util.GetLogger(ctx).WithError(err).Warn("Transaction: Failed to extract room ID from event")
 			// We don't know the event ID at this point so we can't return the
 			// failure in the PDU results
@@ -290,7 +290,7 @@ func (t *txnReq) processEDUs(ctx context.Context) {
 				UserID string `json:"user_id"`
 				Typing bool   `json:"typing"`
 			}
-			if err := json.Unmarshal(e.Content, &typingPayload); err != nil {
+			if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(e.Content, &typingPayload); err != nil {
 				util.GetLogger(ctx).WithError(err).Error("Failed to unmarshal typing event")
 				continue
 			}
@@ -300,7 +300,7 @@ func (t *txnReq) processEDUs(ctx context.Context) {
 		case gomatrixserverlib.MDirectToDevice:
 			// https://matrix.org/docs/spec/server_server/r0.1.3#m-direct-to-device-schema
 			var directPayload gomatrixserverlib.ToDeviceMessage
-			if err := json.Unmarshal(e.Content, &directPayload); err != nil {
+			if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(e.Content, &directPayload); err != nil {
 				util.GetLogger(ctx).WithError(err).Error("Failed to unmarshal send-to-device events")
 				continue
 			}
@@ -326,7 +326,7 @@ func (t *txnReq) processEDUs(ctx context.Context) {
 
 func (t *txnReq) processDeviceListUpdate(ctx context.Context, e gomatrixserverlib.EDU) {
 	var payload gomatrixserverlib.DeviceListUpdateEvent
-	if err := json.Unmarshal(e.Content, &payload); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(e.Content, &payload); err != nil {
 		util.GetLogger(ctx).WithError(err).Error("Failed to unmarshal device list update event")
 		return
 	}

--- a/federationapi/routing/send_test.go
+++ b/federationapi/routing/send_test.go
@@ -2,7 +2,7 @@ package routing
 
 import (
 	"context"
-	"encoding/json"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"reflect"
 	"testing"

--- a/federationapi/routing/send_test.go
+++ b/federationapi/routing/send_test.go
@@ -2,11 +2,12 @@ package routing
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"reflect"
 	"testing"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	eduAPI "github.com/matrix-org/dendrite/eduserver/api"
 	fsAPI "github.com/matrix-org/dendrite/federationsender/api"

--- a/federationapi/routing/send_test.go
+++ b/federationapi/routing/send_test.go
@@ -2,7 +2,7 @@ package routing
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"reflect"
 	"testing"

--- a/federationapi/routing/send_test.go
+++ b/federationapi/routing/send_test.go
@@ -2,7 +2,7 @@ package routing
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"

--- a/federationapi/routing/threepid.go
+++ b/federationapi/routing/threepid.go
@@ -111,7 +111,7 @@ func ExchangeThirdPartyInvite(
 	federation *gomatrixserverlib.FederationClient,
 ) util.JSONResponse {
 	var builder gomatrixserverlib.EventBuilder
-	if err := json.Unmarshal(request.Content(), &builder); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(request.Content(), &builder); err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.NotJSON("The request body could not be decoded into valid JSON. " + err.Error()),
@@ -368,7 +368,7 @@ func fillDisplayName(
 	builder *gomatrixserverlib.EventBuilder, authEvents gomatrixserverlib.AuthEvents,
 ) error {
 	var content gomatrixserverlib.MemberContent
-	if err := json.Unmarshal(builder.Content, &content); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(builder.Content, &content); err != nil {
 		return err
 	}
 
@@ -381,7 +381,7 @@ func fillDisplayName(
 	}
 
 	var thirdPartyInviteContent gomatrixserverlib.ThirdPartyInviteContent
-	if err := json.Unmarshal(thirdPartyInviteEvent.Content(), &thirdPartyInviteContent); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(thirdPartyInviteEvent.Content(), &thirdPartyInviteContent); err != nil {
 		return err
 	}
 

--- a/federationapi/routing/threepid.go
+++ b/federationapi/routing/threepid.go
@@ -16,7 +16,7 @@ package routing
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"errors"
 	"net/http"
 	"time"
@@ -110,7 +110,7 @@ func ExchangeThirdPartyInvite(
 	federation *gomatrixserverlib.FederationClient,
 ) util.JSONResponse {
 	var builder gomatrixserverlib.EventBuilder
-	if err := jsoniter.Unmarshal(request.Content(), &builder); err != nil {
+	if err := json.Unmarshal(request.Content(), &builder); err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.NotJSON("The request body could not be decoded into valid JSON. " + err.Error()),
@@ -367,7 +367,7 @@ func fillDisplayName(
 	builder *gomatrixserverlib.EventBuilder, authEvents gomatrixserverlib.AuthEvents,
 ) error {
 	var content gomatrixserverlib.MemberContent
-	if err := jsoniter.Unmarshal(builder.Content, &content); err != nil {
+	if err := json.Unmarshal(builder.Content, &content); err != nil {
 		return err
 	}
 
@@ -380,7 +380,7 @@ func fillDisplayName(
 	}
 
 	var thirdPartyInviteContent gomatrixserverlib.ThirdPartyInviteContent
-	if err := jsoniter.Unmarshal(thirdPartyInviteEvent.Content(), &thirdPartyInviteContent); err != nil {
+	if err := json.Unmarshal(thirdPartyInviteEvent.Content(), &thirdPartyInviteContent); err != nil {
 		return err
 	}
 

--- a/federationapi/routing/threepid.go
+++ b/federationapi/routing/threepid.go
@@ -16,10 +16,11 @@ package routing
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"errors"
 	"net/http"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"

--- a/federationapi/routing/threepid.go
+++ b/federationapi/routing/threepid.go
@@ -16,7 +16,7 @@ package routing
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"errors"
 	"net/http"
 	"time"
@@ -110,7 +110,7 @@ func ExchangeThirdPartyInvite(
 	federation *gomatrixserverlib.FederationClient,
 ) util.JSONResponse {
 	var builder gomatrixserverlib.EventBuilder
-	if err := json.Unmarshal(request.Content(), &builder); err != nil {
+	if err := jsoniter.Unmarshal(request.Content(), &builder); err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.NotJSON("The request body could not be decoded into valid JSON. " + err.Error()),
@@ -367,7 +367,7 @@ func fillDisplayName(
 	builder *gomatrixserverlib.EventBuilder, authEvents gomatrixserverlib.AuthEvents,
 ) error {
 	var content gomatrixserverlib.MemberContent
-	if err := json.Unmarshal(builder.Content, &content); err != nil {
+	if err := jsoniter.Unmarshal(builder.Content, &content); err != nil {
 		return err
 	}
 
@@ -380,7 +380,7 @@ func fillDisplayName(
 	}
 
 	var thirdPartyInviteContent gomatrixserverlib.ThirdPartyInviteContent
-	if err := json.Unmarshal(thirdPartyInviteEvent.Content(), &thirdPartyInviteContent); err != nil {
+	if err := jsoniter.Unmarshal(thirdPartyInviteEvent.Content(), &thirdPartyInviteContent); err != nil {
 		return err
 	}
 

--- a/federationsender/consumers/eduserver.go
+++ b/federationsender/consumers/eduserver.go
@@ -16,9 +16,9 @@ package consumers
 
 import (
 	"context"
-	"encoding/json"
-	"github.com/json-iterator/go"
+	stdjson "encoding/json"
 	"fmt"
+	json "github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"
 	"github.com/matrix-org/dendrite/eduserver/api"
@@ -90,7 +90,7 @@ func (t *OutputEDUConsumer) Start() error {
 func (t *OutputEDUConsumer) onSendToDeviceEvent(msg *sarama.ConsumerMessage) error {
 	// Extract the send-to-device event from msg.
 	var ote api.OutputSendToDeviceEvent
-	if err := jsoniter.Unmarshal(msg.Value, &ote); err != nil {
+	if err := json.Unmarshal(msg.Value, &ote); err != nil {
 		log.WithError(err).Errorf("eduserver output log: message parse failed (expected send-to-device)")
 		return nil
 	}
@@ -121,13 +121,13 @@ func (t *OutputEDUConsumer) onSendToDeviceEvent(msg *sarama.ConsumerMessage) err
 		Sender:    ote.Sender,
 		Type:      ote.Type,
 		MessageID: util.RandomString(32),
-		Messages: map[string]map[string]json.RawMessage{
+		Messages: map[string]map[string]stdjson.RawMessage{
 			ote.UserID: {
 				ote.DeviceID: ote.Content,
 			},
 		},
 	}
-	if edu.Content, err = jsoniter.Marshal(tdm); err != nil {
+	if edu.Content, err = json.Marshal(tdm); err != nil {
 		return err
 	}
 
@@ -140,7 +140,7 @@ func (t *OutputEDUConsumer) onSendToDeviceEvent(msg *sarama.ConsumerMessage) err
 func (t *OutputEDUConsumer) onTypingEvent(msg *sarama.ConsumerMessage) error {
 	// Extract the typing event from msg.
 	var ote api.OutputTypingEvent
-	if err := jsoniter.Unmarshal(msg.Value, &ote); err != nil {
+	if err := json.Unmarshal(msg.Value, &ote); err != nil {
 		// Skip this msg but continue processing messages.
 		log.WithError(err).Errorf("eduserver output log: message parse failed (expected typing)")
 		return nil
@@ -168,7 +168,7 @@ func (t *OutputEDUConsumer) onTypingEvent(msg *sarama.ConsumerMessage) error {
 	}
 
 	edu := &gomatrixserverlib.EDU{Type: ote.Event.Type}
-	if edu.Content, err = jsoniter.Marshal(map[string]interface{}{
+	if edu.Content, err = json.Marshal(map[string]interface{}{
 		"room_id": ote.Event.RoomID,
 		"user_id": ote.Event.UserID,
 		"typing":  ote.Event.Typing,

--- a/federationsender/consumers/eduserver.go
+++ b/federationsender/consumers/eduserver.go
@@ -17,6 +17,7 @@ package consumers
 import (
 	"context"
 	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 
 	"github.com/Shopify/sarama"
@@ -89,7 +90,7 @@ func (t *OutputEDUConsumer) Start() error {
 func (t *OutputEDUConsumer) onSendToDeviceEvent(msg *sarama.ConsumerMessage) error {
 	// Extract the send-to-device event from msg.
 	var ote api.OutputSendToDeviceEvent
-	if err := json.Unmarshal(msg.Value, &ote); err != nil {
+	if err := jsoniter.Unmarshal(msg.Value, &ote); err != nil {
 		log.WithError(err).Errorf("eduserver output log: message parse failed (expected send-to-device)")
 		return nil
 	}
@@ -126,7 +127,7 @@ func (t *OutputEDUConsumer) onSendToDeviceEvent(msg *sarama.ConsumerMessage) err
 			},
 		},
 	}
-	if edu.Content, err = json.Marshal(tdm); err != nil {
+	if edu.Content, err = jsoniter.Marshal(tdm); err != nil {
 		return err
 	}
 
@@ -139,7 +140,7 @@ func (t *OutputEDUConsumer) onSendToDeviceEvent(msg *sarama.ConsumerMessage) err
 func (t *OutputEDUConsumer) onTypingEvent(msg *sarama.ConsumerMessage) error {
 	// Extract the typing event from msg.
 	var ote api.OutputTypingEvent
-	if err := json.Unmarshal(msg.Value, &ote); err != nil {
+	if err := jsoniter.Unmarshal(msg.Value, &ote); err != nil {
 		// Skip this msg but continue processing messages.
 		log.WithError(err).Errorf("eduserver output log: message parse failed (expected typing)")
 		return nil
@@ -167,7 +168,7 @@ func (t *OutputEDUConsumer) onTypingEvent(msg *sarama.ConsumerMessage) error {
 	}
 
 	edu := &gomatrixserverlib.EDU{Type: ote.Event.Type}
-	if edu.Content, err = json.Marshal(map[string]interface{}{
+	if edu.Content, err = jsoniter.Marshal(map[string]interface{}{
 		"room_id": ote.Event.RoomID,
 		"user_id": ote.Event.UserID,
 		"typing":  ote.Event.Typing,

--- a/federationsender/consumers/eduserver.go
+++ b/federationsender/consumers/eduserver.go
@@ -90,7 +90,7 @@ func (t *OutputEDUConsumer) Start() error {
 func (t *OutputEDUConsumer) onSendToDeviceEvent(msg *sarama.ConsumerMessage) error {
 	// Extract the send-to-device event from msg.
 	var ote api.OutputSendToDeviceEvent
-	if err := json.Unmarshal(msg.Value, &ote); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(msg.Value, &ote); err != nil {
 		log.WithError(err).Errorf("eduserver output log: message parse failed (expected send-to-device)")
 		return nil
 	}
@@ -127,7 +127,7 @@ func (t *OutputEDUConsumer) onSendToDeviceEvent(msg *sarama.ConsumerMessage) err
 			},
 		},
 	}
-	if edu.Content, err = json.Marshal(tdm); err != nil {
+	if edu.Content, err = json.ConfigCompatibleWithStandardLibrary.Marshal(tdm); err != nil {
 		return err
 	}
 
@@ -140,7 +140,7 @@ func (t *OutputEDUConsumer) onSendToDeviceEvent(msg *sarama.ConsumerMessage) err
 func (t *OutputEDUConsumer) onTypingEvent(msg *sarama.ConsumerMessage) error {
 	// Extract the typing event from msg.
 	var ote api.OutputTypingEvent
-	if err := json.Unmarshal(msg.Value, &ote); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(msg.Value, &ote); err != nil {
 		// Skip this msg but continue processing messages.
 		log.WithError(err).Errorf("eduserver output log: message parse failed (expected typing)")
 		return nil
@@ -168,7 +168,7 @@ func (t *OutputEDUConsumer) onTypingEvent(msg *sarama.ConsumerMessage) error {
 	}
 
 	edu := &gomatrixserverlib.EDU{Type: ote.Event.Type}
-	if edu.Content, err = json.Marshal(map[string]interface{}{
+	if edu.Content, err = json.ConfigCompatibleWithStandardLibrary.Marshal(map[string]interface{}{
 		"room_id": ote.Event.RoomID,
 		"user_id": ote.Event.UserID,
 		"typing":  ote.Event.Typing,

--- a/federationsender/consumers/eduserver.go
+++ b/federationsender/consumers/eduserver.go
@@ -17,6 +17,7 @@ package consumers
 import (
 	"context"
 	"fmt"
+
 	json "github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"

--- a/federationsender/consumers/eduserver.go
+++ b/federationsender/consumers/eduserver.go
@@ -16,7 +16,6 @@ package consumers
 
 import (
 	"context"
-	stdjson "encoding/json"
 	"fmt"
 	json "github.com/json-iterator/go"
 
@@ -121,7 +120,7 @@ func (t *OutputEDUConsumer) onSendToDeviceEvent(msg *sarama.ConsumerMessage) err
 		Sender:    ote.Sender,
 		Type:      ote.Type,
 		MessageID: util.RandomString(32),
-		Messages: map[string]map[string]stdjson.RawMessage{
+		Messages: map[string]map[string]json.RawMessage{
 			ote.UserID: {
 				ote.DeviceID: ote.Content,
 			},

--- a/federationsender/consumers/keychange.go
+++ b/federationsender/consumers/keychange.go
@@ -16,7 +16,7 @@ package consumers
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 
 	"github.com/Shopify/sarama"
@@ -76,7 +76,7 @@ func (t *KeyChangeConsumer) Start() error {
 // key change events topic from the key server.
 func (t *KeyChangeConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	var m api.DeviceMessage
-	if err := json.Unmarshal(msg.Value, &m); err != nil {
+	if err := jsoniter.Unmarshal(msg.Value, &m); err != nil {
 		log.WithError(err).Errorf("failed to read device message from key change topic")
 		return nil
 	}
@@ -122,7 +122,7 @@ func (t *KeyChangeConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 		Deleted:           len(m.KeyJSON) == 0,
 		Keys:              m.KeyJSON,
 	}
-	if edu.Content, err = json.Marshal(event); err != nil {
+	if edu.Content, err = jsoniter.Marshal(event); err != nil {
 		return err
 	}
 

--- a/federationsender/consumers/keychange.go
+++ b/federationsender/consumers/keychange.go
@@ -16,8 +16,9 @@ package consumers
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"fmt"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"
 	"github.com/matrix-org/dendrite/federationsender/queue"

--- a/federationsender/consumers/keychange.go
+++ b/federationsender/consumers/keychange.go
@@ -77,7 +77,7 @@ func (t *KeyChangeConsumer) Start() error {
 // key change events topic from the key server.
 func (t *KeyChangeConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	var m api.DeviceMessage
-	if err := json.Unmarshal(msg.Value, &m); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(msg.Value, &m); err != nil {
 		log.WithError(err).Errorf("failed to read device message from key change topic")
 		return nil
 	}
@@ -123,7 +123,7 @@ func (t *KeyChangeConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 		Deleted:           len(m.KeyJSON) == 0,
 		Keys:              m.KeyJSON,
 	}
-	if edu.Content, err = json.Marshal(event); err != nil {
+	if edu.Content, err = json.ConfigCompatibleWithStandardLibrary.Marshal(event); err != nil {
 		return err
 	}
 

--- a/federationsender/consumers/keychange.go
+++ b/federationsender/consumers/keychange.go
@@ -16,7 +16,7 @@ package consumers
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 
 	"github.com/Shopify/sarama"
@@ -76,7 +76,7 @@ func (t *KeyChangeConsumer) Start() error {
 // key change events topic from the key server.
 func (t *KeyChangeConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	var m api.DeviceMessage
-	if err := jsoniter.Unmarshal(msg.Value, &m); err != nil {
+	if err := json.Unmarshal(msg.Value, &m); err != nil {
 		log.WithError(err).Errorf("failed to read device message from key change topic")
 		return nil
 	}
@@ -122,7 +122,7 @@ func (t *KeyChangeConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 		Deleted:           len(m.KeyJSON) == 0,
 		Keys:              m.KeyJSON,
 	}
-	if edu.Content, err = jsoniter.Marshal(event); err != nil {
+	if edu.Content, err = json.Marshal(event); err != nil {
 		return err
 	}
 

--- a/federationsender/consumers/roomserver.go
+++ b/federationsender/consumers/roomserver.go
@@ -16,8 +16,9 @@ package consumers
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"fmt"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"
 	"github.com/matrix-org/dendrite/federationsender/queue"

--- a/federationsender/consumers/roomserver.go
+++ b/federationsender/consumers/roomserver.go
@@ -78,7 +78,7 @@ func (s *OutputRoomEventConsumer) Start() error {
 func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	// Parse out the event JSON
 	var output api.OutputEvent
-	if err := json.Unmarshal(msg.Value, &output); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Errorf("roomserver output log: message parse failure")
 		return nil

--- a/federationsender/consumers/roomserver.go
+++ b/federationsender/consumers/roomserver.go
@@ -16,7 +16,7 @@ package consumers
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 
 	"github.com/Shopify/sarama"
@@ -77,7 +77,7 @@ func (s *OutputRoomEventConsumer) Start() error {
 func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	// Parse out the event JSON
 	var output api.OutputEvent
-	if err := jsoniter.Unmarshal(msg.Value, &output); err != nil {
+	if err := json.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Errorf("roomserver output log: message parse failure")
 		return nil

--- a/federationsender/consumers/roomserver.go
+++ b/federationsender/consumers/roomserver.go
@@ -16,7 +16,7 @@ package consumers
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 
 	"github.com/Shopify/sarama"
@@ -77,7 +77,7 @@ func (s *OutputRoomEventConsumer) Start() error {
 func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	// Parse out the event JSON
 	var output api.OutputEvent
-	if err := json.Unmarshal(msg.Value, &output); err != nil {
+	if err := jsoniter.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Errorf("roomserver output log: message parse failure")
 		return nil

--- a/federationsender/inthttp/server.go
+++ b/federationsender/inthttp/server.go
@@ -1,7 +1,7 @@
 package inthttp
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -18,7 +18,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		httputil.MakeInternalAPI("QueryJoinedHostServerNamesInRoom", func(req *http.Request) util.JSONResponse {
 			var request api.QueryJoinedHostServerNamesInRoomRequest
 			var response api.QueryJoinedHostServerNamesInRoomResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := intAPI.QueryJoinedHostServerNamesInRoom(req.Context(), &request, &response); err != nil {
@@ -32,7 +32,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		httputil.MakeInternalAPI("PerformJoinRequest", func(req *http.Request) util.JSONResponse {
 			var request api.PerformJoinRequest
 			var response api.PerformJoinResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			intAPI.PerformJoin(req.Context(), &request, &response)
@@ -44,7 +44,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		httputil.MakeInternalAPI("PerformLeaveRequest", func(req *http.Request) util.JSONResponse {
 			var request api.PerformLeaveRequest
 			var response api.PerformLeaveResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := intAPI.PerformLeave(req.Context(), &request, &response); err != nil {
@@ -58,7 +58,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		httputil.MakeInternalAPI("PerformInviteRequest", func(req *http.Request) util.JSONResponse {
 			var request api.PerformInviteRequest
 			var response api.PerformInviteResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := intAPI.PerformInvite(req.Context(), &request, &response); err != nil {
@@ -72,7 +72,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		httputil.MakeInternalAPI("PerformDirectoryLookupRequest", func(req *http.Request) util.JSONResponse {
 			var request api.PerformDirectoryLookupRequest
 			var response api.PerformDirectoryLookupResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := intAPI.PerformDirectoryLookup(req.Context(), &request, &response); err != nil {
@@ -86,7 +86,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		httputil.MakeInternalAPI("PerformServersAliveRequest", func(req *http.Request) util.JSONResponse {
 			var request api.PerformServersAliveRequest
 			var response api.PerformServersAliveResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := intAPI.PerformServersAlive(req.Context(), &request, &response); err != nil {
@@ -100,7 +100,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		httputil.MakeInternalAPI("PerformBroadcastEDU", func(req *http.Request) util.JSONResponse {
 			var request api.PerformBroadcastEDURequest
 			var response api.PerformBroadcastEDUResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := intAPI.PerformBroadcastEDU(req.Context(), &request, &response); err != nil {
@@ -113,7 +113,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		FederationSenderGetUserDevicesPath,
 		httputil.MakeInternalAPI("GetUserDevices", func(req *http.Request) util.JSONResponse {
 			var request getUserDevices
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			res, err := intAPI.GetUserDevices(req.Context(), request.S, request.UserID)
@@ -135,7 +135,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		FederationSenderClaimKeysPath,
 		httputil.MakeInternalAPI("ClaimKeys", func(req *http.Request) util.JSONResponse {
 			var request claimKeys
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			res, err := intAPI.ClaimKeys(req.Context(), request.S, request.OneTimeKeys)
@@ -157,7 +157,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		FederationSenderQueryKeysPath,
 		httputil.MakeInternalAPI("QueryKeys", func(req *http.Request) util.JSONResponse {
 			var request queryKeys
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			res, err := intAPI.QueryKeys(req.Context(), request.S, request.Keys)
@@ -179,7 +179,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		FederationSenderBackfillPath,
 		httputil.MakeInternalAPI("Backfill", func(req *http.Request) util.JSONResponse {
 			var request backfill
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			res, err := intAPI.Backfill(req.Context(), request.S, request.RoomID, request.Limit, request.EventIDs)
@@ -201,7 +201,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		FederationSenderLookupStatePath,
 		httputil.MakeInternalAPI("LookupState", func(req *http.Request) util.JSONResponse {
 			var request lookupState
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			res, err := intAPI.LookupState(req.Context(), request.S, request.RoomID, request.EventID, request.RoomVersion)
@@ -223,7 +223,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		FederationSenderLookupStateIDsPath,
 		httputil.MakeInternalAPI("LookupStateIDs", func(req *http.Request) util.JSONResponse {
 			var request lookupStateIDs
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			res, err := intAPI.LookupStateIDs(req.Context(), request.S, request.RoomID, request.EventID)
@@ -245,7 +245,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		FederationSenderGetEventPath,
 		httputil.MakeInternalAPI("GetEvent", func(req *http.Request) util.JSONResponse {
 			var request getEvent
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			res, err := intAPI.GetEvent(req.Context(), request.S, request.EventID)
@@ -267,7 +267,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		FederationSenderGetServerKeysPath,
 		httputil.MakeInternalAPI("GetServerKeys", func(req *http.Request) util.JSONResponse {
 			var request getServerKeys
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			res, err := intAPI.GetServerKeys(req.Context(), request.S)
@@ -289,7 +289,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		FederationSenderLookupServerKeysPath,
 		httputil.MakeInternalAPI("LookupServerKeys", func(req *http.Request) util.JSONResponse {
 			var request lookupServerKeys
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			res, err := intAPI.LookupServerKeys(req.Context(), request.S, request.KeyRequests)

--- a/federationsender/inthttp/server.go
+++ b/federationsender/inthttp/server.go
@@ -1,7 +1,7 @@
 package inthttp
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -18,7 +18,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		httputil.MakeInternalAPI("QueryJoinedHostServerNamesInRoom", func(req *http.Request) util.JSONResponse {
 			var request api.QueryJoinedHostServerNamesInRoomRequest
 			var response api.QueryJoinedHostServerNamesInRoomResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := intAPI.QueryJoinedHostServerNamesInRoom(req.Context(), &request, &response); err != nil {
@@ -32,7 +32,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		httputil.MakeInternalAPI("PerformJoinRequest", func(req *http.Request) util.JSONResponse {
 			var request api.PerformJoinRequest
 			var response api.PerformJoinResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			intAPI.PerformJoin(req.Context(), &request, &response)
@@ -44,7 +44,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		httputil.MakeInternalAPI("PerformLeaveRequest", func(req *http.Request) util.JSONResponse {
 			var request api.PerformLeaveRequest
 			var response api.PerformLeaveResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := intAPI.PerformLeave(req.Context(), &request, &response); err != nil {
@@ -58,7 +58,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		httputil.MakeInternalAPI("PerformInviteRequest", func(req *http.Request) util.JSONResponse {
 			var request api.PerformInviteRequest
 			var response api.PerformInviteResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := intAPI.PerformInvite(req.Context(), &request, &response); err != nil {
@@ -72,7 +72,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		httputil.MakeInternalAPI("PerformDirectoryLookupRequest", func(req *http.Request) util.JSONResponse {
 			var request api.PerformDirectoryLookupRequest
 			var response api.PerformDirectoryLookupResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := intAPI.PerformDirectoryLookup(req.Context(), &request, &response); err != nil {
@@ -86,7 +86,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		httputil.MakeInternalAPI("PerformServersAliveRequest", func(req *http.Request) util.JSONResponse {
 			var request api.PerformServersAliveRequest
 			var response api.PerformServersAliveResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := intAPI.PerformServersAlive(req.Context(), &request, &response); err != nil {
@@ -100,7 +100,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		httputil.MakeInternalAPI("PerformBroadcastEDU", func(req *http.Request) util.JSONResponse {
 			var request api.PerformBroadcastEDURequest
 			var response api.PerformBroadcastEDUResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := intAPI.PerformBroadcastEDU(req.Context(), &request, &response); err != nil {
@@ -113,7 +113,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		FederationSenderGetUserDevicesPath,
 		httputil.MakeInternalAPI("GetUserDevices", func(req *http.Request) util.JSONResponse {
 			var request getUserDevices
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			res, err := intAPI.GetUserDevices(req.Context(), request.S, request.UserID)
@@ -135,7 +135,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		FederationSenderClaimKeysPath,
 		httputil.MakeInternalAPI("ClaimKeys", func(req *http.Request) util.JSONResponse {
 			var request claimKeys
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			res, err := intAPI.ClaimKeys(req.Context(), request.S, request.OneTimeKeys)
@@ -157,7 +157,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		FederationSenderQueryKeysPath,
 		httputil.MakeInternalAPI("QueryKeys", func(req *http.Request) util.JSONResponse {
 			var request queryKeys
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			res, err := intAPI.QueryKeys(req.Context(), request.S, request.Keys)
@@ -179,7 +179,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		FederationSenderBackfillPath,
 		httputil.MakeInternalAPI("Backfill", func(req *http.Request) util.JSONResponse {
 			var request backfill
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			res, err := intAPI.Backfill(req.Context(), request.S, request.RoomID, request.Limit, request.EventIDs)
@@ -201,7 +201,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		FederationSenderLookupStatePath,
 		httputil.MakeInternalAPI("LookupState", func(req *http.Request) util.JSONResponse {
 			var request lookupState
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			res, err := intAPI.LookupState(req.Context(), request.S, request.RoomID, request.EventID, request.RoomVersion)
@@ -223,7 +223,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		FederationSenderLookupStateIDsPath,
 		httputil.MakeInternalAPI("LookupStateIDs", func(req *http.Request) util.JSONResponse {
 			var request lookupStateIDs
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			res, err := intAPI.LookupStateIDs(req.Context(), request.S, request.RoomID, request.EventID)
@@ -245,7 +245,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		FederationSenderGetEventPath,
 		httputil.MakeInternalAPI("GetEvent", func(req *http.Request) util.JSONResponse {
 			var request getEvent
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			res, err := intAPI.GetEvent(req.Context(), request.S, request.EventID)
@@ -267,7 +267,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		FederationSenderGetServerKeysPath,
 		httputil.MakeInternalAPI("GetServerKeys", func(req *http.Request) util.JSONResponse {
 			var request getServerKeys
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			res, err := intAPI.GetServerKeys(req.Context(), request.S)
@@ -289,7 +289,7 @@ func AddRoutes(intAPI api.FederationSenderInternalAPI, internalAPIMux *mux.Route
 		FederationSenderLookupServerKeysPath,
 		httputil.MakeInternalAPI("LookupServerKeys", func(req *http.Request) util.JSONResponse {
 			var request lookupServerKeys
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			res, err := intAPI.LookupServerKeys(req.Context(), request.S, request.KeyRequests)

--- a/federationsender/inthttp/server.go
+++ b/federationsender/inthttp/server.go
@@ -1,8 +1,9 @@
 package inthttp
 
 import (
-	json "github.com/json-iterator/go"
 	"net/http"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/federationsender/api"

--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -16,7 +16,7 @@ package queue
 
 import (
 	"context"
-	"encoding/json"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"sync"
 	"time"

--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -16,10 +16,11 @@ package queue
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"sync"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/federationsender/statistics"
 	"github.com/matrix-org/dendrite/federationsender/storage"

--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -333,7 +333,7 @@ func (oq *destinationQueue) nextTransaction() (bool, error) {
 	// Go through PDUs that we retrieved from the database, if any,
 	// and add them into the transaction.
 	for _, pdu := range pdus {
-		// Append the JSON of the event, since this is a jsoniter.RawMessage type in the
+		// Append the JSON of the event, since this is a json.RawMessage type in the
 		// gomatrixserverlib.Transaction struct
 		t.PDUs = append(t.PDUs, (*pdu).JSON())
 	}

--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -333,7 +333,7 @@ func (oq *destinationQueue) nextTransaction() (bool, error) {
 	// Go through PDUs that we retrieved from the database, if any,
 	// and add them into the transaction.
 	for _, pdu := range pdus {
-		// Append the JSON of the event, since this is a json.RawMessage type in the
+		// Append the JSON of the event, since this is a jsoniter.RawMessage type in the
 		// gomatrixserverlib.Transaction struct
 		t.PDUs = append(t.PDUs, (*pdu).JSON())
 	}

--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -160,7 +160,7 @@ func (oqs *OutgoingQueues) SendEvent(
 		"destinations": len(destmap), "event": ev.EventID(),
 	}).Infof("Sending event")
 
-	headeredJSON, err := json.Marshal(ev)
+	headeredJSON, err := json.ConfigCompatibleWithStandardLibrary.Marshal(ev)
 	if err != nil {
 		return fmt.Errorf("json.Marshal: %w", err)
 	}
@@ -225,7 +225,7 @@ func (oqs *OutgoingQueues) SendEDU(
 		"destinations": len(destmap), "edu_type": e.Type,
 	}).Info("Sending EDU event")
 
-	ephemeralJSON, err := json.Marshal(e)
+	ephemeralJSON, err := json.ConfigCompatibleWithStandardLibrary.Marshal(e)
 	if err != nil {
 		return fmt.Errorf("json.Marshal: %w", err)
 	}

--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -17,10 +17,11 @@ package queue
 import (
 	"context"
 	"crypto/ed25519"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"sync"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/federationsender/statistics"
 	"github.com/matrix-org/dendrite/federationsender/storage"

--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -17,7 +17,7 @@ package queue
 import (
 	"context"
 	"crypto/ed25519"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"sync"
 	"time"
@@ -159,9 +159,9 @@ func (oqs *OutgoingQueues) SendEvent(
 		"destinations": len(destmap), "event": ev.EventID(),
 	}).Infof("Sending event")
 
-	headeredJSON, err := json.Marshal(ev)
+	headeredJSON, err := jsoniter.Marshal(ev)
 	if err != nil {
-		return fmt.Errorf("json.Marshal: %w", err)
+		return fmt.Errorf("jsoniter.Marshal: %w", err)
 	}
 
 	nid, err := oqs.db.StoreJSON(context.TODO(), string(headeredJSON))
@@ -224,9 +224,9 @@ func (oqs *OutgoingQueues) SendEDU(
 		"destinations": len(destmap), "edu_type": e.Type,
 	}).Info("Sending EDU event")
 
-	ephemeralJSON, err := json.Marshal(e)
+	ephemeralJSON, err := jsoniter.Marshal(e)
 	if err != nil {
-		return fmt.Errorf("json.Marshal: %w", err)
+		return fmt.Errorf("jsoniter.Marshal: %w", err)
 	}
 
 	nid, err := oqs.db.StoreJSON(context.TODO(), string(ephemeralJSON))

--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -17,7 +17,7 @@ package queue
 import (
 	"context"
 	"crypto/ed25519"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"sync"
 	"time"
@@ -159,9 +159,9 @@ func (oqs *OutgoingQueues) SendEvent(
 		"destinations": len(destmap), "event": ev.EventID(),
 	}).Infof("Sending event")
 
-	headeredJSON, err := jsoniter.Marshal(ev)
+	headeredJSON, err := json.Marshal(ev)
 	if err != nil {
-		return fmt.Errorf("jsoniter.Marshal: %w", err)
+		return fmt.Errorf("json.Marshal: %w", err)
 	}
 
 	nid, err := oqs.db.StoreJSON(context.TODO(), string(headeredJSON))
@@ -224,9 +224,9 @@ func (oqs *OutgoingQueues) SendEDU(
 		"destinations": len(destmap), "edu_type": e.Type,
 	}).Info("Sending EDU event")
 
-	ephemeralJSON, err := jsoniter.Marshal(e)
+	ephemeralJSON, err := json.Marshal(e)
 	if err != nil {
-		return fmt.Errorf("jsoniter.Marshal: %w", err)
+		return fmt.Errorf("json.Marshal: %w", err)
 	}
 
 	nid, err := oqs.db.StoreJSON(context.TODO(), string(ephemeralJSON))

--- a/federationsender/storage/shared/storage.go
+++ b/federationsender/storage/shared/storage.go
@@ -17,7 +17,7 @@ package shared
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 
 	"github.com/matrix-org/dendrite/federationsender/storage/tables"
@@ -50,7 +50,7 @@ func (e *Receipt) Empty() bool {
 }
 
 func (e *Receipt) String() string {
-	j, _ := jsoniter.Marshal(e.nids)
+	j, _ := json.Marshal(e.nids)
 	return string(j)
 }
 

--- a/federationsender/storage/shared/storage.go
+++ b/federationsender/storage/shared/storage.go
@@ -17,8 +17,9 @@ package shared
 import (
 	"context"
 	"database/sql"
-	json "github.com/json-iterator/go"
 	"fmt"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/federationsender/storage/tables"
 	"github.com/matrix-org/dendrite/federationsender/types"

--- a/federationsender/storage/shared/storage.go
+++ b/federationsender/storage/shared/storage.go
@@ -17,7 +17,7 @@ package shared
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 
 	"github.com/matrix-org/dendrite/federationsender/storage/tables"
@@ -50,7 +50,7 @@ func (e *Receipt) Empty() bool {
 }
 
 func (e *Receipt) String() string {
-	j, _ := json.Marshal(e.nids)
+	j, _ := jsoniter.Marshal(e.nids)
 	return string(j)
 }
 

--- a/federationsender/storage/shared/storage.go
+++ b/federationsender/storage/shared/storage.go
@@ -51,7 +51,7 @@ func (e *Receipt) Empty() bool {
 }
 
 func (e *Receipt) String() string {
-	j, _ := json.Marshal(e.nids)
+	j, _ := json.ConfigCompatibleWithStandardLibrary.Marshal(e.nids)
 	return string(j)
 }
 

--- a/federationsender/storage/shared/storage_edus.go
+++ b/federationsender/storage/shared/storage_edus.go
@@ -77,7 +77,7 @@ func (d *Database) GetNextTransactionEDUs(
 
 		for _, blob := range blobs {
 			var event gomatrixserverlib.EDU
-			if err := json.Unmarshal(blob, &event); err != nil {
+			if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(blob, &event); err != nil {
 				return fmt.Errorf("json.Unmarshal: %w", err)
 			}
 			edus = append(edus, &event)

--- a/federationsender/storage/shared/storage_edus.go
+++ b/federationsender/storage/shared/storage_edus.go
@@ -17,7 +17,7 @@ package shared
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"errors"
 	"fmt"
 
@@ -76,7 +76,7 @@ func (d *Database) GetNextTransactionEDUs(
 
 		for _, blob := range blobs {
 			var event gomatrixserverlib.EDU
-			if err := json.Unmarshal(blob, &event); err != nil {
+			if err := jsoniter.Unmarshal(blob, &event); err != nil {
 				return fmt.Errorf("json.Unmarshal: %w", err)
 			}
 			edus = append(edus, &event)

--- a/federationsender/storage/shared/storage_edus.go
+++ b/federationsender/storage/shared/storage_edus.go
@@ -17,9 +17,10 @@ package shared
 import (
 	"context"
 	"database/sql"
-	json "github.com/json-iterator/go"
 	"errors"
 	"fmt"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/gomatrixserverlib"
 )

--- a/federationsender/storage/shared/storage_edus.go
+++ b/federationsender/storage/shared/storage_edus.go
@@ -17,7 +17,7 @@ package shared
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"errors"
 	"fmt"
 
@@ -76,7 +76,7 @@ func (d *Database) GetNextTransactionEDUs(
 
 		for _, blob := range blobs {
 			var event gomatrixserverlib.EDU
-			if err := jsoniter.Unmarshal(blob, &event); err != nil {
+			if err := json.Unmarshal(blob, &event); err != nil {
 				return fmt.Errorf("json.Unmarshal: %w", err)
 			}
 			edus = append(edus, &event)

--- a/federationsender/storage/shared/storage_pdus.go
+++ b/federationsender/storage/shared/storage_pdus.go
@@ -17,7 +17,7 @@ package shared
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"errors"
 	"fmt"
 
@@ -92,7 +92,7 @@ func (d *Database) GetNextTransactionPDUs(
 
 		for _, blob := range blobs {
 			var event gomatrixserverlib.HeaderedEvent
-			if err := jsoniter.Unmarshal(blob, &event); err != nil {
+			if err := json.Unmarshal(blob, &event); err != nil {
 				return fmt.Errorf("json.Unmarshal: %w", err)
 			}
 			events = append(events, &event)

--- a/federationsender/storage/shared/storage_pdus.go
+++ b/federationsender/storage/shared/storage_pdus.go
@@ -17,7 +17,7 @@ package shared
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"errors"
 	"fmt"
 
@@ -92,7 +92,7 @@ func (d *Database) GetNextTransactionPDUs(
 
 		for _, blob := range blobs {
 			var event gomatrixserverlib.HeaderedEvent
-			if err := json.Unmarshal(blob, &event); err != nil {
+			if err := jsoniter.Unmarshal(blob, &event); err != nil {
 				return fmt.Errorf("json.Unmarshal: %w", err)
 			}
 			events = append(events, &event)

--- a/federationsender/storage/shared/storage_pdus.go
+++ b/federationsender/storage/shared/storage_pdus.go
@@ -17,9 +17,10 @@ package shared
 import (
 	"context"
 	"database/sql"
-	json "github.com/json-iterator/go"
 	"errors"
 	"fmt"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/gomatrixserverlib"
 )

--- a/federationsender/storage/shared/storage_pdus.go
+++ b/federationsender/storage/shared/storage_pdus.go
@@ -93,7 +93,7 @@ func (d *Database) GetNextTransactionPDUs(
 
 		for _, blob := range blobs {
 			var event gomatrixserverlib.HeaderedEvent
-			if err := json.Unmarshal(blob, &event); err != nil {
+			if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(blob, &event); err != nil {
 				return fmt.Errorf("json.Unmarshal: %w", err)
 			}
 			events = append(events, &event)

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/matrix-org/dendrite
 
+replace github.com/matrix-org/gomatrixserverlib v0.0.0-20201006143701-222e7423a5e3 => github.com/bn4t/gomatrixserverlib v0.0.0-20201009140335-23904a431004
+
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/Shopify/sarama v1.27.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/matrix-org/dendrite
 
-replace github.com/matrix-org/gomatrixserverlib v0.0.0-20201006143701-222e7423a5e3 => github.com/bn4t/gomatrixserverlib v0.0.0-20201009140335-23904a431004
+replace github.com/matrix-org/gomatrixserverlib v0.0.0-20201006143701-222e7423a5e3 => github.com/bn4t/gomatrixserverlib v0.0.0-20201011104814-08fd27fa6e59
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gologme/log v1.2.0
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/golang-lru v0.5.4
+	github.com/json-iterator/go v1.1.10
 	github.com/lib/pq v1.8.0
 	github.com/libp2p/go-libp2p v0.11.0
 	github.com/libp2p/go-libp2p-circuit v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -282,6 +282,7 @@ github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
+github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
@@ -609,8 +610,10 @@ github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mr-tron/base58 v1.1.0/go.mod h1:xcD2VGqlgYjBdcBLw+TuYLr8afG+Hj8g2eTVqeSzSU8=
 github.com/mr-tron/base58 v1.1.1/go.mod h1:xcD2VGqlgYjBdcBLw+TuYLr8afG+Hj8g2eTVqeSzSU8=

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bn4t/gomatrixserverlib v0.0.0-20201009140335-23904a431004 h1:tCV04ZHNonEtY4Vhdda3Juzg/zk7eFla3ixDDs8dBos=
-github.com/bn4t/gomatrixserverlib v0.0.0-20201009140335-23904a431004/go.mod h1:dV8PqfHZAzs+eyEiIdCLt3Y3R7zb4scFsdHJ/N0aAsM=
+github.com/bn4t/gomatrixserverlib v0.0.0-20201011104814-08fd27fa6e59 h1:GCncFjpDXA9EmryIzanObuHqr2oN2rXpa/gROer/nC4=
+github.com/bn4t/gomatrixserverlib v0.0.0-20201011104814-08fd27fa6e59/go.mod h1:dV8PqfHZAzs+eyEiIdCLt3Y3R7zb4scFsdHJ/N0aAsM=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/btcsuite/btcd v0.0.0-20190213025234-306aecffea32/go.mod h1:DrZx5ec/dmnfpw9KyYoQyYo7d0KEvTkk/5M/vbZjAr8=
 github.com/btcsuite/btcd v0.0.0-20190523000118-16327141da8c/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=

--- a/go.sum
+++ b/go.sum
@@ -42,6 +42,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bn4t/gomatrixserverlib v0.0.0-20201009140335-23904a431004 h1:tCV04ZHNonEtY4Vhdda3Juzg/zk7eFla3ixDDs8dBos=
+github.com/bn4t/gomatrixserverlib v0.0.0-20201009140335-23904a431004/go.mod h1:dV8PqfHZAzs+eyEiIdCLt3Y3R7zb4scFsdHJ/N0aAsM=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/btcsuite/btcd v0.0.0-20190213025234-306aecffea32/go.mod h1:DrZx5ec/dmnfpw9KyYoQyYo7d0KEvTkk/5M/vbZjAr8=
 github.com/btcsuite/btcd v0.0.0-20190523000118-16327141da8c/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
@@ -570,8 +572,6 @@ github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26 h1:Hr3zjRsq2bh
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
 github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd h1:xVrqJK3xHREMNjwjljkAUaadalWc0rRbmVuQatzmgwg=
 github.com/matrix-org/gomatrix v0.0.0-20200827122206-7dd5e2a05bcd/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20201006143701-222e7423a5e3 h1:lWR/w6rXKZJJU1yGHb2zem/EK7+aYhUcRgAOiouZAxk=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20201006143701-222e7423a5e3/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
 github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91 h1:HJ6U3S3ljJqNffYMcIeAncp5qT/i+ZMiJ2JC2F0aXP4=
 github.com/matrix-org/naffka v0.0.0-20200901083833-bcdd62999a91/go.mod h1:sjyPyRxKM5uw1nD2cJ6O2OxI6GOqyVBfNXqKjBZTBZE=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7 h1:ntrLa/8xVzeSs8vHFHK25k0C+NV74sYMJnNSg5NoSRo=

--- a/internal/httputil/http.go
+++ b/internal/httputil/http.go
@@ -17,7 +17,7 @@ package httputil
 import (
 	"bytes"
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -32,7 +32,7 @@ func PostJSON(
 	ctx context.Context, span opentracing.Span, httpClient *http.Client,
 	apiURL string, request, response interface{},
 ) error {
-	jsonBytes, err := json.Marshal(request)
+	jsonBytes, err := jsoniter.Marshal(request)
 	if err != nil {
 		return err
 	}
@@ -72,10 +72,10 @@ func PostJSON(
 		var errorBody struct {
 			Message string `json:"message"`
 		}
-		if msgerr := json.NewDecoder(res.Body).Decode(&errorBody); msgerr == nil {
+		if msgerr := jsoniter.NewDecoder(res.Body).Decode(&errorBody); msgerr == nil {
 			return fmt.Errorf("Internal API: %d from %s: %s", res.StatusCode, apiURL, errorBody.Message)
 		}
 		return fmt.Errorf("Internal API: %d from %s", res.StatusCode, apiURL)
 	}
-	return json.NewDecoder(res.Body).Decode(response)
+	return jsoniter.NewDecoder(res.Body).Decode(response)
 }

--- a/internal/httputil/http.go
+++ b/internal/httputil/http.go
@@ -17,7 +17,7 @@ package httputil
 import (
 	"bytes"
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -32,7 +32,7 @@ func PostJSON(
 	ctx context.Context, span opentracing.Span, httpClient *http.Client,
 	apiURL string, request, response interface{},
 ) error {
-	jsonBytes, err := jsoniter.Marshal(request)
+	jsonBytes, err := json.Marshal(request)
 	if err != nil {
 		return err
 	}
@@ -72,10 +72,10 @@ func PostJSON(
 		var errorBody struct {
 			Message string `json:"message"`
 		}
-		if msgerr := jsoniter.NewDecoder(res.Body).Decode(&errorBody); msgerr == nil {
+		if msgerr := json.NewDecoder(res.Body).Decode(&errorBody); msgerr == nil {
 			return fmt.Errorf("Internal API: %d from %s: %s", res.StatusCode, apiURL, errorBody.Message)
 		}
 		return fmt.Errorf("Internal API: %d from %s", res.StatusCode, apiURL)
 	}
-	return jsoniter.NewDecoder(res.Body).Decode(response)
+	return json.NewDecoder(res.Body).Decode(response)
 }

--- a/internal/httputil/http.go
+++ b/internal/httputil/http.go
@@ -33,7 +33,7 @@ func PostJSON(
 	ctx context.Context, span opentracing.Span, httpClient *http.Client,
 	apiURL string, request, response interface{},
 ) error {
-	jsonBytes, err := json.Marshal(request)
+	jsonBytes, err := json.ConfigCompatibleWithStandardLibrary.Marshal(request)
 	if err != nil {
 		return err
 	}

--- a/internal/httputil/http.go
+++ b/internal/httputil/http.go
@@ -17,11 +17,12 @@ package httputil
 import (
 	"bytes"
 	"context"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
+
+	json "github.com/json-iterator/go"
 
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"

--- a/keyserver/api/api.go
+++ b/keyserver/api/api.go
@@ -16,9 +16,10 @@ package api
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"strings"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"

--- a/keyserver/api/api.go
+++ b/keyserver/api/api.go
@@ -16,7 +16,7 @@ package api
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"strings"
 	"time"
 
@@ -83,7 +83,7 @@ type OneTimeKeys struct {
 	// The device ID of this device
 	DeviceID string
 	// A map of algorithm:key_id => key JSON
-	KeyJSON map[string]json.RawMessage
+	KeyJSON map[string]jsoniter.RawMessage
 }
 
 // Split a key in KeyJSON into algorithm and key ID
@@ -142,7 +142,7 @@ type PerformClaimKeysRequest struct {
 
 type PerformClaimKeysResponse struct {
 	// Map of user_id to device_id to algorithm:key_id to key JSON
-	OneTimeKeys map[string]map[string]map[string]json.RawMessage
+	OneTimeKeys map[string]map[string]map[string]jsoniter.RawMessage
 	// Map of remote server domain to error JSON
 	Failures map[string]interface{}
 	// Set if there was a fatal error processing this action
@@ -159,7 +159,7 @@ type QueryKeysResponse struct {
 	// Map of remote server domain to error JSON
 	Failures map[string]interface{}
 	// Map of user_id to device_id to device_key
-	DeviceKeys map[string]map[string]json.RawMessage
+	DeviceKeys map[string]map[string]jsoniter.RawMessage
 	// Set if there was a fatal error processing this query
 	Error *KeyError
 }

--- a/keyserver/api/api.go
+++ b/keyserver/api/api.go
@@ -16,7 +16,7 @@ package api
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"strings"
 	"time"
 
@@ -83,7 +83,7 @@ type OneTimeKeys struct {
 	// The device ID of this device
 	DeviceID string
 	// A map of algorithm:key_id => key JSON
-	KeyJSON map[string]jsoniter.RawMessage
+	KeyJSON map[string]json.RawMessage
 }
 
 // Split a key in KeyJSON into algorithm and key ID
@@ -142,7 +142,7 @@ type PerformClaimKeysRequest struct {
 
 type PerformClaimKeysResponse struct {
 	// Map of user_id to device_id to algorithm:key_id to key JSON
-	OneTimeKeys map[string]map[string]map[string]jsoniter.RawMessage
+	OneTimeKeys map[string]map[string]map[string]json.RawMessage
 	// Map of remote server domain to error JSON
 	Failures map[string]interface{}
 	// Set if there was a fatal error processing this action
@@ -159,7 +159,7 @@ type QueryKeysResponse struct {
 	// Map of remote server domain to error JSON
 	Failures map[string]interface{}
 	// Map of user_id to device_id to device_key
-	DeviceKeys map[string]map[string]jsoniter.RawMessage
+	DeviceKeys map[string]map[string]json.RawMessage
 	// Set if there was a fatal error processing this query
 	Error *KeyError
 }

--- a/keyserver/internal/device_list_update.go
+++ b/keyserver/internal/device_list_update.go
@@ -370,7 +370,7 @@ func (u *DeviceListUpdater) updateDeviceList(res *gomatrixserverlib.RespUserDevi
 	keys := make([]api.DeviceMessage, len(res.Devices))
 	existingKeys := make([]api.DeviceMessage, len(res.Devices))
 	for i, device := range res.Devices {
-		keyJSON, err := json.Marshal(device.Keys)
+		keyJSON, err := json.ConfigCompatibleWithStandardLibrary.Marshal(device.Keys)
 		if err != nil {
 			util.GetLogger(ctx).WithField("keys", device.Keys).Error("failed to marshal keys, skipping device")
 			continue

--- a/keyserver/internal/device_list_update.go
+++ b/keyserver/internal/device_list_update.go
@@ -16,7 +16,7 @@ package internal
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"hash/fnv"
 	"sync"
@@ -369,7 +369,7 @@ func (u *DeviceListUpdater) updateDeviceList(res *gomatrixserverlib.RespUserDevi
 	keys := make([]api.DeviceMessage, len(res.Devices))
 	existingKeys := make([]api.DeviceMessage, len(res.Devices))
 	for i, device := range res.Devices {
-		keyJSON, err := jsoniter.Marshal(device.Keys)
+		keyJSON, err := json.Marshal(device.Keys)
 		if err != nil {
 			util.GetLogger(ctx).WithField("keys", device.Keys).Error("failed to marshal keys, skipping device")
 			continue

--- a/keyserver/internal/device_list_update.go
+++ b/keyserver/internal/device_list_update.go
@@ -16,11 +16,12 @@ package internal
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"hash/fnv"
 	"sync"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	fedsenderapi "github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/dendrite/keyserver/api"

--- a/keyserver/internal/device_list_update.go
+++ b/keyserver/internal/device_list_update.go
@@ -16,7 +16,7 @@ package internal
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"hash/fnv"
 	"sync"
@@ -369,7 +369,7 @@ func (u *DeviceListUpdater) updateDeviceList(res *gomatrixserverlib.RespUserDevi
 	keys := make([]api.DeviceMessage, len(res.Devices))
 	existingKeys := make([]api.DeviceMessage, len(res.Devices))
 	for i, device := range res.Devices {
-		keyJSON, err := json.Marshal(device.Keys)
+		keyJSON, err := jsoniter.Marshal(device.Keys)
 		if err != nil {
 			util.GetLogger(ctx).WithField("keys", device.Keys).Error("failed to marshal keys, skipping device")
 			continue

--- a/keyserver/internal/internal.go
+++ b/keyserver/internal/internal.go
@@ -17,10 +17,11 @@ package internal
 import (
 	"bytes"
 	"context"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"sync"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	fedsenderapi "github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/dendrite/keyserver/api"

--- a/keyserver/internal/internal.go
+++ b/keyserver/internal/internal.go
@@ -17,7 +17,7 @@ package internal
 import (
 	"bytes"
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"sync"
 	"time"
@@ -80,7 +80,7 @@ func (a *KeyInternalAPI) PerformUploadKeys(ctx context.Context, req *api.Perform
 }
 
 func (a *KeyInternalAPI) PerformClaimKeys(ctx context.Context, req *api.PerformClaimKeysRequest, res *api.PerformClaimKeysResponse) {
-	res.OneTimeKeys = make(map[string]map[string]map[string]jsoniter.RawMessage)
+	res.OneTimeKeys = make(map[string]map[string]map[string]json.RawMessage)
 	res.Failures = make(map[string]interface{})
 	// wrap request map in a top-level by-domain map
 	domainToDeviceKeys := make(map[string]map[string]map[string]string)
@@ -108,11 +108,11 @@ func (a *KeyInternalAPI) PerformClaimKeys(ctx context.Context, req *api.PerformC
 		for _, key := range keys {
 			_, ok := res.OneTimeKeys[key.UserID]
 			if !ok {
-				res.OneTimeKeys[key.UserID] = make(map[string]map[string]jsoniter.RawMessage)
+				res.OneTimeKeys[key.UserID] = make(map[string]map[string]json.RawMessage)
 			}
 			_, ok = res.OneTimeKeys[key.UserID][key.DeviceID]
 			if !ok {
-				res.OneTimeKeys[key.UserID][key.DeviceID] = make(map[string]jsoniter.RawMessage)
+				res.OneTimeKeys[key.UserID][key.DeviceID] = make(map[string]json.RawMessage)
 			}
 			for keyID, keyJSON := range key.KeyJSON {
 				res.OneTimeKeys[key.UserID][key.DeviceID][keyID] = keyJSON
@@ -165,11 +165,11 @@ func (a *KeyInternalAPI) claimRemoteKeys(
 	keysClaimed := 0
 	for result := range resultCh {
 		for userID, nest := range result.OneTimeKeys {
-			res.OneTimeKeys[userID] = make(map[string]map[string]jsoniter.RawMessage)
+			res.OneTimeKeys[userID] = make(map[string]map[string]json.RawMessage)
 			for deviceID, nest2 := range nest {
-				res.OneTimeKeys[userID][deviceID] = make(map[string]jsoniter.RawMessage)
+				res.OneTimeKeys[userID][deviceID] = make(map[string]json.RawMessage)
 				for keyIDWithAlgo, otk := range nest2 {
-					keyJSON, err := jsoniter.Marshal(otk)
+					keyJSON, err := json.Marshal(otk)
 					if err != nil {
 						continue
 					}
@@ -220,7 +220,7 @@ func (a *KeyInternalAPI) QueryDeviceMessages(ctx context.Context, req *api.Query
 }
 
 func (a *KeyInternalAPI) QueryKeys(ctx context.Context, req *api.QueryKeysRequest, res *api.QueryKeysResponse) {
-	res.DeviceKeys = make(map[string]map[string]jsoniter.RawMessage)
+	res.DeviceKeys = make(map[string]map[string]json.RawMessage)
 	res.Failures = make(map[string]interface{})
 	// make a map from domain to device keys
 	domainToDeviceKeys := make(map[string]map[string][]string)
@@ -254,7 +254,7 @@ func (a *KeyInternalAPI) QueryKeys(ctx context.Context, req *api.QueryKeysReques
 			}
 
 			if res.DeviceKeys[userID] == nil {
-				res.DeviceKeys[userID] = make(map[string]jsoniter.RawMessage)
+				res.DeviceKeys[userID] = make(map[string]json.RawMessage)
 			}
 			for _, dk := range deviceKeys {
 				if len(dk.KeyJSON) == 0 {
@@ -335,9 +335,9 @@ func (a *KeyInternalAPI) queryRemoteKeys(
 
 	for result := range resultCh {
 		for userID, nest := range result.DeviceKeys {
-			res.DeviceKeys[userID] = make(map[string]jsoniter.RawMessage)
+			res.DeviceKeys[userID] = make(map[string]json.RawMessage)
 			for deviceID, deviceKey := range nest {
-				keyJSON, err := jsoniter.Marshal(deviceKey)
+				keyJSON, err := json.Marshal(deviceKey)
 				if err != nil {
 					continue
 				}
@@ -432,7 +432,7 @@ func (a *KeyInternalAPI) populateResponseWithDeviceKeysFromDatabase(
 		return fmt.Errorf("DeviceKeysForUser %s returned no keys but wanted all keys, falling back to remote", userID)
 	}
 	if res.DeviceKeys[userID] == nil {
-		res.DeviceKeys[userID] = make(map[string]jsoniter.RawMessage)
+		res.DeviceKeys[userID] = make(map[string]json.RawMessage)
 	}
 
 	for _, key := range keys {

--- a/keyserver/internal/internal.go
+++ b/keyserver/internal/internal.go
@@ -170,7 +170,7 @@ func (a *KeyInternalAPI) claimRemoteKeys(
 			for deviceID, nest2 := range nest {
 				res.OneTimeKeys[userID][deviceID] = make(map[string]json.RawMessage)
 				for keyIDWithAlgo, otk := range nest2 {
-					keyJSON, err := json.Marshal(otk)
+					keyJSON, err := json.ConfigCompatibleWithStandardLibrary.Marshal(otk)
 					if err != nil {
 						continue
 					}
@@ -338,7 +338,7 @@ func (a *KeyInternalAPI) queryRemoteKeys(
 		for userID, nest := range result.DeviceKeys {
 			res.DeviceKeys[userID] = make(map[string]json.RawMessage)
 			for deviceID, deviceKey := range nest {
-				keyJSON, err := json.Marshal(deviceKey)
+				keyJSON, err := json.ConfigCompatibleWithStandardLibrary.Marshal(deviceKey)
 				if err != nil {
 					continue
 				}

--- a/keyserver/internal/internal.go
+++ b/keyserver/internal/internal.go
@@ -17,7 +17,7 @@ package internal
 import (
 	"bytes"
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"sync"
 	"time"
@@ -80,7 +80,7 @@ func (a *KeyInternalAPI) PerformUploadKeys(ctx context.Context, req *api.Perform
 }
 
 func (a *KeyInternalAPI) PerformClaimKeys(ctx context.Context, req *api.PerformClaimKeysRequest, res *api.PerformClaimKeysResponse) {
-	res.OneTimeKeys = make(map[string]map[string]map[string]json.RawMessage)
+	res.OneTimeKeys = make(map[string]map[string]map[string]jsoniter.RawMessage)
 	res.Failures = make(map[string]interface{})
 	// wrap request map in a top-level by-domain map
 	domainToDeviceKeys := make(map[string]map[string]map[string]string)
@@ -108,11 +108,11 @@ func (a *KeyInternalAPI) PerformClaimKeys(ctx context.Context, req *api.PerformC
 		for _, key := range keys {
 			_, ok := res.OneTimeKeys[key.UserID]
 			if !ok {
-				res.OneTimeKeys[key.UserID] = make(map[string]map[string]json.RawMessage)
+				res.OneTimeKeys[key.UserID] = make(map[string]map[string]jsoniter.RawMessage)
 			}
 			_, ok = res.OneTimeKeys[key.UserID][key.DeviceID]
 			if !ok {
-				res.OneTimeKeys[key.UserID][key.DeviceID] = make(map[string]json.RawMessage)
+				res.OneTimeKeys[key.UserID][key.DeviceID] = make(map[string]jsoniter.RawMessage)
 			}
 			for keyID, keyJSON := range key.KeyJSON {
 				res.OneTimeKeys[key.UserID][key.DeviceID][keyID] = keyJSON
@@ -165,11 +165,11 @@ func (a *KeyInternalAPI) claimRemoteKeys(
 	keysClaimed := 0
 	for result := range resultCh {
 		for userID, nest := range result.OneTimeKeys {
-			res.OneTimeKeys[userID] = make(map[string]map[string]json.RawMessage)
+			res.OneTimeKeys[userID] = make(map[string]map[string]jsoniter.RawMessage)
 			for deviceID, nest2 := range nest {
-				res.OneTimeKeys[userID][deviceID] = make(map[string]json.RawMessage)
+				res.OneTimeKeys[userID][deviceID] = make(map[string]jsoniter.RawMessage)
 				for keyIDWithAlgo, otk := range nest2 {
-					keyJSON, err := json.Marshal(otk)
+					keyJSON, err := jsoniter.Marshal(otk)
 					if err != nil {
 						continue
 					}
@@ -220,7 +220,7 @@ func (a *KeyInternalAPI) QueryDeviceMessages(ctx context.Context, req *api.Query
 }
 
 func (a *KeyInternalAPI) QueryKeys(ctx context.Context, req *api.QueryKeysRequest, res *api.QueryKeysResponse) {
-	res.DeviceKeys = make(map[string]map[string]json.RawMessage)
+	res.DeviceKeys = make(map[string]map[string]jsoniter.RawMessage)
 	res.Failures = make(map[string]interface{})
 	// make a map from domain to device keys
 	domainToDeviceKeys := make(map[string]map[string][]string)
@@ -254,7 +254,7 @@ func (a *KeyInternalAPI) QueryKeys(ctx context.Context, req *api.QueryKeysReques
 			}
 
 			if res.DeviceKeys[userID] == nil {
-				res.DeviceKeys[userID] = make(map[string]json.RawMessage)
+				res.DeviceKeys[userID] = make(map[string]jsoniter.RawMessage)
 			}
 			for _, dk := range deviceKeys {
 				if len(dk.KeyJSON) == 0 {
@@ -335,9 +335,9 @@ func (a *KeyInternalAPI) queryRemoteKeys(
 
 	for result := range resultCh {
 		for userID, nest := range result.DeviceKeys {
-			res.DeviceKeys[userID] = make(map[string]json.RawMessage)
+			res.DeviceKeys[userID] = make(map[string]jsoniter.RawMessage)
 			for deviceID, deviceKey := range nest {
-				keyJSON, err := json.Marshal(deviceKey)
+				keyJSON, err := jsoniter.Marshal(deviceKey)
 				if err != nil {
 					continue
 				}
@@ -432,7 +432,7 @@ func (a *KeyInternalAPI) populateResponseWithDeviceKeysFromDatabase(
 		return fmt.Errorf("DeviceKeysForUser %s returned no keys but wanted all keys, falling back to remote", userID)
 	}
 	if res.DeviceKeys[userID] == nil {
-		res.DeviceKeys[userID] = make(map[string]json.RawMessage)
+		res.DeviceKeys[userID] = make(map[string]jsoniter.RawMessage)
 	}
 
 	for _, key := range keys {

--- a/keyserver/inthttp/server.go
+++ b/keyserver/inthttp/server.go
@@ -15,7 +15,7 @@
 package inthttp
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -29,7 +29,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.KeyInternalAPI) {
 		httputil.MakeInternalAPI("inputDeviceListUpdate", func(req *http.Request) util.JSONResponse {
 			request := api.InputDeviceListUpdateRequest{}
 			response := api.InputDeviceListUpdateResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			s.InputDeviceListUpdate(req.Context(), &request, &response)
@@ -40,7 +40,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.KeyInternalAPI) {
 		httputil.MakeInternalAPI("performClaimKeys", func(req *http.Request) util.JSONResponse {
 			request := api.PerformClaimKeysRequest{}
 			response := api.PerformClaimKeysResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			s.PerformClaimKeys(req.Context(), &request, &response)
@@ -51,7 +51,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.KeyInternalAPI) {
 		httputil.MakeInternalAPI("performUploadKeys", func(req *http.Request) util.JSONResponse {
 			request := api.PerformUploadKeysRequest{}
 			response := api.PerformUploadKeysResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			s.PerformUploadKeys(req.Context(), &request, &response)
@@ -62,7 +62,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.KeyInternalAPI) {
 		httputil.MakeInternalAPI("queryKeys", func(req *http.Request) util.JSONResponse {
 			request := api.QueryKeysRequest{}
 			response := api.QueryKeysResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			s.QueryKeys(req.Context(), &request, &response)
@@ -73,7 +73,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.KeyInternalAPI) {
 		httputil.MakeInternalAPI("queryOneTimeKeys", func(req *http.Request) util.JSONResponse {
 			request := api.QueryOneTimeKeysRequest{}
 			response := api.QueryOneTimeKeysResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			s.QueryOneTimeKeys(req.Context(), &request, &response)
@@ -84,7 +84,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.KeyInternalAPI) {
 		httputil.MakeInternalAPI("queryDeviceMessages", func(req *http.Request) util.JSONResponse {
 			request := api.QueryDeviceMessagesRequest{}
 			response := api.QueryDeviceMessagesResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			s.QueryDeviceMessages(req.Context(), &request, &response)
@@ -95,7 +95,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.KeyInternalAPI) {
 		httputil.MakeInternalAPI("queryKeyChanges", func(req *http.Request) util.JSONResponse {
 			request := api.QueryKeyChangesRequest{}
 			response := api.QueryKeyChangesResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			s.QueryKeyChanges(req.Context(), &request, &response)

--- a/keyserver/inthttp/server.go
+++ b/keyserver/inthttp/server.go
@@ -15,7 +15,7 @@
 package inthttp
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -29,7 +29,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.KeyInternalAPI) {
 		httputil.MakeInternalAPI("inputDeviceListUpdate", func(req *http.Request) util.JSONResponse {
 			request := api.InputDeviceListUpdateRequest{}
 			response := api.InputDeviceListUpdateResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			s.InputDeviceListUpdate(req.Context(), &request, &response)
@@ -40,7 +40,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.KeyInternalAPI) {
 		httputil.MakeInternalAPI("performClaimKeys", func(req *http.Request) util.JSONResponse {
 			request := api.PerformClaimKeysRequest{}
 			response := api.PerformClaimKeysResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			s.PerformClaimKeys(req.Context(), &request, &response)
@@ -51,7 +51,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.KeyInternalAPI) {
 		httputil.MakeInternalAPI("performUploadKeys", func(req *http.Request) util.JSONResponse {
 			request := api.PerformUploadKeysRequest{}
 			response := api.PerformUploadKeysResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			s.PerformUploadKeys(req.Context(), &request, &response)
@@ -62,7 +62,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.KeyInternalAPI) {
 		httputil.MakeInternalAPI("queryKeys", func(req *http.Request) util.JSONResponse {
 			request := api.QueryKeysRequest{}
 			response := api.QueryKeysResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			s.QueryKeys(req.Context(), &request, &response)
@@ -73,7 +73,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.KeyInternalAPI) {
 		httputil.MakeInternalAPI("queryOneTimeKeys", func(req *http.Request) util.JSONResponse {
 			request := api.QueryOneTimeKeysRequest{}
 			response := api.QueryOneTimeKeysResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			s.QueryOneTimeKeys(req.Context(), &request, &response)
@@ -84,7 +84,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.KeyInternalAPI) {
 		httputil.MakeInternalAPI("queryDeviceMessages", func(req *http.Request) util.JSONResponse {
 			request := api.QueryDeviceMessagesRequest{}
 			response := api.QueryDeviceMessagesResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			s.QueryDeviceMessages(req.Context(), &request, &response)
@@ -95,7 +95,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.KeyInternalAPI) {
 		httputil.MakeInternalAPI("queryKeyChanges", func(req *http.Request) util.JSONResponse {
 			request := api.QueryKeyChangesRequest{}
 			response := api.QueryKeyChangesResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			s.QueryKeyChanges(req.Context(), &request, &response)

--- a/keyserver/inthttp/server.go
+++ b/keyserver/inthttp/server.go
@@ -15,8 +15,9 @@
 package inthttp
 
 import (
-	json "github.com/json-iterator/go"
 	"net/http"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/internal/httputil"

--- a/keyserver/producers/keychange.go
+++ b/keyserver/producers/keychange.go
@@ -47,7 +47,7 @@ func (p *KeyChange) ProduceKeyChanges(keys []api.DeviceMessage) error {
 	for _, key := range keys {
 		var m sarama.ProducerMessage
 
-		value, err := json.Marshal(key)
+		value, err := json.ConfigCompatibleWithStandardLibrary.Marshal(key)
 		if err != nil {
 			return err
 		}

--- a/keyserver/producers/keychange.go
+++ b/keyserver/producers/keychange.go
@@ -16,7 +16,7 @@ package producers
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"
 	"github.com/matrix-org/dendrite/keyserver/api"
@@ -46,7 +46,7 @@ func (p *KeyChange) ProduceKeyChanges(keys []api.DeviceMessage) error {
 	for _, key := range keys {
 		var m sarama.ProducerMessage
 
-		value, err := jsoniter.Marshal(key)
+		value, err := json.Marshal(key)
 		if err != nil {
 			return err
 		}

--- a/keyserver/producers/keychange.go
+++ b/keyserver/producers/keychange.go
@@ -16,7 +16,7 @@ package producers
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"
 	"github.com/matrix-org/dendrite/keyserver/api"
@@ -46,7 +46,7 @@ func (p *KeyChange) ProduceKeyChanges(keys []api.DeviceMessage) error {
 	for _, key := range keys {
 		var m sarama.ProducerMessage
 
-		value, err := json.Marshal(key)
+		value, err := jsoniter.Marshal(key)
 		if err != nil {
 			return err
 		}

--- a/keyserver/producers/keychange.go
+++ b/keyserver/producers/keychange.go
@@ -16,6 +16,7 @@ package producers
 
 import (
 	"context"
+
 	json "github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"

--- a/keyserver/storage/interface.go
+++ b/keyserver/storage/interface.go
@@ -16,8 +16,7 @@ package storage
 
 import (
 	"context"
-	"encoding/json"
-
+	jsoniter "github.com/json-iterator/go"
 	"github.com/matrix-org/dendrite/keyserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
 )
@@ -25,7 +24,7 @@ import (
 type Database interface {
 	// ExistingOneTimeKeys returns a map of keyIDWithAlgorithm to key JSON for the given parameters. If no keys exist with this combination
 	// of user/device/key/algorithm 4-uple then it is omitted from the map. Returns an error when failing to communicate with the database.
-	ExistingOneTimeKeys(ctx context.Context, userID, deviceID string, keyIDsWithAlgorithms []string) (map[string]json.RawMessage, error)
+	ExistingOneTimeKeys(ctx context.Context, userID, deviceID string, keyIDsWithAlgorithms []string) (map[string]jsoniter.RawMessage, error)
 
 	// StoreOneTimeKeys persists the given one-time keys.
 	StoreOneTimeKeys(ctx context.Context, keys api.OneTimeKeys) (*api.OneTimeKeysCount, error)

--- a/keyserver/storage/interface.go
+++ b/keyserver/storage/interface.go
@@ -16,6 +16,7 @@ package storage
 
 import (
 	"context"
+
 	json "github.com/json-iterator/go"
 	"github.com/matrix-org/dendrite/keyserver/api"
 	"github.com/matrix-org/gomatrixserverlib"

--- a/keyserver/storage/interface.go
+++ b/keyserver/storage/interface.go
@@ -16,7 +16,7 @@ package storage
 
 import (
 	"context"
-	jsoniter "github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"github.com/matrix-org/dendrite/keyserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
 )
@@ -24,7 +24,7 @@ import (
 type Database interface {
 	// ExistingOneTimeKeys returns a map of keyIDWithAlgorithm to key JSON for the given parameters. If no keys exist with this combination
 	// of user/device/key/algorithm 4-uple then it is omitted from the map. Returns an error when failing to communicate with the database.
-	ExistingOneTimeKeys(ctx context.Context, userID, deviceID string, keyIDsWithAlgorithms []string) (map[string]jsoniter.RawMessage, error)
+	ExistingOneTimeKeys(ctx context.Context, userID, deviceID string, keyIDsWithAlgorithms []string) (map[string]json.RawMessage, error)
 
 	// StoreOneTimeKeys persists the given one-time keys.
 	StoreOneTimeKeys(ctx context.Context, keys api.OneTimeKeys) (*api.OneTimeKeysCount, error)

--- a/keyserver/storage/postgres/one_time_keys_table.go
+++ b/keyserver/storage/postgres/one_time_keys_table.go
@@ -17,8 +17,9 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	json "github.com/json-iterator/go"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"

--- a/keyserver/storage/postgres/one_time_keys_table.go
+++ b/keyserver/storage/postgres/one_time_keys_table.go
@@ -17,7 +17,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"time"
 
 	"github.com/matrix-org/dendrite/internal"
@@ -93,7 +93,7 @@ func NewPostgresOneTimeKeysTable(db *sql.DB) (tables.OneTimeKeys, error) {
 	return s, nil
 }
 
-func (s *oneTimeKeysStatements) SelectOneTimeKeys(ctx context.Context, userID, deviceID string, keyIDsWithAlgorithms []string) (map[string]json.RawMessage, error) {
+func (s *oneTimeKeysStatements) SelectOneTimeKeys(ctx context.Context, userID, deviceID string, keyIDsWithAlgorithms []string) (map[string]jsoniter.RawMessage, error) {
 	rows, err := s.selectKeysStmt.QueryContext(ctx, userID, deviceID)
 	if err != nil {
 		return nil, err
@@ -105,7 +105,7 @@ func (s *oneTimeKeysStatements) SelectOneTimeKeys(ctx context.Context, userID, d
 		wantSet[ka] = true
 	}
 
-	result := make(map[string]json.RawMessage)
+	result := make(map[string]jsoniter.RawMessage)
 	for rows.Next() {
 		var keyID string
 		var algorithm string
@@ -115,7 +115,7 @@ func (s *oneTimeKeysStatements) SelectOneTimeKeys(ctx context.Context, userID, d
 		}
 		keyIDWithAlgo := algorithm + ":" + keyID
 		if wantSet[keyIDWithAlgo] {
-			result[keyIDWithAlgo] = json.RawMessage(keyJSONStr)
+			result[keyIDWithAlgo] = jsoniter.RawMessage(keyJSONStr)
 		}
 	}
 	return result, rows.Err()
@@ -178,7 +178,7 @@ func (s *oneTimeKeysStatements) InsertOneTimeKeys(ctx context.Context, txn *sql.
 
 func (s *oneTimeKeysStatements) SelectAndDeleteOneTimeKey(
 	ctx context.Context, txn *sql.Tx, userID, deviceID, algorithm string,
-) (map[string]json.RawMessage, error) {
+) (map[string]jsoniter.RawMessage, error) {
 	var keyID string
 	var keyJSON string
 	err := sqlutil.TxStmtContext(ctx, txn, s.selectKeyByAlgorithmStmt).QueryRowContext(ctx, userID, deviceID, algorithm).Scan(&keyID, &keyJSON)
@@ -189,7 +189,7 @@ func (s *oneTimeKeysStatements) SelectAndDeleteOneTimeKey(
 		return nil, err
 	}
 	_, err = sqlutil.TxStmtContext(ctx, txn, s.deleteOneTimeKeyStmt).ExecContext(ctx, userID, deviceID, algorithm, keyID)
-	return map[string]json.RawMessage{
-		algorithm + ":" + keyID: json.RawMessage(keyJSON),
+	return map[string]jsoniter.RawMessage{
+		algorithm + ":" + keyID: jsoniter.RawMessage(keyJSON),
 	}, err
 }

--- a/keyserver/storage/postgres/one_time_keys_table.go
+++ b/keyserver/storage/postgres/one_time_keys_table.go
@@ -17,7 +17,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"time"
 
 	"github.com/matrix-org/dendrite/internal"
@@ -93,7 +93,7 @@ func NewPostgresOneTimeKeysTable(db *sql.DB) (tables.OneTimeKeys, error) {
 	return s, nil
 }
 
-func (s *oneTimeKeysStatements) SelectOneTimeKeys(ctx context.Context, userID, deviceID string, keyIDsWithAlgorithms []string) (map[string]jsoniter.RawMessage, error) {
+func (s *oneTimeKeysStatements) SelectOneTimeKeys(ctx context.Context, userID, deviceID string, keyIDsWithAlgorithms []string) (map[string]json.RawMessage, error) {
 	rows, err := s.selectKeysStmt.QueryContext(ctx, userID, deviceID)
 	if err != nil {
 		return nil, err
@@ -105,7 +105,7 @@ func (s *oneTimeKeysStatements) SelectOneTimeKeys(ctx context.Context, userID, d
 		wantSet[ka] = true
 	}
 
-	result := make(map[string]jsoniter.RawMessage)
+	result := make(map[string]json.RawMessage)
 	for rows.Next() {
 		var keyID string
 		var algorithm string
@@ -115,7 +115,7 @@ func (s *oneTimeKeysStatements) SelectOneTimeKeys(ctx context.Context, userID, d
 		}
 		keyIDWithAlgo := algorithm + ":" + keyID
 		if wantSet[keyIDWithAlgo] {
-			result[keyIDWithAlgo] = jsoniter.RawMessage(keyJSONStr)
+			result[keyIDWithAlgo] = json.RawMessage(keyJSONStr)
 		}
 	}
 	return result, rows.Err()
@@ -178,7 +178,7 @@ func (s *oneTimeKeysStatements) InsertOneTimeKeys(ctx context.Context, txn *sql.
 
 func (s *oneTimeKeysStatements) SelectAndDeleteOneTimeKey(
 	ctx context.Context, txn *sql.Tx, userID, deviceID, algorithm string,
-) (map[string]jsoniter.RawMessage, error) {
+) (map[string]json.RawMessage, error) {
 	var keyID string
 	var keyJSON string
 	err := sqlutil.TxStmtContext(ctx, txn, s.selectKeyByAlgorithmStmt).QueryRowContext(ctx, userID, deviceID, algorithm).Scan(&keyID, &keyJSON)
@@ -189,7 +189,7 @@ func (s *oneTimeKeysStatements) SelectAndDeleteOneTimeKey(
 		return nil, err
 	}
 	_, err = sqlutil.TxStmtContext(ctx, txn, s.deleteOneTimeKeyStmt).ExecContext(ctx, userID, deviceID, algorithm, keyID)
-	return map[string]jsoniter.RawMessage{
-		algorithm + ":" + keyID: jsoniter.RawMessage(keyJSON),
+	return map[string]json.RawMessage{
+		algorithm + ":" + keyID: json.RawMessage(keyJSON),
 	}, err
 }

--- a/keyserver/storage/shared/storage.go
+++ b/keyserver/storage/shared/storage.go
@@ -17,6 +17,7 @@ package shared
 import (
 	"context"
 	"database/sql"
+
 	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal/sqlutil"

--- a/keyserver/storage/shared/storage.go
+++ b/keyserver/storage/shared/storage.go
@@ -17,7 +17,7 @@ package shared
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/keyserver/api"
@@ -34,7 +34,7 @@ type Database struct {
 	StaleDeviceListsTable tables.StaleDeviceLists
 }
 
-func (d *Database) ExistingOneTimeKeys(ctx context.Context, userID, deviceID string, keyIDsWithAlgorithms []string) (map[string]json.RawMessage, error) {
+func (d *Database) ExistingOneTimeKeys(ctx context.Context, userID, deviceID string, keyIDsWithAlgorithms []string) (map[string]jsoniter.RawMessage, error) {
 	return d.OneTimeKeysTable.SelectOneTimeKeys(ctx, userID, deviceID, keyIDsWithAlgorithms)
 }
 

--- a/keyserver/storage/shared/storage.go
+++ b/keyserver/storage/shared/storage.go
@@ -17,7 +17,7 @@ package shared
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/keyserver/api"
@@ -34,7 +34,7 @@ type Database struct {
 	StaleDeviceListsTable tables.StaleDeviceLists
 }
 
-func (d *Database) ExistingOneTimeKeys(ctx context.Context, userID, deviceID string, keyIDsWithAlgorithms []string) (map[string]jsoniter.RawMessage, error) {
+func (d *Database) ExistingOneTimeKeys(ctx context.Context, userID, deviceID string, keyIDsWithAlgorithms []string) (map[string]json.RawMessage, error) {
 	return d.OneTimeKeysTable.SelectOneTimeKeys(ctx, userID, deviceID, keyIDsWithAlgorithms)
 }
 

--- a/keyserver/storage/sqlite3/one_time_keys_table.go
+++ b/keyserver/storage/sqlite3/one_time_keys_table.go
@@ -17,8 +17,9 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	json "github.com/json-iterator/go"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"

--- a/keyserver/storage/sqlite3/one_time_keys_table.go
+++ b/keyserver/storage/sqlite3/one_time_keys_table.go
@@ -17,7 +17,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"time"
 
 	"github.com/matrix-org/dendrite/internal"
@@ -93,7 +93,7 @@ func NewSqliteOneTimeKeysTable(db *sql.DB) (tables.OneTimeKeys, error) {
 	return s, nil
 }
 
-func (s *oneTimeKeysStatements) SelectOneTimeKeys(ctx context.Context, userID, deviceID string, keyIDsWithAlgorithms []string) (map[string]jsoniter.RawMessage, error) {
+func (s *oneTimeKeysStatements) SelectOneTimeKeys(ctx context.Context, userID, deviceID string, keyIDsWithAlgorithms []string) (map[string]json.RawMessage, error) {
 	rows, err := s.selectKeysStmt.QueryContext(ctx, userID, deviceID)
 	if err != nil {
 		return nil, err
@@ -105,7 +105,7 @@ func (s *oneTimeKeysStatements) SelectOneTimeKeys(ctx context.Context, userID, d
 		wantSet[ka] = true
 	}
 
-	result := make(map[string]jsoniter.RawMessage)
+	result := make(map[string]json.RawMessage)
 	for rows.Next() {
 		var keyID string
 		var algorithm string
@@ -115,7 +115,7 @@ func (s *oneTimeKeysStatements) SelectOneTimeKeys(ctx context.Context, userID, d
 		}
 		keyIDWithAlgo := algorithm + ":" + keyID
 		if wantSet[keyIDWithAlgo] {
-			result[keyIDWithAlgo] = jsoniter.RawMessage(keyJSONStr)
+			result[keyIDWithAlgo] = json.RawMessage(keyJSONStr)
 		}
 	}
 	return result, rows.Err()
@@ -180,7 +180,7 @@ func (s *oneTimeKeysStatements) InsertOneTimeKeys(
 
 func (s *oneTimeKeysStatements) SelectAndDeleteOneTimeKey(
 	ctx context.Context, txn *sql.Tx, userID, deviceID, algorithm string,
-) (map[string]jsoniter.RawMessage, error) {
+) (map[string]json.RawMessage, error) {
 	var keyID string
 	var keyJSON string
 	err := sqlutil.TxStmtContext(ctx, txn, s.selectKeyByAlgorithmStmt).QueryRowContext(ctx, userID, deviceID, algorithm).Scan(&keyID, &keyJSON)
@@ -197,7 +197,7 @@ func (s *oneTimeKeysStatements) SelectAndDeleteOneTimeKey(
 	if keyJSON == "" {
 		return nil, nil
 	}
-	return map[string]jsoniter.RawMessage{
-		algorithm + ":" + keyID: jsoniter.RawMessage(keyJSON),
+	return map[string]json.RawMessage{
+		algorithm + ":" + keyID: json.RawMessage(keyJSON),
 	}, err
 }

--- a/keyserver/storage/tables/interface.go
+++ b/keyserver/storage/tables/interface.go
@@ -17,19 +17,18 @@ package tables
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
-
+	jsoniter "github.com/json-iterator/go"
 	"github.com/matrix-org/dendrite/keyserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
 type OneTimeKeys interface {
-	SelectOneTimeKeys(ctx context.Context, userID, deviceID string, keyIDsWithAlgorithms []string) (map[string]json.RawMessage, error)
+	SelectOneTimeKeys(ctx context.Context, userID, deviceID string, keyIDsWithAlgorithms []string) (map[string]jsoniter.RawMessage, error)
 	CountOneTimeKeys(ctx context.Context, userID, deviceID string) (*api.OneTimeKeysCount, error)
 	InsertOneTimeKeys(ctx context.Context, txn *sql.Tx, keys api.OneTimeKeys) (*api.OneTimeKeysCount, error)
 	// SelectAndDeleteOneTimeKey selects a single one time key matching the user/device/algorithm specified and returns the algo:key_id => JSON.
 	// Returns an empty map if the key does not exist.
-	SelectAndDeleteOneTimeKey(ctx context.Context, txn *sql.Tx, userID, deviceID, algorithm string) (map[string]json.RawMessage, error)
+	SelectAndDeleteOneTimeKey(ctx context.Context, txn *sql.Tx, userID, deviceID, algorithm string) (map[string]jsoniter.RawMessage, error)
 }
 
 type DeviceKeys interface {

--- a/keyserver/storage/tables/interface.go
+++ b/keyserver/storage/tables/interface.go
@@ -17,6 +17,7 @@ package tables
 import (
 	"context"
 	"database/sql"
+
 	json "github.com/json-iterator/go"
 	"github.com/matrix-org/dendrite/keyserver/api"
 	"github.com/matrix-org/gomatrixserverlib"

--- a/keyserver/storage/tables/interface.go
+++ b/keyserver/storage/tables/interface.go
@@ -17,18 +17,18 @@ package tables
 import (
 	"context"
 	"database/sql"
-	jsoniter "github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"github.com/matrix-org/dendrite/keyserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
 type OneTimeKeys interface {
-	SelectOneTimeKeys(ctx context.Context, userID, deviceID string, keyIDsWithAlgorithms []string) (map[string]jsoniter.RawMessage, error)
+	SelectOneTimeKeys(ctx context.Context, userID, deviceID string, keyIDsWithAlgorithms []string) (map[string]json.RawMessage, error)
 	CountOneTimeKeys(ctx context.Context, userID, deviceID string) (*api.OneTimeKeysCount, error)
 	InsertOneTimeKeys(ctx context.Context, txn *sql.Tx, keys api.OneTimeKeys) (*api.OneTimeKeysCount, error)
 	// SelectAndDeleteOneTimeKey selects a single one time key matching the user/device/algorithm specified and returns the algo:key_id => JSON.
 	// Returns an empty map if the key does not exist.
-	SelectAndDeleteOneTimeKey(ctx context.Context, txn *sql.Tx, userID, deviceID, algorithm string) (map[string]jsoniter.RawMessage, error)
+	SelectAndDeleteOneTimeKey(ctx context.Context, txn *sql.Tx, userID, deviceID, algorithm string) (map[string]json.RawMessage, error)
 }
 
 type DeviceKeys interface {

--- a/mediaapi/routing/download.go
+++ b/mediaapi/routing/download.go
@@ -16,7 +16,7 @@ package routing
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"io"
 	"mime"
@@ -146,12 +146,12 @@ func Download(
 
 func (r *downloadRequest) jsonErrorResponse(w http.ResponseWriter, res util.JSONResponse) {
 	// Marshal JSON response into raw bytes to send as the HTTP body
-	resBytes, err := json.Marshal(res.JSON)
+	resBytes, err := jsoniter.Marshal(res.JSON)
 	if err != nil {
 		r.Logger.WithError(err).Error("Failed to marshal JSONResponse")
 		// this should never fail to be marshalled so drop err to the floor
 		res = util.MessageResponse(http.StatusNotFound, "Download request failed: "+err.Error())
-		resBytes, _ = json.Marshal(res.JSON)
+		resBytes, _ = jsoniter.Marshal(res.JSON)
 	}
 
 	// Set status code and write the body

--- a/mediaapi/routing/download.go
+++ b/mediaapi/routing/download.go
@@ -147,12 +147,12 @@ func Download(
 
 func (r *downloadRequest) jsonErrorResponse(w http.ResponseWriter, res util.JSONResponse) {
 	// Marshal JSON response into raw bytes to send as the HTTP body
-	resBytes, err := json.Marshal(res.JSON)
+	resBytes, err := json.ConfigCompatibleWithStandardLibrary.Marshal(res.JSON)
 	if err != nil {
 		r.Logger.WithError(err).Error("Failed to marshal JSONResponse")
 		// this should never fail to be marshalled so drop err to the floor
 		res = util.MessageResponse(http.StatusNotFound, "Download request failed: "+err.Error())
-		resBytes, _ = json.Marshal(res.JSON)
+		resBytes, _ = json.ConfigCompatibleWithStandardLibrary.Marshal(res.JSON)
 	}
 
 	// Set status code and write the body

--- a/mediaapi/routing/download.go
+++ b/mediaapi/routing/download.go
@@ -16,7 +16,7 @@ package routing
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"io"
 	"mime"
@@ -146,12 +146,12 @@ func Download(
 
 func (r *downloadRequest) jsonErrorResponse(w http.ResponseWriter, res util.JSONResponse) {
 	// Marshal JSON response into raw bytes to send as the HTTP body
-	resBytes, err := jsoniter.Marshal(res.JSON)
+	resBytes, err := json.Marshal(res.JSON)
 	if err != nil {
 		r.Logger.WithError(err).Error("Failed to marshal JSONResponse")
 		// this should never fail to be marshalled so drop err to the floor
 		res = util.MessageResponse(http.StatusNotFound, "Download request failed: "+err.Error())
-		resBytes, _ = jsoniter.Marshal(res.JSON)
+		resBytes, _ = json.Marshal(res.JSON)
 	}
 
 	// Set status code and write the body

--- a/mediaapi/routing/download.go
+++ b/mediaapi/routing/download.go
@@ -16,7 +16,6 @@ package routing
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"io"
 	"mime"
@@ -29,6 +28,8 @@ import (
 	"strings"
 	"sync"
 	"unicode"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/internal/config"

--- a/roomserver/acls/acls.go
+++ b/roomserver/acls/acls.go
@@ -16,7 +16,7 @@ package acls
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"net"
 	"regexp"
@@ -88,7 +88,7 @@ func compileACLRegex(orig string) (*regexp.Regexp, error) {
 
 func (s *ServerACLs) OnServerACLUpdate(state *gomatrixserverlib.Event) {
 	acls := &serverACL{}
-	if err := json.Unmarshal(state.Content(), &acls.ServerACL); err != nil {
+	if err := jsoniter.Unmarshal(state.Content(), &acls.ServerACL); err != nil {
 		logrus.WithError(err).Errorf("Failed to unmarshal state content for server ACLs")
 		return
 	}

--- a/roomserver/acls/acls.go
+++ b/roomserver/acls/acls.go
@@ -16,7 +16,7 @@ package acls
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"net"
 	"regexp"
@@ -88,7 +88,7 @@ func compileACLRegex(orig string) (*regexp.Regexp, error) {
 
 func (s *ServerACLs) OnServerACLUpdate(state *gomatrixserverlib.Event) {
 	acls := &serverACL{}
-	if err := jsoniter.Unmarshal(state.Content(), &acls.ServerACL); err != nil {
+	if err := json.Unmarshal(state.Content(), &acls.ServerACL); err != nil {
 		logrus.WithError(err).Errorf("Failed to unmarshal state content for server ACLs")
 		return
 	}

--- a/roomserver/acls/acls.go
+++ b/roomserver/acls/acls.go
@@ -89,7 +89,7 @@ func compileACLRegex(orig string) (*regexp.Regexp, error) {
 
 func (s *ServerACLs) OnServerACLUpdate(state *gomatrixserverlib.Event) {
 	acls := &serverACL{}
-	if err := json.Unmarshal(state.Content(), &acls.ServerACL); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(state.Content(), &acls.ServerACL); err != nil {
 		logrus.WithError(err).Errorf("Failed to unmarshal state content for server ACLs")
 		return
 	}

--- a/roomserver/acls/acls.go
+++ b/roomserver/acls/acls.go
@@ -16,12 +16,13 @@ package acls
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"net"
 	"regexp"
 	"strings"
 	"sync"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/sirupsen/logrus"

--- a/roomserver/api/api_trace.go
+++ b/roomserver/api/api_trace.go
@@ -2,8 +2,9 @@ package api
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"fmt"
+
+	json "github.com/json-iterator/go"
 
 	fsAPI "github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/util"

--- a/roomserver/api/api_trace.go
+++ b/roomserver/api/api_trace.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 
 	fsAPI "github.com/matrix-org/dendrite/federationsender/api"
@@ -306,7 +306,7 @@ func (t *RoomserverInternalAPITrace) QueryServerBannedFromRoom(ctx context.Conte
 }
 
 func js(thing interface{}) string {
-	b, err := json.Marshal(thing)
+	b, err := jsoniter.Marshal(thing)
 	if err != nil {
 		return fmt.Sprintf("Marshal error:%s", err)
 	}

--- a/roomserver/api/api_trace.go
+++ b/roomserver/api/api_trace.go
@@ -307,7 +307,7 @@ func (t *RoomserverInternalAPITrace) QueryServerBannedFromRoom(ctx context.Conte
 }
 
 func js(thing interface{}) string {
-	b, err := json.Marshal(thing)
+	b, err := json.ConfigCompatibleWithStandardLibrary.Marshal(thing)
 	if err != nil {
 		return fmt.Sprintf("Marshal error:%s", err)
 	}

--- a/roomserver/api/api_trace.go
+++ b/roomserver/api/api_trace.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 
 	fsAPI "github.com/matrix-org/dendrite/federationsender/api"
@@ -306,7 +306,7 @@ func (t *RoomserverInternalAPITrace) QueryServerBannedFromRoom(ctx context.Conte
 }
 
 func js(thing interface{}) string {
-	b, err := jsoniter.Marshal(thing)
+	b, err := json.Marshal(thing)
 	if err != nil {
 		return fmt.Sprintf("Marshal error:%s", err)
 	}

--- a/roomserver/api/perform.go
+++ b/roomserver/api/perform.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"net/http"
 
@@ -54,7 +54,7 @@ func (p *PerformError) JSONResponse() util.JSONResponse {
 		return util.JSONResponse{
 			Code: p.RemoteCode,
 			// TODO: Should we assert this is in fact JSON? E.g gjson parse?
-			JSON: json.RawMessage(p.Msg),
+			JSON: jsoniter.RawMessage(p.Msg),
 		}
 	default:
 		return util.ErrorResponse(p)

--- a/roomserver/api/perform.go
+++ b/roomserver/api/perform.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"net/http"
 
@@ -54,7 +54,7 @@ func (p *PerformError) JSONResponse() util.JSONResponse {
 		return util.JSONResponse{
 			Code: p.RemoteCode,
 			// TODO: Should we assert this is in fact JSON? E.g gjson parse?
-			JSON: jsoniter.RawMessage(p.Msg),
+			JSON: json.RawMessage(p.Msg),
 		}
 	default:
 		return util.ErrorResponse(p)

--- a/roomserver/api/perform.go
+++ b/roomserver/api/perform.go
@@ -1,9 +1,10 @@
 package api
 
 import (
-	json "github.com/json-iterator/go"
 	"fmt"
 	"net/http"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/gomatrixserverlib"

--- a/roomserver/api/query.go
+++ b/roomserver/api/query.go
@@ -352,12 +352,12 @@ func (r *QueryBulkStateContentResponse) MarshalJSON() ([]byte, error) {
 			se[fmt.Sprintf("%s\x1F%s\x1F%s", roomID, tuple.EventType, tuple.StateKey)] = event
 		}
 	}
-	return json.Marshal(se)
+	return json.ConfigCompatibleWithStandardLibrary.Marshal(se)
 }
 
 func (r *QueryBulkStateContentResponse) UnmarshalJSON(data []byte) error {
 	wireFormat := make(map[string]string)
-	err := json.Unmarshal(data, &wireFormat)
+	err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(data, &wireFormat)
 	if err != nil {
 		return err
 	}
@@ -383,12 +383,12 @@ func (r *QueryCurrentStateResponse) MarshalJSON() ([]byte, error) {
 		// use 0x1F (unit separator) as the delimiter between type/state key,
 		se[fmt.Sprintf("%s\x1F%s", k.EventType, k.StateKey)] = v
 	}
-	return json.Marshal(se)
+	return json.ConfigCompatibleWithStandardLibrary.Marshal(se)
 }
 
 func (r *QueryCurrentStateResponse) UnmarshalJSON(data []byte) error {
 	res := make(map[string]*gomatrixserverlib.HeaderedEvent)
-	err := json.Unmarshal(data, &res)
+	err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(data, &res)
 	if err != nil {
 		return err
 	}

--- a/roomserver/api/query.go
+++ b/roomserver/api/query.go
@@ -17,7 +17,7 @@
 package api
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"strings"
 
@@ -351,12 +351,12 @@ func (r *QueryBulkStateContentResponse) MarshalJSON() ([]byte, error) {
 			se[fmt.Sprintf("%s\x1F%s\x1F%s", roomID, tuple.EventType, tuple.StateKey)] = event
 		}
 	}
-	return jsoniter.Marshal(se)
+	return json.Marshal(se)
 }
 
 func (r *QueryBulkStateContentResponse) UnmarshalJSON(data []byte) error {
 	wireFormat := make(map[string]string)
-	err := jsoniter.Unmarshal(data, &wireFormat)
+	err := json.Unmarshal(data, &wireFormat)
 	if err != nil {
 		return err
 	}
@@ -382,12 +382,12 @@ func (r *QueryCurrentStateResponse) MarshalJSON() ([]byte, error) {
 		// use 0x1F (unit separator) as the delimiter between type/state key,
 		se[fmt.Sprintf("%s\x1F%s", k.EventType, k.StateKey)] = v
 	}
-	return jsoniter.Marshal(se)
+	return json.Marshal(se)
 }
 
 func (r *QueryCurrentStateResponse) UnmarshalJSON(data []byte) error {
 	res := make(map[string]*gomatrixserverlib.HeaderedEvent)
-	err := jsoniter.Unmarshal(data, &res)
+	err := json.Unmarshal(data, &res)
 	if err != nil {
 		return err
 	}

--- a/roomserver/api/query.go
+++ b/roomserver/api/query.go
@@ -17,7 +17,7 @@
 package api
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"strings"
 
@@ -351,12 +351,12 @@ func (r *QueryBulkStateContentResponse) MarshalJSON() ([]byte, error) {
 			se[fmt.Sprintf("%s\x1F%s\x1F%s", roomID, tuple.EventType, tuple.StateKey)] = event
 		}
 	}
-	return json.Marshal(se)
+	return jsoniter.Marshal(se)
 }
 
 func (r *QueryBulkStateContentResponse) UnmarshalJSON(data []byte) error {
 	wireFormat := make(map[string]string)
-	err := json.Unmarshal(data, &wireFormat)
+	err := jsoniter.Unmarshal(data, &wireFormat)
 	if err != nil {
 		return err
 	}
@@ -382,12 +382,12 @@ func (r *QueryCurrentStateResponse) MarshalJSON() ([]byte, error) {
 		// use 0x1F (unit separator) as the delimiter between type/state key,
 		se[fmt.Sprintf("%s\x1F%s", k.EventType, k.StateKey)] = v
 	}
-	return json.Marshal(se)
+	return jsoniter.Marshal(se)
 }
 
 func (r *QueryCurrentStateResponse) UnmarshalJSON(data []byte) error {
 	res := make(map[string]*gomatrixserverlib.HeaderedEvent)
-	err := json.Unmarshal(data, &res)
+	err := jsoniter.Unmarshal(data, &res)
 	if err != nil {
 		return err
 	}

--- a/roomserver/api/query.go
+++ b/roomserver/api/query.go
@@ -17,9 +17,10 @@
 package api
 
 import (
-	json "github.com/json-iterator/go"
 	"fmt"
 	"strings"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/gomatrixserverlib"

--- a/roomserver/auth/auth.go
+++ b/roomserver/auth/auth.go
@@ -65,7 +65,7 @@ func HistoryVisibilityForRoom(authEvents []gomatrixserverlib.Event) string {
 		content := struct {
 			HistoryVisibility string `json:"history_visibility"`
 		}{}
-		if err := json.Unmarshal(ev.Content(), &content); err != nil {
+		if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(ev.Content(), &content); err != nil {
 			break // value is not understood
 		}
 		for _, s := range knownStates {

--- a/roomserver/auth/auth.go
+++ b/roomserver/auth/auth.go
@@ -13,7 +13,7 @@
 package auth
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/gomatrixserverlib"
 )
@@ -65,7 +65,7 @@ func HistoryVisibilityForRoom(authEvents []gomatrixserverlib.Event) string {
 		content := struct {
 			HistoryVisibility string `json:"history_visibility"`
 		}{}
-		if err := jsoniter.Unmarshal(ev.Content(), &content); err != nil {
+		if err := json.Unmarshal(ev.Content(), &content); err != nil {
 			break // value is not understood
 		}
 		for _, s := range knownStates {

--- a/roomserver/auth/auth.go
+++ b/roomserver/auth/auth.go
@@ -13,7 +13,7 @@
 package auth
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 
 	"github.com/matrix-org/gomatrixserverlib"
 )
@@ -65,7 +65,7 @@ func HistoryVisibilityForRoom(authEvents []gomatrixserverlib.Event) string {
 		content := struct {
 			HistoryVisibility string `json:"history_visibility"`
 		}{}
-		if err := json.Unmarshal(ev.Content(), &content); err != nil {
+		if err := jsoniter.Unmarshal(ev.Content(), &content); err != nil {
 			break // value is not understood
 		}
 		for _, s := range knownStates {

--- a/roomserver/internal/alias.go
+++ b/roomserver/internal/alias.go
@@ -199,7 +199,7 @@ func (r *RoomserverInternalAPI) sendUpdatedAliasesEvent(
 		return err
 	}
 	content := roomAliasesContent{Aliases: aliases}
-	rawContent, err := json.Marshal(content)
+	rawContent, err := json.ConfigCompatibleWithStandardLibrary.Marshal(content)
 	if err != nil {
 		return err
 	}

--- a/roomserver/internal/alias.go
+++ b/roomserver/internal/alias.go
@@ -16,10 +16,11 @@ package internal
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"errors"
 	"fmt"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"

--- a/roomserver/internal/alias.go
+++ b/roomserver/internal/alias.go
@@ -16,7 +16,7 @@ package internal
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"errors"
 	"fmt"
 	"time"
@@ -198,11 +198,11 @@ func (r *RoomserverInternalAPI) sendUpdatedAliasesEvent(
 		return err
 	}
 	content := roomAliasesContent{Aliases: aliases}
-	rawContent, err := json.Marshal(content)
+	rawContent, err := jsoniter.Marshal(content)
 	if err != nil {
 		return err
 	}
-	err = builder.SetContent(json.RawMessage(rawContent))
+	err = builder.SetContent(jsoniter.RawMessage(rawContent))
 	if err != nil {
 		return err
 	}

--- a/roomserver/internal/alias.go
+++ b/roomserver/internal/alias.go
@@ -16,7 +16,7 @@ package internal
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"errors"
 	"fmt"
 	"time"
@@ -198,11 +198,11 @@ func (r *RoomserverInternalAPI) sendUpdatedAliasesEvent(
 		return err
 	}
 	content := roomAliasesContent{Aliases: aliases}
-	rawContent, err := jsoniter.Marshal(content)
+	rawContent, err := json.Marshal(content)
 	if err != nil {
 		return err
 	}
-	err = builder.SetContent(jsoniter.RawMessage(rawContent))
+	err = builder.SetContent(json.RawMessage(rawContent))
 	if err != nil {
 		return err
 	}

--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -17,7 +17,7 @@ package input
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"sync"
 	"time"
 
@@ -73,7 +73,7 @@ func (w *inputWorker) start() {
 func (r *Inputer) WriteOutputEvents(roomID string, updates []api.OutputEvent) error {
 	messages := make([]*sarama.ProducerMessage, len(updates))
 	for i := range updates {
-		value, err := json.Marshal(updates[i])
+		value, err := jsoniter.Marshal(updates[i])
 		if err != nil {
 			return err
 		}

--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -17,9 +17,10 @@ package input
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"sync"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"
 	"github.com/matrix-org/dendrite/roomserver/acls"

--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -74,7 +74,7 @@ func (w *inputWorker) start() {
 func (r *Inputer) WriteOutputEvents(roomID string, updates []api.OutputEvent) error {
 	messages := make([]*sarama.ProducerMessage, len(updates))
 	for i := range updates {
-		value, err := json.Marshal(updates[i])
+		value, err := json.ConfigCompatibleWithStandardLibrary.Marshal(updates[i])
 		if err != nil {
 			return err
 		}

--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -17,7 +17,7 @@ package input
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"sync"
 	"time"
 
@@ -73,7 +73,7 @@ func (w *inputWorker) start() {
 func (r *Inputer) WriteOutputEvents(roomID string, updates []api.OutputEvent) error {
 	messages := make([]*sarama.ProducerMessage, len(updates))
 	for i := range updates {
-		value, err := jsoniter.Marshal(updates[i])
+		value, err := json.Marshal(updates[i])
 		if err != nil {
 			return err
 		}

--- a/roomserver/internal/perform/perform_peek.go
+++ b/roomserver/internal/perform/perform_peek.go
@@ -16,7 +16,7 @@ package perform
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"strings"
 
@@ -166,7 +166,7 @@ func (r *Peeker) performPeekRoomByID(
 	ev, _ := r.DB.GetStateEvent(ctx, roomID, "m.room.history_visibility", "")
 	if ev != nil {
 		content := map[string]string{}
-		if err = jsoniter.Unmarshal(ev.Content(), &content); err != nil {
+		if err = json.Unmarshal(ev.Content(), &content); err != nil {
 			util.GetLogger(ctx).WithError(err).Error("json.Unmarshal for history visibility failed")
 			return
 		}

--- a/roomserver/internal/perform/perform_peek.go
+++ b/roomserver/internal/perform/perform_peek.go
@@ -16,9 +16,10 @@ package perform
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"strings"
+
+	json "github.com/json-iterator/go"
 
 	fsAPI "github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/dendrite/internal/config"

--- a/roomserver/internal/perform/perform_peek.go
+++ b/roomserver/internal/perform/perform_peek.go
@@ -16,7 +16,7 @@ package perform
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"strings"
 
@@ -166,7 +166,7 @@ func (r *Peeker) performPeekRoomByID(
 	ev, _ := r.DB.GetStateEvent(ctx, roomID, "m.room.history_visibility", "")
 	if ev != nil {
 		content := map[string]string{}
-		if err = json.Unmarshal(ev.Content(), &content); err != nil {
+		if err = jsoniter.Unmarshal(ev.Content(), &content); err != nil {
 			util.GetLogger(ctx).WithError(err).Error("json.Unmarshal for history visibility failed")
 			return
 		}

--- a/roomserver/internal/perform/perform_peek.go
+++ b/roomserver/internal/perform/perform_peek.go
@@ -167,7 +167,7 @@ func (r *Peeker) performPeekRoomByID(
 	ev, _ := r.DB.GetStateEvent(ctx, roomID, "m.room.history_visibility", "")
 	if ev != nil {
 		content := map[string]string{}
-		if err = json.Unmarshal(ev.Content(), &content); err != nil {
+		if err = json.ConfigCompatibleWithStandardLibrary.Unmarshal(ev.Content(), &content); err != nil {
 			util.GetLogger(ctx).WithError(err).Error("json.Unmarshal for history visibility failed")
 			return
 		}

--- a/roomserver/internal/query/query_test.go
+++ b/roomserver/internal/query/query_test.go
@@ -16,7 +16,7 @@ package query
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"testing"
 
 	"github.com/matrix-org/dendrite/internal/test"
@@ -49,7 +49,7 @@ func (db *getEventDB) addFakeEvent(eventID string, authIDs []string) error {
 		"auth_events": authEvents,
 	}
 
-	eventJSON, err := json.Marshal(&builder)
+	eventJSON, err := jsoniter.Marshal(&builder)
 	if err != nil {
 		return err
 	}

--- a/roomserver/internal/query/query_test.go
+++ b/roomserver/internal/query/query_test.go
@@ -50,7 +50,7 @@ func (db *getEventDB) addFakeEvent(eventID string, authIDs []string) error {
 		"auth_events": authEvents,
 	}
 
-	eventJSON, err := json.Marshal(&builder)
+	eventJSON, err := json.ConfigCompatibleWithStandardLibrary.Marshal(&builder)
 	if err != nil {
 		return err
 	}

--- a/roomserver/internal/query/query_test.go
+++ b/roomserver/internal/query/query_test.go
@@ -16,8 +16,9 @@ package query
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"testing"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal/test"
 	"github.com/matrix-org/dendrite/roomserver/types"

--- a/roomserver/internal/query/query_test.go
+++ b/roomserver/internal/query/query_test.go
@@ -16,7 +16,7 @@ package query
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"testing"
 
 	"github.com/matrix-org/dendrite/internal/test"
@@ -49,7 +49,7 @@ func (db *getEventDB) addFakeEvent(eventID string, authIDs []string) error {
 		"auth_events": authEvents,
 	}
 
-	eventJSON, err := jsoniter.Marshal(&builder)
+	eventJSON, err := json.Marshal(&builder)
 	if err != nil {
 		return err
 	}

--- a/roomserver/inthttp/server.go
+++ b/roomserver/inthttp/server.go
@@ -1,8 +1,9 @@
 package inthttp
 
 import (
-	json "github.com/json-iterator/go"
 	"net/http"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/internal/httputil"

--- a/roomserver/inthttp/server.go
+++ b/roomserver/inthttp/server.go
@@ -1,7 +1,7 @@
 package inthttp
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -17,7 +17,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("inputRoomEvents", func(req *http.Request) util.JSONResponse {
 			var request api.InputRoomEventsRequest
 			var response api.InputRoomEventsResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			r.InputRoomEvents(req.Context(), &request, &response)
@@ -28,7 +28,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("performInvite", func(req *http.Request) util.JSONResponse {
 			var request api.PerformInviteRequest
 			var response api.PerformInviteResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := r.PerformInvite(req.Context(), &request, &response); err != nil {
@@ -41,7 +41,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("performJoin", func(req *http.Request) util.JSONResponse {
 			var request api.PerformJoinRequest
 			var response api.PerformJoinResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			r.PerformJoin(req.Context(), &request, &response)
@@ -52,7 +52,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("performLeave", func(req *http.Request) util.JSONResponse {
 			var request api.PerformLeaveRequest
 			var response api.PerformLeaveResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := r.PerformLeave(req.Context(), &request, &response); err != nil {
@@ -65,7 +65,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("performPeek", func(req *http.Request) util.JSONResponse {
 			var request api.PerformPeekRequest
 			var response api.PerformPeekResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			r.PerformPeek(req.Context(), &request, &response)
@@ -76,7 +76,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("performPublish", func(req *http.Request) util.JSONResponse {
 			var request api.PerformPublishRequest
 			var response api.PerformPublishResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			r.PerformPublish(req.Context(), &request, &response)
@@ -88,7 +88,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryPublishedRooms", func(req *http.Request) util.JSONResponse {
 			var request api.QueryPublishedRoomsRequest
 			var response api.QueryPublishedRoomsResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryPublishedRooms(req.Context(), &request, &response); err != nil {
@@ -102,7 +102,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryLatestEventsAndState", func(req *http.Request) util.JSONResponse {
 			var request api.QueryLatestEventsAndStateRequest
 			var response api.QueryLatestEventsAndStateResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryLatestEventsAndState(req.Context(), &request, &response); err != nil {
@@ -116,7 +116,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryStateAfterEvents", func(req *http.Request) util.JSONResponse {
 			var request api.QueryStateAfterEventsRequest
 			var response api.QueryStateAfterEventsResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryStateAfterEvents(req.Context(), &request, &response); err != nil {
@@ -130,7 +130,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryMissingAuthPrevEvents", func(req *http.Request) util.JSONResponse {
 			var request api.QueryMissingAuthPrevEventsRequest
 			var response api.QueryMissingAuthPrevEventsResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryMissingAuthPrevEvents(req.Context(), &request, &response); err != nil {
@@ -144,7 +144,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryEventsByID", func(req *http.Request) util.JSONResponse {
 			var request api.QueryEventsByIDRequest
 			var response api.QueryEventsByIDResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryEventsByID(req.Context(), &request, &response); err != nil {
@@ -158,7 +158,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("QueryMembershipForUser", func(req *http.Request) util.JSONResponse {
 			var request api.QueryMembershipForUserRequest
 			var response api.QueryMembershipForUserResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryMembershipForUser(req.Context(), &request, &response); err != nil {
@@ -172,7 +172,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryMembershipsForRoom", func(req *http.Request) util.JSONResponse {
 			var request api.QueryMembershipsForRoomRequest
 			var response api.QueryMembershipsForRoomResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryMembershipsForRoom(req.Context(), &request, &response); err != nil {
@@ -186,7 +186,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryServerJoinedToRoom", func(req *http.Request) util.JSONResponse {
 			var request api.QueryServerJoinedToRoomRequest
 			var response api.QueryServerJoinedToRoomResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryServerJoinedToRoom(req.Context(), &request, &response); err != nil {
@@ -200,7 +200,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryServerAllowedToSeeEvent", func(req *http.Request) util.JSONResponse {
 			var request api.QueryServerAllowedToSeeEventRequest
 			var response api.QueryServerAllowedToSeeEventResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryServerAllowedToSeeEvent(req.Context(), &request, &response); err != nil {
@@ -214,7 +214,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryMissingEvents", func(req *http.Request) util.JSONResponse {
 			var request api.QueryMissingEventsRequest
 			var response api.QueryMissingEventsResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryMissingEvents(req.Context(), &request, &response); err != nil {
@@ -228,7 +228,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryStateAndAuthChain", func(req *http.Request) util.JSONResponse {
 			var request api.QueryStateAndAuthChainRequest
 			var response api.QueryStateAndAuthChainResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryStateAndAuthChain(req.Context(), &request, &response); err != nil {
@@ -242,7 +242,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("PerformBackfill", func(req *http.Request) util.JSONResponse {
 			var request api.PerformBackfillRequest
 			var response api.PerformBackfillResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.PerformBackfill(req.Context(), &request, &response); err != nil {
@@ -256,7 +256,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("QueryRoomVersionCapabilities", func(req *http.Request) util.JSONResponse {
 			var request api.QueryRoomVersionCapabilitiesRequest
 			var response api.QueryRoomVersionCapabilitiesResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryRoomVersionCapabilities(req.Context(), &request, &response); err != nil {
@@ -270,7 +270,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("QueryRoomVersionForRoom", func(req *http.Request) util.JSONResponse {
 			var request api.QueryRoomVersionForRoomRequest
 			var response api.QueryRoomVersionForRoomResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryRoomVersionForRoom(req.Context(), &request, &response); err != nil {
@@ -284,7 +284,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("setRoomAlias", func(req *http.Request) util.JSONResponse {
 			var request api.SetRoomAliasRequest
 			var response api.SetRoomAliasResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.SetRoomAlias(req.Context(), &request, &response); err != nil {
@@ -298,7 +298,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("GetRoomIDForAlias", func(req *http.Request) util.JSONResponse {
 			var request api.GetRoomIDForAliasRequest
 			var response api.GetRoomIDForAliasResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.GetRoomIDForAlias(req.Context(), &request, &response); err != nil {
@@ -312,7 +312,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("GetCreatorIDForAlias", func(req *http.Request) util.JSONResponse {
 			var request api.GetCreatorIDForAliasRequest
 			var response api.GetCreatorIDForAliasResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.GetCreatorIDForAlias(req.Context(), &request, &response); err != nil {
@@ -326,7 +326,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("getAliasesForRoomID", func(req *http.Request) util.JSONResponse {
 			var request api.GetAliasesForRoomIDRequest
 			var response api.GetAliasesForRoomIDResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.GetAliasesForRoomID(req.Context(), &request, &response); err != nil {
@@ -340,7 +340,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("removeRoomAlias", func(req *http.Request) util.JSONResponse {
 			var request api.RemoveRoomAliasRequest
 			var response api.RemoveRoomAliasResponse
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.RemoveRoomAlias(req.Context(), &request, &response); err != nil {
@@ -353,7 +353,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryCurrentState", func(req *http.Request) util.JSONResponse {
 			request := api.QueryCurrentStateRequest{}
 			response := api.QueryCurrentStateResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := r.QueryCurrentState(req.Context(), &request, &response); err != nil {
@@ -366,7 +366,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryRoomsForUser", func(req *http.Request) util.JSONResponse {
 			request := api.QueryRoomsForUserRequest{}
 			response := api.QueryRoomsForUserResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := r.QueryRoomsForUser(req.Context(), &request, &response); err != nil {
@@ -379,7 +379,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryBulkStateContent", func(req *http.Request) util.JSONResponse {
 			request := api.QueryBulkStateContentRequest{}
 			response := api.QueryBulkStateContentResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := r.QueryBulkStateContent(req.Context(), &request, &response); err != nil {
@@ -392,7 +392,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("querySharedUsers", func(req *http.Request) util.JSONResponse {
 			request := api.QuerySharedUsersRequest{}
 			response := api.QuerySharedUsersResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := r.QuerySharedUsers(req.Context(), &request, &response); err != nil {
@@ -405,7 +405,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryKnownUsers", func(req *http.Request) util.JSONResponse {
 			request := api.QueryKnownUsersRequest{}
 			response := api.QueryKnownUsersResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := r.QueryKnownUsers(req.Context(), &request, &response); err != nil {
@@ -418,7 +418,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryServerBannedFromRoom", func(req *http.Request) util.JSONResponse {
 			request := api.QueryServerBannedFromRoomRequest{}
 			response := api.QueryServerBannedFromRoomResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := r.QueryServerBannedFromRoom(req.Context(), &request, &response); err != nil {

--- a/roomserver/inthttp/server.go
+++ b/roomserver/inthttp/server.go
@@ -1,7 +1,7 @@
 package inthttp
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -17,7 +17,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("inputRoomEvents", func(req *http.Request) util.JSONResponse {
 			var request api.InputRoomEventsRequest
 			var response api.InputRoomEventsResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			r.InputRoomEvents(req.Context(), &request, &response)
@@ -28,7 +28,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("performInvite", func(req *http.Request) util.JSONResponse {
 			var request api.PerformInviteRequest
 			var response api.PerformInviteResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := r.PerformInvite(req.Context(), &request, &response); err != nil {
@@ -41,7 +41,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("performJoin", func(req *http.Request) util.JSONResponse {
 			var request api.PerformJoinRequest
 			var response api.PerformJoinResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			r.PerformJoin(req.Context(), &request, &response)
@@ -52,7 +52,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("performLeave", func(req *http.Request) util.JSONResponse {
 			var request api.PerformLeaveRequest
 			var response api.PerformLeaveResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := r.PerformLeave(req.Context(), &request, &response); err != nil {
@@ -65,7 +65,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("performPeek", func(req *http.Request) util.JSONResponse {
 			var request api.PerformPeekRequest
 			var response api.PerformPeekResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			r.PerformPeek(req.Context(), &request, &response)
@@ -76,7 +76,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("performPublish", func(req *http.Request) util.JSONResponse {
 			var request api.PerformPublishRequest
 			var response api.PerformPublishResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			r.PerformPublish(req.Context(), &request, &response)
@@ -88,7 +88,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryPublishedRooms", func(req *http.Request) util.JSONResponse {
 			var request api.QueryPublishedRoomsRequest
 			var response api.QueryPublishedRoomsResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryPublishedRooms(req.Context(), &request, &response); err != nil {
@@ -102,7 +102,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryLatestEventsAndState", func(req *http.Request) util.JSONResponse {
 			var request api.QueryLatestEventsAndStateRequest
 			var response api.QueryLatestEventsAndStateResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryLatestEventsAndState(req.Context(), &request, &response); err != nil {
@@ -116,7 +116,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryStateAfterEvents", func(req *http.Request) util.JSONResponse {
 			var request api.QueryStateAfterEventsRequest
 			var response api.QueryStateAfterEventsResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryStateAfterEvents(req.Context(), &request, &response); err != nil {
@@ -130,7 +130,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryMissingAuthPrevEvents", func(req *http.Request) util.JSONResponse {
 			var request api.QueryMissingAuthPrevEventsRequest
 			var response api.QueryMissingAuthPrevEventsResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryMissingAuthPrevEvents(req.Context(), &request, &response); err != nil {
@@ -144,7 +144,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryEventsByID", func(req *http.Request) util.JSONResponse {
 			var request api.QueryEventsByIDRequest
 			var response api.QueryEventsByIDResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryEventsByID(req.Context(), &request, &response); err != nil {
@@ -158,7 +158,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("QueryMembershipForUser", func(req *http.Request) util.JSONResponse {
 			var request api.QueryMembershipForUserRequest
 			var response api.QueryMembershipForUserResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryMembershipForUser(req.Context(), &request, &response); err != nil {
@@ -172,7 +172,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryMembershipsForRoom", func(req *http.Request) util.JSONResponse {
 			var request api.QueryMembershipsForRoomRequest
 			var response api.QueryMembershipsForRoomResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryMembershipsForRoom(req.Context(), &request, &response); err != nil {
@@ -186,7 +186,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryServerJoinedToRoom", func(req *http.Request) util.JSONResponse {
 			var request api.QueryServerJoinedToRoomRequest
 			var response api.QueryServerJoinedToRoomResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryServerJoinedToRoom(req.Context(), &request, &response); err != nil {
@@ -200,7 +200,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryServerAllowedToSeeEvent", func(req *http.Request) util.JSONResponse {
 			var request api.QueryServerAllowedToSeeEventRequest
 			var response api.QueryServerAllowedToSeeEventResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryServerAllowedToSeeEvent(req.Context(), &request, &response); err != nil {
@@ -214,7 +214,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryMissingEvents", func(req *http.Request) util.JSONResponse {
 			var request api.QueryMissingEventsRequest
 			var response api.QueryMissingEventsResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryMissingEvents(req.Context(), &request, &response); err != nil {
@@ -228,7 +228,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryStateAndAuthChain", func(req *http.Request) util.JSONResponse {
 			var request api.QueryStateAndAuthChainRequest
 			var response api.QueryStateAndAuthChainResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryStateAndAuthChain(req.Context(), &request, &response); err != nil {
@@ -242,7 +242,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("PerformBackfill", func(req *http.Request) util.JSONResponse {
 			var request api.PerformBackfillRequest
 			var response api.PerformBackfillResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.PerformBackfill(req.Context(), &request, &response); err != nil {
@@ -256,7 +256,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("QueryRoomVersionCapabilities", func(req *http.Request) util.JSONResponse {
 			var request api.QueryRoomVersionCapabilitiesRequest
 			var response api.QueryRoomVersionCapabilitiesResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryRoomVersionCapabilities(req.Context(), &request, &response); err != nil {
@@ -270,7 +270,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("QueryRoomVersionForRoom", func(req *http.Request) util.JSONResponse {
 			var request api.QueryRoomVersionForRoomRequest
 			var response api.QueryRoomVersionForRoomResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.QueryRoomVersionForRoom(req.Context(), &request, &response); err != nil {
@@ -284,7 +284,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("setRoomAlias", func(req *http.Request) util.JSONResponse {
 			var request api.SetRoomAliasRequest
 			var response api.SetRoomAliasResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.SetRoomAlias(req.Context(), &request, &response); err != nil {
@@ -298,7 +298,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("GetRoomIDForAlias", func(req *http.Request) util.JSONResponse {
 			var request api.GetRoomIDForAliasRequest
 			var response api.GetRoomIDForAliasResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.GetRoomIDForAlias(req.Context(), &request, &response); err != nil {
@@ -312,7 +312,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("GetCreatorIDForAlias", func(req *http.Request) util.JSONResponse {
 			var request api.GetCreatorIDForAliasRequest
 			var response api.GetCreatorIDForAliasResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.GetCreatorIDForAlias(req.Context(), &request, &response); err != nil {
@@ -326,7 +326,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("getAliasesForRoomID", func(req *http.Request) util.JSONResponse {
 			var request api.GetAliasesForRoomIDRequest
 			var response api.GetAliasesForRoomIDResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.GetAliasesForRoomID(req.Context(), &request, &response); err != nil {
@@ -340,7 +340,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("removeRoomAlias", func(req *http.Request) util.JSONResponse {
 			var request api.RemoveRoomAliasRequest
 			var response api.RemoveRoomAliasResponse
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.ErrorResponse(err)
 			}
 			if err := r.RemoveRoomAlias(req.Context(), &request, &response); err != nil {
@@ -353,7 +353,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryCurrentState", func(req *http.Request) util.JSONResponse {
 			request := api.QueryCurrentStateRequest{}
 			response := api.QueryCurrentStateResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := r.QueryCurrentState(req.Context(), &request, &response); err != nil {
@@ -366,7 +366,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryRoomsForUser", func(req *http.Request) util.JSONResponse {
 			request := api.QueryRoomsForUserRequest{}
 			response := api.QueryRoomsForUserResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := r.QueryRoomsForUser(req.Context(), &request, &response); err != nil {
@@ -379,7 +379,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryBulkStateContent", func(req *http.Request) util.JSONResponse {
 			request := api.QueryBulkStateContentRequest{}
 			response := api.QueryBulkStateContentResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := r.QueryBulkStateContent(req.Context(), &request, &response); err != nil {
@@ -392,7 +392,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("querySharedUsers", func(req *http.Request) util.JSONResponse {
 			request := api.QuerySharedUsersRequest{}
 			response := api.QuerySharedUsersResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := r.QuerySharedUsers(req.Context(), &request, &response); err != nil {
@@ -405,7 +405,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryKnownUsers", func(req *http.Request) util.JSONResponse {
 			request := api.QueryKnownUsersRequest{}
 			response := api.QueryKnownUsersResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := r.QueryKnownUsers(req.Context(), &request, &response); err != nil {
@@ -418,7 +418,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		httputil.MakeInternalAPI("queryServerBannedFromRoom", func(req *http.Request) util.JSONResponse {
 			request := api.QueryServerBannedFromRoomRequest{}
 			response := api.QueryServerBannedFromRoomResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := r.QueryServerBannedFromRoom(req.Context(), &request, &response); err != nil {

--- a/roomserver/roomserver_test.go
+++ b/roomserver/roomserver_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"os"
 	"reflect"
@@ -46,10 +46,10 @@ func (p *dummyProducer) SendMessage(msg *sarama.ProducerMessage) (partition int3
 		return 0, 0, nil
 	}
 	be := msg.Value.(sarama.ByteEncoder)
-	b := jsoniter.RawMessage(be)
+	b := json.RawMessage(be)
 	fmt.Println("SENDING >>>>>>>> ", string(b))
 	var out api.OutputEvent
-	err = jsoniter.Unmarshal(b, &out)
+	err = json.Unmarshal(b, &out)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/roomserver/roomserver_test.go
+++ b/roomserver/roomserver_test.go
@@ -50,7 +50,7 @@ func (p *dummyProducer) SendMessage(msg *sarama.ProducerMessage) (partition int3
 	b := json.RawMessage(be)
 	fmt.Println("SENDING >>>>>>>> ", string(b))
 	var out api.OutputEvent
-	err = json.Unmarshal(b, &out)
+	err = json.ConfigCompatibleWithStandardLibrary.Unmarshal(b, &out)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/roomserver/roomserver_test.go
+++ b/roomserver/roomserver_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"os"
 	"reflect"
 	"testing"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"
 	"github.com/matrix-org/dendrite/internal/caching"

--- a/roomserver/roomserver_test.go
+++ b/roomserver/roomserver_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"os"
 	"reflect"
@@ -46,10 +46,10 @@ func (p *dummyProducer) SendMessage(msg *sarama.ProducerMessage) (partition int3
 		return 0, 0, nil
 	}
 	be := msg.Value.(sarama.ByteEncoder)
-	b := json.RawMessage(be)
+	b := jsoniter.RawMessage(be)
 	fmt.Println("SENDING >>>>>>>> ", string(b))
 	var out api.OutputEvent
-	err = json.Unmarshal(b, &out)
+	err = jsoniter.Unmarshal(b, &out)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -3,9 +3,10 @@ package shared
 import (
 	"context"
 	"database/sql"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"sort"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal/caching"
 	"github.com/matrix-org/dendrite/internal/sqlutil"

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -3,7 +3,7 @@ package shared
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"sort"
 
@@ -602,7 +602,7 @@ func extractRoomVersionFromCreateEvent(event gomatrixserverlib.Event) (
 	var createContent gomatrixserverlib.CreateContent
 	// The m.room.create event contains an optional "room_version" key in
 	// the event content, so we need to unmarshal that first.
-	if err = jsoniter.Unmarshal(event.Content(), &createContent); err != nil {
+	if err = json.Unmarshal(event.Content(), &createContent); err != nil {
 		return gomatrixserverlib.RoomVersion(""), err
 	}
 	// A room version was specified in the event content?

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -3,7 +3,7 @@ package shared
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"sort"
 
@@ -602,7 +602,7 @@ func extractRoomVersionFromCreateEvent(event gomatrixserverlib.Event) (
 	var createContent gomatrixserverlib.CreateContent
 	// The m.room.create event contains an optional "room_version" key in
 	// the event content, so we need to unmarshal that first.
-	if err = json.Unmarshal(event.Content(), &createContent); err != nil {
+	if err = jsoniter.Unmarshal(event.Content(), &createContent); err != nil {
 		return gomatrixserverlib.RoomVersion(""), err
 	}
 	// A room version was specified in the event content?

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -603,7 +603,7 @@ func extractRoomVersionFromCreateEvent(event gomatrixserverlib.Event) (
 	var createContent gomatrixserverlib.CreateContent
 	// The m.room.create event contains an optional "room_version" key in
 	// the event content, so we need to unmarshal that first.
-	if err = json.Unmarshal(event.Content(), &createContent); err != nil {
+	if err = json.ConfigCompatibleWithStandardLibrary.Unmarshal(event.Content(), &createContent); err != nil {
 		return gomatrixserverlib.RoomVersion(""), err
 	}
 	// A room version was specified in the event content?

--- a/roomserver/storage/sqlite3/events_table.go
+++ b/roomserver/storage/sqlite3/events_table.go
@@ -489,6 +489,6 @@ func (s *eventStatements) SelectRoomNIDForEventNID(
 }
 
 func eventNIDsAsArray(eventNIDs []types.EventNID) string {
-	b, _ := json.Marshal(eventNIDs)
+	b, _ := json.ConfigCompatibleWithStandardLibrary.Marshal(eventNIDs)
 	return string(b)
 }

--- a/roomserver/storage/sqlite3/events_table.go
+++ b/roomserver/storage/sqlite3/events_table.go
@@ -18,7 +18,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"strings"
 
@@ -488,6 +488,6 @@ func (s *eventStatements) SelectRoomNIDForEventNID(
 }
 
 func eventNIDsAsArray(eventNIDs []types.EventNID) string {
-	b, _ := json.Marshal(eventNIDs)
+	b, _ := jsoniter.Marshal(eventNIDs)
 	return string(b)
 }

--- a/roomserver/storage/sqlite3/events_table.go
+++ b/roomserver/storage/sqlite3/events_table.go
@@ -18,9 +18,10 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"strings"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"

--- a/roomserver/storage/sqlite3/events_table.go
+++ b/roomserver/storage/sqlite3/events_table.go
@@ -18,7 +18,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"strings"
 
@@ -488,6 +488,6 @@ func (s *eventStatements) SelectRoomNIDForEventNID(
 }
 
 func eventNIDsAsArray(eventNIDs []types.EventNID) string {
-	b, _ := jsoniter.Marshal(eventNIDs)
+	b, _ := json.Marshal(eventNIDs)
 	return string(b)
 }

--- a/roomserver/storage/sqlite3/rooms_table.go
+++ b/roomserver/storage/sqlite3/rooms_table.go
@@ -18,7 +18,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"errors"
 	"fmt"
 	"strings"
@@ -137,7 +137,7 @@ func (s *roomStatements) SelectRoomInfo(ctx context.Context, roomID string) (*ty
 		return nil, err
 	}
 	var latestNIDs []int64
-	if err = jsoniter.Unmarshal([]byte(latestNIDsJSON), &latestNIDs); err != nil {
+	if err = json.Unmarshal([]byte(latestNIDsJSON), &latestNIDs); err != nil {
 		return nil, err
 	}
 	info.IsStub = len(latestNIDs) == 0
@@ -180,7 +180,7 @@ func (s *roomStatements) SelectLatestEventNIDs(
 	if err != nil {
 		return nil, 0, err
 	}
-	if err := jsoniter.Unmarshal([]byte(nidsJSON), &eventNIDs); err != nil {
+	if err := json.Unmarshal([]byte(nidsJSON), &eventNIDs); err != nil {
 		return nil, 0, err
 	}
 	return eventNIDs, types.StateSnapshotNID(stateSnapshotNID), nil
@@ -198,7 +198,7 @@ func (s *roomStatements) SelectLatestEventsNIDsForUpdate(
 	if err != nil {
 		return nil, 0, 0, err
 	}
-	if err := jsoniter.Unmarshal([]byte(nidsJSON), &eventNIDs); err != nil {
+	if err := json.Unmarshal([]byte(nidsJSON), &eventNIDs); err != nil {
 		return nil, 0, 0, err
 	}
 	return eventNIDs, types.EventNID(lastEventSentNID), types.StateSnapshotNID(stateSnapshotNID), nil

--- a/roomserver/storage/sqlite3/rooms_table.go
+++ b/roomserver/storage/sqlite3/rooms_table.go
@@ -138,7 +138,7 @@ func (s *roomStatements) SelectRoomInfo(ctx context.Context, roomID string) (*ty
 		return nil, err
 	}
 	var latestNIDs []int64
-	if err = json.Unmarshal([]byte(latestNIDsJSON), &latestNIDs); err != nil {
+	if err = json.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(latestNIDsJSON), &latestNIDs); err != nil {
 		return nil, err
 	}
 	info.IsStub = len(latestNIDs) == 0
@@ -181,7 +181,7 @@ func (s *roomStatements) SelectLatestEventNIDs(
 	if err != nil {
 		return nil, 0, err
 	}
-	if err := json.Unmarshal([]byte(nidsJSON), &eventNIDs); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(nidsJSON), &eventNIDs); err != nil {
 		return nil, 0, err
 	}
 	return eventNIDs, types.StateSnapshotNID(stateSnapshotNID), nil
@@ -199,7 +199,7 @@ func (s *roomStatements) SelectLatestEventsNIDsForUpdate(
 	if err != nil {
 		return nil, 0, 0, err
 	}
-	if err := json.Unmarshal([]byte(nidsJSON), &eventNIDs); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(nidsJSON), &eventNIDs); err != nil {
 		return nil, 0, 0, err
 	}
 	return eventNIDs, types.EventNID(lastEventSentNID), types.StateSnapshotNID(stateSnapshotNID), nil

--- a/roomserver/storage/sqlite3/rooms_table.go
+++ b/roomserver/storage/sqlite3/rooms_table.go
@@ -18,10 +18,11 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	json "github.com/json-iterator/go"
 	"errors"
 	"fmt"
 	"strings"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"

--- a/roomserver/storage/sqlite3/rooms_table.go
+++ b/roomserver/storage/sqlite3/rooms_table.go
@@ -18,7 +18,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"errors"
 	"fmt"
 	"strings"
@@ -137,7 +137,7 @@ func (s *roomStatements) SelectRoomInfo(ctx context.Context, roomID string) (*ty
 		return nil, err
 	}
 	var latestNIDs []int64
-	if err = json.Unmarshal([]byte(latestNIDsJSON), &latestNIDs); err != nil {
+	if err = jsoniter.Unmarshal([]byte(latestNIDsJSON), &latestNIDs); err != nil {
 		return nil, err
 	}
 	info.IsStub = len(latestNIDs) == 0
@@ -180,7 +180,7 @@ func (s *roomStatements) SelectLatestEventNIDs(
 	if err != nil {
 		return nil, 0, err
 	}
-	if err := json.Unmarshal([]byte(nidsJSON), &eventNIDs); err != nil {
+	if err := jsoniter.Unmarshal([]byte(nidsJSON), &eventNIDs); err != nil {
 		return nil, 0, err
 	}
 	return eventNIDs, types.StateSnapshotNID(stateSnapshotNID), nil
@@ -198,7 +198,7 @@ func (s *roomStatements) SelectLatestEventsNIDsForUpdate(
 	if err != nil {
 		return nil, 0, 0, err
 	}
-	if err := json.Unmarshal([]byte(nidsJSON), &eventNIDs); err != nil {
+	if err := jsoniter.Unmarshal([]byte(nidsJSON), &eventNIDs); err != nil {
 		return nil, 0, 0, err
 	}
 	return eventNIDs, types.EventNID(lastEventSentNID), types.StateSnapshotNID(stateSnapshotNID), nil

--- a/roomserver/storage/sqlite3/state_snapshot_table.go
+++ b/roomserver/storage/sqlite3/state_snapshot_table.go
@@ -18,7 +18,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"strings"
 
@@ -72,7 +72,7 @@ func NewSqliteStateSnapshotTable(db *sql.DB) (tables.StateSnapshot, error) {
 func (s *stateSnapshotStatements) InsertState(
 	ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, stateBlockNIDs []types.StateBlockNID,
 ) (stateNID types.StateSnapshotNID, err error) {
-	stateBlockNIDsJSON, err := json.Marshal(stateBlockNIDs)
+	stateBlockNIDsJSON, err := jsoniter.Marshal(stateBlockNIDs)
 	if err != nil {
 		return
 	}
@@ -115,7 +115,7 @@ func (s *stateSnapshotStatements) BulkSelectStateBlockNIDs(
 		if err := rows.Scan(&result.StateSnapshotNID, &stateBlockNIDsJSON); err != nil {
 			return nil, err
 		}
-		if err := json.Unmarshal([]byte(stateBlockNIDsJSON), &result.StateBlockNIDs); err != nil {
+		if err := jsoniter.Unmarshal([]byte(stateBlockNIDsJSON), &result.StateBlockNIDs); err != nil {
 			return nil, err
 		}
 	}

--- a/roomserver/storage/sqlite3/state_snapshot_table.go
+++ b/roomserver/storage/sqlite3/state_snapshot_table.go
@@ -18,7 +18,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"strings"
 
@@ -72,7 +72,7 @@ func NewSqliteStateSnapshotTable(db *sql.DB) (tables.StateSnapshot, error) {
 func (s *stateSnapshotStatements) InsertState(
 	ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, stateBlockNIDs []types.StateBlockNID,
 ) (stateNID types.StateSnapshotNID, err error) {
-	stateBlockNIDsJSON, err := jsoniter.Marshal(stateBlockNIDs)
+	stateBlockNIDsJSON, err := json.Marshal(stateBlockNIDs)
 	if err != nil {
 		return
 	}
@@ -115,7 +115,7 @@ func (s *stateSnapshotStatements) BulkSelectStateBlockNIDs(
 		if err := rows.Scan(&result.StateSnapshotNID, &stateBlockNIDsJSON); err != nil {
 			return nil, err
 		}
-		if err := jsoniter.Unmarshal([]byte(stateBlockNIDsJSON), &result.StateBlockNIDs); err != nil {
+		if err := json.Unmarshal([]byte(stateBlockNIDsJSON), &result.StateBlockNIDs); err != nil {
 			return nil, err
 		}
 	}

--- a/roomserver/storage/sqlite3/state_snapshot_table.go
+++ b/roomserver/storage/sqlite3/state_snapshot_table.go
@@ -18,9 +18,10 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"strings"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"

--- a/roomserver/storage/sqlite3/state_snapshot_table.go
+++ b/roomserver/storage/sqlite3/state_snapshot_table.go
@@ -73,7 +73,7 @@ func NewSqliteStateSnapshotTable(db *sql.DB) (tables.StateSnapshot, error) {
 func (s *stateSnapshotStatements) InsertState(
 	ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, stateBlockNIDs []types.StateBlockNID,
 ) (stateNID types.StateSnapshotNID, err error) {
-	stateBlockNIDsJSON, err := json.Marshal(stateBlockNIDs)
+	stateBlockNIDsJSON, err := json.ConfigCompatibleWithStandardLibrary.Marshal(stateBlockNIDs)
 	if err != nil {
 		return
 	}
@@ -116,7 +116,7 @@ func (s *stateSnapshotStatements) BulkSelectStateBlockNIDs(
 		if err := rows.Scan(&result.StateSnapshotNID, &stateBlockNIDsJSON); err != nil {
 			return nil, err
 		}
-		if err := json.Unmarshal([]byte(stateBlockNIDsJSON), &result.StateBlockNIDs); err != nil {
+		if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(stateBlockNIDsJSON), &result.StateBlockNIDs); err != nil {
 			return nil, err
 		}
 	}

--- a/signingkeyserver/inthttp/server.go
+++ b/signingkeyserver/inthttp/server.go
@@ -1,7 +1,7 @@
 package inthttp
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -16,7 +16,7 @@ func AddRoutes(s api.SigningKeyServerAPI, internalAPIMux *mux.Router, cache cach
 		httputil.MakeInternalAPI("queryPublicKeys", func(req *http.Request) util.JSONResponse {
 			request := api.QueryPublicKeysRequest{}
 			response := api.QueryPublicKeysResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			keys, err := s.FetchKeys(req.Context(), request.Requests)
@@ -31,7 +31,7 @@ func AddRoutes(s api.SigningKeyServerAPI, internalAPIMux *mux.Router, cache cach
 		httputil.MakeInternalAPI("inputPublicKeys", func(req *http.Request) util.JSONResponse {
 			request := api.InputPublicKeysRequest{}
 			response := api.InputPublicKeysResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.StoreKeys(req.Context(), request.Keys); err != nil {

--- a/signingkeyserver/inthttp/server.go
+++ b/signingkeyserver/inthttp/server.go
@@ -1,7 +1,7 @@
 package inthttp
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -16,7 +16,7 @@ func AddRoutes(s api.SigningKeyServerAPI, internalAPIMux *mux.Router, cache cach
 		httputil.MakeInternalAPI("queryPublicKeys", func(req *http.Request) util.JSONResponse {
 			request := api.QueryPublicKeysRequest{}
 			response := api.QueryPublicKeysResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			keys, err := s.FetchKeys(req.Context(), request.Requests)
@@ -31,7 +31,7 @@ func AddRoutes(s api.SigningKeyServerAPI, internalAPIMux *mux.Router, cache cach
 		httputil.MakeInternalAPI("inputPublicKeys", func(req *http.Request) util.JSONResponse {
 			request := api.InputPublicKeysRequest{}
 			response := api.InputPublicKeysResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.StoreKeys(req.Context(), request.Keys); err != nil {

--- a/signingkeyserver/inthttp/server.go
+++ b/signingkeyserver/inthttp/server.go
@@ -1,8 +1,9 @@
 package inthttp
 
 import (
-	json "github.com/json-iterator/go"
 	"net/http"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/internal/caching"

--- a/signingkeyserver/serverkeyapi_test.go
+++ b/signingkeyserver/serverkeyapi_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -12,6 +11,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/federationapi/routing"
 	"github.com/matrix-org/dendrite/internal/caching"

--- a/signingkeyserver/serverkeyapi_test.go
+++ b/signingkeyserver/serverkeyapi_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -119,7 +119,7 @@ func (m *MockRoundTripper) RoundTrip(req *http.Request) (res *http.Response, err
 
 	// Get the keys and JSON-ify them.
 	keys := routing.LocalKeys(s.fedconfig)
-	body, err := json.MarshalIndent(keys.JSON, "", "  ")
+	body, err := jsoniter.MarshalIndent(keys.JSON, "", "  ")
 	if err != nil {
 		return nil, err
 	}

--- a/signingkeyserver/serverkeyapi_test.go
+++ b/signingkeyserver/serverkeyapi_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -119,7 +119,7 @@ func (m *MockRoundTripper) RoundTrip(req *http.Request) (res *http.Response, err
 
 	// Get the keys and JSON-ify them.
 	keys := routing.LocalKeys(s.fedconfig)
-	body, err := jsoniter.MarshalIndent(keys.JSON, "", "  ")
+	body, err := json.MarshalIndent(keys.JSON, "", "  ")
 	if err != nil {
 		return nil, err
 	}

--- a/syncapi/consumers/clientapi.go
+++ b/syncapi/consumers/clientapi.go
@@ -16,6 +16,7 @@ package consumers
 
 import (
 	"context"
+
 	json "github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"

--- a/syncapi/consumers/clientapi.go
+++ b/syncapi/consumers/clientapi.go
@@ -16,7 +16,7 @@ package consumers
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"
 	"github.com/matrix-org/dendrite/internal"
@@ -70,7 +70,7 @@ func (s *OutputClientDataConsumer) Start() error {
 func (s *OutputClientDataConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	// Parse out the event JSON
 	var output eventutil.AccountData
-	if err := jsoniter.Unmarshal(msg.Value, &output); err != nil {
+	if err := json.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Errorf("client API server output log: message parse failure")
 		return nil

--- a/syncapi/consumers/clientapi.go
+++ b/syncapi/consumers/clientapi.go
@@ -71,7 +71,7 @@ func (s *OutputClientDataConsumer) Start() error {
 func (s *OutputClientDataConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	// Parse out the event JSON
 	var output eventutil.AccountData
-	if err := json.Unmarshal(msg.Value, &output); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Errorf("client API server output log: message parse failure")
 		return nil

--- a/syncapi/consumers/clientapi.go
+++ b/syncapi/consumers/clientapi.go
@@ -16,7 +16,7 @@ package consumers
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"
 	"github.com/matrix-org/dendrite/internal"
@@ -70,7 +70,7 @@ func (s *OutputClientDataConsumer) Start() error {
 func (s *OutputClientDataConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	// Parse out the event JSON
 	var output eventutil.AccountData
-	if err := json.Unmarshal(msg.Value, &output); err != nil {
+	if err := jsoniter.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Errorf("client API server output log: message parse failure")
 		return nil

--- a/syncapi/consumers/eduserver_sendtodevice.go
+++ b/syncapi/consumers/eduserver_sendtodevice.go
@@ -74,7 +74,7 @@ func (s *OutputSendToDeviceEventConsumer) Start() error {
 
 func (s *OutputSendToDeviceEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	var output api.OutputSendToDeviceEvent
-	if err := json.Unmarshal(msg.Value, &output); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Errorf("EDU server output log: message parse failure")
 		return err

--- a/syncapi/consumers/eduserver_sendtodevice.go
+++ b/syncapi/consumers/eduserver_sendtodevice.go
@@ -16,7 +16,7 @@ package consumers
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"
 	"github.com/matrix-org/dendrite/eduserver/api"
@@ -73,7 +73,7 @@ func (s *OutputSendToDeviceEventConsumer) Start() error {
 
 func (s *OutputSendToDeviceEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	var output api.OutputSendToDeviceEvent
-	if err := jsoniter.Unmarshal(msg.Value, &output); err != nil {
+	if err := json.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Errorf("EDU server output log: message parse failure")
 		return err

--- a/syncapi/consumers/eduserver_sendtodevice.go
+++ b/syncapi/consumers/eduserver_sendtodevice.go
@@ -16,6 +16,7 @@ package consumers
 
 import (
 	"context"
+
 	json "github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"

--- a/syncapi/consumers/eduserver_sendtodevice.go
+++ b/syncapi/consumers/eduserver_sendtodevice.go
@@ -16,7 +16,7 @@ package consumers
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"
 	"github.com/matrix-org/dendrite/eduserver/api"
@@ -73,7 +73,7 @@ func (s *OutputSendToDeviceEventConsumer) Start() error {
 
 func (s *OutputSendToDeviceEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	var output api.OutputSendToDeviceEvent
-	if err := json.Unmarshal(msg.Value, &output); err != nil {
+	if err := jsoniter.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Errorf("EDU server output log: message parse failure")
 		return err

--- a/syncapi/consumers/eduserver_typing.go
+++ b/syncapi/consumers/eduserver_typing.go
@@ -75,7 +75,7 @@ func (s *OutputTypingEventConsumer) Start() error {
 
 func (s *OutputTypingEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	var output api.OutputTypingEvent
-	if err := json.Unmarshal(msg.Value, &output); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Errorf("EDU server output log: message parse failure")
 		return nil

--- a/syncapi/consumers/eduserver_typing.go
+++ b/syncapi/consumers/eduserver_typing.go
@@ -15,7 +15,7 @@
 package consumers
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"
 	"github.com/matrix-org/dendrite/eduserver/api"
@@ -75,7 +75,7 @@ func (s *OutputTypingEventConsumer) Start() error {
 
 func (s *OutputTypingEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	var output api.OutputTypingEvent
-	if err := jsoniter.Unmarshal(msg.Value, &output); err != nil {
+	if err := json.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Errorf("EDU server output log: message parse failure")
 		return nil

--- a/syncapi/consumers/eduserver_typing.go
+++ b/syncapi/consumers/eduserver_typing.go
@@ -15,7 +15,7 @@
 package consumers
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"
 	"github.com/matrix-org/dendrite/eduserver/api"
@@ -75,7 +75,7 @@ func (s *OutputTypingEventConsumer) Start() error {
 
 func (s *OutputTypingEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	var output api.OutputTypingEvent
-	if err := json.Unmarshal(msg.Value, &output); err != nil {
+	if err := jsoniter.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Errorf("EDU server output log: message parse failure")
 		return nil

--- a/syncapi/consumers/keychange.go
+++ b/syncapi/consumers/keychange.go
@@ -100,7 +100,7 @@ func (s *OutputKeyChangeEventConsumer) onMessage(msg *sarama.ConsumerMessage) er
 	defer s.updateOffset(msg)
 
 	var output api.DeviceMessage
-	if err := json.Unmarshal(msg.Value, &output); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Error("syncapi: failed to unmarshal key change event from key server")
 		return err

--- a/syncapi/consumers/keychange.go
+++ b/syncapi/consumers/keychange.go
@@ -16,8 +16,9 @@ package consumers
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"sync"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"
 	"github.com/matrix-org/dendrite/internal"

--- a/syncapi/consumers/keychange.go
+++ b/syncapi/consumers/keychange.go
@@ -16,7 +16,7 @@ package consumers
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"sync"
 
 	"github.com/Shopify/sarama"
@@ -99,7 +99,7 @@ func (s *OutputKeyChangeEventConsumer) onMessage(msg *sarama.ConsumerMessage) er
 	defer s.updateOffset(msg)
 
 	var output api.DeviceMessage
-	if err := jsoniter.Unmarshal(msg.Value, &output); err != nil {
+	if err := json.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Error("syncapi: failed to unmarshal key change event from key server")
 		return err

--- a/syncapi/consumers/keychange.go
+++ b/syncapi/consumers/keychange.go
@@ -16,7 +16,7 @@ package consumers
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"sync"
 
 	"github.com/Shopify/sarama"
@@ -99,7 +99,7 @@ func (s *OutputKeyChangeEventConsumer) onMessage(msg *sarama.ConsumerMessage) er
 	defer s.updateOffset(msg)
 
 	var output api.DeviceMessage
-	if err := json.Unmarshal(msg.Value, &output); err != nil {
+	if err := jsoniter.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Error("syncapi: failed to unmarshal key change event from key server")
 		return err

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -79,7 +79,7 @@ func (s *OutputRoomEventConsumer) Start() error {
 func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	// Parse out the event JSON
 	var output api.OutputEvent
-	if err := json.Unmarshal(msg.Value, &output); err != nil {
+	if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Errorf("roomserver output log: message parse failure")
 		return nil

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -16,7 +16,7 @@ package consumers
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 
 	"github.com/Shopify/sarama"
@@ -78,7 +78,7 @@ func (s *OutputRoomEventConsumer) Start() error {
 func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	// Parse out the event JSON
 	var output api.OutputEvent
-	if err := json.Unmarshal(msg.Value, &output); err != nil {
+	if err := jsoniter.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Errorf("roomserver output log: message parse failure")
 		return nil

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -16,8 +16,9 @@ package consumers
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"fmt"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/Shopify/sarama"
 	"github.com/matrix-org/dendrite/internal"

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -16,7 +16,7 @@ package consumers
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 
 	"github.com/Shopify/sarama"
@@ -78,7 +78,7 @@ func (s *OutputRoomEventConsumer) Start() error {
 func (s *OutputRoomEventConsumer) onMessage(msg *sarama.ConsumerMessage) error {
 	// Parse out the event JSON
 	var output api.OutputEvent
-	if err := jsoniter.Unmarshal(msg.Value, &output); err != nil {
+	if err := json.Unmarshal(msg.Value, &output); err != nil {
 		// If the message was invalid, log it and move on to the next message in the stream
 		log.WithError(err).Errorf("roomserver output log: message parse failure")
 		return nil

--- a/syncapi/routing/filter.go
+++ b/syncapi/routing/filter.go
@@ -94,7 +94,7 @@ func PutFilter(
 		}
 	}
 
-	if err = json.Unmarshal(body, &filter); err != nil {
+	if err = json.ConfigCompatibleWithStandardLibrary.Unmarshal(body, &filter); err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.BadJSON("The request body could not be decoded into valid JSON. " + err.Error()),

--- a/syncapi/routing/filter.go
+++ b/syncapi/routing/filter.go
@@ -15,7 +15,7 @@
 package routing
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"io/ioutil"
 	"net/http"
 
@@ -93,7 +93,7 @@ func PutFilter(
 		}
 	}
 
-	if err = json.Unmarshal(body, &filter); err != nil {
+	if err = jsoniter.Unmarshal(body, &filter); err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.BadJSON("The request body could not be decoded into valid JSON. " + err.Error()),

--- a/syncapi/routing/filter.go
+++ b/syncapi/routing/filter.go
@@ -15,7 +15,7 @@
 package routing
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"io/ioutil"
 	"net/http"
 
@@ -93,7 +93,7 @@ func PutFilter(
 		}
 	}
 
-	if err = jsoniter.Unmarshal(body, &filter); err != nil {
+	if err = json.Unmarshal(body, &filter); err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.BadJSON("The request body could not be decoded into valid JSON. " + err.Error()),

--- a/syncapi/routing/filter.go
+++ b/syncapi/routing/filter.go
@@ -15,9 +15,10 @@
 package routing
 
 import (
-	json "github.com/json-iterator/go"
 	"io/ioutil"
 	"net/http"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/syncapi/storage"

--- a/syncapi/storage/postgres/current_room_state_table.go
+++ b/syncapi/storage/postgres/current_room_state_table.go
@@ -237,12 +237,12 @@ func (s *currentRoomStateStatements) UpsertRoomState(
 	// Parse content as JSON and search for an "url" key
 	containsURL := false
 	var content map[string]interface{}
-	if json.Unmarshal(event.Content(), &content) != nil {
+	if json.ConfigCompatibleWithStandardLibrary.Unmarshal(event.Content(), &content) != nil {
 		// Set containsURL to true if url is present
 		_, containsURL = content["url"]
 	}
 
-	headeredJSON, err := json.Marshal(event)
+	headeredJSON, err := json.ConfigCompatibleWithStandardLibrary.Marshal(event)
 	if err != nil {
 		return err
 	}
@@ -285,7 +285,7 @@ func rowsToEvents(rows *sql.Rows) ([]gomatrixserverlib.HeaderedEvent, error) {
 		}
 		// TODO: Handle redacted events
 		var ev gomatrixserverlib.HeaderedEvent
-		if err := json.Unmarshal(eventBytes, &ev); err != nil {
+		if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, err
 		}
 		result = append(result, ev)
@@ -306,7 +306,7 @@ func (s *currentRoomStateStatements) SelectStateEvent(
 		return nil, err
 	}
 	var ev gomatrixserverlib.HeaderedEvent
-	if err = json.Unmarshal(res, &ev); err != nil {
+	if err = json.ConfigCompatibleWithStandardLibrary.Unmarshal(res, &ev); err != nil {
 		return nil, err
 	}
 	return &ev, err

--- a/syncapi/storage/postgres/current_room_state_table.go
+++ b/syncapi/storage/postgres/current_room_state_table.go
@@ -18,7 +18,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 
 	"github.com/lib/pq"
 	"github.com/matrix-org/dendrite/internal"
@@ -236,12 +236,12 @@ func (s *currentRoomStateStatements) UpsertRoomState(
 	// Parse content as JSON and search for an "url" key
 	containsURL := false
 	var content map[string]interface{}
-	if json.Unmarshal(event.Content(), &content) != nil {
+	if jsoniter.Unmarshal(event.Content(), &content) != nil {
 		// Set containsURL to true if url is present
 		_, containsURL = content["url"]
 	}
 
-	headeredJSON, err := json.Marshal(event)
+	headeredJSON, err := jsoniter.Marshal(event)
 	if err != nil {
 		return err
 	}
@@ -284,7 +284,7 @@ func rowsToEvents(rows *sql.Rows) ([]gomatrixserverlib.HeaderedEvent, error) {
 		}
 		// TODO: Handle redacted events
 		var ev gomatrixserverlib.HeaderedEvent
-		if err := json.Unmarshal(eventBytes, &ev); err != nil {
+		if err := jsoniter.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, err
 		}
 		result = append(result, ev)
@@ -305,7 +305,7 @@ func (s *currentRoomStateStatements) SelectStateEvent(
 		return nil, err
 	}
 	var ev gomatrixserverlib.HeaderedEvent
-	if err = json.Unmarshal(res, &ev); err != nil {
+	if err = jsoniter.Unmarshal(res, &ev); err != nil {
 		return nil, err
 	}
 	return &ev, err

--- a/syncapi/storage/postgres/current_room_state_table.go
+++ b/syncapi/storage/postgres/current_room_state_table.go
@@ -18,7 +18,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 
 	"github.com/lib/pq"
 	"github.com/matrix-org/dendrite/internal"
@@ -236,12 +236,12 @@ func (s *currentRoomStateStatements) UpsertRoomState(
 	// Parse content as JSON and search for an "url" key
 	containsURL := false
 	var content map[string]interface{}
-	if jsoniter.Unmarshal(event.Content(), &content) != nil {
+	if json.Unmarshal(event.Content(), &content) != nil {
 		// Set containsURL to true if url is present
 		_, containsURL = content["url"]
 	}
 
-	headeredJSON, err := jsoniter.Marshal(event)
+	headeredJSON, err := json.Marshal(event)
 	if err != nil {
 		return err
 	}
@@ -284,7 +284,7 @@ func rowsToEvents(rows *sql.Rows) ([]gomatrixserverlib.HeaderedEvent, error) {
 		}
 		// TODO: Handle redacted events
 		var ev gomatrixserverlib.HeaderedEvent
-		if err := jsoniter.Unmarshal(eventBytes, &ev); err != nil {
+		if err := json.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, err
 		}
 		result = append(result, ev)
@@ -305,7 +305,7 @@ func (s *currentRoomStateStatements) SelectStateEvent(
 		return nil, err
 	}
 	var ev gomatrixserverlib.HeaderedEvent
-	if err = jsoniter.Unmarshal(res, &ev); err != nil {
+	if err = json.Unmarshal(res, &ev); err != nil {
 		return nil, err
 	}
 	return &ev, err

--- a/syncapi/storage/postgres/current_room_state_table.go
+++ b/syncapi/storage/postgres/current_room_state_table.go
@@ -18,6 +18,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+
 	json "github.com/json-iterator/go"
 
 	"github.com/lib/pq"

--- a/syncapi/storage/postgres/filter_table.go
+++ b/syncapi/storage/postgres/filter_table.go
@@ -17,7 +17,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/syncapi/storage/tables"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -84,7 +84,7 @@ func (s *filterStatements) SelectFilter(
 
 	// Unmarshal JSON into Filter struct
 	var filter gomatrixserverlib.Filter
-	if err = jsoniter.Unmarshal(filterData, &filter); err != nil {
+	if err = json.Unmarshal(filterData, &filter); err != nil {
 		return nil, err
 	}
 	return &filter, nil
@@ -96,7 +96,7 @@ func (s *filterStatements) InsertFilter(
 	var existingFilterID string
 
 	// Serialise json
-	filterJSON, err := jsoniter.Marshal(filter)
+	filterJSON, err := json.Marshal(filter)
 	if err != nil {
 		return "", err
 	}

--- a/syncapi/storage/postgres/filter_table.go
+++ b/syncapi/storage/postgres/filter_table.go
@@ -85,7 +85,7 @@ func (s *filterStatements) SelectFilter(
 
 	// Unmarshal JSON into Filter struct
 	var filter gomatrixserverlib.Filter
-	if err = json.Unmarshal(filterData, &filter); err != nil {
+	if err = json.ConfigCompatibleWithStandardLibrary.Unmarshal(filterData, &filter); err != nil {
 		return nil, err
 	}
 	return &filter, nil
@@ -97,7 +97,7 @@ func (s *filterStatements) InsertFilter(
 	var existingFilterID string
 
 	// Serialise json
-	filterJSON, err := json.Marshal(filter)
+	filterJSON, err := json.ConfigCompatibleWithStandardLibrary.Marshal(filter)
 	if err != nil {
 		return "", err
 	}

--- a/syncapi/storage/postgres/filter_table.go
+++ b/syncapi/storage/postgres/filter_table.go
@@ -17,7 +17,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/syncapi/storage/tables"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -84,7 +84,7 @@ func (s *filterStatements) SelectFilter(
 
 	// Unmarshal JSON into Filter struct
 	var filter gomatrixserverlib.Filter
-	if err = json.Unmarshal(filterData, &filter); err != nil {
+	if err = jsoniter.Unmarshal(filterData, &filter); err != nil {
 		return nil, err
 	}
 	return &filter, nil
@@ -96,7 +96,7 @@ func (s *filterStatements) InsertFilter(
 	var existingFilterID string
 
 	// Serialise json
-	filterJSON, err := json.Marshal(filter)
+	filterJSON, err := jsoniter.Marshal(filter)
 	if err != nil {
 		return "", err
 	}

--- a/syncapi/storage/postgres/filter_table.go
+++ b/syncapi/storage/postgres/filter_table.go
@@ -17,6 +17,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+
 	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/syncapi/storage/tables"

--- a/syncapi/storage/postgres/invites_table.go
+++ b/syncapi/storage/postgres/invites_table.go
@@ -95,7 +95,7 @@ func (s *inviteEventsStatements) InsertInviteEvent(
 	ctx context.Context, txn *sql.Tx, inviteEvent gomatrixserverlib.HeaderedEvent,
 ) (streamPos types.StreamPosition, err error) {
 	var headeredJSON []byte
-	headeredJSON, err = json.Marshal(inviteEvent)
+	headeredJSON, err = json.ConfigCompatibleWithStandardLibrary.Marshal(inviteEvent)
 	if err != nil {
 		return
 	}
@@ -150,7 +150,7 @@ func (s *inviteEventsStatements) SelectInviteEventsInRange(
 		}
 
 		var event gomatrixserverlib.HeaderedEvent
-		if err := json.Unmarshal(eventJSON, &event); err != nil {
+		if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(eventJSON, &event); err != nil {
 			return nil, nil, err
 		}
 

--- a/syncapi/storage/postgres/invites_table.go
+++ b/syncapi/storage/postgres/invites_table.go
@@ -18,7 +18,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
@@ -94,7 +94,7 @@ func (s *inviteEventsStatements) InsertInviteEvent(
 	ctx context.Context, txn *sql.Tx, inviteEvent gomatrixserverlib.HeaderedEvent,
 ) (streamPos types.StreamPosition, err error) {
 	var headeredJSON []byte
-	headeredJSON, err = json.Marshal(inviteEvent)
+	headeredJSON, err = jsoniter.Marshal(inviteEvent)
 	if err != nil {
 		return
 	}
@@ -149,7 +149,7 @@ func (s *inviteEventsStatements) SelectInviteEventsInRange(
 		}
 
 		var event gomatrixserverlib.HeaderedEvent
-		if err := json.Unmarshal(eventJSON, &event); err != nil {
+		if err := jsoniter.Unmarshal(eventJSON, &event); err != nil {
 			return nil, nil, err
 		}
 

--- a/syncapi/storage/postgres/invites_table.go
+++ b/syncapi/storage/postgres/invites_table.go
@@ -18,6 +18,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+
 	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal"

--- a/syncapi/storage/postgres/invites_table.go
+++ b/syncapi/storage/postgres/invites_table.go
@@ -18,7 +18,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
@@ -94,7 +94,7 @@ func (s *inviteEventsStatements) InsertInviteEvent(
 	ctx context.Context, txn *sql.Tx, inviteEvent gomatrixserverlib.HeaderedEvent,
 ) (streamPos types.StreamPosition, err error) {
 	var headeredJSON []byte
-	headeredJSON, err = jsoniter.Marshal(inviteEvent)
+	headeredJSON, err = json.Marshal(inviteEvent)
 	if err != nil {
 		return
 	}
@@ -149,7 +149,7 @@ func (s *inviteEventsStatements) SelectInviteEventsInRange(
 		}
 
 		var event gomatrixserverlib.HeaderedEvent
-		if err := jsoniter.Unmarshal(eventJSON, &event); err != nil {
+		if err := json.Unmarshal(eventJSON, &event); err != nil {
 			return nil, nil, err
 		}
 

--- a/syncapi/storage/postgres/output_room_events_table.go
+++ b/syncapi/storage/postgres/output_room_events_table.go
@@ -18,8 +18,9 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	json "github.com/json-iterator/go"
 	"sort"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/roomserver/api"

--- a/syncapi/storage/postgres/output_room_events_table.go
+++ b/syncapi/storage/postgres/output_room_events_table.go
@@ -18,7 +18,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"sort"
 
 	"github.com/matrix-org/dendrite/internal"
@@ -167,7 +167,7 @@ func NewPostgresEventsTable(db *sql.DB) (tables.Events, error) {
 }
 
 func (s *outputRoomEventsStatements) UpdateEventJSON(ctx context.Context, event *gomatrixserverlib.HeaderedEvent) error {
-	headeredJSON, err := jsoniter.Marshal(event)
+	headeredJSON, err := json.Marshal(event)
 	if err != nil {
 		return err
 	}
@@ -231,7 +231,7 @@ func (s *outputRoomEventsStatements) SelectStateInRange(
 
 		// TODO: Handle redacted events
 		var ev gomatrixserverlib.HeaderedEvent
-		if err := jsoniter.Unmarshal(eventBytes, &ev); err != nil {
+		if err := json.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, nil, err
 		}
 		needSet := stateNeeded[ev.RoomID()]
@@ -288,13 +288,13 @@ func (s *outputRoomEventsStatements) InsertEvent(
 	// Parse content as JSON and search for an "url" key
 	containsURL := false
 	var content map[string]interface{}
-	if jsoniter.Unmarshal(event.Content(), &content) != nil {
+	if json.Unmarshal(event.Content(), &content) != nil {
 		// Set containsURL to true if url is present
 		_, containsURL = content["url"]
 	}
 
 	var headeredJSON []byte
-	headeredJSON, err = jsoniter.Marshal(event)
+	headeredJSON, err = json.Marshal(event)
 	if err != nil {
 		return
 	}
@@ -425,7 +425,7 @@ func rowsToStreamEvents(rows *sql.Rows) ([]types.StreamEvent, error) {
 		}
 		// TODO: Handle redacted events
 		var ev gomatrixserverlib.HeaderedEvent
-		if err := jsoniter.Unmarshal(eventBytes, &ev); err != nil {
+		if err := json.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, err
 		}
 

--- a/syncapi/storage/postgres/output_room_events_table.go
+++ b/syncapi/storage/postgres/output_room_events_table.go
@@ -168,7 +168,7 @@ func NewPostgresEventsTable(db *sql.DB) (tables.Events, error) {
 }
 
 func (s *outputRoomEventsStatements) UpdateEventJSON(ctx context.Context, event *gomatrixserverlib.HeaderedEvent) error {
-	headeredJSON, err := json.Marshal(event)
+	headeredJSON, err := json.ConfigCompatibleWithStandardLibrary.Marshal(event)
 	if err != nil {
 		return err
 	}
@@ -232,7 +232,7 @@ func (s *outputRoomEventsStatements) SelectStateInRange(
 
 		// TODO: Handle redacted events
 		var ev gomatrixserverlib.HeaderedEvent
-		if err := json.Unmarshal(eventBytes, &ev); err != nil {
+		if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, nil, err
 		}
 		needSet := stateNeeded[ev.RoomID()]
@@ -289,13 +289,13 @@ func (s *outputRoomEventsStatements) InsertEvent(
 	// Parse content as JSON and search for an "url" key
 	containsURL := false
 	var content map[string]interface{}
-	if json.Unmarshal(event.Content(), &content) != nil {
+	if json.ConfigCompatibleWithStandardLibrary.Unmarshal(event.Content(), &content) != nil {
 		// Set containsURL to true if url is present
 		_, containsURL = content["url"]
 	}
 
 	var headeredJSON []byte
-	headeredJSON, err = json.Marshal(event)
+	headeredJSON, err = json.ConfigCompatibleWithStandardLibrary.Marshal(event)
 	if err != nil {
 		return
 	}
@@ -426,7 +426,7 @@ func rowsToStreamEvents(rows *sql.Rows) ([]types.StreamEvent, error) {
 		}
 		// TODO: Handle redacted events
 		var ev gomatrixserverlib.HeaderedEvent
-		if err := json.Unmarshal(eventBytes, &ev); err != nil {
+		if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, err
 		}
 

--- a/syncapi/storage/postgres/output_room_events_table.go
+++ b/syncapi/storage/postgres/output_room_events_table.go
@@ -18,7 +18,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"sort"
 
 	"github.com/matrix-org/dendrite/internal"
@@ -167,7 +167,7 @@ func NewPostgresEventsTable(db *sql.DB) (tables.Events, error) {
 }
 
 func (s *outputRoomEventsStatements) UpdateEventJSON(ctx context.Context, event *gomatrixserverlib.HeaderedEvent) error {
-	headeredJSON, err := json.Marshal(event)
+	headeredJSON, err := jsoniter.Marshal(event)
 	if err != nil {
 		return err
 	}
@@ -231,7 +231,7 @@ func (s *outputRoomEventsStatements) SelectStateInRange(
 
 		// TODO: Handle redacted events
 		var ev gomatrixserverlib.HeaderedEvent
-		if err := json.Unmarshal(eventBytes, &ev); err != nil {
+		if err := jsoniter.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, nil, err
 		}
 		needSet := stateNeeded[ev.RoomID()]
@@ -288,13 +288,13 @@ func (s *outputRoomEventsStatements) InsertEvent(
 	// Parse content as JSON and search for an "url" key
 	containsURL := false
 	var content map[string]interface{}
-	if json.Unmarshal(event.Content(), &content) != nil {
+	if jsoniter.Unmarshal(event.Content(), &content) != nil {
 		// Set containsURL to true if url is present
 		_, containsURL = content["url"]
 	}
 
 	var headeredJSON []byte
-	headeredJSON, err = json.Marshal(event)
+	headeredJSON, err = jsoniter.Marshal(event)
 	if err != nil {
 		return
 	}
@@ -425,7 +425,7 @@ func rowsToStreamEvents(rows *sql.Rows) ([]types.StreamEvent, error) {
 		}
 		// TODO: Handle redacted events
 		var ev gomatrixserverlib.HeaderedEvent
-		if err := json.Unmarshal(eventBytes, &ev); err != nil {
+		if err := jsoniter.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, err
 		}
 

--- a/syncapi/storage/postgres/send_to_device_table.go
+++ b/syncapi/storage/postgres/send_to_device_table.go
@@ -17,7 +17,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 
 	"github.com/lib/pq"
 	"github.com/matrix-org/dendrite/internal"
@@ -143,7 +143,7 @@ func (s *sendToDeviceStatements) SelectSendToDeviceMessages(
 			UserID:   userID,
 			DeviceID: deviceID,
 		}
-		if err = json.Unmarshal([]byte(content), &event.SendToDeviceEvent); err != nil {
+		if err = jsoniter.Unmarshal([]byte(content), &event.SendToDeviceEvent); err != nil {
 			return
 		}
 		if sentByToken != nil {

--- a/syncapi/storage/postgres/send_to_device_table.go
+++ b/syncapi/storage/postgres/send_to_device_table.go
@@ -144,7 +144,7 @@ func (s *sendToDeviceStatements) SelectSendToDeviceMessages(
 			UserID:   userID,
 			DeviceID: deviceID,
 		}
-		if err = json.Unmarshal([]byte(content), &event.SendToDeviceEvent); err != nil {
+		if err = json.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(content), &event.SendToDeviceEvent); err != nil {
 			return
 		}
 		if sentByToken != nil {

--- a/syncapi/storage/postgres/send_to_device_table.go
+++ b/syncapi/storage/postgres/send_to_device_table.go
@@ -17,6 +17,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+
 	json "github.com/json-iterator/go"
 
 	"github.com/lib/pq"

--- a/syncapi/storage/postgres/send_to_device_table.go
+++ b/syncapi/storage/postgres/send_to_device_table.go
@@ -17,7 +17,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 
 	"github.com/lib/pq"
 	"github.com/matrix-org/dendrite/internal"
@@ -143,7 +143,7 @@ func (s *sendToDeviceStatements) SelectSendToDeviceMessages(
 			UserID:   userID,
 			DeviceID: deviceID,
 		}
-		if err = jsoniter.Unmarshal([]byte(content), &event.SendToDeviceEvent); err != nil {
+		if err = json.Unmarshal([]byte(content), &event.SendToDeviceEvent); err != nil {
 			return
 		}
 		if sentByToken != nil {

--- a/syncapi/storage/shared/syncserver.go
+++ b/syncapi/storage/shared/syncserver.go
@@ -17,7 +17,7 @@ package shared
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"time"
 
@@ -546,7 +546,7 @@ func (d *Database) addTypingDeltaToResponse(
 			ev := gomatrixserverlib.ClientEvent{
 				Type: gomatrixserverlib.MTyping,
 			}
-			ev.Content, err = jsoniter.Marshal(map[string]interface{}{
+			ev.Content, err = json.Marshal(map[string]interface{}{
 				"user_ids": typingUsers,
 			})
 			if err != nil {
@@ -1280,7 +1280,7 @@ func (d *Database) SendToDeviceUpdatesWaiting(
 func (d *Database) StoreNewSendForDeviceMessage(
 	ctx context.Context, streamPos types.StreamPosition, userID, deviceID string, event gomatrixserverlib.SendToDeviceEvent,
 ) (types.StreamPosition, error) {
-	j, err := jsoniter.Marshal(event)
+	j, err := json.Marshal(event)
 	if err != nil {
 		return streamPos, err
 	}

--- a/syncapi/storage/shared/syncserver.go
+++ b/syncapi/storage/shared/syncserver.go
@@ -17,7 +17,7 @@ package shared
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"time"
 
@@ -546,7 +546,7 @@ func (d *Database) addTypingDeltaToResponse(
 			ev := gomatrixserverlib.ClientEvent{
 				Type: gomatrixserverlib.MTyping,
 			}
-			ev.Content, err = json.Marshal(map[string]interface{}{
+			ev.Content, err = jsoniter.Marshal(map[string]interface{}{
 				"user_ids": typingUsers,
 			})
 			if err != nil {
@@ -1280,7 +1280,7 @@ func (d *Database) SendToDeviceUpdatesWaiting(
 func (d *Database) StoreNewSendForDeviceMessage(
 	ctx context.Context, streamPos types.StreamPosition, userID, deviceID string, event gomatrixserverlib.SendToDeviceEvent,
 ) (types.StreamPosition, error) {
-	j, err := json.Marshal(event)
+	j, err := jsoniter.Marshal(event)
 	if err != nil {
 		return streamPos, err
 	}

--- a/syncapi/storage/shared/syncserver.go
+++ b/syncapi/storage/shared/syncserver.go
@@ -17,9 +17,10 @@ package shared
 import (
 	"context"
 	"database/sql"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 

--- a/syncapi/storage/shared/syncserver.go
+++ b/syncapi/storage/shared/syncserver.go
@@ -547,7 +547,7 @@ func (d *Database) addTypingDeltaToResponse(
 			ev := gomatrixserverlib.ClientEvent{
 				Type: gomatrixserverlib.MTyping,
 			}
-			ev.Content, err = json.Marshal(map[string]interface{}{
+			ev.Content, err = json.ConfigCompatibleWithStandardLibrary.Marshal(map[string]interface{}{
 				"user_ids": typingUsers,
 			})
 			if err != nil {
@@ -1281,7 +1281,7 @@ func (d *Database) SendToDeviceUpdatesWaiting(
 func (d *Database) StoreNewSendForDeviceMessage(
 	ctx context.Context, streamPos types.StreamPosition, userID, deviceID string, event gomatrixserverlib.SendToDeviceEvent,
 ) (types.StreamPosition, error) {
-	j, err := json.Marshal(event)
+	j, err := json.ConfigCompatibleWithStandardLibrary.Marshal(event)
 	if err != nil {
 		return streamPos, err
 	}

--- a/syncapi/storage/sqlite3/current_room_state_table.go
+++ b/syncapi/storage/sqlite3/current_room_state_table.go
@@ -18,8 +18,9 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	json "github.com/json-iterator/go"
 	"strings"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"

--- a/syncapi/storage/sqlite3/current_room_state_table.go
+++ b/syncapi/storage/sqlite3/current_room_state_table.go
@@ -18,7 +18,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"strings"
 
 	"github.com/matrix-org/dendrite/internal"
@@ -225,12 +225,12 @@ func (s *currentRoomStateStatements) UpsertRoomState(
 	// Parse content as JSON and search for an "url" key
 	containsURL := false
 	var content map[string]interface{}
-	if json.Unmarshal(event.Content(), &content) != nil {
+	if jsoniter.Unmarshal(event.Content(), &content) != nil {
 		// Set containsURL to true if url is present
 		_, containsURL = content["url"]
 	}
 
-	headeredJSON, err := json.Marshal(event)
+	headeredJSON, err := jsoniter.Marshal(event)
 	if err != nil {
 		return err
 	}
@@ -295,7 +295,7 @@ func rowsToEvents(rows *sql.Rows) ([]gomatrixserverlib.HeaderedEvent, error) {
 		}
 		// TODO: Handle redacted events
 		var ev gomatrixserverlib.HeaderedEvent
-		if err := json.Unmarshal(eventBytes, &ev); err != nil {
+		if err := jsoniter.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, err
 		}
 		result = append(result, ev)
@@ -316,7 +316,7 @@ func (s *currentRoomStateStatements) SelectStateEvent(
 		return nil, err
 	}
 	var ev gomatrixserverlib.HeaderedEvent
-	if err = json.Unmarshal(res, &ev); err != nil {
+	if err = jsoniter.Unmarshal(res, &ev); err != nil {
 		return nil, err
 	}
 	return &ev, err

--- a/syncapi/storage/sqlite3/current_room_state_table.go
+++ b/syncapi/storage/sqlite3/current_room_state_table.go
@@ -226,12 +226,12 @@ func (s *currentRoomStateStatements) UpsertRoomState(
 	// Parse content as JSON and search for an "url" key
 	containsURL := false
 	var content map[string]interface{}
-	if json.Unmarshal(event.Content(), &content) != nil {
+	if json.ConfigCompatibleWithStandardLibrary.Unmarshal(event.Content(), &content) != nil {
 		// Set containsURL to true if url is present
 		_, containsURL = content["url"]
 	}
 
-	headeredJSON, err := json.Marshal(event)
+	headeredJSON, err := json.ConfigCompatibleWithStandardLibrary.Marshal(event)
 	if err != nil {
 		return err
 	}
@@ -296,7 +296,7 @@ func rowsToEvents(rows *sql.Rows) ([]gomatrixserverlib.HeaderedEvent, error) {
 		}
 		// TODO: Handle redacted events
 		var ev gomatrixserverlib.HeaderedEvent
-		if err := json.Unmarshal(eventBytes, &ev); err != nil {
+		if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, err
 		}
 		result = append(result, ev)
@@ -317,7 +317,7 @@ func (s *currentRoomStateStatements) SelectStateEvent(
 		return nil, err
 	}
 	var ev gomatrixserverlib.HeaderedEvent
-	if err = json.Unmarshal(res, &ev); err != nil {
+	if err = json.ConfigCompatibleWithStandardLibrary.Unmarshal(res, &ev); err != nil {
 		return nil, err
 	}
 	return &ev, err

--- a/syncapi/storage/sqlite3/current_room_state_table.go
+++ b/syncapi/storage/sqlite3/current_room_state_table.go
@@ -18,7 +18,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"strings"
 
 	"github.com/matrix-org/dendrite/internal"
@@ -225,12 +225,12 @@ func (s *currentRoomStateStatements) UpsertRoomState(
 	// Parse content as JSON and search for an "url" key
 	containsURL := false
 	var content map[string]interface{}
-	if jsoniter.Unmarshal(event.Content(), &content) != nil {
+	if json.Unmarshal(event.Content(), &content) != nil {
 		// Set containsURL to true if url is present
 		_, containsURL = content["url"]
 	}
 
-	headeredJSON, err := jsoniter.Marshal(event)
+	headeredJSON, err := json.Marshal(event)
 	if err != nil {
 		return err
 	}
@@ -295,7 +295,7 @@ func rowsToEvents(rows *sql.Rows) ([]gomatrixserverlib.HeaderedEvent, error) {
 		}
 		// TODO: Handle redacted events
 		var ev gomatrixserverlib.HeaderedEvent
-		if err := jsoniter.Unmarshal(eventBytes, &ev); err != nil {
+		if err := json.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, err
 		}
 		result = append(result, ev)
@@ -316,7 +316,7 @@ func (s *currentRoomStateStatements) SelectStateEvent(
 		return nil, err
 	}
 	var ev gomatrixserverlib.HeaderedEvent
-	if err = jsoniter.Unmarshal(res, &ev); err != nil {
+	if err = json.Unmarshal(res, &ev); err != nil {
 		return nil, err
 	}
 	return &ev, err

--- a/syncapi/storage/sqlite3/filter_table.go
+++ b/syncapi/storage/sqlite3/filter_table.go
@@ -17,7 +17,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 
 	"github.com/matrix-org/dendrite/syncapi/storage/tables"
@@ -88,7 +88,7 @@ func (s *filterStatements) SelectFilter(
 
 	// Unmarshal JSON into Filter struct
 	var filter gomatrixserverlib.Filter
-	if err = json.Unmarshal(filterData, &filter); err != nil {
+	if err = jsoniter.Unmarshal(filterData, &filter); err != nil {
 		return nil, err
 	}
 	return &filter, nil
@@ -100,7 +100,7 @@ func (s *filterStatements) InsertFilter(
 	var existingFilterID string
 
 	// Serialise json
-	filterJSON, err := json.Marshal(filter)
+	filterJSON, err := jsoniter.Marshal(filter)
 	if err != nil {
 		return "", err
 	}

--- a/syncapi/storage/sqlite3/filter_table.go
+++ b/syncapi/storage/sqlite3/filter_table.go
@@ -17,8 +17,9 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	json "github.com/json-iterator/go"
 	"fmt"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/syncapi/storage/tables"
 	"github.com/matrix-org/gomatrixserverlib"

--- a/syncapi/storage/sqlite3/filter_table.go
+++ b/syncapi/storage/sqlite3/filter_table.go
@@ -17,7 +17,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 
 	"github.com/matrix-org/dendrite/syncapi/storage/tables"
@@ -88,7 +88,7 @@ func (s *filterStatements) SelectFilter(
 
 	// Unmarshal JSON into Filter struct
 	var filter gomatrixserverlib.Filter
-	if err = jsoniter.Unmarshal(filterData, &filter); err != nil {
+	if err = json.Unmarshal(filterData, &filter); err != nil {
 		return nil, err
 	}
 	return &filter, nil
@@ -100,7 +100,7 @@ func (s *filterStatements) InsertFilter(
 	var existingFilterID string
 
 	// Serialise json
-	filterJSON, err := jsoniter.Marshal(filter)
+	filterJSON, err := json.Marshal(filter)
 	if err != nil {
 		return "", err
 	}

--- a/syncapi/storage/sqlite3/filter_table.go
+++ b/syncapi/storage/sqlite3/filter_table.go
@@ -89,7 +89,7 @@ func (s *filterStatements) SelectFilter(
 
 	// Unmarshal JSON into Filter struct
 	var filter gomatrixserverlib.Filter
-	if err = json.Unmarshal(filterData, &filter); err != nil {
+	if err = json.ConfigCompatibleWithStandardLibrary.Unmarshal(filterData, &filter); err != nil {
 		return nil, err
 	}
 	return &filter, nil
@@ -101,7 +101,7 @@ func (s *filterStatements) InsertFilter(
 	var existingFilterID string
 
 	// Serialise json
-	filterJSON, err := json.Marshal(filter)
+	filterJSON, err := json.ConfigCompatibleWithStandardLibrary.Marshal(filter)
 	if err != nil {
 		return "", err
 	}

--- a/syncapi/storage/sqlite3/invites_table.go
+++ b/syncapi/storage/sqlite3/invites_table.go
@@ -18,7 +18,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
@@ -99,7 +99,7 @@ func (s *inviteEventsStatements) InsertInviteEvent(
 	}
 
 	var headeredJSON []byte
-	headeredJSON, err = jsoniter.Marshal(inviteEvent)
+	headeredJSON, err = json.Marshal(inviteEvent)
 	if err != nil {
 		return
 	}
@@ -160,7 +160,7 @@ func (s *inviteEventsStatements) SelectInviteEventsInRange(
 		}
 
 		var event gomatrixserverlib.HeaderedEvent
-		if err := jsoniter.Unmarshal(eventJSON, &event); err != nil {
+		if err := json.Unmarshal(eventJSON, &event); err != nil {
 			return nil, nil, err
 		}
 		if deleted {

--- a/syncapi/storage/sqlite3/invites_table.go
+++ b/syncapi/storage/sqlite3/invites_table.go
@@ -18,6 +18,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
+
 	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal"

--- a/syncapi/storage/sqlite3/invites_table.go
+++ b/syncapi/storage/sqlite3/invites_table.go
@@ -100,7 +100,7 @@ func (s *inviteEventsStatements) InsertInviteEvent(
 	}
 
 	var headeredJSON []byte
-	headeredJSON, err = json.Marshal(inviteEvent)
+	headeredJSON, err = json.ConfigCompatibleWithStandardLibrary.Marshal(inviteEvent)
 	if err != nil {
 		return
 	}
@@ -161,7 +161,7 @@ func (s *inviteEventsStatements) SelectInviteEventsInRange(
 		}
 
 		var event gomatrixserverlib.HeaderedEvent
-		if err := json.Unmarshal(eventJSON, &event); err != nil {
+		if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(eventJSON, &event); err != nil {
 			return nil, nil, err
 		}
 		if deleted {

--- a/syncapi/storage/sqlite3/invites_table.go
+++ b/syncapi/storage/sqlite3/invites_table.go
@@ -18,7 +18,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
@@ -99,7 +99,7 @@ func (s *inviteEventsStatements) InsertInviteEvent(
 	}
 
 	var headeredJSON []byte
-	headeredJSON, err = json.Marshal(inviteEvent)
+	headeredJSON, err = jsoniter.Marshal(inviteEvent)
 	if err != nil {
 		return
 	}
@@ -160,7 +160,7 @@ func (s *inviteEventsStatements) SelectInviteEventsInRange(
 		}
 
 		var event gomatrixserverlib.HeaderedEvent
-		if err := json.Unmarshal(eventJSON, &event); err != nil {
+		if err := jsoniter.Unmarshal(eventJSON, &event); err != nil {
 			return nil, nil, err
 		}
 		if deleted {

--- a/syncapi/storage/sqlite3/output_room_events_table.go
+++ b/syncapi/storage/sqlite3/output_room_events_table.go
@@ -18,8 +18,9 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	json "github.com/json-iterator/go"
 	"sort"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/roomserver/api"

--- a/syncapi/storage/sqlite3/output_room_events_table.go
+++ b/syncapi/storage/sqlite3/output_room_events_table.go
@@ -18,7 +18,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"sort"
 
 	"github.com/matrix-org/dendrite/internal"
@@ -160,7 +160,7 @@ func NewSqliteEventsTable(db *sql.DB, streamID *streamIDStatements) (tables.Even
 }
 
 func (s *outputRoomEventsStatements) UpdateEventJSON(ctx context.Context, event *gomatrixserverlib.HeaderedEvent) error {
-	headeredJSON, err := jsoniter.Marshal(event)
+	headeredJSON, err := json.Marshal(event)
 	if err != nil {
 		return err
 	}
@@ -230,7 +230,7 @@ func (s *outputRoomEventsStatements) SelectStateInRange(
 
 		// TODO: Handle redacted events
 		var ev gomatrixserverlib.HeaderedEvent
-		if err := jsoniter.Unmarshal(eventBytes, &ev); err != nil {
+		if err := json.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, nil, err
 		}
 		needSet := stateNeeded[ev.RoomID()]
@@ -287,22 +287,22 @@ func (s *outputRoomEventsStatements) InsertEvent(
 	// Parse content as JSON and search for an "url" key
 	containsURL := false
 	var content map[string]interface{}
-	if jsoniter.Unmarshal(event.Content(), &content) != nil {
+	if json.Unmarshal(event.Content(), &content) != nil {
 		// Set containsURL to true if url is present
 		_, containsURL = content["url"]
 	}
 
 	var headeredJSON []byte
-	headeredJSON, err := jsoniter.Marshal(event)
+	headeredJSON, err := json.Marshal(event)
 	if err != nil {
 		return 0, err
 	}
 
-	addStateJSON, err := jsoniter.Marshal(addState)
+	addStateJSON, err := json.Marshal(addState)
 	if err != nil {
 		return 0, err
 	}
-	removeStateJSON, err := jsoniter.Marshal(removeState)
+	removeStateJSON, err := json.Marshal(removeState)
 	if err != nil {
 		return 0, err
 	}
@@ -440,7 +440,7 @@ func rowsToStreamEvents(rows *sql.Rows) ([]types.StreamEvent, error) {
 		}
 		// TODO: Handle redacted events
 		var ev gomatrixserverlib.HeaderedEvent
-		if err := jsoniter.Unmarshal(eventBytes, &ev); err != nil {
+		if err := json.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, err
 		}
 
@@ -463,12 +463,12 @@ func rowsToStreamEvents(rows *sql.Rows) ([]types.StreamEvent, error) {
 
 func unmarshalStateIDs(addIDsJSON, delIDsJSON string) (addIDs []string, delIDs []string, err error) {
 	if len(addIDsJSON) > 0 {
-		if err = jsoniter.Unmarshal([]byte(addIDsJSON), &addIDs); err != nil {
+		if err = json.Unmarshal([]byte(addIDsJSON), &addIDs); err != nil {
 			return
 		}
 	}
 	if len(delIDsJSON) > 0 {
-		if err = jsoniter.Unmarshal([]byte(delIDsJSON), &delIDs); err != nil {
+		if err = json.Unmarshal([]byte(delIDsJSON), &delIDs); err != nil {
 			return
 		}
 	}

--- a/syncapi/storage/sqlite3/output_room_events_table.go
+++ b/syncapi/storage/sqlite3/output_room_events_table.go
@@ -161,7 +161,7 @@ func NewSqliteEventsTable(db *sql.DB, streamID *streamIDStatements) (tables.Even
 }
 
 func (s *outputRoomEventsStatements) UpdateEventJSON(ctx context.Context, event *gomatrixserverlib.HeaderedEvent) error {
-	headeredJSON, err := json.Marshal(event)
+	headeredJSON, err := json.ConfigCompatibleWithStandardLibrary.Marshal(event)
 	if err != nil {
 		return err
 	}
@@ -231,7 +231,7 @@ func (s *outputRoomEventsStatements) SelectStateInRange(
 
 		// TODO: Handle redacted events
 		var ev gomatrixserverlib.HeaderedEvent
-		if err := json.Unmarshal(eventBytes, &ev); err != nil {
+		if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, nil, err
 		}
 		needSet := stateNeeded[ev.RoomID()]
@@ -288,22 +288,22 @@ func (s *outputRoomEventsStatements) InsertEvent(
 	// Parse content as JSON and search for an "url" key
 	containsURL := false
 	var content map[string]interface{}
-	if json.Unmarshal(event.Content(), &content) != nil {
+	if json.ConfigCompatibleWithStandardLibrary.Unmarshal(event.Content(), &content) != nil {
 		// Set containsURL to true if url is present
 		_, containsURL = content["url"]
 	}
 
 	var headeredJSON []byte
-	headeredJSON, err := json.Marshal(event)
+	headeredJSON, err := json.ConfigCompatibleWithStandardLibrary.Marshal(event)
 	if err != nil {
 		return 0, err
 	}
 
-	addStateJSON, err := json.Marshal(addState)
+	addStateJSON, err := json.ConfigCompatibleWithStandardLibrary.Marshal(addState)
 	if err != nil {
 		return 0, err
 	}
-	removeStateJSON, err := json.Marshal(removeState)
+	removeStateJSON, err := json.ConfigCompatibleWithStandardLibrary.Marshal(removeState)
 	if err != nil {
 		return 0, err
 	}
@@ -441,7 +441,7 @@ func rowsToStreamEvents(rows *sql.Rows) ([]types.StreamEvent, error) {
 		}
 		// TODO: Handle redacted events
 		var ev gomatrixserverlib.HeaderedEvent
-		if err := json.Unmarshal(eventBytes, &ev); err != nil {
+		if err := json.ConfigCompatibleWithStandardLibrary.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, err
 		}
 
@@ -464,12 +464,12 @@ func rowsToStreamEvents(rows *sql.Rows) ([]types.StreamEvent, error) {
 
 func unmarshalStateIDs(addIDsJSON, delIDsJSON string) (addIDs []string, delIDs []string, err error) {
 	if len(addIDsJSON) > 0 {
-		if err = json.Unmarshal([]byte(addIDsJSON), &addIDs); err != nil {
+		if err = json.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(addIDsJSON), &addIDs); err != nil {
 			return
 		}
 	}
 	if len(delIDsJSON) > 0 {
-		if err = json.Unmarshal([]byte(delIDsJSON), &delIDs); err != nil {
+		if err = json.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(delIDsJSON), &delIDs); err != nil {
 			return
 		}
 	}

--- a/syncapi/storage/sqlite3/output_room_events_table.go
+++ b/syncapi/storage/sqlite3/output_room_events_table.go
@@ -18,7 +18,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"sort"
 
 	"github.com/matrix-org/dendrite/internal"
@@ -160,7 +160,7 @@ func NewSqliteEventsTable(db *sql.DB, streamID *streamIDStatements) (tables.Even
 }
 
 func (s *outputRoomEventsStatements) UpdateEventJSON(ctx context.Context, event *gomatrixserverlib.HeaderedEvent) error {
-	headeredJSON, err := json.Marshal(event)
+	headeredJSON, err := jsoniter.Marshal(event)
 	if err != nil {
 		return err
 	}
@@ -230,7 +230,7 @@ func (s *outputRoomEventsStatements) SelectStateInRange(
 
 		// TODO: Handle redacted events
 		var ev gomatrixserverlib.HeaderedEvent
-		if err := json.Unmarshal(eventBytes, &ev); err != nil {
+		if err := jsoniter.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, nil, err
 		}
 		needSet := stateNeeded[ev.RoomID()]
@@ -287,22 +287,22 @@ func (s *outputRoomEventsStatements) InsertEvent(
 	// Parse content as JSON and search for an "url" key
 	containsURL := false
 	var content map[string]interface{}
-	if json.Unmarshal(event.Content(), &content) != nil {
+	if jsoniter.Unmarshal(event.Content(), &content) != nil {
 		// Set containsURL to true if url is present
 		_, containsURL = content["url"]
 	}
 
 	var headeredJSON []byte
-	headeredJSON, err := json.Marshal(event)
+	headeredJSON, err := jsoniter.Marshal(event)
 	if err != nil {
 		return 0, err
 	}
 
-	addStateJSON, err := json.Marshal(addState)
+	addStateJSON, err := jsoniter.Marshal(addState)
 	if err != nil {
 		return 0, err
 	}
-	removeStateJSON, err := json.Marshal(removeState)
+	removeStateJSON, err := jsoniter.Marshal(removeState)
 	if err != nil {
 		return 0, err
 	}
@@ -440,7 +440,7 @@ func rowsToStreamEvents(rows *sql.Rows) ([]types.StreamEvent, error) {
 		}
 		// TODO: Handle redacted events
 		var ev gomatrixserverlib.HeaderedEvent
-		if err := json.Unmarshal(eventBytes, &ev); err != nil {
+		if err := jsoniter.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, err
 		}
 
@@ -463,12 +463,12 @@ func rowsToStreamEvents(rows *sql.Rows) ([]types.StreamEvent, error) {
 
 func unmarshalStateIDs(addIDsJSON, delIDsJSON string) (addIDs []string, delIDs []string, err error) {
 	if len(addIDsJSON) > 0 {
-		if err = json.Unmarshal([]byte(addIDsJSON), &addIDs); err != nil {
+		if err = jsoniter.Unmarshal([]byte(addIDsJSON), &addIDs); err != nil {
 			return
 		}
 	}
 	if len(delIDsJSON) > 0 {
-		if err = json.Unmarshal([]byte(delIDsJSON), &delIDs); err != nil {
+		if err = jsoniter.Unmarshal([]byte(delIDsJSON), &delIDs); err != nil {
 			return
 		}
 	}

--- a/syncapi/storage/sqlite3/send_to_device_table.go
+++ b/syncapi/storage/sqlite3/send_to_device_table.go
@@ -17,7 +17,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"strings"
 
 	"github.com/matrix-org/dendrite/internal"
@@ -136,7 +136,7 @@ func (s *sendToDeviceStatements) SelectSendToDeviceMessages(
 			UserID:   userID,
 			DeviceID: deviceID,
 		}
-		if err = json.Unmarshal([]byte(content), &event.SendToDeviceEvent); err != nil {
+		if err = jsoniter.Unmarshal([]byte(content), &event.SendToDeviceEvent); err != nil {
 			return
 		}
 		if sentByToken != nil {

--- a/syncapi/storage/sqlite3/send_to_device_table.go
+++ b/syncapi/storage/sqlite3/send_to_device_table.go
@@ -17,8 +17,9 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	json "github.com/json-iterator/go"
 	"strings"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"

--- a/syncapi/storage/sqlite3/send_to_device_table.go
+++ b/syncapi/storage/sqlite3/send_to_device_table.go
@@ -137,7 +137,7 @@ func (s *sendToDeviceStatements) SelectSendToDeviceMessages(
 			UserID:   userID,
 			DeviceID: deviceID,
 		}
-		if err = json.Unmarshal([]byte(content), &event.SendToDeviceEvent); err != nil {
+		if err = json.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(content), &event.SendToDeviceEvent); err != nil {
 			return
 		}
 		if sentByToken != nil {

--- a/syncapi/storage/sqlite3/send_to_device_table.go
+++ b/syncapi/storage/sqlite3/send_to_device_table.go
@@ -17,7 +17,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"strings"
 
 	"github.com/matrix-org/dendrite/internal"
@@ -136,7 +136,7 @@ func (s *sendToDeviceStatements) SelectSendToDeviceMessages(
 			UserID:   userID,
 			DeviceID: deviceID,
 		}
-		if err = jsoniter.Unmarshal([]byte(content), &event.SendToDeviceEvent); err != nil {
+		if err = json.Unmarshal([]byte(content), &event.SendToDeviceEvent); err != nil {
 			return
 		}
 		if sentByToken != nil {

--- a/syncapi/storage/storage_test.go
+++ b/syncapi/storage/storage_test.go
@@ -3,7 +3,7 @@ package storage_test
 import (
 	"context"
 	"crypto/ed25519"
-	"encoding/json"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"os"
 	"testing"

--- a/syncapi/storage/storage_test.go
+++ b/syncapi/storage/storage_test.go
@@ -3,7 +3,7 @@ package storage_test
 import (
 	"context"
 	"crypto/ed25519"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"os"
 	"testing"
@@ -550,7 +550,7 @@ func TestSendToDeviceBehaviour(t *testing.T) {
 	streamPos, err := db.StoreNewSendForDeviceMessage(ctx, types.StreamPosition(0), "alice", "one", gomatrixserverlib.SendToDeviceEvent{
 		Sender:  "bob",
 		Type:    "m.type",
-		Content: json.RawMessage("{}"),
+		Content: jsoniter.RawMessage("{}"),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/syncapi/storage/storage_test.go
+++ b/syncapi/storage/storage_test.go
@@ -3,11 +3,12 @@ package storage_test
 import (
 	"context"
 	"crypto/ed25519"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"os"
 	"testing"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal/config"
 	"github.com/matrix-org/dendrite/syncapi/storage"

--- a/syncapi/storage/storage_test.go
+++ b/syncapi/storage/storage_test.go
@@ -3,7 +3,7 @@ package storage_test
 import (
 	"context"
 	"crypto/ed25519"
-	"github.com/json-iterator/go"
+	"encoding/json"
 	"fmt"
 	"os"
 	"testing"
@@ -550,7 +550,7 @@ func TestSendToDeviceBehaviour(t *testing.T) {
 	streamPos, err := db.StoreNewSendForDeviceMessage(ctx, types.StreamPosition(0), "alice", "one", gomatrixserverlib.SendToDeviceEvent{
 		Sender:  "bob",
 		Type:    "m.type",
-		Content: jsoniter.RawMessage("{}"),
+		Content: json.RawMessage("{}"),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/syncapi/sync/notifier_test.go
+++ b/syncapi/sync/notifier_test.go
@@ -16,7 +16,7 @@ package sync
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"fmt"
 	"sync"
 	"testing"
@@ -49,7 +49,7 @@ var (
 
 func init() {
 	var err error
-	err = json.Unmarshal([]byte(`{
+	err = jsoniter.Unmarshal([]byte(`{
 		"_room_version": "1",
 		"type": "m.room.message",
 		"content": {
@@ -65,7 +65,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	err = json.Unmarshal([]byte(`{
+	err = jsoniter.Unmarshal([]byte(`{
 		"_room_version": "1",
 		"type": "m.room.member",
 		"state_key": "`+bob+`",
@@ -81,7 +81,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	err = json.Unmarshal([]byte(`{
+	err = jsoniter.Unmarshal([]byte(`{
 		"_room_version": "1",
 		"type": "m.room.member",
 		"state_key": "`+bob+`",

--- a/syncapi/sync/notifier_test.go
+++ b/syncapi/sync/notifier_test.go
@@ -50,7 +50,7 @@ var (
 
 func init() {
 	var err error
-	err = json.Unmarshal([]byte(`{
+	err = json.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(`{
 		"_room_version": "1",
 		"type": "m.room.message",
 		"content": {
@@ -66,7 +66,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	err = json.Unmarshal([]byte(`{
+	err = json.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(`{
 		"_room_version": "1",
 		"type": "m.room.member",
 		"state_key": "`+bob+`",
@@ -82,7 +82,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	err = json.Unmarshal([]byte(`{
+	err = json.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(`{
 		"_room_version": "1",
 		"type": "m.room.member",
 		"state_key": "`+bob+`",

--- a/syncapi/sync/notifier_test.go
+++ b/syncapi/sync/notifier_test.go
@@ -16,7 +16,7 @@ package sync
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"fmt"
 	"sync"
 	"testing"
@@ -49,7 +49,7 @@ var (
 
 func init() {
 	var err error
-	err = jsoniter.Unmarshal([]byte(`{
+	err = json.Unmarshal([]byte(`{
 		"_room_version": "1",
 		"type": "m.room.message",
 		"content": {
@@ -65,7 +65,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	err = jsoniter.Unmarshal([]byte(`{
+	err = json.Unmarshal([]byte(`{
 		"_room_version": "1",
 		"type": "m.room.member",
 		"state_key": "`+bob+`",
@@ -81,7 +81,7 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	err = jsoniter.Unmarshal([]byte(`{
+	err = json.Unmarshal([]byte(`{
 		"_room_version": "1",
 		"type": "m.room.member",
 		"state_key": "`+bob+`",

--- a/syncapi/sync/notifier_test.go
+++ b/syncapi/sync/notifier_test.go
@@ -16,11 +16,12 @@ package sync
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"fmt"
 	"sync"
 	"testing"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/syncapi/types"
 	userapi "github.com/matrix-org/dendrite/userapi/api"

--- a/syncapi/sync/request.go
+++ b/syncapi/sync/request.go
@@ -16,10 +16,11 @@ package sync
 
 import (
 	"context"
-	json "github.com/json-iterator/go"
 	"net/http"
 	"strconv"
 	"time"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/syncapi/storage"
 	"github.com/matrix-org/dendrite/syncapi/types"

--- a/syncapi/sync/request.go
+++ b/syncapi/sync/request.go
@@ -76,7 +76,7 @@ func newSyncRequest(req *http.Request, device userapi.Device, syncDB storage.Dat
 		if filterQuery[0] == '{' {
 			// attempt to parse the timeline limit at least
 			var f filter
-			err := json.Unmarshal([]byte(filterQuery), &f)
+			err := json.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(filterQuery), &f)
 			if err == nil && f.Room.Timeline.Limit != nil {
 				timelineLimit = *f.Room.Timeline.Limit
 			}

--- a/syncapi/sync/request.go
+++ b/syncapi/sync/request.go
@@ -16,7 +16,7 @@ package sync
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"net/http"
 	"strconv"
 	"time"
@@ -75,7 +75,7 @@ func newSyncRequest(req *http.Request, device userapi.Device, syncDB storage.Dat
 		if filterQuery[0] == '{' {
 			// attempt to parse the timeline limit at least
 			var f filter
-			err := jsoniter.Unmarshal([]byte(filterQuery), &f)
+			err := json.Unmarshal([]byte(filterQuery), &f)
 			if err == nil && f.Room.Timeline.Limit != nil {
 				timelineLimit = *f.Room.Timeline.Limit
 			}

--- a/syncapi/sync/request.go
+++ b/syncapi/sync/request.go
@@ -16,7 +16,7 @@ package sync
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"net/http"
 	"strconv"
 	"time"
@@ -75,7 +75,7 @@ func newSyncRequest(req *http.Request, device userapi.Device, syncDB storage.Dat
 		if filterQuery[0] == '{' {
 			// attempt to parse the timeline limit at least
 			var f filter
-			err := json.Unmarshal([]byte(filterQuery), &f)
+			err := jsoniter.Unmarshal([]byte(filterQuery), &f)
 			if err == nil && f.Room.Timeline.Limit != nil {
 				timelineLimit = *f.Room.Timeline.Limit
 			}

--- a/syncapi/types/types.go
+++ b/syncapi/types/types.go
@@ -17,7 +17,7 @@ package types
 import (
 	"errors"
 	"fmt"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"sort"
 	"strconv"
 	"strings"
@@ -372,7 +372,7 @@ func (p *syncToken) String() string {
 
 // PrevEventRef represents a reference to a previous event in a state event upgrade
 type PrevEventRef struct {
-	PrevContent   jsoniter.RawMessage `json:"prev_content"`
+	PrevContent   json.RawMessage `json:"prev_content"`
 	ReplacesState string          `json:"replaces_state"`
 	PrevSender    string          `json:"prev_sender"`
 }
@@ -466,20 +466,20 @@ func NewJoinResponse() *JoinResponse {
 // InviteResponse represents a /sync response for a room which is under the 'invite' key.
 type InviteResponse struct {
 	InviteState struct {
-		Events []jsoniter.RawMessage `json:"events"`
+		Events []json.RawMessage `json:"events"`
 	} `json:"invite_state"`
 }
 
 // NewInviteResponse creates an empty response with initialised arrays.
 func NewInviteResponse(event gomatrixserverlib.HeaderedEvent) *InviteResponse {
 	res := InviteResponse{}
-	res.InviteState.Events = []jsoniter.RawMessage{}
+	res.InviteState.Events = []json.RawMessage{}
 
 	// First see if there's invite_room_state in the unsigned key of the invite.
 	// If there is then unmarshal it into the response. This will contain the
 	// partial room state such as join rules, room name etc.
 	if inviteRoomState := gjson.GetBytes(event.Unsigned(), "invite_room_state"); inviteRoomState.Exists() {
-		_ = jsoniter.Unmarshal([]byte(inviteRoomState.Raw), &res.InviteState.Events)
+		_ = json.Unmarshal([]byte(inviteRoomState.Raw), &res.InviteState.Events)
 	}
 
 	// Then we'll see if we can create a partial of the invite event itself.
@@ -487,7 +487,7 @@ func NewInviteResponse(event gomatrixserverlib.HeaderedEvent) *InviteResponse {
 	format, _ := event.RoomVersion.EventFormat()
 	inviteEvent := gomatrixserverlib.ToClientEvent(event.Unwrap(), format)
 	inviteEvent.Unsigned = nil
-	if ev, err := jsoniter.Marshal(inviteEvent); err == nil {
+	if ev, err := json.Marshal(inviteEvent); err == nil {
 		res.InviteState.Events = append(res.InviteState.Events, ev)
 	}
 

--- a/syncapi/types/types.go
+++ b/syncapi/types/types.go
@@ -17,10 +17,11 @@ package types
 import (
 	"errors"
 	"fmt"
-	json "github.com/json-iterator/go"
 	"sort"
 	"strconv"
 	"strings"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"

--- a/syncapi/types/types.go
+++ b/syncapi/types/types.go
@@ -480,7 +480,7 @@ func NewInviteResponse(event gomatrixserverlib.HeaderedEvent) *InviteResponse {
 	// If there is then unmarshal it into the response. This will contain the
 	// partial room state such as join rules, room name etc.
 	if inviteRoomState := gjson.GetBytes(event.Unsigned(), "invite_room_state"); inviteRoomState.Exists() {
-		_ = json.Unmarshal([]byte(inviteRoomState.Raw), &res.InviteState.Events)
+		_ = json.ConfigCompatibleWithStandardLibrary.Unmarshal([]byte(inviteRoomState.Raw), &res.InviteState.Events)
 	}
 
 	// Then we'll see if we can create a partial of the invite event itself.
@@ -488,7 +488,7 @@ func NewInviteResponse(event gomatrixserverlib.HeaderedEvent) *InviteResponse {
 	format, _ := event.RoomVersion.EventFormat()
 	inviteEvent := gomatrixserverlib.ToClientEvent(event.Unwrap(), format)
 	inviteEvent.Unsigned = nil
-	if ev, err := json.Marshal(inviteEvent); err == nil {
+	if ev, err := json.ConfigCompatibleWithStandardLibrary.Marshal(inviteEvent); err == nil {
 		res.InviteState.Events = append(res.InviteState.Events, ev)
 	}
 

--- a/syncapi/types/types.go
+++ b/syncapi/types/types.go
@@ -15,9 +15,9 @@
 package types
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/json-iterator/go"
 	"sort"
 	"strconv"
 	"strings"
@@ -372,7 +372,7 @@ func (p *syncToken) String() string {
 
 // PrevEventRef represents a reference to a previous event in a state event upgrade
 type PrevEventRef struct {
-	PrevContent   json.RawMessage `json:"prev_content"`
+	PrevContent   jsoniter.RawMessage `json:"prev_content"`
 	ReplacesState string          `json:"replaces_state"`
 	PrevSender    string          `json:"prev_sender"`
 }
@@ -466,20 +466,20 @@ func NewJoinResponse() *JoinResponse {
 // InviteResponse represents a /sync response for a room which is under the 'invite' key.
 type InviteResponse struct {
 	InviteState struct {
-		Events []json.RawMessage `json:"events"`
+		Events []jsoniter.RawMessage `json:"events"`
 	} `json:"invite_state"`
 }
 
 // NewInviteResponse creates an empty response with initialised arrays.
 func NewInviteResponse(event gomatrixserverlib.HeaderedEvent) *InviteResponse {
 	res := InviteResponse{}
-	res.InviteState.Events = []json.RawMessage{}
+	res.InviteState.Events = []jsoniter.RawMessage{}
 
 	// First see if there's invite_room_state in the unsigned key of the invite.
 	// If there is then unmarshal it into the response. This will contain the
 	// partial room state such as join rules, room name etc.
 	if inviteRoomState := gjson.GetBytes(event.Unsigned(), "invite_room_state"); inviteRoomState.Exists() {
-		_ = json.Unmarshal([]byte(inviteRoomState.Raw), &res.InviteState.Events)
+		_ = jsoniter.Unmarshal([]byte(inviteRoomState.Raw), &res.InviteState.Events)
 	}
 
 	// Then we'll see if we can create a partial of the invite event itself.
@@ -487,7 +487,7 @@ func NewInviteResponse(event gomatrixserverlib.HeaderedEvent) *InviteResponse {
 	format, _ := event.RoomVersion.EventFormat()
 	inviteEvent := gomatrixserverlib.ToClientEvent(event.Unwrap(), format)
 	inviteEvent.Unsigned = nil
-	if ev, err := json.Marshal(inviteEvent); err == nil {
+	if ev, err := jsoniter.Marshal(inviteEvent); err == nil {
 		res.InviteState.Events = append(res.InviteState.Events, ev)
 	}
 

--- a/syncapi/types/types_test.go
+++ b/syncapi/types/types_test.go
@@ -102,7 +102,7 @@ func TestNewInviteResponse(t *testing.T) {
 	}
 
 	res := NewInviteResponse(ev.Headered(gomatrixserverlib.RoomVersionV5))
-	j, err := json.Marshal(res)
+	j, err := json.ConfigCompatibleWithStandardLibrary.Marshal(res)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/syncapi/types/types_test.go
+++ b/syncapi/types/types_test.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"reflect"
 	"testing"
 
@@ -101,7 +101,7 @@ func TestNewInviteResponse(t *testing.T) {
 	}
 
 	res := NewInviteResponse(ev.Headered(gomatrixserverlib.RoomVersionV5))
-	j, err := jsoniter.Marshal(res)
+	j, err := json.Marshal(res)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/syncapi/types/types_test.go
+++ b/syncapi/types/types_test.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"reflect"
 	"testing"
 
@@ -101,7 +101,7 @@ func TestNewInviteResponse(t *testing.T) {
 	}
 
 	res := NewInviteResponse(ev.Headered(gomatrixserverlib.RoomVersionV5))
-	j, err := json.Marshal(res)
+	j, err := jsoniter.Marshal(res)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/syncapi/types/types_test.go
+++ b/syncapi/types/types_test.go
@@ -1,9 +1,10 @@
 package types
 
 import (
-	json "github.com/json-iterator/go"
 	"reflect"
 	"testing"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/gomatrixserverlib"
 )

--- a/userapi/api/api.go
+++ b/userapi/api/api.go
@@ -192,6 +192,10 @@ type PerformDeviceCreationRequest struct {
 	DeviceID *string
 	// optional: if nil no display name will be associated with this device.
 	DeviceDisplayName *string
+	// IP address of this device
+	IPAddr string
+	// Useragent for this device
+	UserAgent string
 }
 
 // PerformDeviceCreationResponse is the response for PerformDeviceCreation
@@ -222,6 +226,9 @@ type Device struct {
 	// associated with access tokens.
 	SessionID   int64
 	DisplayName string
+	LastSeenTS  int64
+	LastSeenIP  string
+	UserAgent   string
 }
 
 // Account represents a Matrix account on this home server.

--- a/userapi/api/api.go
+++ b/userapi/api/api.go
@@ -16,7 +16,7 @@ package api
 
 import (
 	"context"
-	"encoding/json"
+	"github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -44,7 +44,7 @@ type InputAccountDataRequest struct {
 	UserID      string          // required: the user to set account data for
 	RoomID      string          // optional: the room to associate the account data with
 	DataType    string          // required: the data type of the data
-	AccountData json.RawMessage // required: the message content
+	AccountData jsoniter.RawMessage // required: the message content
 }
 
 // InputAccountDataResponse is the response for InputAccountData
@@ -110,8 +110,8 @@ type QueryAccountDataRequest struct {
 
 // QueryAccountDataResponse is the response for QueryAccountData
 type QueryAccountDataResponse struct {
-	GlobalAccountData map[string]json.RawMessage            // type -> data
-	RoomAccountData   map[string]map[string]json.RawMessage // room -> type -> data
+	GlobalAccountData map[string]jsoniter.RawMessage            // type -> data
+	RoomAccountData   map[string]map[string]jsoniter.RawMessage // room -> type -> data
 }
 
 // QueryDevicesRequest is the request for QueryDevices

--- a/userapi/api/api.go
+++ b/userapi/api/api.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"context"
+
 	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"

--- a/userapi/api/api.go
+++ b/userapi/api/api.go
@@ -16,7 +16,7 @@ package api
 
 import (
 	"context"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -44,7 +44,7 @@ type InputAccountDataRequest struct {
 	UserID      string          // required: the user to set account data for
 	RoomID      string          // optional: the room to associate the account data with
 	DataType    string          // required: the data type of the data
-	AccountData jsoniter.RawMessage // required: the message content
+	AccountData json.RawMessage // required: the message content
 }
 
 // InputAccountDataResponse is the response for InputAccountData
@@ -110,8 +110,8 @@ type QueryAccountDataRequest struct {
 
 // QueryAccountDataResponse is the response for QueryAccountData
 type QueryAccountDataResponse struct {
-	GlobalAccountData map[string]jsoniter.RawMessage            // type -> data
-	RoomAccountData   map[string]map[string]jsoniter.RawMessage // room -> type -> data
+	GlobalAccountData map[string]json.RawMessage            // type -> data
+	RoomAccountData   map[string]map[string]json.RawMessage // room -> type -> data
 }
 
 // QueryDevicesRequest is the request for QueryDevices

--- a/userapi/internal/api.go
+++ b/userapi/internal/api.go
@@ -113,7 +113,7 @@ func (a *UserInternalAPI) PerformDeviceCreation(ctx context.Context, req *api.Pe
 		"device_id":    req.DeviceID,
 		"display_name": req.DeviceDisplayName,
 	}).Info("PerformDeviceCreation")
-	dev, err := a.DeviceDB.CreateDevice(ctx, req.Localpart, req.DeviceID, req.AccessToken, req.DeviceDisplayName)
+	dev, err := a.DeviceDB.CreateDevice(ctx, req.Localpart, req.DeviceID, req.AccessToken, req.DeviceDisplayName, req.IPAddr, req.UserAgent)
 	if err != nil {
 		return err
 	}

--- a/userapi/internal/api.go
+++ b/userapi/internal/api.go
@@ -19,6 +19,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+
 	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/appservice/types"

--- a/userapi/internal/api.go
+++ b/userapi/internal/api.go
@@ -17,9 +17,9 @@ package internal
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/appservice/types"
 	"github.com/matrix-org/dendrite/clientapi/userutil"
@@ -298,17 +298,17 @@ func (a *UserInternalAPI) QueryAccountData(ctx context.Context, req *api.QueryAc
 		return fmt.Errorf("cannot query account data of remote users: got %s want %s", domain, a.ServerName)
 	}
 	if req.DataType != "" {
-		var data json.RawMessage
+		var data jsoniter.RawMessage
 		data, err = a.AccountDB.GetAccountDataByType(ctx, local, req.RoomID, req.DataType)
 		if err != nil {
 			return err
 		}
-		res.RoomAccountData = make(map[string]map[string]json.RawMessage)
-		res.GlobalAccountData = make(map[string]json.RawMessage)
+		res.RoomAccountData = make(map[string]map[string]jsoniter.RawMessage)
+		res.GlobalAccountData = make(map[string]jsoniter.RawMessage)
 		if data != nil {
 			if req.RoomID != "" {
 				if _, ok := res.RoomAccountData[req.RoomID]; !ok {
-					res.RoomAccountData[req.RoomID] = make(map[string]json.RawMessage)
+					res.RoomAccountData[req.RoomID] = make(map[string]jsoniter.RawMessage)
 				}
 				res.RoomAccountData[req.RoomID][req.DataType] = data
 			} else {

--- a/userapi/internal/api.go
+++ b/userapi/internal/api.go
@@ -19,7 +19,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/appservice/types"
 	"github.com/matrix-org/dendrite/clientapi/userutil"
@@ -298,17 +298,17 @@ func (a *UserInternalAPI) QueryAccountData(ctx context.Context, req *api.QueryAc
 		return fmt.Errorf("cannot query account data of remote users: got %s want %s", domain, a.ServerName)
 	}
 	if req.DataType != "" {
-		var data jsoniter.RawMessage
+		var data json.RawMessage
 		data, err = a.AccountDB.GetAccountDataByType(ctx, local, req.RoomID, req.DataType)
 		if err != nil {
 			return err
 		}
-		res.RoomAccountData = make(map[string]map[string]jsoniter.RawMessage)
-		res.GlobalAccountData = make(map[string]jsoniter.RawMessage)
+		res.RoomAccountData = make(map[string]map[string]json.RawMessage)
+		res.GlobalAccountData = make(map[string]json.RawMessage)
 		if data != nil {
 			if req.RoomID != "" {
 				if _, ok := res.RoomAccountData[req.RoomID]; !ok {
-					res.RoomAccountData[req.RoomID] = make(map[string]jsoniter.RawMessage)
+					res.RoomAccountData[req.RoomID] = make(map[string]json.RawMessage)
 				}
 				res.RoomAccountData[req.RoomID][req.DataType] = data
 			} else {

--- a/userapi/inthttp/server.go
+++ b/userapi/inthttp/server.go
@@ -15,7 +15,7 @@
 package inthttp
 
 import (
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -30,7 +30,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("performAccountCreation", func(req *http.Request) util.JSONResponse {
 			request := api.PerformAccountCreationRequest{}
 			response := api.PerformAccountCreationResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.PerformAccountCreation(req.Context(), &request, &response); err != nil {
@@ -43,7 +43,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("performPasswordUpdate", func(req *http.Request) util.JSONResponse {
 			request := api.PerformPasswordUpdateRequest{}
 			response := api.PerformPasswordUpdateResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.PerformPasswordUpdate(req.Context(), &request, &response); err != nil {
@@ -56,7 +56,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("performDeviceCreation", func(req *http.Request) util.JSONResponse {
 			request := api.PerformDeviceCreationRequest{}
 			response := api.PerformDeviceCreationResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.PerformDeviceCreation(req.Context(), &request, &response); err != nil {
@@ -69,7 +69,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("performDeviceUpdate", func(req *http.Request) util.JSONResponse {
 			request := api.PerformDeviceUpdateRequest{}
 			response := api.PerformDeviceUpdateResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.PerformDeviceUpdate(req.Context(), &request, &response); err != nil {
@@ -82,7 +82,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("performDeviceDeletion", func(req *http.Request) util.JSONResponse {
 			request := api.PerformDeviceDeletionRequest{}
 			response := api.PerformDeviceDeletionResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.PerformDeviceDeletion(req.Context(), &request, &response); err != nil {
@@ -95,7 +95,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("performAccountDeactivation", func(req *http.Request) util.JSONResponse {
 			request := api.PerformAccountDeactivationRequest{}
 			response := api.PerformAccountDeactivationResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.PerformAccountDeactivation(req.Context(), &request, &response); err != nil {
@@ -108,7 +108,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("queryProfile", func(req *http.Request) util.JSONResponse {
 			request := api.QueryProfileRequest{}
 			response := api.QueryProfileResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.QueryProfile(req.Context(), &request, &response); err != nil {
@@ -121,7 +121,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("queryAccessToken", func(req *http.Request) util.JSONResponse {
 			request := api.QueryAccessTokenRequest{}
 			response := api.QueryAccessTokenResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.QueryAccessToken(req.Context(), &request, &response); err != nil {
@@ -134,7 +134,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("queryDevices", func(req *http.Request) util.JSONResponse {
 			request := api.QueryDevicesRequest{}
 			response := api.QueryDevicesResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.QueryDevices(req.Context(), &request, &response); err != nil {
@@ -147,7 +147,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("queryAccountData", func(req *http.Request) util.JSONResponse {
 			request := api.QueryAccountDataRequest{}
 			response := api.QueryAccountDataResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.QueryAccountData(req.Context(), &request, &response); err != nil {
@@ -160,7 +160,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("queryDeviceInfos", func(req *http.Request) util.JSONResponse {
 			request := api.QueryDeviceInfosRequest{}
 			response := api.QueryDeviceInfosResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.QueryDeviceInfos(req.Context(), &request, &response); err != nil {
@@ -173,7 +173,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("querySearchProfiles", func(req *http.Request) util.JSONResponse {
 			request := api.QuerySearchProfilesRequest{}
 			response := api.QuerySearchProfilesResponse{}
-			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.QuerySearchProfiles(req.Context(), &request, &response); err != nil {

--- a/userapi/inthttp/server.go
+++ b/userapi/inthttp/server.go
@@ -15,8 +15,9 @@
 package inthttp
 
 import (
-	json "github.com/json-iterator/go"
 	"net/http"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/dendrite/internal/httputil"

--- a/userapi/inthttp/server.go
+++ b/userapi/inthttp/server.go
@@ -15,7 +15,7 @@
 package inthttp
 
 import (
-	"encoding/json"
+	"github.com/json-iterator/go"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -30,7 +30,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("performAccountCreation", func(req *http.Request) util.JSONResponse {
 			request := api.PerformAccountCreationRequest{}
 			response := api.PerformAccountCreationResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.PerformAccountCreation(req.Context(), &request, &response); err != nil {
@@ -43,7 +43,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("performPasswordUpdate", func(req *http.Request) util.JSONResponse {
 			request := api.PerformPasswordUpdateRequest{}
 			response := api.PerformPasswordUpdateResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.PerformPasswordUpdate(req.Context(), &request, &response); err != nil {
@@ -56,7 +56,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("performDeviceCreation", func(req *http.Request) util.JSONResponse {
 			request := api.PerformDeviceCreationRequest{}
 			response := api.PerformDeviceCreationResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.PerformDeviceCreation(req.Context(), &request, &response); err != nil {
@@ -69,7 +69,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("performDeviceUpdate", func(req *http.Request) util.JSONResponse {
 			request := api.PerformDeviceUpdateRequest{}
 			response := api.PerformDeviceUpdateResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.PerformDeviceUpdate(req.Context(), &request, &response); err != nil {
@@ -82,7 +82,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("performDeviceDeletion", func(req *http.Request) util.JSONResponse {
 			request := api.PerformDeviceDeletionRequest{}
 			response := api.PerformDeviceDeletionResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.PerformDeviceDeletion(req.Context(), &request, &response); err != nil {
@@ -95,7 +95,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("performAccountDeactivation", func(req *http.Request) util.JSONResponse {
 			request := api.PerformAccountDeactivationRequest{}
 			response := api.PerformAccountDeactivationResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.PerformAccountDeactivation(req.Context(), &request, &response); err != nil {
@@ -108,7 +108,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("queryProfile", func(req *http.Request) util.JSONResponse {
 			request := api.QueryProfileRequest{}
 			response := api.QueryProfileResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.QueryProfile(req.Context(), &request, &response); err != nil {
@@ -121,7 +121,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("queryAccessToken", func(req *http.Request) util.JSONResponse {
 			request := api.QueryAccessTokenRequest{}
 			response := api.QueryAccessTokenResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.QueryAccessToken(req.Context(), &request, &response); err != nil {
@@ -134,7 +134,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("queryDevices", func(req *http.Request) util.JSONResponse {
 			request := api.QueryDevicesRequest{}
 			response := api.QueryDevicesResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.QueryDevices(req.Context(), &request, &response); err != nil {
@@ -147,7 +147,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("queryAccountData", func(req *http.Request) util.JSONResponse {
 			request := api.QueryAccountDataRequest{}
 			response := api.QueryAccountDataResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.QueryAccountData(req.Context(), &request, &response); err != nil {
@@ -160,7 +160,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("queryDeviceInfos", func(req *http.Request) util.JSONResponse {
 			request := api.QueryDeviceInfosRequest{}
 			response := api.QueryDeviceInfosResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.QueryDeviceInfos(req.Context(), &request, &response); err != nil {
@@ -173,7 +173,7 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 		httputil.MakeInternalAPI("querySearchProfiles", func(req *http.Request) util.JSONResponse {
 			request := api.QuerySearchProfilesRequest{}
 			response := api.QuerySearchProfilesResponse{}
-			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+			if err := jsoniter.NewDecoder(req.Body).Decode(&request); err != nil {
 				return util.MessageResponse(http.StatusBadRequest, err.Error())
 			}
 			if err := s.QuerySearchProfiles(req.Context(), &request, &response); err != nil {

--- a/userapi/storage/accounts/interface.go
+++ b/userapi/storage/accounts/interface.go
@@ -17,6 +17,7 @@ package accounts
 import (
 	"context"
 	"errors"
+
 	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"

--- a/userapi/storage/accounts/interface.go
+++ b/userapi/storage/accounts/interface.go
@@ -16,8 +16,8 @@ package accounts
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
+	"github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/internal"
@@ -36,13 +36,13 @@ type Database interface {
 	// account already exists, it will return nil, ErrUserExists.
 	CreateAccount(ctx context.Context, localpart, plaintextPassword, appserviceID string) (*api.Account, error)
 	CreateGuestAccount(ctx context.Context) (*api.Account, error)
-	SaveAccountData(ctx context.Context, localpart, roomID, dataType string, content json.RawMessage) error
-	GetAccountData(ctx context.Context, localpart string) (global map[string]json.RawMessage, rooms map[string]map[string]json.RawMessage, err error)
+	SaveAccountData(ctx context.Context, localpart, roomID, dataType string, content jsoniter.RawMessage) error
+	GetAccountData(ctx context.Context, localpart string) (global map[string]jsoniter.RawMessage, rooms map[string]map[string]jsoniter.RawMessage, err error)
 	// GetAccountDataByType returns account data matching a given
 	// localpart, room ID and type.
 	// If no account data could be found, returns nil
 	// Returns an error if there was an issue with the retrieval
-	GetAccountDataByType(ctx context.Context, localpart, roomID, dataType string) (data json.RawMessage, err error)
+	GetAccountDataByType(ctx context.Context, localpart, roomID, dataType string) (data jsoniter.RawMessage, err error)
 	GetNewNumericLocalpart(ctx context.Context) (int64, error)
 	SaveThreePIDAssociation(ctx context.Context, threepid, localpart, medium string) (err error)
 	RemoveThreePIDAssociation(ctx context.Context, threepid string, medium string) (err error)

--- a/userapi/storage/accounts/interface.go
+++ b/userapi/storage/accounts/interface.go
@@ -17,7 +17,7 @@ package accounts
 import (
 	"context"
 	"errors"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/internal"
@@ -36,13 +36,13 @@ type Database interface {
 	// account already exists, it will return nil, ErrUserExists.
 	CreateAccount(ctx context.Context, localpart, plaintextPassword, appserviceID string) (*api.Account, error)
 	CreateGuestAccount(ctx context.Context) (*api.Account, error)
-	SaveAccountData(ctx context.Context, localpart, roomID, dataType string, content jsoniter.RawMessage) error
-	GetAccountData(ctx context.Context, localpart string) (global map[string]jsoniter.RawMessage, rooms map[string]map[string]jsoniter.RawMessage, err error)
+	SaveAccountData(ctx context.Context, localpart, roomID, dataType string, content json.RawMessage) error
+	GetAccountData(ctx context.Context, localpart string) (global map[string]json.RawMessage, rooms map[string]map[string]json.RawMessage, err error)
 	// GetAccountDataByType returns account data matching a given
 	// localpart, room ID and type.
 	// If no account data could be found, returns nil
 	// Returns an error if there was an issue with the retrieval
-	GetAccountDataByType(ctx context.Context, localpart, roomID, dataType string) (data jsoniter.RawMessage, err error)
+	GetAccountDataByType(ctx context.Context, localpart, roomID, dataType string) (data json.RawMessage, err error)
 	GetNewNumericLocalpart(ctx context.Context) (int64, error)
 	SaveThreePIDAssociation(ctx context.Context, threepid, localpart, medium string) (err error)
 	RemoveThreePIDAssociation(ctx context.Context, threepid string, medium string) (err error)

--- a/userapi/storage/accounts/postgres/account_data_table.go
+++ b/userapi/storage/accounts/postgres/account_data_table.go
@@ -17,6 +17,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+
 	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal"

--- a/userapi/storage/accounts/postgres/account_data_table.go
+++ b/userapi/storage/accounts/postgres/account_data_table.go
@@ -17,7 +17,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
@@ -74,7 +74,7 @@ func (s *accountDataStatements) prepare(db *sql.DB) (err error) {
 }
 
 func (s *accountDataStatements) insertAccountData(
-	ctx context.Context, txn *sql.Tx, localpart, roomID, dataType string, content jsoniter.RawMessage,
+	ctx context.Context, txn *sql.Tx, localpart, roomID, dataType string, content json.RawMessage,
 ) (err error) {
 	stmt := sqlutil.TxStmt(txn, s.insertAccountDataStmt)
 	_, err = stmt.ExecContext(ctx, localpart, roomID, dataType, content)
@@ -84,8 +84,8 @@ func (s *accountDataStatements) insertAccountData(
 func (s *accountDataStatements) selectAccountData(
 	ctx context.Context, localpart string,
 ) (
-	/* global */ map[string]jsoniter.RawMessage,
-	/* rooms */ map[string]map[string]jsoniter.RawMessage,
+	/* global */ map[string]json.RawMessage,
+	/* rooms */ map[string]map[string]json.RawMessage,
 	error,
 ) {
 	rows, err := s.selectAccountDataStmt.QueryContext(ctx, localpart)
@@ -94,8 +94,8 @@ func (s *accountDataStatements) selectAccountData(
 	}
 	defer internal.CloseAndLogIfError(ctx, rows, "selectAccountData: rows.close() failed")
 
-	global := map[string]jsoniter.RawMessage{}
-	rooms := map[string]map[string]jsoniter.RawMessage{}
+	global := map[string]json.RawMessage{}
+	rooms := map[string]map[string]json.RawMessage{}
 
 	for rows.Next() {
 		var roomID string
@@ -108,7 +108,7 @@ func (s *accountDataStatements) selectAccountData(
 
 		if roomID != "" {
 			if _, ok := rooms[roomID]; !ok {
-				rooms[roomID] = map[string]jsoniter.RawMessage{}
+				rooms[roomID] = map[string]json.RawMessage{}
 			}
 			rooms[roomID][dataType] = content
 		} else {
@@ -121,7 +121,7 @@ func (s *accountDataStatements) selectAccountData(
 
 func (s *accountDataStatements) selectAccountDataByType(
 	ctx context.Context, localpart, roomID, dataType string,
-) (data jsoniter.RawMessage, err error) {
+) (data json.RawMessage, err error) {
 	var bytes []byte
 	stmt := s.selectAccountDataByTypeStmt
 	if err = stmt.QueryRowContext(ctx, localpart, roomID, dataType).Scan(&bytes); err != nil {
@@ -130,6 +130,6 @@ func (s *accountDataStatements) selectAccountDataByType(
 		}
 		return
 	}
-	data = jsoniter.RawMessage(bytes)
+	data = json.RawMessage(bytes)
 	return
 }

--- a/userapi/storage/accounts/postgres/account_data_table.go
+++ b/userapi/storage/accounts/postgres/account_data_table.go
@@ -17,7 +17,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
+	"github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
@@ -74,7 +74,7 @@ func (s *accountDataStatements) prepare(db *sql.DB) (err error) {
 }
 
 func (s *accountDataStatements) insertAccountData(
-	ctx context.Context, txn *sql.Tx, localpart, roomID, dataType string, content json.RawMessage,
+	ctx context.Context, txn *sql.Tx, localpart, roomID, dataType string, content jsoniter.RawMessage,
 ) (err error) {
 	stmt := sqlutil.TxStmt(txn, s.insertAccountDataStmt)
 	_, err = stmt.ExecContext(ctx, localpart, roomID, dataType, content)
@@ -84,8 +84,8 @@ func (s *accountDataStatements) insertAccountData(
 func (s *accountDataStatements) selectAccountData(
 	ctx context.Context, localpart string,
 ) (
-	/* global */ map[string]json.RawMessage,
-	/* rooms */ map[string]map[string]json.RawMessage,
+	/* global */ map[string]jsoniter.RawMessage,
+	/* rooms */ map[string]map[string]jsoniter.RawMessage,
 	error,
 ) {
 	rows, err := s.selectAccountDataStmt.QueryContext(ctx, localpart)
@@ -94,8 +94,8 @@ func (s *accountDataStatements) selectAccountData(
 	}
 	defer internal.CloseAndLogIfError(ctx, rows, "selectAccountData: rows.close() failed")
 
-	global := map[string]json.RawMessage{}
-	rooms := map[string]map[string]json.RawMessage{}
+	global := map[string]jsoniter.RawMessage{}
+	rooms := map[string]map[string]jsoniter.RawMessage{}
 
 	for rows.Next() {
 		var roomID string
@@ -108,7 +108,7 @@ func (s *accountDataStatements) selectAccountData(
 
 		if roomID != "" {
 			if _, ok := rooms[roomID]; !ok {
-				rooms[roomID] = map[string]json.RawMessage{}
+				rooms[roomID] = map[string]jsoniter.RawMessage{}
 			}
 			rooms[roomID][dataType] = content
 		} else {
@@ -121,7 +121,7 @@ func (s *accountDataStatements) selectAccountData(
 
 func (s *accountDataStatements) selectAccountDataByType(
 	ctx context.Context, localpart, roomID, dataType string,
-) (data json.RawMessage, err error) {
+) (data jsoniter.RawMessage, err error) {
 	var bytes []byte
 	stmt := s.selectAccountDataByTypeStmt
 	if err = stmt.QueryRowContext(ctx, localpart, roomID, dataType).Scan(&bytes); err != nil {
@@ -130,6 +130,6 @@ func (s *accountDataStatements) selectAccountDataByType(
 		}
 		return
 	}
-	data = json.RawMessage(bytes)
+	data = jsoniter.RawMessage(bytes)
 	return
 }

--- a/userapi/storage/accounts/postgres/storage.go
+++ b/userapi/storage/accounts/postgres/storage.go
@@ -18,8 +18,9 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	json "github.com/json-iterator/go"
 	"strconv"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/internal/config"

--- a/userapi/storage/accounts/postgres/storage.go
+++ b/userapi/storage/accounts/postgres/storage.go
@@ -17,8 +17,8 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
+	"github.com/json-iterator/go"
 	"strconv"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
@@ -172,7 +172,7 @@ func (d *Database) createAccount(
 		return nil, err
 	}
 
-	if err := d.accountDatas.insertAccountData(ctx, txn, localpart, "", "m.push_rules", json.RawMessage(`{
+	if err := d.accountDatas.insertAccountData(ctx, txn, localpart, "", "m.push_rules", jsoniter.RawMessage(`{
 		"global": {
 			"content": [],
 			"override": [],
@@ -192,7 +192,7 @@ func (d *Database) createAccount(
 // update the corresponding row with the new content
 // Returns a SQL error if there was an issue with the insertion/update
 func (d *Database) SaveAccountData(
-	ctx context.Context, localpart, roomID, dataType string, content json.RawMessage,
+	ctx context.Context, localpart, roomID, dataType string, content jsoniter.RawMessage,
 ) error {
 	return sqlutil.WithTransaction(d.db, func(txn *sql.Tx) error {
 		return d.accountDatas.insertAccountData(ctx, txn, localpart, roomID, dataType, content)
@@ -203,8 +203,8 @@ func (d *Database) SaveAccountData(
 // If no account data could be found, returns an empty arrays
 // Returns an error if there was an issue with the retrieval
 func (d *Database) GetAccountData(ctx context.Context, localpart string) (
-	global map[string]json.RawMessage,
-	rooms map[string]map[string]json.RawMessage,
+	global map[string]jsoniter.RawMessage,
+	rooms map[string]map[string]jsoniter.RawMessage,
 	err error,
 ) {
 	return d.accountDatas.selectAccountData(ctx, localpart)
@@ -216,7 +216,7 @@ func (d *Database) GetAccountData(ctx context.Context, localpart string) (
 // Returns an error if there was an issue with the retrieval
 func (d *Database) GetAccountDataByType(
 	ctx context.Context, localpart, roomID, dataType string,
-) (data json.RawMessage, err error) {
+) (data jsoniter.RawMessage, err error) {
 	return d.accountDatas.selectAccountDataByType(
 		ctx, localpart, roomID, dataType,
 	)

--- a/userapi/storage/accounts/postgres/storage.go
+++ b/userapi/storage/accounts/postgres/storage.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"strconv"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
@@ -172,7 +172,7 @@ func (d *Database) createAccount(
 		return nil, err
 	}
 
-	if err := d.accountDatas.insertAccountData(ctx, txn, localpart, "", "m.push_rules", jsoniter.RawMessage(`{
+	if err := d.accountDatas.insertAccountData(ctx, txn, localpart, "", "m.push_rules", json.RawMessage(`{
 		"global": {
 			"content": [],
 			"override": [],
@@ -192,7 +192,7 @@ func (d *Database) createAccount(
 // update the corresponding row with the new content
 // Returns a SQL error if there was an issue with the insertion/update
 func (d *Database) SaveAccountData(
-	ctx context.Context, localpart, roomID, dataType string, content jsoniter.RawMessage,
+	ctx context.Context, localpart, roomID, dataType string, content json.RawMessage,
 ) error {
 	return sqlutil.WithTransaction(d.db, func(txn *sql.Tx) error {
 		return d.accountDatas.insertAccountData(ctx, txn, localpart, roomID, dataType, content)
@@ -203,8 +203,8 @@ func (d *Database) SaveAccountData(
 // If no account data could be found, returns an empty arrays
 // Returns an error if there was an issue with the retrieval
 func (d *Database) GetAccountData(ctx context.Context, localpart string) (
-	global map[string]jsoniter.RawMessage,
-	rooms map[string]map[string]jsoniter.RawMessage,
+	global map[string]json.RawMessage,
+	rooms map[string]map[string]json.RawMessage,
 	err error,
 ) {
 	return d.accountDatas.selectAccountData(ctx, localpart)
@@ -216,7 +216,7 @@ func (d *Database) GetAccountData(ctx context.Context, localpart string) (
 // Returns an error if there was an issue with the retrieval
 func (d *Database) GetAccountDataByType(
 	ctx context.Context, localpart, roomID, dataType string,
-) (data jsoniter.RawMessage, err error) {
+) (data json.RawMessage, err error) {
 	return d.accountDatas.selectAccountDataByType(
 		ctx, localpart, roomID, dataType,
 	)

--- a/userapi/storage/accounts/sqlite3/account_data_table.go
+++ b/userapi/storage/accounts/sqlite3/account_data_table.go
@@ -17,7 +17,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 )
@@ -75,7 +75,7 @@ func (s *accountDataStatements) prepare(db *sql.DB) (err error) {
 }
 
 func (s *accountDataStatements) insertAccountData(
-	ctx context.Context, txn *sql.Tx, localpart, roomID, dataType string, content jsoniter.RawMessage,
+	ctx context.Context, txn *sql.Tx, localpart, roomID, dataType string, content json.RawMessage,
 ) error {
 	_, err := sqlutil.TxStmt(txn, s.insertAccountDataStmt).ExecContext(ctx, localpart, roomID, dataType, content)
 	return err
@@ -84,8 +84,8 @@ func (s *accountDataStatements) insertAccountData(
 func (s *accountDataStatements) selectAccountData(
 	ctx context.Context, localpart string,
 ) (
-	/* global */ map[string]jsoniter.RawMessage,
-	/* rooms */ map[string]map[string]jsoniter.RawMessage,
+	/* global */ map[string]json.RawMessage,
+	/* rooms */ map[string]map[string]json.RawMessage,
 	error,
 ) {
 	rows, err := s.selectAccountDataStmt.QueryContext(ctx, localpart)
@@ -93,8 +93,8 @@ func (s *accountDataStatements) selectAccountData(
 		return nil, nil, err
 	}
 
-	global := map[string]jsoniter.RawMessage{}
-	rooms := map[string]map[string]jsoniter.RawMessage{}
+	global := map[string]json.RawMessage{}
+	rooms := map[string]map[string]json.RawMessage{}
 
 	for rows.Next() {
 		var roomID string
@@ -107,7 +107,7 @@ func (s *accountDataStatements) selectAccountData(
 
 		if roomID != "" {
 			if _, ok := rooms[roomID]; !ok {
-				rooms[roomID] = map[string]jsoniter.RawMessage{}
+				rooms[roomID] = map[string]json.RawMessage{}
 			}
 			rooms[roomID][dataType] = content
 		} else {
@@ -120,7 +120,7 @@ func (s *accountDataStatements) selectAccountData(
 
 func (s *accountDataStatements) selectAccountDataByType(
 	ctx context.Context, localpart, roomID, dataType string,
-) (data jsoniter.RawMessage, err error) {
+) (data json.RawMessage, err error) {
 	var bytes []byte
 	stmt := s.selectAccountDataByTypeStmt
 	if err = stmt.QueryRowContext(ctx, localpart, roomID, dataType).Scan(&bytes); err != nil {
@@ -129,6 +129,6 @@ func (s *accountDataStatements) selectAccountDataByType(
 		}
 		return
 	}
-	data = jsoniter.RawMessage(bytes)
+	data = json.RawMessage(bytes)
 	return
 }

--- a/userapi/storage/accounts/sqlite3/account_data_table.go
+++ b/userapi/storage/accounts/sqlite3/account_data_table.go
@@ -17,6 +17,7 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
+
 	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/internal/sqlutil"

--- a/userapi/storage/accounts/sqlite3/storage.go
+++ b/userapi/storage/accounts/sqlite3/storage.go
@@ -18,9 +18,10 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	json "github.com/json-iterator/go"
 	"strconv"
 	"sync"
+
+	json "github.com/json-iterator/go"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/internal/config"

--- a/userapi/storage/accounts/sqlite3/storage.go
+++ b/userapi/storage/accounts/sqlite3/storage.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"github.com/json-iterator/go"
+	json "github.com/json-iterator/go"
 	"strconv"
 	"sync"
 
@@ -206,7 +206,7 @@ func (d *Database) createAccount(
 		return nil, err
 	}
 
-	if err := d.accountDatas.insertAccountData(ctx, txn, localpart, "", "m.push_rules", jsoniter.RawMessage(`{
+	if err := d.accountDatas.insertAccountData(ctx, txn, localpart, "", "m.push_rules", json.RawMessage(`{
 		"global": {
 			"content": [],
 			"override": [],
@@ -226,7 +226,7 @@ func (d *Database) createAccount(
 // update the corresponding row with the new content
 // Returns a SQL error if there was an issue with the insertion/update
 func (d *Database) SaveAccountData(
-	ctx context.Context, localpart, roomID, dataType string, content jsoniter.RawMessage,
+	ctx context.Context, localpart, roomID, dataType string, content json.RawMessage,
 ) error {
 	d.accountDatasMu.Lock()
 	defer d.accountDatasMu.Unlock()
@@ -239,8 +239,8 @@ func (d *Database) SaveAccountData(
 // If no account data could be found, returns an empty arrays
 // Returns an error if there was an issue with the retrieval
 func (d *Database) GetAccountData(ctx context.Context, localpart string) (
-	global map[string]jsoniter.RawMessage,
-	rooms map[string]map[string]jsoniter.RawMessage,
+	global map[string]json.RawMessage,
+	rooms map[string]map[string]json.RawMessage,
 	err error,
 ) {
 	return d.accountDatas.selectAccountData(ctx, localpart)
@@ -252,7 +252,7 @@ func (d *Database) GetAccountData(ctx context.Context, localpart string) (
 // Returns an error if there was an issue with the retrieval
 func (d *Database) GetAccountDataByType(
 	ctx context.Context, localpart, roomID, dataType string,
-) (data jsoniter.RawMessage, err error) {
+) (data json.RawMessage, err error) {
 	return d.accountDatas.selectAccountDataByType(
 		ctx, localpart, roomID, dataType,
 	)

--- a/userapi/storage/accounts/sqlite3/storage.go
+++ b/userapi/storage/accounts/sqlite3/storage.go
@@ -17,8 +17,8 @@ package sqlite3
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
+	"github.com/json-iterator/go"
 	"strconv"
 	"sync"
 
@@ -206,7 +206,7 @@ func (d *Database) createAccount(
 		return nil, err
 	}
 
-	if err := d.accountDatas.insertAccountData(ctx, txn, localpart, "", "m.push_rules", json.RawMessage(`{
+	if err := d.accountDatas.insertAccountData(ctx, txn, localpart, "", "m.push_rules", jsoniter.RawMessage(`{
 		"global": {
 			"content": [],
 			"override": [],
@@ -226,7 +226,7 @@ func (d *Database) createAccount(
 // update the corresponding row with the new content
 // Returns a SQL error if there was an issue with the insertion/update
 func (d *Database) SaveAccountData(
-	ctx context.Context, localpart, roomID, dataType string, content json.RawMessage,
+	ctx context.Context, localpart, roomID, dataType string, content jsoniter.RawMessage,
 ) error {
 	d.accountDatasMu.Lock()
 	defer d.accountDatasMu.Unlock()
@@ -239,8 +239,8 @@ func (d *Database) SaveAccountData(
 // If no account data could be found, returns an empty arrays
 // Returns an error if there was an issue with the retrieval
 func (d *Database) GetAccountData(ctx context.Context, localpart string) (
-	global map[string]json.RawMessage,
-	rooms map[string]map[string]json.RawMessage,
+	global map[string]jsoniter.RawMessage,
+	rooms map[string]map[string]jsoniter.RawMessage,
 	err error,
 ) {
 	return d.accountDatas.selectAccountData(ctx, localpart)
@@ -252,7 +252,7 @@ func (d *Database) GetAccountData(ctx context.Context, localpart string) (
 // Returns an error if there was an issue with the retrieval
 func (d *Database) GetAccountDataByType(
 	ctx context.Context, localpart, roomID, dataType string,
-) (data json.RawMessage, err error) {
+) (data jsoniter.RawMessage, err error) {
 	return d.accountDatas.selectAccountDataByType(
 		ctx, localpart, roomID, dataType,
 	)

--- a/userapi/storage/devices/interface.go
+++ b/userapi/storage/devices/interface.go
@@ -31,10 +31,11 @@ type Database interface {
 	// an error will be returned.
 	// If no device ID is given one is generated.
 	// Returns the device on success.
-	CreateDevice(ctx context.Context, localpart string, deviceID *string, accessToken string, displayName *string) (dev *api.Device, returnErr error)
+	CreateDevice(ctx context.Context, localpart string, deviceID *string, accessToken string, displayName *string, ipAddr, userAgent string) (dev *api.Device, returnErr error)
 	UpdateDevice(ctx context.Context, localpart, deviceID string, displayName *string) error
 	RemoveDevice(ctx context.Context, deviceID, localpart string) error
 	RemoveDevices(ctx context.Context, localpart string, devices []string) error
 	// RemoveAllDevices deleted all devices for this user. Returns the devices deleted.
 	RemoveAllDevices(ctx context.Context, localpart, exceptDeviceID string) (devices []api.Device, err error)
+	UpdateDeviceLastSeen(ctx context.Context, deviceID, ipAddr string) error
 }

--- a/userapi/storage/devices/postgres/deltas/20201001204705_last_seen_ts_ip.sql
+++ b/userapi/storage/devices/postgres/deltas/20201001204705_last_seen_ts_ip.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE device_devices ADD COLUMN IF NOT EXISTS last_seen_ts BIGINT NOT NULL;
+ALTER TABLE device_devices ADD COLUMN IF NOT EXISTS ip TEXT;
+ALTER TABLE device_devices ADD COLUMN IF NOT EXISTS user_agent TEXT;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE device_devices DROP COLUMN last_seen_ts;
+ALTER TABLE device_devices DROP COLUMN ip;
+ALTER TABLE device_devices DROP COLUMN user_agent;
+-- +goose StatementEnd

--- a/userapi/storage/devices/postgres/devices_table.go
+++ b/userapi/storage/devices/postgres/devices_table.go
@@ -51,8 +51,15 @@ CREATE TABLE IF NOT EXISTS device_devices (
     -- When this devices was first recognised on the network, as a unix timestamp (ms resolution).
     created_ts BIGINT NOT NULL,
     -- The display name, human friendlier than device_id and updatable
-    display_name TEXT
-    -- TODO: device keys, device display names, last used ts and IP address?, token restrictions (if 3rd-party OAuth app)
+    display_name TEXT,
+	-- The time the device was last used, as a unix timestamp (ms resolution).
+	last_seen_ts BIGINT NOT NULL,
+	-- The last seen IP address of this device
+	ip TEXT,
+	-- User agent of this device
+	user_agent TEXT
+                                          
+    -- TODO: device keys, device display names, token restrictions (if 3rd-party OAuth app)
 );
 
 -- Device IDs must be unique for a given user.
@@ -60,7 +67,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS device_localpart_id_idx ON device_devices(loca
 `
 
 const insertDeviceSQL = "" +
-	"INSERT INTO device_devices(device_id, localpart, access_token, created_ts, display_name) VALUES ($1, $2, $3, $4, $5)" +
+	"INSERT INTO device_devices(device_id, localpart, access_token, created_ts, display_name, last_seen_ts, ip, user_agent) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)" +
 	" RETURNING session_id"
 
 const selectDeviceByTokenSQL = "" +
@@ -87,6 +94,9 @@ const deleteDevicesSQL = "" +
 const selectDevicesByIDSQL = "" +
 	"SELECT device_id, localpart, display_name FROM device_devices WHERE device_id = ANY($1)"
 
+const updateDeviceLastSeen = "" +
+	"UPDATE device_devices SET last_seen_ts = $1, ip = $2 WHERE device_id = $3"
+
 type devicesStatements struct {
 	insertDeviceStmt             *sql.Stmt
 	selectDeviceByTokenStmt      *sql.Stmt
@@ -94,6 +104,7 @@ type devicesStatements struct {
 	selectDevicesByLocalpartStmt *sql.Stmt
 	selectDevicesByIDStmt        *sql.Stmt
 	updateDeviceNameStmt         *sql.Stmt
+	updateDeviceLastSeenStmt     *sql.Stmt
 	deleteDeviceStmt             *sql.Stmt
 	deleteDevicesByLocalpartStmt *sql.Stmt
 	deleteDevicesStmt            *sql.Stmt
@@ -132,6 +143,9 @@ func (s *devicesStatements) prepare(db *sql.DB, server gomatrixserverlib.ServerN
 	if s.selectDevicesByIDStmt, err = db.Prepare(selectDevicesByIDSQL); err != nil {
 		return
 	}
+	if s.updateDeviceLastSeenStmt, err = db.Prepare(updateDeviceLastSeen); err != nil {
+		return
+	}
 	s.serverName = server
 	return
 }
@@ -141,12 +155,12 @@ func (s *devicesStatements) prepare(db *sql.DB, server gomatrixserverlib.ServerN
 // Returns the device on success.
 func (s *devicesStatements) insertDevice(
 	ctx context.Context, txn *sql.Tx, id, localpart, accessToken string,
-	displayName *string,
+	displayName *string, ipAddr, userAgent string,
 ) (*api.Device, error) {
 	createdTimeMS := time.Now().UnixNano() / 1000000
 	var sessionID int64
 	stmt := sqlutil.TxStmt(txn, s.insertDeviceStmt)
-	if err := stmt.QueryRowContext(ctx, id, localpart, accessToken, createdTimeMS, displayName).Scan(&sessionID); err != nil {
+	if err := stmt.QueryRowContext(ctx, id, localpart, accessToken, createdTimeMS, displayName, createdTimeMS, ipAddr, userAgent).Scan(&sessionID); err != nil {
 		return nil, err
 	}
 	return &api.Device{
@@ -154,6 +168,9 @@ func (s *devicesStatements) insertDevice(
 		UserID:      userutil.MakeUserID(localpart, s.serverName),
 		AccessToken: accessToken,
 		SessionID:   sessionID,
+		LastSeenTS:  createdTimeMS,
+		LastSeenIP:  ipAddr,
+		UserAgent:   userAgent,
 	}, nil
 }
 
@@ -279,4 +296,11 @@ func (s *devicesStatements) selectDevicesByLocalpart(
 	}
 
 	return devices, rows.Err()
+}
+
+func (s *devicesStatements) updateDeviceLastSeen(ctx context.Context, txn *sql.Tx, deviceID, ipAddr string) error {
+	lastSeenTs := time.Now().UnixNano() / 1000000
+	stmt := sqlutil.TxStmt(txn, s.updateDeviceLastSeenStmt)
+	_, err := stmt.ExecContext(ctx, lastSeenTs, ipAddr, deviceID)
+	return err
 }

--- a/userapi/storage/devices/postgres/storage.go
+++ b/userapi/storage/devices/postgres/storage.go
@@ -83,7 +83,7 @@ func (d *Database) GetDevicesByID(ctx context.Context, deviceIDs []string) ([]ap
 // Returns the device on success.
 func (d *Database) CreateDevice(
 	ctx context.Context, localpart string, deviceID *string, accessToken string,
-	displayName *string,
+	displayName *string, ipAddr, userAgent string,
 ) (dev *api.Device, returnErr error) {
 	if deviceID != nil {
 		returnErr = sqlutil.WithTransaction(d.db, func(txn *sql.Tx) error {
@@ -93,7 +93,7 @@ func (d *Database) CreateDevice(
 				return err
 			}
 
-			dev, err = d.devices.insertDevice(ctx, txn, *deviceID, localpart, accessToken, displayName)
+			dev, err = d.devices.insertDevice(ctx, txn, *deviceID, localpart, accessToken, displayName, ipAddr, userAgent)
 			return err
 		})
 	} else {
@@ -108,7 +108,7 @@ func (d *Database) CreateDevice(
 
 			returnErr = sqlutil.WithTransaction(d.db, func(txn *sql.Tx) error {
 				var err error
-				dev, err = d.devices.insertDevice(ctx, txn, newDeviceID, localpart, accessToken, displayName)
+				dev, err = d.devices.insertDevice(ctx, txn, newDeviceID, localpart, accessToken, displayName, ipAddr, userAgent)
 				return err
 			})
 			if returnErr == nil {
@@ -188,4 +188,11 @@ func (d *Database) RemoveAllDevices(
 		return nil
 	})
 	return
+}
+
+// UpdateDeviceLastSeen updates a the last seen timestamp and the ip address
+func (d *Database) UpdateDeviceLastSeen(ctx context.Context, deviceID, ipAddr string) error {
+	return sqlutil.WithTransaction(d.db, func(txn *sql.Tx) error {
+		return d.devices.updateDeviceLastSeen(ctx, txn, deviceID, ipAddr)
+	})
 }

--- a/userapi/storage/devices/sqlite3/deltas/20201001204705_last_seen_ts_ip.sql
+++ b/userapi/storage/devices/sqlite3/deltas/20201001204705_last_seen_ts_ip.sql
@@ -1,0 +1,44 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE device_devices RENAME TO device_devices_tmp;
+CREATE TABLE device_devices (
+    access_token TEXT PRIMARY KEY,
+    session_id INTEGER,
+    device_id TEXT ,
+    localpart TEXT ,
+    created_ts BIGINT,
+    display_name TEXT,
+    last_seen_ts BIGINT,
+    ip TEXT,
+    user_agent TEXT,
+    UNIQUE (localpart, device_id)
+);
+INSERT
+INTO device_devices (
+    access_token, session_id, device_id, localpart, created_ts, display_name, last_seen_ts, ip, user_agent
+)  SELECT
+       access_token, session_id, device_id, localpart, created_ts, display_name, created_ts, '', ''
+FROM device_devices_tmp;
+DROP TABLE device_devices_tmp;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE device_devices RENAME TO device_devices_tmp;
+CREATE TABLE IF NOT EXISTS device_devices (
+    access_token TEXT PRIMARY KEY,
+    session_id INTEGER,
+    device_id TEXT ,
+    localpart TEXT ,
+    created_ts BIGINT,
+    display_name TEXT,
+    UNIQUE (localpart, device_id)
+);
+INSERT
+INTO device_devices (
+    access_token, session_id, device_id, localpart, created_ts, display_name
+) SELECT
+       access_token, session_id, device_id, localpart, created_ts, display_name
+FROM device_devices_tmp;
+DROP TABLE device_devices_tmp;
+-- +goose StatementEnd

--- a/userapi/storage/devices/sqlite3/devices_table.go
+++ b/userapi/storage/devices/sqlite3/devices_table.go
@@ -40,14 +40,17 @@ CREATE TABLE IF NOT EXISTS device_devices (
     localpart TEXT ,
     created_ts BIGINT,
     display_name TEXT,
+    last_seen_ts BIGINT,
+    ip TEXT,
+    user_agent TEXT,
 
 		UNIQUE (localpart, device_id)
 );
 `
 
 const insertDeviceSQL = "" +
-	"INSERT INTO device_devices (device_id, localpart, access_token, created_ts, display_name, session_id)" +
-	" VALUES ($1, $2, $3, $4, $5, $6)"
+	"INSERT INTO device_devices (device_id, localpart, access_token, created_ts, display_name, session_id, last_seen_ts, ip, user_agent)" +
+	" VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)"
 
 const selectDevicesCountSQL = "" +
 	"SELECT COUNT(access_token) FROM device_devices"
@@ -76,6 +79,9 @@ const deleteDevicesSQL = "" +
 const selectDevicesByIDSQL = "" +
 	"SELECT device_id, localpart, display_name FROM device_devices WHERE device_id IN ($1)"
 
+const updateDeviceLastSeen = "" +
+	"UPDATE device_devices SET last_seen_ts = $1, ip = $2 WHERE device_id = $3"
+
 type devicesStatements struct {
 	db                           *sql.DB
 	writer                       sqlutil.Writer
@@ -86,6 +92,7 @@ type devicesStatements struct {
 	selectDevicesByIDStmt        *sql.Stmt
 	selectDevicesByLocalpartStmt *sql.Stmt
 	updateDeviceNameStmt         *sql.Stmt
+	updateDeviceLastSeenStmt     *sql.Stmt
 	deleteDeviceStmt             *sql.Stmt
 	deleteDevicesByLocalpartStmt *sql.Stmt
 	serverName                   gomatrixserverlib.ServerName
@@ -125,6 +132,9 @@ func (s *devicesStatements) prepare(db *sql.DB, writer sqlutil.Writer, server go
 	if s.selectDevicesByIDStmt, err = db.Prepare(selectDevicesByIDSQL); err != nil {
 		return
 	}
+	if s.updateDeviceLastSeenStmt, err = db.Prepare(updateDeviceLastSeen); err != nil {
+		return
+	}
 	s.serverName = server
 	return
 }
@@ -134,7 +144,7 @@ func (s *devicesStatements) prepare(db *sql.DB, writer sqlutil.Writer, server go
 // Returns the device on success.
 func (s *devicesStatements) insertDevice(
 	ctx context.Context, txn *sql.Tx, id, localpart, accessToken string,
-	displayName *string,
+	displayName *string, ipAddr, userAgent string,
 ) (*api.Device, error) {
 	createdTimeMS := time.Now().UnixNano() / 1000000
 	var sessionID int64
@@ -144,7 +154,7 @@ func (s *devicesStatements) insertDevice(
 		return nil, err
 	}
 	sessionID++
-	if _, err := insertStmt.ExecContext(ctx, id, localpart, accessToken, createdTimeMS, displayName, sessionID); err != nil {
+	if _, err := insertStmt.ExecContext(ctx, id, localpart, accessToken, createdTimeMS, displayName, sessionID, createdTimeMS, ipAddr, userAgent); err != nil {
 		return nil, err
 	}
 	return &api.Device{
@@ -152,6 +162,9 @@ func (s *devicesStatements) insertDevice(
 		UserID:      userutil.MakeUserID(localpart, s.serverName),
 		AccessToken: accessToken,
 		SessionID:   sessionID,
+		LastSeenTS:  createdTimeMS,
+		LastSeenIP:  ipAddr,
+		UserAgent:   userAgent,
 	}, nil
 }
 
@@ -287,4 +300,11 @@ func (s *devicesStatements) selectDevicesByID(ctx context.Context, deviceIDs []s
 		devices = append(devices, dev)
 	}
 	return devices, rows.Err()
+}
+
+func (s *devicesStatements) updateDeviceLastSeen(ctx context.Context, txn *sql.Tx, deviceID, ipAddr string) error {
+	lastSeenTs := time.Now().UnixNano() / 1000000
+	stmt := sqlutil.TxStmt(txn, s.updateDeviceLastSeenStmt)
+	_, err := stmt.ExecContext(ctx, lastSeenTs, ipAddr, deviceID)
+	return err
 }

--- a/userapi/storage/devices/sqlite3/storage.go
+++ b/userapi/storage/devices/sqlite3/storage.go
@@ -87,7 +87,7 @@ func (d *Database) GetDevicesByID(ctx context.Context, deviceIDs []string) ([]ap
 // Returns the device on success.
 func (d *Database) CreateDevice(
 	ctx context.Context, localpart string, deviceID *string, accessToken string,
-	displayName *string,
+	displayName *string, ipAddr, userAgent string,
 ) (dev *api.Device, returnErr error) {
 	if deviceID != nil {
 		returnErr = d.writer.Do(d.db, nil, func(txn *sql.Tx) error {
@@ -97,7 +97,7 @@ func (d *Database) CreateDevice(
 				return err
 			}
 
-			dev, err = d.devices.insertDevice(ctx, txn, *deviceID, localpart, accessToken, displayName)
+			dev, err = d.devices.insertDevice(ctx, txn, *deviceID, localpart, accessToken, displayName, ipAddr, userAgent)
 			return err
 		})
 	} else {
@@ -112,7 +112,7 @@ func (d *Database) CreateDevice(
 
 			returnErr = d.writer.Do(d.db, nil, func(txn *sql.Tx) error {
 				var err error
-				dev, err = d.devices.insertDevice(ctx, txn, newDeviceID, localpart, accessToken, displayName)
+				dev, err = d.devices.insertDevice(ctx, txn, newDeviceID, localpart, accessToken, displayName, ipAddr, userAgent)
 				return err
 			})
 			if returnErr == nil {
@@ -192,4 +192,11 @@ func (d *Database) RemoveAllDevices(
 		return nil
 	})
 	return
+}
+
+// UpdateDeviceLastSeen updates a the last seen timestamp and the ip address
+func (d *Database) UpdateDeviceLastSeen(ctx context.Context, deviceID, ipAddr string) error {
+	return d.writer.Do(d.db, nil, func(txn *sql.Tx) error {
+		return d.devices.updateDeviceLastSeen(ctx, txn, deviceID, ipAddr)
+	})
 }


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Uses jsoniter instead of encoding/json wherever possible. With some structs from gomatrixserverlib it's currently not possible to use jsoniter.

Some sytest tests seem to fail with this change. I suspect this is because jsoniter sorts map keys differently than encoding/json.
If this is the case jsoniter could be configured to sort map keys like encoding/json.


Signed-off-by: `Benjamin Nater <me@bn4t.me>`
