### PR TITLE
Only return 500 on /send if a database error occurs

### DIFF
--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -16,6 +16,7 @@ package routing
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -234,17 +235,10 @@ func (t *txnReq) processTransaction(ctx context.Context) (*gomatrixserverlib.Res
 // we should stop processing the transaction, and returns false if it
 // is just some less serious error about a specific event.
 func isProcessingErrorFatal(err error) bool {
-	switch err.(type) {
-	case roomNotFoundError:
-	case *gomatrixserverlib.NotAllowed:
-	case missingPrevEventsError:
-	default:
-		switch err {
-		case context.Canceled:
-		case context.DeadlineExceeded:
-		default:
-			return true
-		}
+	switch err {
+	case sql.ErrConnDone:
+	case sql.ErrTxDone:
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
`/send` can return errors in one of two ways - we can either record the error in the JSON response for specific PDUs, or we can return a HTTP status code and fail the entire transaction.

We seemed to be returning 500s readily for any but a small list of errors, but that also caught all sorts of things like failing to find state events. As a result we were missing lots of other events by killing the entire transaction and then other servers would back off because of the 500 error.

This updates it *temporarily* to just fail if it looks like a database error. We really need to do something about #1441 to solve this properly, since right now it's difficult to tell when an error occurs *from* an API call, or if an error occured with *making* the API call itself.