### PR TITLE
Don't ignore local keys from fetchers

### DIFF
--- a/signingkeyserver/internal/api.go
+++ b/signingkeyserver/internal/api.go
@@ -224,10 +224,6 @@ func (s *ServerKeyAPI) handleFetcherKeys(
 
 	// Now let's look at the results that we got from this fetcher.
 	for req, res := range fetcherResults {
-		if req.ServerName == s.ServerName {
-			continue
-		}
-
 		if prev, ok := results[req]; ok {
 			// We've already got a previous entry for this request
 			// so let's see if the newly retrieved one contains a more


### PR DESCRIPTION
This PR updates the fetchers to not ignore keys for the local server.

Ideally, keys for the local domain should always be either one of the configured key, or configured in the `old_private_keys`. However, this doesn't really consider the case where the admin has lost the key altogether and therefore relies on being able to fetch it from a perspective server to rejoin old rooms.

This should fix #1508.