### PR TITLE
Send cumulative state when creating room

### DIFF
--- a/clientapi/routing/createroom.go
+++ b/clientapi/routing/createroom.go
@@ -339,12 +339,21 @@ func createRoom(
 			util.GetLogger(req.Context()).WithError(err).Error("authEvents.AddEvent failed")
 			return jsonerror.InternalServerError()
 		}
-	}
 
-	// send events to the room server
-	if err = roomserverAPI.SendEvents(req.Context(), rsAPI, builtEvents, cfg.Matrix.ServerName, nil); err != nil {
-		util.GetLogger(req.Context()).WithError(err).Error("SendEvents failed")
-		return jsonerror.InternalServerError()
+		accumulated := gomatrixserverlib.UnwrapEventHeaders(builtEvents)
+		if err = roomserverAPI.SendEventWithState(
+			req.Context(),
+			rsAPI,
+			&gomatrixserverlib.RespState{
+				StateEvents: accumulated,
+				AuthEvents:  accumulated,
+			},
+			ev.Headered(roomVersion),
+			nil,
+		); err != nil {
+			util.GetLogger(req.Context()).WithError(err).Error("SendEventWithState failed")
+			return jsonerror.InternalServerError()
+		}
 	}
 
 	// TODO(#269): Reserve room alias while we create the room. This stops us

--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -416,13 +416,38 @@ func (t *txnReq) retrieveMissingAuthEvents(
 	if len(servers) > 5 {
 		servers = servers[:5]
 	}
-
+withNextEvent:
 	for missingAuthEventID := range missingAuthEvents {
-		if _, err := t.lookupEvent(ctx, stateResp.RoomVersion, missingAuthEventID, true, servers); err != nil {
-			logger.WithError(err).Warnf("Failed to retrieve auth event %q", missingAuthEventID)
-			continue
+	withNextServer:
+		for _, server := range servers {
+			logger.Infof("Retrieving missing auth event %q from %q", missingAuthEventID, server)
+			tx, err := t.federation.GetEvent(ctx, server, missingAuthEventID)
+			if err != nil {
+				logger.WithError(err).Warnf("Failed to retrieve auth event %q", missingAuthEventID)
+				continue withNextServer
+			}
+			ev, err := gomatrixserverlib.NewEventFromUntrustedJSON(tx.PDUs[0], stateResp.RoomVersion)
+			if err != nil {
+				logger.WithError(err).Warnf("Failed to unmarshal auth event %q", missingAuthEventID)
+				continue withNextServer
+			}
+			if err = api.SendInputRoomEvents(
+				context.Background(),
+				t.rsAPI,
+				[]api.InputRoomEvent{
+					{
+						Kind:         api.KindOutlier,
+						Event:        ev.Headered(stateResp.RoomVersion),
+						AuthEventIDs: ev.AuthEventIDs(),
+						SendAsServer: api.DoNotSendToOtherServers,
+					},
+				},
+			); err != nil {
+				return fmt.Errorf("api.SendEvents: %w", err)
+			}
+			delete(missingAuthEvents, missingAuthEventID)
+			continue withNextEvent
 		}
-		delete(missingAuthEvents, missingAuthEventID)
 	}
 
 	if missing := len(missingAuthEvents); missing > 0 {
@@ -1016,20 +1041,6 @@ func (t *txnReq) lookupEvent(ctx context.Context, roomVersion gomatrixserverlib.
 		return nil, verifySigError{event.EventID(), err}
 	}
 	h := event.Headered(roomVersion)
-	if err := api.SendInputRoomEvents(
-		context.Background(),
-		t.rsAPI,
-		[]api.InputRoomEvent{
-			{
-				Kind:         api.KindOutlier,
-				Event:        h,
-				AuthEventIDs: h.AuthEventIDs(),
-				SendAsServer: api.DoNotSendToOtherServers,
-			},
-		},
-	); err != nil {
-		return nil, fmt.Errorf("api.SendInputRoomEvents: %w", err)
-	}
 	t.newEvents[h.EventID()] = true
 	return &h, nil
 }


### PR DESCRIPTION
When we create a local room, we know what the room state is at the bootstrap events, so we should send that state rather than leaving the events with empty state snapshots in the roomserver.