### PR TITLE
Improved state handling in /send

### DIFF
--- a/roomserver/api/query.go
+++ b/roomserver/api/query.go
@@ -63,7 +63,8 @@ type QueryStateAfterEventsRequest struct {
 	RoomID string `json:"room_id"`
 	// The list of previous events to return the events after.
 	PrevEventIDs []string `json:"prev_event_ids"`
-	// The state key tuples to fetch from the state
+	// The state key tuples to fetch from the state. If none are specified then
+	// the entire resolved room state will be returned.
 	StateToFetch []gomatrixserverlib.StateKeyTuple `json:"state_to_fetch"`
 }
 

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -78,10 +78,19 @@ func (r *Queryer) QueryStateAfterEvents(
 	}
 	response.PrevEventsExist = true
 
-	// Look up the currrent state for the requested tuples.
-	stateEntries, err := roomState.LoadStateAfterEventsForStringTuples(
-		ctx, prevStates, request.StateToFetch,
-	)
+	var stateEntries []types.StateEntry
+	if len(request.StateToFetch) == 0 {
+		// Look up all of the current room state.
+		// TODO: This can return duplicate state-key tuples, is this a problem?
+		stateEntries, err = roomState.LoadCombinedStateAfterEvents(
+			ctx, prevStates,
+		)
+	} else {
+		// Look up the current state for the requested tuples.
+		stateEntries, err = roomState.LoadStateAfterEventsForStringTuples(
+			ctx, prevStates, request.StateToFetch,
+		)
+	}
 	if err != nil {
 		return err
 	}

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -49,6 +49,7 @@ func (r *Queryer) QueryLatestEventsAndState(
 }
 
 // QueryStateAfterEvents implements api.RoomserverInternalAPI
+// nolint:gocyclo
 func (r *Queryer) QueryStateAfterEvents(
 	ctx context.Context,
 	request *api.QueryStateAfterEventsRequest,
@@ -81,7 +82,6 @@ func (r *Queryer) QueryStateAfterEvents(
 	var stateEntries []types.StateEntry
 	if len(request.StateToFetch) == 0 {
 		// Look up all of the current room state.
-		// TODO: This can return duplicate state-key tuples, is this a problem?
 		stateEntries, err = roomState.LoadCombinedStateAfterEvents(
 			ctx, prevStates,
 		)
@@ -98,6 +98,24 @@ func (r *Queryer) QueryStateAfterEvents(
 	stateEvents, err := helpers.LoadStateEvents(ctx, r.DB, stateEntries)
 	if err != nil {
 		return err
+	}
+
+	if len(request.PrevEventIDs) > 1 && len(request.StateToFetch) == 0 {
+		var authEventIDs []string
+		for _, e := range stateEvents {
+			authEventIDs = append(authEventIDs, e.AuthEventIDs()...)
+		}
+		authEventIDs = util.UniqueStrings(authEventIDs)
+
+		authEvents, err := getAuthChain(ctx, r.DB.EventsFromIDs, authEventIDs)
+		if err != nil {
+			return fmt.Errorf("getAuthChain: %w", err)
+		}
+
+		stateEvents, err = state.ResolveConflictsAdhoc(info.RoomVersion, stateEvents, authEvents)
+		if err != nil {
+			return fmt.Errorf("state.ResolveConflictsAdhoc: %w", err)
+		}
 	}
 
 	for _, event := range stateEvents {


### PR DESCRIPTION
This fixes some bugs in the federation API `/send` endpoint where we'd only request state tuples for events needed for auth, but then try to send on that state as if it were the full state before an event.

This instead requests the entire room state, and updates `QueryStateAfterEvents` so that it performs state resolution.