### PR TITLE
Ignore typing events where sender doesn't match origin

### DIFF
--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -289,6 +289,15 @@ func (t *txnReq) processEDUs(ctx context.Context) {
 				util.GetLogger(ctx).WithError(err).Error("Failed to unmarshal typing event")
 				continue
 			}
+			_, domain, err := gomatrixserverlib.SplitID('@', typingPayload.UserID)
+			if err != nil {
+				util.GetLogger(ctx).WithError(err).Error("Failed to split domain from typing event sender")
+				continue
+			}
+			if domain != t.Origin {
+				util.GetLogger(ctx).Warnf("Dropping typing event where sender domain (%d) doesn't match origin (%d)", domain, t.Origin)
+				continue
+			}
 			if err := eduserverAPI.SendTyping(ctx, t.eduAPI, typingPayload.UserID, typingPayload.RoomID, typingPayload.Typing, 30*1000); err != nil {
 				util.GetLogger(ctx).WithError(err).Error("Failed to send typing event to edu server")
 			}

--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -295,7 +295,7 @@ func (t *txnReq) processEDUs(ctx context.Context) {
 				continue
 			}
 			if domain != t.Origin {
-				util.GetLogger(ctx).Warnf("Dropping typing event where sender domain (%d) doesn't match origin (%d)", domain, t.Origin)
+				util.GetLogger(ctx).Warnf("Dropping typing event where sender domain (%q) doesn't match origin (%q)", domain, t.Origin)
 				continue
 			}
 			if err := eduserverAPI.SendTyping(ctx, t.eduAPI, typingPayload.UserID, typingPayload.RoomID, typingPayload.Typing, 30*1000); err != nil {

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -483,3 +483,4 @@ POST rejects invalid utf-8 in JSON
 Users cannot kick users who have already left a room
 A prev_batch token from incremental sync can be used in the v1 messages API
 Event with an invalid signature in the send_join response should not cause room join to fail
+Inbound federation rejects typing notifications from wrong remote


### PR DESCRIPTION
This should fix a sytest (see #1327) and stop us from accepting typing notifications that lie about the sender from another server.