### PR TITLE
Fix state endpoints

### DIFF
--- a/clientapi/routing/state.go
+++ b/clientapi/routing/state.go
@@ -141,7 +141,7 @@ func OnIncomingStateRequest(ctx context.Context, device *userapi.Device, rsAPI a
 			util.GetLogger(ctx).WithError(err).Error("Failed to QueryMembershipForUser")
 			return jsonerror.InternalServerError()
 		}
-		for _, ev := range stateRes.StateEvents {
+		for _, ev := range stateAfterRes.StateEvents {
 			stateEvents = append(
 				stateEvents,
 				gomatrixserverlib.HeaderedToClientEvent(ev, gomatrixserverlib.FormatAll),

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -482,5 +482,5 @@ m.room.history_visibility == "joined" allows/forbids appropriately for Real user
 POST rejects invalid utf-8 in JSON
 Users cannot kick users who have already left a room
 A prev_batch token from incremental sync can be used in the v1 messages API
-Event with an invalid signature in the send_join response should not cause room join to fail
-Inbound federation rejects typing notifications from wrong remote
+Can get rooms/{roomId}/state for a departed room (SPEC-216)
+Inbound federation can return missing events for shared visibility

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -484,3 +484,5 @@ Users cannot kick users who have already left a room
 A prev_batch token from incremental sync can be used in the v1 messages API
 Can get rooms/{roomId}/state for a departed room (SPEC-216)
 Inbound federation can return missing events for shared visibility
+Event with an invalid signature in the send_join response should not cause room join to fail
+Inbound federation rejects typing notifications from wrong remote


### PR DESCRIPTION
Should fix underlying issues in #1329 

Doesn't fix the tests associated because it looks like those invoke `/rooms/{roomID}/initialSync`which returns a forbidden status. 
Modifying the return status  in clientapi/routing/routing.go will cause the tests to pass, however wasn't sure of any underlying client bugs that might cause. 

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `Devon Johnson <djohnson1865@gmail.com>`
