### PR TITLE
Update Docker

### DIFF
--- a/build/docker/Dockerfile.component
+++ b/build/docker/Dockerfile.component
@@ -6,6 +6,7 @@ ARG component=monolith
 ENV entrypoint=${component}
 
 COPY --from=base /build/bin/${component} /usr/bin
+COPY --from=base /build/bin/goose /usr/bin
 
 VOLUME /etc/dendrite
 WORKDIR /etc/dendrite

--- a/build/docker/docker-compose.monolith.yml
+++ b/build/docker/docker-compose.monolith.yml
@@ -2,7 +2,7 @@ version: "3.4"
 services:
   monolith:
     hostname: monolith
-    image: matrixdotorg/dendrite:monolith
+    image: matrixdotorg/dendrite-monolith:latest
     command: [
       "--config=dendrite.yaml",
       "--tls-cert=server.crt",

--- a/build/docker/docker-compose.polylith.yml
+++ b/build/docker/docker-compose.polylith.yml
@@ -1,28 +1,8 @@
 version: "3.4"
 services:
-  client_api_proxy:
-    hostname: client_api_proxy
-    image: matrixdotorg/dendrite:clientproxy
-    command: [
-      "--bind-address=:8008",
-      "--client-api-server-url=http://client_api:8071",
-      "--sync-api-server-url=http://sync_api:8073",
-      "--media-api-server-url=http://media_api:8074"
-    ]
-    volumes:
-      - ./config:/etc/dendrite
-    networks:
-      - internal
-    depends_on:
-      - sync_api
-      - client_api
-      - media_api
-    ports:
-      - "8008:8008"
-
   client_api:
     hostname: client_api
-    image: matrixdotorg/dendrite:clientapi
+    image: matrixdotorg/dendrite-clientapi:latest
     command: [
       "--config=dendrite.yaml"
     ]
@@ -34,7 +14,7 @@ services:
 
   media_api:
     hostname: media_api
-    image: matrixdotorg/dendrite:mediaapi
+    image: matrixdotorg/dendrite-mediaapi:latest
     command: [
       "--config=dendrite.yaml"
     ]
@@ -45,7 +25,7 @@ services:
 
   sync_api:
     hostname: sync_api
-    image: matrixdotorg/dendrite:syncapi
+    image: matrixdotorg/dendrite-syncapi:latest
     command: [
       "--config=dendrite.yaml"
     ]
@@ -56,7 +36,7 @@ services:
 
   room_server:
     hostname: room_server
-    image: matrixdotorg/dendrite:roomserver
+    image: matrixdotorg/dendrite-roomserver:latest
     command: [
       "--config=dendrite.yaml"
     ]
@@ -67,7 +47,7 @@ services:
 
   edu_server:
     hostname: edu_server
-    image: matrixdotorg/dendrite:eduserver
+    image: matrixdotorg/dendrite-eduserver:latest
     command: [
       "--config=dendrite.yaml"
     ]
@@ -76,28 +56,9 @@ services:
     networks:
       - internal
 
-  federation_api_proxy:
-    hostname: federation_api_proxy
-    image: matrixdotorg/dendrite:federationproxy
-    command: [
-      "--bind-address=:8448",
-      "--federation-api-url=http://federation_api:8072",
-      "--media-api-server-url=http://media_api:8074"
-    ]
-    volumes:
-      - ./config:/etc/dendrite
-    depends_on:
-      - federation_api
-      - federation_sender
-      - media_api
-    networks:
-      - internal
-    ports:
-      - "8448:8448"
-
   federation_api:
     hostname: federation_api
-    image: matrixdotorg/dendrite:federationapi
+    image: matrixdotorg/dendrite-federationapi:latest
     command: [
       "--config=dendrite.yaml"
     ]
@@ -108,7 +69,7 @@ services:
 
   federation_sender:
     hostname: federation_sender
-    image: matrixdotorg/dendrite:federationsender
+    image: matrixdotorg/dendrite-federationsender:latest
     command: [
       "--config=dendrite.yaml"
     ]
@@ -119,7 +80,7 @@ services:
       
   key_server:
     hostname: key_server
-    image: matrixdotorg/dendrite:keyserver
+    image: matrixdotorg/dendrite-keyserver:latest
     command: [
       "--config=dendrite.yaml"
     ]
@@ -130,7 +91,7 @@ services:
 
   signing_key_server:
     hostname: signing_key_server
-    image: matrixdotorg/dendrite:signingkeyserver
+    image: matrixdotorg/dendrite-signingkeyserver:latest
     command: [
       "--config=dendrite.yaml"
     ]
@@ -141,7 +102,7 @@ services:
 
   user_api:
     hostname: user_api
-    image: matrixdotorg/dendrite:userapi
+    image: matrixdotorg/dendrite-userapi:latest
     command: [
         "--config=dendrite.yaml"
     ]
@@ -152,7 +113,7 @@ services:
 
   appservice_api:
     hostname: appservice_api
-    image: matrixdotorg/dendrite:appservice
+    image: matrixdotorg/dendrite-appservice:latest
     command: [
       "--config=dendrite.yaml"
     ]

--- a/build/docker/images-build.sh
+++ b/build/docker/images-build.sh
@@ -4,18 +4,16 @@ cd $(git rev-parse --show-toplevel)
 
 docker build -f build/docker/Dockerfile -t matrixdotorg/dendrite:latest .
 
-docker build -t matrixdotorg/dendrite:monolith          --build-arg component=dendrite-monolith-server          -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-monolith:latest          --build-arg component=dendrite-monolith-server          -f build/docker/Dockerfile.component .
 
-docker build -t matrixdotorg/dendrite:appservice        --build-arg component=dendrite-appservice-server        -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite:clientapi         --build-arg component=dendrite-client-api-server        -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite:clientproxy       --build-arg component=client-api-proxy                  -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite:eduserver         --build-arg component=dendrite-edu-server               -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite:federationapi     --build-arg component=dendrite-federation-api-server    -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite:federationsender  --build-arg component=dendrite-federation-sender-server -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite:federationproxy   --build-arg component=federation-api-proxy              -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite:keyserver         --build-arg component=dendrite-key-server               -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite:mediaapi          --build-arg component=dendrite-media-api-server         -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite:roomserver        --build-arg component=dendrite-room-server              -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite:syncapi           --build-arg component=dendrite-sync-api-server          -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite:signingkeyserver      --build-arg component=dendrite-signing-key-server    -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite:userapi           --build-arg component=dendrite-user-api-server          -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-appservice:latest        --build-arg component=dendrite-appservice-server        -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-clientapi:latest         --build-arg component=dendrite-client-api-server        -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-eduserver:latest         --build-arg component=dendrite-edu-server               -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-federationapi:latest     --build-arg component=dendrite-federation-api-server    -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-federationsender:latest  --build-arg component=dendrite-federation-sender-server -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-keyserver:latest         --build-arg component=dendrite-key-server               -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-mediaapi:latest          --build-arg component=dendrite-media-api-server         -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-roomserver:latest        --build-arg component=dendrite-room-server              -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-syncapi:latest           --build-arg component=dendrite-sync-api-server          -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-signingkeyserver:latest  --build-arg component=dendrite-signing-key-server       -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-userapi:latest           --build-arg component=dendrite-user-api-server          -f build/docker/Dockerfile.component .

--- a/build/docker/images-build.sh
+++ b/build/docker/images-build.sh
@@ -2,18 +2,22 @@
 
 cd $(git rev-parse --show-toplevel)
 
-docker build -f build/docker/Dockerfile -t matrixdotorg/dendrite:latest .
+TAG=${1:-latest}
 
-docker build -t matrixdotorg/dendrite-monolith:latest          --build-arg component=dendrite-monolith-server          -f build/docker/Dockerfile.component .
+echo "Building tag '${TAG}'"
 
-docker build -t matrixdotorg/dendrite-appservice:latest        --build-arg component=dendrite-appservice-server        -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite-clientapi:latest         --build-arg component=dendrite-client-api-server        -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite-eduserver:latest         --build-arg component=dendrite-edu-server               -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite-federationapi:latest     --build-arg component=dendrite-federation-api-server    -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite-federationsender:latest  --build-arg component=dendrite-federation-sender-server -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite-keyserver:latest         --build-arg component=dendrite-key-server               -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite-mediaapi:latest          --build-arg component=dendrite-media-api-server         -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite-roomserver:latest        --build-arg component=dendrite-room-server              -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite-syncapi:latest           --build-arg component=dendrite-sync-api-server          -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite-signingkeyserver:latest  --build-arg component=dendrite-signing-key-server       -f build/docker/Dockerfile.component .
-docker build -t matrixdotorg/dendrite-userapi:latest           --build-arg component=dendrite-user-api-server          -f build/docker/Dockerfile.component .
+docker build -f build/docker/Dockerfile -t matrixdotorg/dendrite:${TAG} .
+
+docker build -t matrixdotorg/dendrite-monolith:${TAG}          --build-arg component=dendrite-monolith-server          -f build/docker/Dockerfile.component .
+
+docker build -t matrixdotorg/dendrite-appservice:${TAG}        --build-arg component=dendrite-appservice-server        -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-clientapi:${TAG}         --build-arg component=dendrite-client-api-server        -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-eduserver:${TAG}         --build-arg component=dendrite-edu-server               -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-federationapi:${TAG}     --build-arg component=dendrite-federation-api-server    -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-federationsender:${TAG}  --build-arg component=dendrite-federation-sender-server -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-keyserver:${TAG}         --build-arg component=dendrite-key-server               -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-mediaapi:${TAG}          --build-arg component=dendrite-media-api-server         -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-roomserver:${TAG}        --build-arg component=dendrite-room-server              -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-syncapi:${TAG}           --build-arg component=dendrite-sync-api-server          -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-signingkeyserver:${TAG}  --build-arg component=dendrite-signing-key-server       -f build/docker/Dockerfile.component .
+docker build -t matrixdotorg/dendrite-userapi:${TAG}           --build-arg component=dendrite-user-api-server          -f build/docker/Dockerfile.component .

--- a/build/docker/images-pull.sh
+++ b/build/docker/images-pull.sh
@@ -1,17 +1,15 @@
 #!/bin/bash
 
-docker pull matrixdotorg/dendrite:monolith
+docker pull matrixdotorg/dendrite-monolith:latest
 
-docker pull matrixdotorg/dendrite:appservice
-docker pull matrixdotorg/dendrite:clientapi
-docker pull matrixdotorg/dendrite:clientproxy
-docker pull matrixdotorg/dendrite:eduserver
-docker pull matrixdotorg/dendrite:federationapi
-docker pull matrixdotorg/dendrite:federationsender
-docker pull matrixdotorg/dendrite:federationproxy
-docker pull matrixdotorg/dendrite:keyserver
-docker pull matrixdotorg/dendrite:mediaapi
-docker pull matrixdotorg/dendrite:roomserver
-docker pull matrixdotorg/dendrite:syncapi
-docker pull matrixdotorg/dendrite:signingkeyserver
-docker pull matrixdotorg/dendrite:userapi
+docker pull matrixdotorg/dendrite-appservice:latest
+docker pull matrixdotorg/dendrite-clientapi:latest
+docker pull matrixdotorg/dendrite-eduserver:latest
+docker pull matrixdotorg/dendrite-federationapi:latest
+docker pull matrixdotorg/dendrite-federationsender:latest
+docker pull matrixdotorg/dendrite-keyserver:latest
+docker pull matrixdotorg/dendrite-mediaapi:latest
+docker pull matrixdotorg/dendrite-roomserver:latest
+docker pull matrixdotorg/dendrite-syncapi:latest
+docker pull matrixdotorg/dendrite-signingkeyserver:latest
+docker pull matrixdotorg/dendrite-userapi:latest

--- a/build/docker/images-pull.sh
+++ b/build/docker/images-pull.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 
-docker pull matrixdotorg/dendrite-monolith:latest
+TAG=${1:-latest}
 
-docker pull matrixdotorg/dendrite-appservice:latest
-docker pull matrixdotorg/dendrite-clientapi:latest
-docker pull matrixdotorg/dendrite-eduserver:latest
-docker pull matrixdotorg/dendrite-federationapi:latest
-docker pull matrixdotorg/dendrite-federationsender:latest
-docker pull matrixdotorg/dendrite-keyserver:latest
-docker pull matrixdotorg/dendrite-mediaapi:latest
-docker pull matrixdotorg/dendrite-roomserver:latest
-docker pull matrixdotorg/dendrite-syncapi:latest
-docker pull matrixdotorg/dendrite-signingkeyserver:latest
-docker pull matrixdotorg/dendrite-userapi:latest
+echo "Pulling tag '${TAG}'"
+
+docker pull matrixdotorg/dendrite-monolith:${TAG}
+
+docker pull matrixdotorg/dendrite-appservice:${TAG}
+docker pull matrixdotorg/dendrite-clientapi:${TAG}
+docker pull matrixdotorg/dendrite-eduserver:${TAG}
+docker pull matrixdotorg/dendrite-federationapi:${TAG}
+docker pull matrixdotorg/dendrite-federationsender:${TAG}
+docker pull matrixdotorg/dendrite-keyserver:${TAG}
+docker pull matrixdotorg/dendrite-mediaapi:${TAG}
+docker pull matrixdotorg/dendrite-roomserver:${TAG}
+docker pull matrixdotorg/dendrite-syncapi:${TAG}
+docker pull matrixdotorg/dendrite-signingkeyserver:${TAG}
+docker pull matrixdotorg/dendrite-userapi:${TAG}

--- a/build/docker/images-push.sh
+++ b/build/docker/images-push.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 
-docker push matrixdotorg/dendrite-monolith:latest
+TAG=${1:-latest}
 
-docker push matrixdotorg/dendrite-appservice:latest
-docker push matrixdotorg/dendrite-clientapi:latest
-docker push matrixdotorg/dendrite-eduserver:latest
-docker push matrixdotorg/dendrite-federationapi:latest
-docker push matrixdotorg/dendrite-federationsender:latest
-docker push matrixdotorg/dendrite-keyserver:latest
-docker push matrixdotorg/dendrite-mediaapi:latest
-docker push matrixdotorg/dendrite-roomserver:latest
-docker push matrixdotorg/dendrite-syncapi:latest
-docker push matrixdotorg/dendrite-signingkeyserver:latest
-docker push matrixdotorg/dendrite-userapi:latest
+echo "Pushing tag '${TAG}'"
+
+docker push matrixdotorg/dendrite-monolith:${TAG}
+
+docker push matrixdotorg/dendrite-appservice:${TAG}
+docker push matrixdotorg/dendrite-clientapi:${TAG}
+docker push matrixdotorg/dendrite-eduserver:${TAG}
+docker push matrixdotorg/dendrite-federationapi:${TAG}
+docker push matrixdotorg/dendrite-federationsender:${TAG}
+docker push matrixdotorg/dendrite-keyserver:${TAG}
+docker push matrixdotorg/dendrite-mediaapi:${TAG}
+docker push matrixdotorg/dendrite-roomserver:${TAG}
+docker push matrixdotorg/dendrite-syncapi:${TAG}
+docker push matrixdotorg/dendrite-signingkeyserver:${TAG}
+docker push matrixdotorg/dendrite-userapi:${TAG}

--- a/build/docker/images-push.sh
+++ b/build/docker/images-push.sh
@@ -1,17 +1,15 @@
 #!/bin/bash
 
-docker push matrixdotorg/dendrite:monolith
+docker push matrixdotorg/dendrite-monolith:latest
 
-docker push matrixdotorg/dendrite:appservice
-docker push matrixdotorg/dendrite:clientapi
-docker push matrixdotorg/dendrite:clientproxy
-docker push matrixdotorg/dendrite:eduserver
-docker push matrixdotorg/dendrite:federationapi
-docker push matrixdotorg/dendrite:federationsender
-docker push matrixdotorg/dendrite:federationproxy
-docker push matrixdotorg/dendrite:keyserver
-docker push matrixdotorg/dendrite:mediaapi
-docker push matrixdotorg/dendrite:roomserver
-docker push matrixdotorg/dendrite:syncapi
-docker push matrixdotorg/dendrite:signingkeyserver
-docker push matrixdotorg/dendrite:userapi
+docker push matrixdotorg/dendrite-appservice:latest
+docker push matrixdotorg/dendrite-clientapi:latest
+docker push matrixdotorg/dendrite-eduserver:latest
+docker push matrixdotorg/dendrite-federationapi:latest
+docker push matrixdotorg/dendrite-federationsender:latest
+docker push matrixdotorg/dendrite-keyserver:latest
+docker push matrixdotorg/dendrite-mediaapi:latest
+docker push matrixdotorg/dendrite-roomserver:latest
+docker push matrixdotorg/dendrite-syncapi:latest
+docker push matrixdotorg/dendrite-signingkeyserver:latest
+docker push matrixdotorg/dendrite-userapi:latest


### PR DESCRIPTION
This updates the Docker stuff so that we create altogether separate images, rather than tags in one image. This requires multiple repositories on Docker Hub (that now exist), but we can now push versions as tags.