### PR TITLE
Version 0.2.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,8 +8,8 @@
 * Old state events will no longer be processed by the sync API as new, which should fix some cases where clients incorrectly believe they have joined or left rooms
 * Internal HTTP API calls are now made using H2C (HTTP/2) in polylith mode, mitigating some potential head-of-line blocking issues
 * Roomserver output events no longer incorrectly flag state rewrites
-* Notification levels are now parsed correctly in power level events
-* Invalid UTF-8 is now correctly rejected when making federation requests
+* Notification levels are now parsed correctly in power level events (contributed by [Pestdoktor](https://github.com/Pestdoktor))
+* Invalid UTF-8 is now correctly rejected when making federation requests (contributed by [Pestdoktor](https://github.com/Pestdoktor))
 
 ## Dendrite 0.2.0 (2020-10-20)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Dendrite 0.2.1 (2020-10-22)
+
+### Fixes
+
+* Forward extremities are now calculated using only references from other extremities, rather than including outliers, which should fix some state resets
+* Old state events will no longer be processed by the sync API as new, which should fix some cases where clients incorrectly believe they have joined or left rooms
+* Internal HTTP API calls are now made using H2C (HTTP/2) in polylith mode, mitigating some potential head-of-line blocking issues
+* Roomserver output events no longer incorrectly flag state rewrites
+* Notification levels are now parsed correctly in power level events
+* Invalid UTF-8 is now correctly rejected when making federation requests
+
 ## Dendrite 0.2.0 (2020-10-20)
 
 ### Important

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,12 +4,13 @@
 
 ### Fixes
 
-* Forward extremities are now calculated using only references from other extremities, rather than including outliers, which should fix cases where state can become corrupted
-* Old state events will no longer be processed by the sync API as new, which should fix some cases where clients incorrectly believe they have joined or left rooms
-* Internal HTTP API calls are now made using H2C (HTTP/2) in polylith mode, mitigating some potential head-of-line blocking issues
-* Roomserver output events no longer incorrectly flag state rewrites
-* Notification levels are now parsed correctly in power level events (contributed by [Pestdoktor](https://github.com/Pestdoktor))
-* Invalid UTF-8 is now correctly rejected when making federation requests (contributed by [Pestdoktor](https://github.com/Pestdoktor))
+* Forward extremities are now calculated using only references from other extremities, rather than including outliers, which should fix cases where state can become corrupted ([#1556](https://github.com/matrix-org/dendrite/pull/1556))
+* Old state events will no longer be processed by the sync API as new, which should fix some cases where clients incorrectly believe they have joined or left rooms ([#1548](https://github.com/matrix-org/dendrite/pull/1548))
+* More SQLite database locking issues have been resolved in the latest events updater ([#1554](https://github.com/matrix-org/dendrite/pull/1554))
+* Internal HTTP API calls are now made using H2C (HTTP/2) in polylith mode, mitigating some potential head-of-line blocking issues ([#1541](https://github.com/matrix-org/dendrite/pull/1541))
+* Roomserver output events no longer incorrectly flag state rewrites ([#1557](https://github.com/matrix-org/dendrite/pull/1557))
+* Notification levels are now parsed correctly in power level events ([gomatrixserverlib#228](https://github.com/matrix-org/gomatrixserverlib/pull/228), contributed by [Pestdoktor](https://github.com/Pestdoktor))
+* Invalid UTF-8 is now correctly rejected when making federation requests ([gomatrixserverlib#229](https://github.com/matrix-org/gomatrixserverlib/pull/229), contributed by [Pestdoktor](https://github.com/Pestdoktor))
 
 ## Dendrite 0.2.0 (2020-10-20)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-* Forward extremities are now calculated using only references from other extremities, rather than including outliers, which should fix some state resets
+* Forward extremities are now calculated using only references from other extremities, rather than including outliers, which should fix cases where state can become corrupted
 * Old state events will no longer be processed by the sync API as new, which should fix some cases where clients incorrectly believe they have joined or left rooms
 * Internal HTTP API calls are now made using H2C (HTTP/2) in polylith mode, mitigating some potential head-of-line blocking issues
 * Roomserver output events no longer incorrectly flag state rewrites

--- a/internal/version.go
+++ b/internal/version.go
@@ -17,7 +17,7 @@ var build string
 const (
 	VersionMajor = 0
 	VersionMinor = 2
-	VersionPatch = 0
+	VersionPatch = 1
 	VersionTag   = "" // example: "rc1"
 )
 


### PR DESCRIPTION
* Forward extremities are now calculated using only references from other extremities, rather than including outliers, which should fix cases where state can become corrupted
* Old state events will no longer be processed by the sync API as new, which should fix some cases where clients incorrectly believe they have joined or left rooms
* More SQLite database locking issues have been resolved in the latest events updater
* Internal HTTP API calls are now made using H2C (HTTP/2) in polylith mode, mitigating some potential head-of-line blocking issues
* Roomserver output events no longer incorrectly flag state rewrites
* Notification levels are now parsed correctly in power level events
* Invalid UTF-8 is now correctly rejected when making federation requests