### PR TITLE
Add possibilty to configure MaxMessageBytes for sarama

### DIFF
--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -74,8 +74,11 @@ global:
     # Kafka.
     use_naffka: true
 
-    # The maximal size of messages passed between Kafka producers and consumers
-    max_message_bytes: 1048576
+    # The max size a Kafka message is allowed to use.
+    # You only need to change this value, if you encounter issues with too large messages.
+    # Must be less than/equal to "max.message.bytes" configured in Kafka.
+    # Defaults to 8388608 bytes.
+    # max_message_bytes: 8388608
 
     # Naffka database options. Not required when using Kafka.
     naffka_database:

--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -74,6 +74,9 @@ global:
     # Kafka.
     use_naffka: true
 
+    # The maximal size of messages passed between Kafka producers and consumers
+    max_message_bytes: 1048576
+
     # Naffka database options. Not required when using Kafka.
     naffka_database:
       connection_string: file:naffka.db

--- a/internal/config/config_kafka.go
+++ b/internal/config/config_kafka.go
@@ -24,6 +24,8 @@ type Kafka struct {
 	UseNaffka bool `yaml:"use_naffka"`
 	// The Naffka database is used internally by the naffka library, if used.
 	Database DatabaseOptions `yaml:"naffka_database"`
+	// The max size a message can have
+	MaxMessageBytes *int `yaml:"max_message_bytes"`
 }
 
 func (k *Kafka) TopicFor(name string) string {
@@ -36,6 +38,9 @@ func (c *Kafka) Defaults() {
 	c.Addresses = []string{"localhost:2181"}
 	c.Database.ConnectionString = DataSource("file:naffka.db")
 	c.TopicPrefix = "Dendrite"
+
+	maxBytes := 2 << 22 // about 8MB
+	c.MaxMessageBytes = &maxBytes
 }
 
 func (c *Kafka) Verify(configErrs *ConfigErrors, isMonolith bool) {
@@ -50,4 +55,5 @@ func (c *Kafka) Verify(configErrs *ConfigErrors, isMonolith bool) {
 		checkNotZero(configErrs, "global.kafka.addresses", int64(len(c.Addresses)))
 	}
 	checkNotEmpty(configErrs, "global.kafka.topic_prefix", string(c.TopicPrefix))
+	checkPositive(configErrs, "global.kafka.max_message_bytes", int64(*c.MaxMessageBytes))
 }

--- a/internal/config/config_kafka.go
+++ b/internal/config/config_kafka.go
@@ -24,7 +24,8 @@ type Kafka struct {
 	UseNaffka bool `yaml:"use_naffka"`
 	// The Naffka database is used internally by the naffka library, if used.
 	Database DatabaseOptions `yaml:"naffka_database"`
-	// The max size a message can have
+	// The max size a Kafka message passed between consumer/producer can have
+	// Equals roughly max.message.bytes / fetch.message.max.bytes in Kafka
 	MaxMessageBytes *int `yaml:"max_message_bytes"`
 }
 
@@ -39,7 +40,7 @@ func (c *Kafka) Defaults() {
 	c.Database.ConnectionString = DataSource("file:naffka.db")
 	c.TopicPrefix = "Dendrite"
 
-	maxBytes := 2 << 22 // about 8MB
+	maxBytes := 1024 * 1024 * 8 // about 8MB
 	c.MaxMessageBytes = &maxBytes
 }
 

--- a/internal/setup/kafka/kafka.go
+++ b/internal/setup/kafka/kafka.go
@@ -17,12 +17,16 @@ func SetupConsumerProducer(cfg *config.Kafka) (sarama.Consumer, sarama.SyncProdu
 
 // setupKafka creates kafka consumer/producer pair from the config.
 func setupKafka(cfg *config.Kafka) (sarama.Consumer, sarama.SyncProducer) {
-	consumer, err := sarama.NewConsumer(cfg.Addresses, nil)
+	sCfg := sarama.NewConfig()
+	sCfg.Producer.MaxMessageBytes = *cfg.MaxMessageBytes
+	sCfg.Producer.Return.Successes = true
+
+	consumer, err := sarama.NewConsumer(cfg.Addresses, sCfg)
 	if err != nil {
 		logrus.WithError(err).Panic("failed to start kafka consumer")
 	}
 
-	producer, err := sarama.NewSyncProducer(cfg.Addresses, nil)
+	producer, err := sarama.NewSyncProducer(cfg.Addresses, sCfg)
 	if err != nil {
 		logrus.WithError(err).Panic("failed to setup kafka producers")
 	}

--- a/internal/setup/kafka/kafka.go
+++ b/internal/setup/kafka/kafka.go
@@ -20,6 +20,7 @@ func setupKafka(cfg *config.Kafka) (sarama.Consumer, sarama.SyncProducer) {
 	sCfg := sarama.NewConfig()
 	sCfg.Producer.MaxMessageBytes = *cfg.MaxMessageBytes
 	sCfg.Producer.Return.Successes = true
+	sCfg.Consumer.Fetch.Default = int32(*cfg.MaxMessageBytes)
 
 	consumer, err := sarama.NewConsumer(cfg.Addresses, sCfg)
 	if err != nil {

--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -102,7 +102,13 @@ func (r *Inputer) WriteOutputEvents(roomID string, updates []api.OutputEvent) er
 			Value: sarama.ByteEncoder(value),
 		}
 	}
-	return r.Producer.SendMessages(messages)
+	errs := r.Producer.SendMessages(messages)
+	if errs != nil {
+		for _, err := range errs.(sarama.ProducerErrors) {
+			log.WithError(err).WithField("message_bytes", err.Msg.Value.Length()).Error("Write to kafka failed")
+		}
+	}
+	return errs
 }
 
 // InputRoomEvents implements api.RoomserverInternalAPI


### PR DESCRIPTION
This adds the possibility to configure the `MaxMessageBytes` used in sarama.
The default is to low, if joining large rooms. (User count?)
```go
c.Producer.MaxMessageBytes = 1000000
```

Also adds some more logging when sending messages to Kafka/Naffka in `roomserver`

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

