### PR TITLE
Fix username regex to allow = character

### DIFF
--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -113,7 +113,7 @@ var (
 	// TODO: Remove old sessions. Need to do so on a session-specific timeout.
 	// sessions stores the completed flow stages for all sessions. Referenced using their sessionID.
 	sessions           = newSessionsDict()
-	validUsernameRegex = regexp.MustCompile(`^[0-9a-z_\-./]+$`)
+	validUsernameRegex = regexp.MustCompile(`^[0-9a-z_\-=./]+$`)
 )
 
 // registerRequest represents the submitted registration request.


### PR DESCRIPTION
The [spec](https://matrix.org/docs/spec/appendices#user-identifiers) allows `=` but we didn't include that in `validUsernameRegex`.