### PR TITLE
Fix failing federation tests

### DIFF
--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -496,3 +496,5 @@ Forgotten room messages cannot be paginated
 Forgetting room does not show up in v2 /sync
 Can forget room you've been kicked from
 Can re-join room if re-invited
+Remote servers should reject attempts by non-creators to set the power levels
+Remote servers cannot set power levels in rooms without existing powerlevels


### PR DESCRIPTION
This solves #1327 (notifications test is already passing)

I'm a bit unhappy with getting the power levels, is there a better way?

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

