### PR TITLE
Add IPv6 setting to nginx conf

### DIFF
--- a/docs/nginx/monolith-sample.conf
+++ b/docs/nginx/monolith-sample.conf
@@ -1,5 +1,6 @@
 server {
-    listen 443 ssl;
+    listen 443 ssl; # IPv4
+    listen [::]:443; # IPv6
     server_name my.hostname.com;
 
     ssl_certificate /path/to/fullchain.pem;

--- a/docs/nginx/polylith-sample.conf
+++ b/docs/nginx/polylith-sample.conf
@@ -1,5 +1,6 @@
 server {
-    listen 443 ssl;
+    listen 443 ssl; # IPv4
+    listen [::]:443; # IPv6
     server_name my.hostname.com;
 
     ssl_certificate /path/to/fullchain.pem;


### PR DESCRIPTION
A tiny tweak to the example nginx config related to the following messages:
- https://matrix.to/#/!yomrOFwgFXzmeMAbzX:matrix.org/$b4UApDVwR1Sbeuo8SpBqUuAUtQbHKji0YsKuf3Mj4yQ?via=matrix.org&via=privacytools.io&via=dendrite.link
- https://matrix.to/#/!yomrOFwgFXzmeMAbzX:matrix.org/$sIkSxL002BKottY1Fop-bkusuyCJ1Y0zIFzqSWDYRrc?via=matrix.org&via=privacytools.io&via=dendrite.link

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: TR_SLimey | tr_slimey@protonmail.com | @tr_slimey:an-atom-in.space
