### PR TITLE
MSC2836:  Threading - part one

### DIFF
--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/matrix-org/dendrite/eduserver/cache"
 	"github.com/matrix-org/dendrite/federationsender"
 	"github.com/matrix-org/dendrite/internal/config"
+	"github.com/matrix-org/dendrite/internal/mscs"
 	"github.com/matrix-org/dendrite/internal/setup"
 	"github.com/matrix-org/dendrite/keyserver"
 	"github.com/matrix-org/dendrite/roomserver"
@@ -147,6 +148,12 @@ func main() {
 		base.PublicKeyAPIMux,
 		base.PublicMediaAPIMux,
 	)
+
+	if len(base.Cfg.MSCs.MSCs) > 0 {
+		if err := mscs.Enable(base, &monolith); err != nil {
+			logrus.WithError(err).Fatalf("Failed to enable MSCs")
+		}
+	}
 
 	// Expose the matrix APIs directly rather than putting them under a /api path.
 	go func() {

--- a/federationsender/api/api.go
+++ b/federationsender/api/api.go
@@ -48,6 +48,7 @@ type FederationSenderInternalAPI interface {
 	// Query the server names of the joined hosts in a room.
 	// Unlike QueryJoinedHostsInRoom, this function returns a de-duplicated slice
 	// containing only the server names (without information for membership events).
+	// The response will include this server if they are joined to the room.
 	QueryJoinedHostServerNamesInRoom(
 		ctx context.Context,
 		request *QueryJoinedHostServerNamesInRoomRequest,

--- a/federationsender/api/api.go
+++ b/federationsender/api/api.go
@@ -105,6 +105,7 @@ type PerformJoinRequest struct {
 }
 
 type PerformJoinResponse struct {
+	JoinedVia gomatrixserverlib.ServerName
 	LastError *gomatrix.HTTPError
 }
 

--- a/federationsender/internal/perform.go
+++ b/federationsender/internal/perform.go
@@ -105,6 +105,7 @@ func (r *FederationSenderInternalAPI) PerformJoin(
 		}
 
 		// We're all good.
+		response.JoinedVia = serverName
 		return
 	}
 

--- a/federationsender/internal/query.go
+++ b/federationsender/internal/query.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/matrix-org/dendrite/federationsender/api"
-	"github.com/matrix-org/gomatrixserverlib"
 )
 
 // QueryJoinedHostServerNamesInRoom implements api.FederationSenderInternalAPI
@@ -13,17 +12,11 @@ func (f *FederationSenderInternalAPI) QueryJoinedHostServerNamesInRoom(
 	request *api.QueryJoinedHostServerNamesInRoomRequest,
 	response *api.QueryJoinedHostServerNamesInRoomResponse,
 ) (err error) {
-	joinedHosts, err := f.db.GetJoinedHosts(ctx, request.RoomID)
+	joinedHosts, err := f.db.GetJoinedHostsForRooms(ctx, []string{request.RoomID})
 	if err != nil {
 		return
 	}
-
-	response.ServerNames = make([]gomatrixserverlib.ServerName, 0, len(joinedHosts))
-	for _, host := range joinedHosts {
-		response.ServerNames = append(response.ServerNames, host.ServerName)
-	}
-
-	// TODO: remove duplicates?
+	response.ServerNames = joinedHosts
 
 	return
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,6 +66,8 @@ type Dendrite struct {
 	SyncAPI          SyncAPI          `yaml:"sync_api"`
 	UserAPI          UserAPI          `yaml:"user_api"`
 
+	MSCs MSCs `yaml:"mscs"`
+
 	// The config for tracing the dendrite servers.
 	Tracing struct {
 		// Set to true to enable tracer hooks. If false, no tracing is set up.
@@ -306,6 +308,7 @@ func (c *Dendrite) Defaults() {
 	c.SyncAPI.Defaults()
 	c.UserAPI.Defaults()
 	c.AppServiceAPI.Defaults()
+	c.MSCs.Defaults()
 
 	c.Wiring()
 }
@@ -319,7 +322,7 @@ func (c *Dendrite) Verify(configErrs *ConfigErrors, isMonolith bool) {
 		&c.EDUServer, &c.FederationAPI, &c.FederationSender,
 		&c.KeyServer, &c.MediaAPI, &c.RoomServer,
 		&c.SigningKeyServer, &c.SyncAPI, &c.UserAPI,
-		&c.AppServiceAPI,
+		&c.AppServiceAPI, &c.MSCs,
 	} {
 		c.Verify(configErrs, isMonolith)
 	}
@@ -337,6 +340,7 @@ func (c *Dendrite) Wiring() {
 	c.SyncAPI.Matrix = &c.Global
 	c.UserAPI.Matrix = &c.Global
 	c.AppServiceAPI.Matrix = &c.Global
+	c.MSCs.Matrix = &c.Global
 
 	c.ClientAPI.Derived = &c.Derived
 	c.AppServiceAPI.Derived = &c.Derived

--- a/internal/config/config_mscs.go
+++ b/internal/config/config_mscs.go
@@ -1,0 +1,19 @@
+package config
+
+type MSCs struct {
+	Matrix *Global `yaml:"-"`
+
+	// The MSCs to enable, currently only `msc2836` is supported.
+	MSCs []string `yaml:"mscs"`
+
+	Database DatabaseOptions `yaml:"database"`
+}
+
+func (c *MSCs) Defaults() {
+	c.Database.Defaults()
+	c.Database.ConnectionString = "file:mscs.db"
+}
+
+func (c *MSCs) Verify(configErrs *ConfigErrors, isMonolith bool) {
+	checkNotEmpty(configErrs, "mscs.database.connection_string", string(c.Database.ConnectionString))
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -19,20 +19,20 @@ package hooks
 import "sync"
 
 const (
-	// KindNewEvent is a hook which is called with *gomatrixserverlib.HeaderedEvent
+	// KindNewEventPersisted is a hook which is called with *gomatrixserverlib.HeaderedEvent
 	// It is run when a new event is persisted in the roomserver.
 	// Usage:
-	//   hooks.Attach(hooks.KindNewEvent, func(headeredEvent interface{}) { ... })
-	KindNewEvent = "new_event"
-	// KindModifyNewEvent is a hook which is called with *gomatrixserverlib.HeaderedEvent
+	//   hooks.Attach(hooks.KindNewEventPersisted, func(headeredEvent interface{}) { ... })
+	KindNewEventPersisted = "new_event_persisted"
+	// KindNewEventReceived is a hook which is called with *gomatrixserverlib.HeaderedEvent
 	// It is run before a new event is processed by the roomserver. This hook can be used
 	// to modify the event before it is persisted by adding data to `unsigned`.
 	// Usage:
-	//   hooks.Attach(hooks.KindModifyNewEvent, func(headeredEvent interface{}) {
+	//   hooks.Attach(hooks.KindNewEventReceived, func(headeredEvent interface{}) {
 	//     ev := headeredEvent.(*gomatrixserverlib.HeaderedEvent)
 	//     _ = ev.SetUnsignedField("key", "val")
 	//   })
-	KindModifyNewEvent = "modify_new_event"
+	KindNewEventReceived = "new_event_received"
 )
 
 var (

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -1,0 +1,21 @@
+// Copyright 2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package hooks exposes places in Dendrite where custom code can be executed, useful for MSCs.
+// Hooks can only be run in monolith mode.
+package hooks
+
+func Attach() {
+
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -24,6 +24,15 @@ const (
 	// Usage:
 	//   hooks.Attach(hooks.KindNewEvent, func(headeredEvent interface{}) { ... })
 	KindNewEvent = "new_event"
+	// KindModifyNewEvent is a hook which is called with *gomatrixserverlib.HeaderedEvent
+	// It is run before a new event is processed by the roomserver. This hook can be used
+	// to modify the event before it is persisted by adding data to `unsigned`.
+	// Usage:
+	//   hooks.Attach(hooks.KindModifyNewEvent, func(headeredEvent interface{}) {
+	//     ev := headeredEvent.(*gomatrixserverlib.HeaderedEvent)
+	//     _ = ev.SetUnsignedField("key", "val")
+	//   })
+	KindModifyNewEvent = "modify_new_event"
 )
 
 var (

--- a/internal/mscs/msc2836/msc2836.go
+++ b/internal/mscs/msc2836/msc2836.go
@@ -154,8 +154,6 @@ func eventRelationshipHandler(db Database, rsAPI roomserver.RoomserverInternalAP
 			for _, ev := range returnEvents {
 				depths[ev.EventID()] = 1
 			}
-			// Begin to walk the thread DAG in the direction specified, either depth or breadth first according to the depth_first flag,
-			// honouring the limit, max_depth and max_breadth values according to the following rules
 			var events []*gomatrixserverlib.HeaderedEvent
 			events, walkLimited = walkThread(
 				req.Context(), db, rsAPI, device.UserID, &relation, depths, remaining,
@@ -215,6 +213,8 @@ func includeChildren(ctx context.Context, rsAPI roomserver.RoomserverInternalAPI
 	return childEvents, nil
 }
 
+// Begin to walk the thread DAG in the direction specified, either depth or breadth first according to the depth_first flag,
+// honouring the limit, max_depth and max_breadth values according to the following rules
 // nolint: unparam
 func walkThread(
 	ctx context.Context, db Database, rsAPI roomserver.RoomserverInternalAPI, userID string, req *EventRelationshipRequest, included map[string]int, limit int,

--- a/internal/mscs/msc2836/msc2836.go
+++ b/internal/mscs/msc2836/msc2836.go
@@ -188,7 +188,7 @@ func eventRelationshipHandler(db Database, rsAPI roomserver.RoomserverInternalAP
 		}
 
 		// Can the user see (according to history visibility) event_id? If no, reject the request, else continue.
-		event := rc.getEventIfVisible(relation.EventID)
+		event := rc.getEventIfVisible(relation.EventID, nil)
 		if event == nil {
 			return util.JSONResponse{
 				Code: 403,
@@ -249,7 +249,7 @@ func (rc *reqCtx) includeParent(event *gomatrixserverlib.HeaderedEvent) (parent 
 	if parentID == "" {
 		return nil
 	}
-	return rc.getEventIfVisible(parentID)
+	return rc.getEventIfVisible(parentID, event)
 }
 
 // If include_children: true, lookup all events which have event_id as an m.relationship
@@ -264,7 +264,7 @@ func (rc *reqCtx) includeChildren(db Database, parentID string, limit int, recen
 	}
 	var childEvents []*gomatrixserverlib.HeaderedEvent
 	for _, child := range children {
-		childEvent := rc.getEventIfVisible(child.EventID)
+		childEvent := rc.getEventIfVisible(child.EventID, nil)
 		if childEvent != nil {
 			childEvents = append(childEvents, childEvent)
 		}
@@ -302,7 +302,7 @@ func walkThread(
 			}
 
 			// Process the event.
-			event := rc.getEventIfVisible(wi.EventID)
+			event := rc.getEventIfVisible(wi.EventID, nil)
 			if event != nil {
 				result = append(result, event)
 			}
@@ -317,7 +317,7 @@ func walkThread(
 	return result, limited
 }
 
-func (rc *reqCtx) getEventIfVisible(eventID string) *gomatrixserverlib.HeaderedEvent {
+func (rc *reqCtx) getEventIfVisible(eventID string, child *gomatrixserverlib.HeaderedEvent) *gomatrixserverlib.HeaderedEvent {
 	event, joinedToRoom := getEventIfVisible(rc.ctx, rc.rsAPI, eventID, rc.userID)
 	if event == nil {
 		return nil

--- a/internal/mscs/msc2836/msc2836.go
+++ b/internal/mscs/msc2836/msc2836.go
@@ -1,0 +1,67 @@
+// Copyright 2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package msc2836 'Threading' implements https://github.com/matrix-org/matrix-doc/pull/2836
+package msc2836
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"github.com/matrix-org/dendrite/internal/httputil"
+	"github.com/matrix-org/dendrite/internal/setup"
+	userapi "github.com/matrix-org/dendrite/userapi/api"
+	"github.com/matrix-org/util"
+)
+
+type eventRelationshipRequest struct {
+	EventID         string `json:"event_id"`
+	MaxDepth        int    `json:"max_depth"`
+	MaxBreadth      int    `json:"max_breadth"`
+	Limit           int    `json:"limit"`
+	DepthFirst      bool   `json:"depth_first"`
+	RecentFirst     bool   `json:"recent_first"`
+	IncludeParent   bool   `json:"include_parent"`
+	IncludeChildren bool   `json:"include_children"`
+	Direction       string `json:"direction"`
+	Batch           string `json:"batch"`
+}
+
+// Enable this MSC
+func Enable(base *setup.BaseDendrite, monolith *setup.Monolith) error {
+	_, err := NewDatabase(&base.Cfg.MSCs.Database)
+	if err != nil {
+		return fmt.Errorf("Cannot enable MSC2836: %w", err)
+	}
+
+	base.PublicClientAPIMux.Handle("/unstable/event_relationships",
+		httputil.MakeAuthAPI("eventRelationships", monolith.UserAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+			var relation eventRelationshipRequest
+			if err := json.NewDecoder(req.Body).Decode(&relation); err != nil {
+				util.GetLogger(req.Context()).WithError(err).Error("failed to decode HTTP request as JSON")
+				return util.JSONResponse{
+					Code: 400,
+					JSON: jsonerror.BadJSON(fmt.Sprintf("invalid json: %s", err)),
+				}
+			}
+			return util.JSONResponse{
+				Code: 200,
+				JSON: struct{}{},
+			}
+		}),
+	).Methods(http.MethodPost, http.MethodOptions)
+	return nil
+}

--- a/internal/mscs/msc2836/msc2836.go
+++ b/internal/mscs/msc2836/msc2836.go
@@ -74,7 +74,7 @@ func (r *EventRelationshipRequest) applyDefaults() {
 	}
 }
 
-type eventRelationshipResponse struct {
+type EventRelationshipResponse struct {
 	Events    []gomatrixserverlib.ClientEvent `json:"events"`
 	NextBatch string                          `json:"next_batch"`
 	Limited   bool                            `json:"limited"`
@@ -109,7 +109,7 @@ func Enable(base *setup.BaseDendrite, rsAPI roomserver.RoomserverInternalAPI, us
 			}
 			// Sanity check request and set defaults.
 			relation.applyDefaults()
-			var res eventRelationshipResponse
+			var res EventRelationshipResponse
 			var returnEvents []*gomatrixserverlib.HeaderedEvent
 
 			// Can the user see (according to history visibility) event_id? If no, reject the request, else continue.

--- a/internal/mscs/msc2836/msc2836.go
+++ b/internal/mscs/msc2836/msc2836.go
@@ -31,7 +31,7 @@ import (
 	"github.com/matrix-org/util"
 )
 
-type eventRelationshipRequest struct {
+type EventRelationshipRequest struct {
 	EventID         string `json:"event_id"`
 	MaxDepth        int    `json:"max_depth"`
 	MaxBreadth      int    `json:"max_breadth"`
@@ -44,7 +44,7 @@ type eventRelationshipRequest struct {
 	Batch           string `json:"batch"`
 }
 
-func (r *eventRelationshipRequest) applyDefaults() {
+func (r *EventRelationshipRequest) applyDefaults() {
 	if r.Limit > 100 || r.Limit < 1 {
 		r.Limit = 100
 	}
@@ -80,7 +80,7 @@ type eventRelationshipResponse struct {
 }
 
 // Enable this MSC
-func Enable(base *setup.BaseDendrite, monolith *setup.Monolith) error {
+func Enable(base *setup.BaseDendrite, userAPI userapi.UserInternalAPI) error {
 	db, err := NewDatabase(&base.Cfg.MSCs.Database)
 	if err != nil {
 		return fmt.Errorf("Cannot enable MSC2836: %w", err)
@@ -97,8 +97,8 @@ func Enable(base *setup.BaseDendrite, monolith *setup.Monolith) error {
 	})
 
 	base.PublicClientAPIMux.Handle("/unstable/event_relationships",
-		httputil.MakeAuthAPI("eventRelationships", monolith.UserAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			var relation eventRelationshipRequest
+		httputil.MakeAuthAPI("eventRelationships", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+			var relation EventRelationshipRequest
 			if err := json.NewDecoder(req.Body).Decode(&relation); err != nil {
 				util.GetLogger(req.Context()).WithError(err).Error("failed to decode HTTP request as JSON")
 				return util.JSONResponse{

--- a/internal/mscs/msc2836/msc2836_test.go
+++ b/internal/mscs/msc2836/msc2836_test.go
@@ -1,0 +1,172 @@
+package msc2836_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	nethttputil "net/http/httputil"
+
+	"github.com/gorilla/mux"
+	"github.com/matrix-org/dendrite/internal/config"
+	"github.com/matrix-org/dendrite/internal/hooks"
+	"github.com/matrix-org/dendrite/internal/httputil"
+	"github.com/matrix-org/dendrite/internal/mscs/msc2836"
+	"github.com/matrix-org/dendrite/internal/setup"
+	userapi "github.com/matrix-org/dendrite/userapi/api"
+	"github.com/matrix-org/gomatrixserverlib"
+)
+
+var (
+	client = &http.Client{
+		Timeout: 10 * time.Second,
+	}
+)
+
+// Basic sanity check of MSC2836 logic. Injects a thread that looks like:
+//   A
+//   |
+//   B
+//  / \
+// C   D
+//    /|\
+//   E F G
+//   |
+//   H
+// And makes sure POST /relationships works with various parameters
+func TestMSC2836(t *testing.T) {
+	router := injectEvents(t)
+	externalServ := &http.Server{
+		Addr:         string(":8009"),
+		WriteTimeout: 60 * time.Second,
+		Handler:      router,
+	}
+	defer externalServ.Shutdown(context.TODO())
+	go func() {
+		err := externalServ.ListenAndServe()
+		if err != nil {
+			t.Logf("ListenAndServe: %s", err)
+		}
+	}()
+	// wait to listen on the port
+	time.Sleep(500 * time.Millisecond)
+
+	res := postRelationships(t, "alice", &msc2836.EventRelationshipRequest{
+		EventID: "$invalid",
+	})
+	if res.StatusCode != 403 {
+		out, _ := nethttputil.DumpResponse(res, true)
+		t.Fatalf("failed to perform request: %s", string(out))
+	}
+}
+
+func postRelationships(t *testing.T, accessToken string, req *msc2836.EventRelationshipRequest) *http.Response {
+	t.Helper()
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal request: %s", err)
+	}
+	httpReq, err := http.NewRequest(
+		"POST", "http://localhost:8009/_matrix/client/unstable/event_relationships",
+		bytes.NewBuffer(data),
+	)
+	httpReq.Header.Set("Authorization", "Bearer "+accessToken)
+	if err != nil {
+		t.Fatalf("failed to prepare request: %s", err)
+	}
+	res, err := client.Do(httpReq)
+	if err != nil {
+		t.Fatalf("failed to do request: %s", err)
+	}
+	return res
+}
+
+type testUserAPI struct {
+	accessTokens map[string]userapi.Device
+}
+
+func (u *testUserAPI) InputAccountData(ctx context.Context, req *userapi.InputAccountDataRequest, res *userapi.InputAccountDataResponse) error {
+	return nil
+}
+func (u *testUserAPI) PerformAccountCreation(ctx context.Context, req *userapi.PerformAccountCreationRequest, res *userapi.PerformAccountCreationResponse) error {
+	return nil
+}
+func (u *testUserAPI) PerformPasswordUpdate(ctx context.Context, req *userapi.PerformPasswordUpdateRequest, res *userapi.PerformPasswordUpdateResponse) error {
+	return nil
+}
+func (u *testUserAPI) PerformDeviceCreation(ctx context.Context, req *userapi.PerformDeviceCreationRequest, res *userapi.PerformDeviceCreationResponse) error {
+	return nil
+}
+func (u *testUserAPI) PerformDeviceDeletion(ctx context.Context, req *userapi.PerformDeviceDeletionRequest, res *userapi.PerformDeviceDeletionResponse) error {
+	return nil
+}
+func (u *testUserAPI) PerformDeviceUpdate(ctx context.Context, req *userapi.PerformDeviceUpdateRequest, res *userapi.PerformDeviceUpdateResponse) error {
+	return nil
+}
+func (u *testUserAPI) PerformAccountDeactivation(ctx context.Context, req *userapi.PerformAccountDeactivationRequest, res *userapi.PerformAccountDeactivationResponse) error {
+	return nil
+}
+func (u *testUserAPI) QueryProfile(ctx context.Context, req *userapi.QueryProfileRequest, res *userapi.QueryProfileResponse) error {
+	return nil
+}
+func (u *testUserAPI) QueryAccessToken(ctx context.Context, req *userapi.QueryAccessTokenRequest, res *userapi.QueryAccessTokenResponse) error {
+	dev, ok := u.accessTokens[req.AccessToken]
+	if !ok {
+		res.Err = fmt.Errorf("unknown token")
+		return nil
+	}
+	res.Device = &dev
+	return nil
+}
+func (u *testUserAPI) QueryDevices(ctx context.Context, req *userapi.QueryDevicesRequest, res *userapi.QueryDevicesResponse) error {
+	return nil
+}
+func (u *testUserAPI) QueryAccountData(ctx context.Context, req *userapi.QueryAccountDataRequest, res *userapi.QueryAccountDataResponse) error {
+	return nil
+}
+func (u *testUserAPI) QueryDeviceInfos(ctx context.Context, req *userapi.QueryDeviceInfosRequest, res *userapi.QueryDeviceInfosResponse) error {
+	return nil
+}
+func (u *testUserAPI) QuerySearchProfiles(ctx context.Context, req *userapi.QuerySearchProfilesRequest, res *userapi.QuerySearchProfilesResponse) error {
+	return nil
+}
+
+func injectEvents(t *testing.T) *mux.Router {
+	t.Helper()
+	cfg := &config.Dendrite{}
+	cfg.Defaults()
+	cfg.Global.ServerName = "localhost"
+	cfg.MSCs.Database.ConnectionString = "file:msc2836_test.db"
+	cfg.MSCs.MSCs = []string{"msc2836"}
+	base := &setup.BaseDendrite{
+		Cfg:                cfg,
+		PublicClientAPIMux: mux.NewRouter().PathPrefix(httputil.PublicClientPathPrefix).Subrouter(),
+	}
+	nopUserAPI := &testUserAPI{
+		accessTokens: make(map[string]userapi.Device),
+	}
+	nopUserAPI.accessTokens["alice"] = userapi.Device{
+		AccessToken: "alice",
+		DisplayName: "Alice",
+		UserID:      "@alice:localhost",
+	}
+	nopUserAPI.accessTokens["bob"] = userapi.Device{
+		AccessToken: "bob",
+		DisplayName: "Bob",
+		UserID:      "@bob:localhost",
+	}
+
+	err := msc2836.Enable(base, nopUserAPI)
+	if err != nil {
+		t.Fatalf("failed to enable MSC2836: %s", err)
+	}
+	var events []*gomatrixserverlib.HeaderedEvent
+	for _, ev := range events {
+		hooks.Run(hooks.KindNewEvent, ev)
+	}
+	return base.PublicClientAPIMux
+}

--- a/internal/mscs/msc2836/msc2836_test.go
+++ b/internal/mscs/msc2836/msc2836_test.go
@@ -353,6 +353,10 @@ func TestMSC2836(t *testing.T) {
 	})
 }
 
+// TODO: TestMSC2836TerminatesLoops (short and long)
+// TODO: TestMSC2836UnknownEventsSkipped
+// TODO: TestMSC2836SkipEventIfNotInRoom
+
 func runServer(t *testing.T, router *mux.Router) func() {
 	t.Helper()
 	externalServ := &http.Server{

--- a/internal/mscs/msc2836/msc2836_test.go
+++ b/internal/mscs/msc2836/msc2836_test.go
@@ -228,14 +228,14 @@ func TestMSC2836(t *testing.T) {
 			EventID:         eventD.EventID(),
 			IncludeChildren: &constTrue,
 			RecentFirst:     &constTrue,
-			Limit:           10,
+			Limit:           4,
 		})
 		assertContains(t, body, []string{eventD.EventID(), eventG.EventID(), eventF.EventID(), eventE.EventID()})
 		body = postRelationships(t, 200, "alice", &msc2836.EventRelationshipRequest{
 			EventID:         eventD.EventID(),
 			IncludeChildren: &constTrue,
 			RecentFirst:     &constFalse,
-			Limit:           10,
+			Limit:           4,
 		})
 		assertContains(t, body, []string{eventD.EventID(), eventE.EventID(), eventF.EventID(), eventG.EventID()})
 	})

--- a/internal/mscs/msc2836/msc2836_test.go
+++ b/internal/mscs/msc2836/msc2836_test.go
@@ -511,11 +511,12 @@ func injectEvents(t *testing.T, userAPI userapi.UserInternalAPI, rsAPI roomserve
 	cfg.MSCs.Database.ConnectionString = "file:msc2836_test.db"
 	cfg.MSCs.MSCs = []string{"msc2836"}
 	base := &setup.BaseDendrite{
-		Cfg:                cfg,
-		PublicClientAPIMux: mux.NewRouter().PathPrefix(httputil.PublicClientPathPrefix).Subrouter(),
+		Cfg:                    cfg,
+		PublicClientAPIMux:     mux.NewRouter().PathPrefix(httputil.PublicClientPathPrefix).Subrouter(),
+		PublicFederationAPIMux: mux.NewRouter().PathPrefix(httputil.PublicFederationPathPrefix).Subrouter(),
 	}
 
-	err := msc2836.Enable(base, rsAPI, userAPI)
+	err := msc2836.Enable(base, rsAPI, nil, userAPI, nil)
 	if err != nil {
 		t.Fatalf("failed to enable MSC2836: %s", err)
 	}

--- a/internal/mscs/msc2836/storage.go
+++ b/internal/mscs/msc2836/storage.go
@@ -1,0 +1,59 @@
+package msc2836
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/matrix-org/dendrite/internal/config"
+	"github.com/matrix-org/dendrite/internal/sqlutil"
+	"github.com/matrix-org/gomatrixserverlib"
+)
+
+type Database interface {
+	// StoreRelation stores the parent->child and child->parent relationship for later querying.
+	StoreRelation(ctx context.Context, ev *gomatrixserverlib.HeaderedEvent) error
+}
+
+type Postgres struct {
+	db *sql.DB
+}
+
+func NewPostgresDatabase(dbOpts *config.DatabaseOptions) (Database, error) {
+	var p Postgres
+	var err error
+	if p.db, err = sqlutil.Open(dbOpts); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+func (db *Postgres) StoreRelation(ctx context.Context, ev *gomatrixserverlib.HeaderedEvent) error {
+	return nil
+}
+
+type SQLite struct {
+	db     *sql.DB
+	writer sqlutil.Writer
+}
+
+func NewSQLiteDatabase(dbOpts *config.DatabaseOptions) (Database, error) {
+	var s SQLite
+	var err error
+	if s.db, err = sqlutil.Open(dbOpts); err != nil {
+		return nil, err
+	}
+	s.writer = sqlutil.NewExclusiveWriter()
+	return &s, nil
+}
+
+func (db *SQLite) StoreRelation(ctx context.Context, ev *gomatrixserverlib.HeaderedEvent) error {
+	return nil
+}
+
+// NewDatabase loads the database for msc2836
+func NewDatabase(dbOpts *config.DatabaseOptions) (Database, error) {
+	if dbOpts.ConnectionString.IsPostgres() {
+		return NewPostgresDatabase(dbOpts)
+	}
+	return NewSQLiteDatabase(dbOpts)
+}

--- a/internal/mscs/msc2836/storage.go
+++ b/internal/mscs/msc2836/storage.go
@@ -36,6 +36,9 @@ func NewPostgresDatabase(dbOpts *config.DatabaseOptions) (Database, error) {
 		CONSTRAINT msc2836_relationships_unique UNIQUE (parent_event_id, child_event_id)
 	);
 	`)
+	if err != nil {
+		return nil, err
+	}
 	if p.insertRelationStmt, err = p.db.Prepare(`
 		INSERT INTO msc2836_relationships(parent_event_id, child_event_id, parent_room_id) VALUES($1, $2, $3) ON CONFLICT DO NOTHING
 	`); err != nil {
@@ -84,6 +87,9 @@ func NewSQLiteDatabase(dbOpts *config.DatabaseOptions) (Database, error) {
 		UNIQUE (parent_event_id, child_event_id)
 	);
 	`)
+	if err != nil {
+		return nil, err
+	}
 	if s.insertRelationStmt, err = s.db.Prepare(`
 		INSERT INTO msc2836_relationships(parent_event_id, child_event_id, room_id) VALUES($1, $2, $3) ON CONFLICT (parent_event_id, child_event_id) DO NOTHING
 	`); err != nil {

--- a/internal/mscs/msc2836/storage.go
+++ b/internal/mscs/msc2836/storage.go
@@ -56,7 +56,7 @@ func newPostgresDatabase(dbOpts *config.DatabaseOptions) (Database, error) {
 		parent_event_id TEXT NOT NULL,
 		child_event_id TEXT NOT NULL,
 		rel_type TEXT NOT NULL,
-		CONSTRAINT msc2836_edges UNIQUE (parent_event_id, child_event_id, rel_type)
+		CONSTRAINT msc2836_edges_uniq UNIQUE (parent_event_id, child_event_id, rel_type)
 	);
 
 	CREATE TABLE IF NOT EXISTS msc2836_nodes (

--- a/internal/mscs/mscs.go
+++ b/internal/mscs/mscs.go
@@ -35,7 +35,7 @@ func Enable(base *setup.BaseDendrite, monolith *setup.Monolith) error {
 func EnableMSC(base *setup.BaseDendrite, monolith *setup.Monolith, msc string) error {
 	switch msc {
 	case "msc2836":
-		return msc2836.Enable(base, monolith.RoomserverAPI, monolith.UserAPI)
+		return msc2836.Enable(base, monolith.RoomserverAPI, monolith.FederationSenderAPI, monolith.UserAPI)
 	default:
 		return fmt.Errorf("EnableMSC: unknown msc '%s'", msc)
 	}

--- a/internal/mscs/mscs.go
+++ b/internal/mscs/mscs.go
@@ -35,7 +35,7 @@ func Enable(base *setup.BaseDendrite, monolith *setup.Monolith) error {
 func EnableMSC(base *setup.BaseDendrite, monolith *setup.Monolith, msc string) error {
 	switch msc {
 	case "msc2836":
-		return msc2836.Enable(base, monolith)
+		return msc2836.Enable(base, monolith.UserAPI)
 	default:
 		return fmt.Errorf("EnableMSC: unknown msc '%s'", msc)
 	}

--- a/internal/mscs/mscs.go
+++ b/internal/mscs/mscs.go
@@ -35,7 +35,7 @@ func Enable(base *setup.BaseDendrite, monolith *setup.Monolith) error {
 func EnableMSC(base *setup.BaseDendrite, monolith *setup.Monolith, msc string) error {
 	switch msc {
 	case "msc2836":
-		return msc2836.Enable(base, monolith.UserAPI)
+		return msc2836.Enable(base, monolith.RoomserverAPI, monolith.UserAPI)
 	default:
 		return fmt.Errorf("EnableMSC: unknown msc '%s'", msc)
 	}

--- a/internal/mscs/mscs.go
+++ b/internal/mscs/mscs.go
@@ -1,0 +1,42 @@
+// Copyright 2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mscs implements Matrix Spec Changes from https://github.com/matrix-org/matrix-doc
+package mscs
+
+import (
+	"fmt"
+
+	"github.com/matrix-org/dendrite/internal/mscs/msc2836"
+	"github.com/matrix-org/dendrite/internal/setup"
+)
+
+// Enable MSCs - returns an error on unknown MSCs
+func Enable(base *setup.BaseDendrite, monolith *setup.Monolith) error {
+	for _, msc := range base.Cfg.MSCs.MSCs {
+		if err := EnableMSC(base, monolith, msc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func EnableMSC(base *setup.BaseDendrite, monolith *setup.Monolith, msc string) error {
+	switch msc {
+	case "msc2836":
+		return msc2836.Enable(base, monolith)
+	default:
+		return fmt.Errorf("EnableMSC: unknown msc '%s'", msc)
+	}
+}

--- a/internal/mscs/mscs.go
+++ b/internal/mscs/mscs.go
@@ -35,7 +35,7 @@ func Enable(base *setup.BaseDendrite, monolith *setup.Monolith) error {
 func EnableMSC(base *setup.BaseDendrite, monolith *setup.Monolith, msc string) error {
 	switch msc {
 	case "msc2836":
-		return msc2836.Enable(base, monolith.RoomserverAPI, monolith.FederationSenderAPI, monolith.UserAPI)
+		return msc2836.Enable(base, monolith.RoomserverAPI, monolith.FederationSenderAPI, monolith.UserAPI, monolith.KeyRing)
 	default:
 		return fmt.Errorf("EnableMSC: unknown msc '%s'", msc)
 	}

--- a/roomserver/api/perform.go
+++ b/roomserver/api/perform.go
@@ -83,7 +83,8 @@ type PerformJoinRequest struct {
 
 type PerformJoinResponse struct {
 	// The room ID, populated on success.
-	RoomID string `json:"room_id"`
+	RoomID    string `json:"room_id"`
+	JoinedVia gomatrixserverlib.ServerName
 	// If non-nil, the join request failed. Contains more information why it failed.
 	Error *PerformError
 }

--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -62,10 +62,10 @@ func (w *inputWorker) start() {
 	for {
 		select {
 		case task := <-w.input:
-			hooks.Run(hooks.KindModifyNewEvent, &task.event.Event)
+			hooks.Run(hooks.KindNewEventReceived, &task.event.Event)
 			_, task.err = w.r.processRoomEvent(task.ctx, task.event)
 			if task.err == nil {
-				hooks.Run(hooks.KindNewEvent, &task.event.Event)
+				hooks.Run(hooks.KindNewEventPersisted, &task.event.Event)
 			}
 			task.wg.Done()
 		case <-time.After(time.Second * 5):

--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -62,6 +62,7 @@ func (w *inputWorker) start() {
 	for {
 		select {
 		case task := <-w.input:
+			hooks.Run(hooks.KindModifyNewEvent, &task.event.Event)
 			_, task.err = w.r.processRoomEvent(task.ctx, task.event)
 			if task.err == nil {
 				hooks.Run(hooks.KindNewEvent, &task.event.Event)

--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/Shopify/sarama"
+	"github.com/matrix-org/dendrite/internal/hooks"
 	"github.com/matrix-org/dendrite/roomserver/acls"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/roomserver/storage"
@@ -62,6 +63,9 @@ func (w *inputWorker) start() {
 		select {
 		case task := <-w.input:
 			_, task.err = w.r.processRoomEvent(task.ctx, task.event)
+			if task.err == nil {
+				hooks.Run(hooks.KindNewEvent, &task.event.Event)
+			}
 			task.wg.Done()
 		case <-time.After(time.Second * 5):
 			return


### PR DESCRIPTION
This is a huge PR which:
 - Adds the concepts of hooks (monolith only)
 - Adds an `mscs` package with MSC2836.
 - Add custom config fields for enabling MSC2836.
 - Adds custom `/unstable` endpoints to both CS API and SS API.
 - Adds some tests for MSC2836.

Currently this only works *locally*.

Best grab a cup of coffee for this one @neilalexander :D