### PR TITLE
Allow = in user identifiers

### DIFF
--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -209,7 +209,7 @@ func validateUsername(username string) *util.JSONResponse {
 	} else if !validUsernameRegex.MatchString(username) {
 		return &util.JSONResponse{
 			Code: http.StatusBadRequest,
-			JSON: jsonerror.InvalidUsername("Username can only contain characters a-z, 0-9, or '_-./'"),
+			JSON: jsonerror.InvalidUsername("Username can only contain characters a-z, 0-9, or '_-./='"),
 		}
 	} else if username[0] == '_' { // Regex checks its not a zero length string
 		return &util.JSONResponse{
@@ -230,7 +230,7 @@ func validateApplicationServiceUsername(username string) *util.JSONResponse {
 	} else if !validUsernameRegex.MatchString(username) {
 		return &util.JSONResponse{
 			Code: http.StatusBadRequest,
-			JSON: jsonerror.InvalidUsername("Username can only contain characters a-z, 0-9, or '_-./'"),
+			JSON: jsonerror.InvalidUsername("Username can only contain characters a-z, 0-9, or '_-./='"),
 		}
 	}
 	return nil

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -16,6 +16,13 @@ POST /register rejects registration of usernames with '£'
 POST /register rejects registration of usernames with 'é'
 POST /register rejects registration of usernames with '\n'
 POST /register rejects registration of usernames with '''
+POST /register allows registration of usernames with 'q'
+POST /register allows registration of usernames with '3'
+POST /register allows registration of usernames with '.'
+POST /register allows registration of usernames with '_'
+POST /register allows registration of usernames with '='
+POST /register allows registration of usernames with '-'
+POST /register allows registration of usernames with '/'
 GET /login yields a set of flows
 POST /login can log in as a user
 POST /login returns the same device_id as that in the request


### PR DESCRIPTION
While I was breaking through all the TDD bureaucracy to finally push this fix,
it turned out that it already got fixed in #1578. Still I push the rest of the
changes (basically, everything except of actually fixing the bug ;)).

`=` is crucial for matrix-bifrost which turns XMPP @'s into =40.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: Bohdan Horbeshko <bodqhrohro@gmail.com>