### PR TITLE
syncapi/requestpool: fix initial sync logic error in appendAccountData()

### DIFF
--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -328,9 +328,7 @@ func (rp *RequestPool) appendAccountData(
 	// data keys were set between two message. This isn't a huge issue since the
 	// duplicate data doesn't represent a huge quantity of data, but an optimisation
 	// here would be making sure each data is sent only once to the client.
-	// TODO: We used to have req.since == nil here, is there any case where req.since
-	// can actually be nil?
-	if req.since.PDUPosition() == 0 && req.since.EDUPosition() == 0 {
+	if req.since == nil || (req.since.PDUPosition() == 0 && req.since.EDUPosition() == 0) {
 		// If this is the initial sync, we don't need to check if a data has
 		// already been sent. Instead, we send the whole batch.
 		dataReq := &userapi.QueryAccountDataRequest{

--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -328,7 +328,9 @@ func (rp *RequestPool) appendAccountData(
 	// data keys were set between two message. This isn't a huge issue since the
 	// duplicate data doesn't represent a huge quantity of data, but an optimisation
 	// here would be making sure each data is sent only once to the client.
-	if req.since == nil {
+	// TODO: We used to have req.since == nil here, is there any case where req.since
+	// can actually be nil?
+	if req.since.PDUPosition() == 0 && req.since.EDUPosition() == 0 {
 		// If this is the initial sync, we don't need to check if a data has
 		// already been sent. Instead, we send the whole batch.
 		dataReq := &userapi.QueryAccountDataRequest{


### PR DESCRIPTION
In initial sync, `req.since` is no longer nil, but instead, `req.since.PDUPosition()` and `req.since.EDUPosition()` returns 0.

Fixing this logic error ensures forgotten rooms do not come back as zombies.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `Ariadne Conill <ariadne@dereferenced.org>`
