### PR TITLE
Add ability to disable federation

### DIFF
--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -60,6 +60,10 @@ global:
   - matrix.org
   - vector.im
 
+  # Disables federation. Dendrite will not be able to make any outbound HTTP requests
+  # to other servers and the federation API will not be exposed.
+  disable_federation: false
+
   # Configuration for Kafka/Naffka.
   kafka:
     # List of Kafka broker addresses to connect to. This is not needed if using

--- a/federationsender/federationsender.go
+++ b/federationsender/federationsender.go
@@ -59,8 +59,8 @@ func NewInternalAPI(
 	consumer, _ := kafka.SetupConsumerProducer(&cfg.Matrix.Kafka)
 
 	queues := queue.NewOutgoingQueues(
-		federationSenderDB, cfg.Matrix.ServerName, federation,
-		rsAPI, stats,
+		federationSenderDB, cfg.Matrix.DisableFederation,
+		cfg.Matrix.ServerName, federation, rsAPI, stats,
 		&queue.SigningInfo{
 			KeyID:      cfg.Matrix.KeyID,
 			PrivateKey: cfg.Matrix.PrivateKey,

--- a/internal/config/config_global.go
+++ b/internal/config/config_global.go
@@ -34,6 +34,10 @@ type Global struct {
 	// Defaults to 24 hours.
 	KeyValidityPeriod time.Duration `yaml:"key_validity_period"`
 
+	// Disables federation. Dendrite will not be able to make any outbound HTTP requests
+	// to other servers and the federation API will not be exposed.
+	DisableFederation bool `yaml:"disable_federation"`
+
 	// List of domains that the server will trust as identity servers to
 	// verify third-party identifiers.
 	// Defaults to an empty array.

--- a/internal/setup/base.go
+++ b/internal/setup/base.go
@@ -249,6 +249,9 @@ func (b *BaseDendrite) CreateAccountsDB() accounts.Database {
 // CreateClient creates a new client (normally used for media fetch requests).
 // Should only be called once per component.
 func (b *BaseDendrite) CreateClient() *gomatrixserverlib.Client {
+	if b.Cfg.Global.DisableFederation {
+		return gomatrixserverlib.NewClientWithTransport(noOpHTTPTransport)
+	}
 	client := gomatrixserverlib.NewClient(
 		b.Cfg.FederationSender.DisableTLSValidation,
 	)
@@ -259,6 +262,12 @@ func (b *BaseDendrite) CreateClient() *gomatrixserverlib.Client {
 // CreateFederationClient creates a new federation client. Should only be called
 // once per component.
 func (b *BaseDendrite) CreateFederationClient() *gomatrixserverlib.FederationClient {
+	if b.Cfg.Global.DisableFederation {
+		return gomatrixserverlib.NewFederationClientWithTransport(
+			b.Cfg.Global.ServerName, b.Cfg.Global.KeyID, b.Cfg.Global.PrivateKey,
+			b.Cfg.FederationSender.DisableTLSValidation, noOpHTTPTransport,
+		)
+	}
 	client := gomatrixserverlib.NewFederationClientWithTimeout(
 		b.Cfg.Global.ServerName, b.Cfg.Global.KeyID, b.Cfg.Global.PrivateKey,
 		b.Cfg.FederationSender.DisableTLSValidation, time.Minute*5,
@@ -308,8 +317,10 @@ func (b *BaseDendrite) SetupAndServeHTTP(
 	}
 
 	externalRouter.PathPrefix(httputil.PublicClientPathPrefix).Handler(b.PublicClientAPIMux)
-	externalRouter.PathPrefix(httputil.PublicKeyPathPrefix).Handler(b.PublicKeyAPIMux)
-	externalRouter.PathPrefix(httputil.PublicFederationPathPrefix).Handler(b.PublicFederationAPIMux)
+	if !b.Cfg.Global.DisableFederation {
+		externalRouter.PathPrefix(httputil.PublicKeyPathPrefix).Handler(b.PublicKeyAPIMux)
+		externalRouter.PathPrefix(httputil.PublicFederationPathPrefix).Handler(b.PublicFederationAPIMux)
+	}
 	externalRouter.PathPrefix(httputil.PublicMediaPathPrefix).Handler(b.PublicMediaAPIMux)
 
 	if internalAddr != NoListener && internalAddr != externalAddr {

--- a/internal/setup/federation.go
+++ b/internal/setup/federation.go
@@ -18,9 +18,6 @@ var noOpHTTPTransport = &http.Transport{
 	DialTLS: func(_, _ string) (net.Conn, error) {
 		return nil, fmt.Errorf("federation prohibited by configuration")
 	},
-	DialTLSContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-		return nil, fmt.Errorf("federation prohibited by configuration")
-	},
 }
 
 func init() {

--- a/internal/setup/federation.go
+++ b/internal/setup/federation.go
@@ -1,0 +1,35 @@
+package setup
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+)
+
+// noOpHTTPTransport is used to disable federation.
+var noOpHTTPTransport = &http.Transport{
+	Dial: func(_, _ string) (net.Conn, error) {
+		return nil, fmt.Errorf("federation prohibited by configuration")
+	},
+	DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+		return nil, fmt.Errorf("federation prohibited by configuration")
+	},
+	DialTLS: func(_, _ string) (net.Conn, error) {
+		return nil, fmt.Errorf("federation prohibited by configuration")
+	},
+	DialTLSContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+		return nil, fmt.Errorf("federation prohibited by configuration")
+	},
+}
+
+func init() {
+	noOpHTTPTransport.RegisterProtocol("matrix", &noOpHTTPRoundTripper{})
+}
+
+type noOpHTTPRoundTripper struct {
+}
+
+func (y *noOpHTTPRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("federation prohibited by configuration")
+}


### PR DESCRIPTION
This adds `disable_federation` to the Dendrite configuration and prohibits all inbound and outbound federation traffic if so. This is done by not adding federation endpoints to the external mux and intercepting all outbound HTTP requests.

In the future, we will want to be able to support running without the federation sender and federation API polylith components altogether, but that is not done by this PR.

Closes #1570.