### PR TITLE
Fix /joined_members API response

### DIFF
--- a/clientapi/routing/memberships.go
+++ b/clientapi/routing/memberships.go
@@ -51,13 +51,6 @@ type databaseJoinedMember struct {
 	AvatarURL   string `json:"avatar_url"`
 }
 
-func (d databaseJoinedMember) toJoinedMember() joinedMember {
-	return joinedMember{
-		DisplayName: d.DisplayName,
-		AvatarURL:   d.AvatarURL,
-	}
-}
-
 // GetMemberships implements GET /rooms/{roomId}/members
 func GetMemberships(
 	req *http.Request, device *userapi.Device, roomID string, joinedOnly bool,
@@ -91,7 +84,7 @@ func GetMemberships(
 				util.GetLogger(req.Context()).WithError(err).Error("failed to unmarshal event content")
 				return jsonerror.InternalServerError()
 			}
-			res.Joined[ev.Sender] = content.toJoinedMember()
+			res.Joined[ev.Sender] = joinedMember(content)
 		}
 		return util.JSONResponse{
 			Code: http.StatusOK,

--- a/clientapi/routing/memberships.go
+++ b/clientapi/routing/memberships.go
@@ -44,6 +44,20 @@ type joinedMember struct {
 	AvatarURL   string `json:"avatar_url"`
 }
 
+// The database stores 'displayname' without an underscore.
+// Deserialize into this and then change to the actual API response
+type databaseJoinedMember struct {
+	DisplayName string `json:"displayname"`
+	AvatarURL   string `json:"avatar_url"`
+}
+
+func (d databaseJoinedMember) toJoinedMember() joinedMember {
+	return joinedMember{
+		DisplayName: d.DisplayName,
+		AvatarURL:   d.AvatarURL,
+	}
+}
+
 // GetMemberships implements GET /rooms/{roomId}/members
 func GetMemberships(
 	req *http.Request, device *userapi.Device, roomID string, joinedOnly bool,
@@ -72,12 +86,12 @@ func GetMemberships(
 		var res getJoinedMembersResponse
 		res.Joined = make(map[string]joinedMember)
 		for _, ev := range queryRes.JoinEvents {
-			var content joinedMember
+			var content databaseJoinedMember
 			if err := json.Unmarshal(ev.Content, &content); err != nil {
 				util.GetLogger(req.Context()).WithError(err).Error("failed to unmarshal event content")
 				return jsonerror.InternalServerError()
 			}
-			res.Joined[ev.Sender] = content
+			res.Joined[ev.Sender] = content.toJoinedMember()
 		}
 		return util.JSONResponse{
 			Code: http.StatusOK,

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -503,3 +503,4 @@ Forgetting room does not show up in v2 /sync
 Can forget room you've been kicked from
 Can re-join room if re-invited
 /whois
+/joined_members return joined members


### PR DESCRIPTION
Closes #1332. Unlike most other APIs that return `avatar_url` and `displayname`, [this API](https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-rooms-roomid-joined-members) uses `display_name`. The field is stored as `displayname` in the database, and so wasn't being unmarshalled into the response struct. This meant that the `display_name` field was always blank.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `Alex Kursell <alex@awk.run>`
