### PR TITLE
Fix broken image in CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -37,7 +37,7 @@ If a job fails, click the "details" button and you should be taken to the job's
 logs.
 
 ![Click the details button on the failing build
-step](docs/images/details-button-location.jpg)
+step](https://raw.githubusercontent.com/matrix-org/dendrite/master/docs/images/details-button-location.jpg)
 
 Scroll down to the failing step and you should see some log output. Scan the
 logs until you find what it's complaining about, fix it, submit a new commit,


### PR DESCRIPTION
The relative path seemed to return a 404 so I replaced it with the full URL

Signed-off-by: `tr_slimey@protonmail.com | @tr_slimey:an-atom-in.space`
