### PR TITLE
Don't panic while federation is disabled

### DIFF
--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -122,13 +122,23 @@ func (oqs *OutgoingQueues) getQueue(destination gomatrixserverlib.ServerName) *d
 	return oq
 }
 
+type ErrorFederationDisabled struct {
+	Message string
+}
+
+func (e *ErrorFederationDisabled) Error() string {
+	return e.Message
+}
+
 // SendEvent sends an event to the destinations
 func (oqs *OutgoingQueues) SendEvent(
 	ev *gomatrixserverlib.HeaderedEvent, origin gomatrixserverlib.ServerName,
 	destinations []gomatrixserverlib.ServerName,
 ) error {
 	if oqs.disabled {
-		return fmt.Errorf("federation is disabled")
+		return &ErrorFederationDisabled{
+			Message: "Federation disabled",
+		}
 	}
 	if origin != oqs.origin {
 		// TODO: Support virtual hosting; gh issue #577.
@@ -190,7 +200,9 @@ func (oqs *OutgoingQueues) SendEDU(
 	destinations []gomatrixserverlib.ServerName,
 ) error {
 	if oqs.disabled {
-		return fmt.Errorf("federation is disabled")
+		return &ErrorFederationDisabled{
+			Message: "Federation disabled",
+		}
 	}
 	if origin != oqs.origin {
 		// TODO: Support virtual hosting; gh issue #577.


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [X] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)  
  I'm not sure i succeeded with the tests. Script exited with
```
Application Services APIs: 24% (6/25 tests)
--------------------------
  Application Services API :  24% (6/25 tests)

+ exit 1

```
* [X] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

### Error

I noticed a weird behaviour while trying out the new `disable_federation` feature:
Create a fresh dendrite instance and two users. The first user creates a room and invites the other.
We get a panic.

The panic originates from `onMessage` in `federationsender/consumers/roomserver.go` (the error on which we panic is on `SendEvent` in `federationsender/queue/queue.go`):
```
time="2020-12-02T21:02:38.823206562Z" level=panic msg="roomserver output log: write room event failure" func="github.com/matrix-org/dendrite/federationsender/consumers.(*OutputRoomEventConsumer).onMessage" file="github.com/matrix-org/dendrite/federationsender/consumers/roomserver.go:103" add="[$MA7zLJ25tYGE1XeHjaDpw089iYCJdAYPXKu0ynXyafo]" del="[]" error="federation is disabled" event="{\"auth_events\":[\"$h0GY1FKTru_N1WvsWaY6d3jgOwKlJiVbCQBNSfFJ_6s\"],\"content\":{\"aliases\":[\"#my-room:localhost\"]},\"depth\":8,\"hashes\":{\"sha256\":\"/mG3Y13UhNSG3W901DQSQ/0iCXoXJ6CP2b6e74HHb4w\"},\"origin\":\"localhost\",\"origin_server_ts\":1606942911625,\"prev_events\":[\"$PByS6EdykyL6VAq4dBRdBO8iTEQ3MlWwZZ0bUghbtSE\"],\"prev_state\":[],\"room_id\":\"!ZIAJObQBrqpqFgb2:localhost\",\"sender\":\"@test2:localhost\",\"signatures\":{\"localhost\":{\"ed25519:F8FCQB\":\"de+vv+5y83USZIbiQJqob4cQC4LgvmykYnmdiTIrySl9ThRQmjg7NftiWYCBbwfnao5tT5ciXVRpWTeyQXGJBw\"}},\"state_key\":\"localhost\",\"type\":\"m.room.aliases\"}"
```
### Fix

Not sure if this can put the db in an inconsistent state..

Signed-off-by: `Ronnie Ebrin <ebrin.ronnie@protonmail.com>`
