### PR TITLE
[WIP] Implement archived rooms

### DIFF
--- a/syncapi/storage/interface.go
+++ b/syncapi/storage/interface.go
@@ -67,7 +67,7 @@ type Database interface {
 	IncrementalSync(ctx context.Context, res *types.Response, device userapi.Device, fromPos, toPos types.StreamingToken, numRecentEventsPerRoom int, wantFullState bool) (*types.Response, error)
 	// CompleteSync returns a complete /sync API response for the given user. A response object
 	// must be provided for CompleteSync to populate - it will not create one.
-	CompleteSync(ctx context.Context, res *types.Response, device userapi.Device, numRecentEventsPerRoom int) (*types.Response, error)
+	CompleteSync(ctx context.Context, res *types.Response, device userapi.Device, numRecentEventsPerRoom int, includeLeave bool) (*types.Response, error)
 	// GetAccountDataInRange returns all account data for a given user inserted or
 	// updated between two given positions
 	// Returns a map following the format data[roomID] = []dataTypes

--- a/syncapi/storage/storage_test.go
+++ b/syncapi/storage/storage_test.go
@@ -195,7 +195,7 @@ func TestSyncResponse(t *testing.T) {
 			DoSync: func() (*types.Response, error) {
 				res := types.NewResponse()
 				// limit set to 5
-				return db.CompleteSync(ctx, res, testUserDeviceA, 5)
+				return db.CompleteSync(ctx, res, testUserDeviceA, 5, false)
 			},
 			// want the last 5 events
 			WantTimeline: events[len(events)-5:],
@@ -208,7 +208,7 @@ func TestSyncResponse(t *testing.T) {
 			Name: "CompleteSync",
 			DoSync: func() (*types.Response, error) {
 				res := types.NewResponse()
-				return db.CompleteSync(ctx, res, testUserDeviceA, len(events)+1)
+				return db.CompleteSync(ctx, res, testUserDeviceA, len(events)+1, false)
 			},
 			WantTimeline: events,
 			// We want no state at all as that field in /sync is the delta between the token (beginning of time)

--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -255,7 +255,7 @@ func (rp *RequestPool) currentSyncForUser(req syncRequest, latestPos types.Strea
 
 	// TODO: handle ignored users
 	if req.since.PDUPosition() == 0 && req.since.EDUPosition() == 0 {
-		res, err = rp.db.CompleteSync(req.ctx, res, req.device, req.limit)
+		res, err = rp.db.CompleteSync(req.ctx, res, req.device, req.limit, req.includeLeave)
 		if err != nil {
 			return res, fmt.Errorf("rp.db.CompleteSync: %w", err)
 		}

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -503,3 +503,4 @@ Forgetting room does not show up in v2 /sync
 Can forget room you've been kicked from
 /whois
 /joined_members return joined members
+Archived rooms only contain history from before the user left


### PR DESCRIPTION
I've added logic to check for the `include_leave` parameter in the filter, to retrieve room events for 'left' rooms and to populate the 'leave' field of the response with them (currently, the field is left blank regardless of the filter parameters) for complete sync requests. However, the test still does not pass.

It seems that while synapse performs the final sync request as an incremental sync, dendrite for some reason does a complete sync, causing it to return extraneous state events (I added the leave-population functionality initially to the complete sync portion of the code because I assumed dendrite was correct in doing this).

As the title says, work in progress PR. Please add comments or concerns where necessary.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `David Spenler <davidspenler@gmail.com>`
