### PR TITLE
Remove incorrect comment in find-lint.sh

### DIFF
--- a/build/scripts/find-lint.sh
+++ b/build/scripts/find-lint.sh
@@ -24,8 +24,6 @@ fi
 echo "Installing golangci-lint..."
 
 # Make a backup of go.{mod,sum} first
-# TODO: Once go 1.13 is out, use go get's -mod=readonly option
-# https://github.com/golang/go/issues/30667
 cp go.mod go.mod.bak && cp go.sum go.sum.bak
 go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.19.1
 


### PR DESCRIPTION
The referenced issue is about `go build`, not `go get`. `go get` does not have a `-mod=readonly` flag, even in go v1.15.

We may also want to consider updating `golangci-lint` at some point.