### PR TITLE
Adjust latest events updater

### DIFF
--- a/roomserver/internal/input/input_latest_events.go
+++ b/roomserver/internal/input/input_latest_events.go
@@ -306,6 +306,14 @@ func (u *latestEventsUpdater) calculateLatest(
 		delete(existingRefs, prevEventID)
 	}
 
+	// Ensure that we don't add any candidate forward extremities from
+	// the old set that are, themselves, referenced by the old set of
+	// forward extremities. This shouldn't happen but guards against
+	// the possibility anyway.
+	for prevEventID := range existingPrevs {
+		delete(existingRefs, prevEventID)
+	}
+
 	// Then re-add any old extremities that are still valid after all.
 	for _, old := range existingRefs {
 		newLatest = append(newLatest, *old)

--- a/roomserver/internal/input/input_latest_events.go
+++ b/roomserver/internal/input/input_latest_events.go
@@ -290,10 +290,8 @@ func (u *latestEventsUpdater) calculateLatest(
 
 	// If the "new" event is already a forward extremity then stop, as
 	// nothing changes.
-	for _, event := range events {
-		if event.EventID() == newEvent.EventID() {
-			return false, nil
-		}
+	if _, ok := existingRefs[newEvent.EventID()]; ok {
+		return false, nil
 	}
 
 	// Include our new event in the extremities.
@@ -303,14 +301,6 @@ func (u *latestEventsUpdater) calculateLatest(
 	// If our new event references them then they are no longer good
 	// candidates.
 	for _, prevEventID := range newEvent.PrevEventIDs() {
-		delete(existingRefs, prevEventID)
-	}
-
-	// Ensure that we don't add any candidate forward extremities from
-	// the old set that are, themselves, referenced by the old set of
-	// forward extremities. This shouldn't happen but guards against
-	// the possibility anyway.
-	for prevEventID := range existingPrevs {
 		delete(existingRefs, prevEventID)
 	}
 

--- a/roomserver/internal/input/input_latest_events.go
+++ b/roomserver/internal/input/input_latest_events.go
@@ -285,12 +285,14 @@ func (u *latestEventsUpdater) calculateLatest(
 	// then do nothing - it's not a candidate to be a new extremity if
 	// it has been referenced.
 	if _, ok := existingPrevs[newEvent.EventID()]; ok {
+		u.latest = oldLatest
 		return false, nil
 	}
 
 	// If the "new" event is already a forward extremity then stop, as
 	// nothing changes.
 	if _, ok := existingRefs[newEvent.EventID()]; ok {
+		u.latest = oldLatest
 		return false, nil
 	}
 


### PR DESCRIPTION
There were a couple of cases where `u.latest` could not be set, and then we'd go and consume it in `makeOutputNewRoomEvent` anyway, so that's fixed now.

This also updates one of the checks to be simpler.