### PR TITLE
Fix device list position in streaming token

### DIFF
--- a/keyserver/storage/postgres/key_changes_table.go
+++ b/keyserver/storage/postgres/key_changes_table.go
@@ -82,6 +82,7 @@ func (s *keyChangesStatements) SelectKeyChanges(
 	if toOffset == sarama.OffsetNewest {
 		toOffset = math.MaxInt64
 	}
+	latestOffset = fromOffset
 	rows, err := s.selectKeyChangesStmt.QueryContext(ctx, partition, fromOffset, toOffset)
 	if err != nil {
 		return nil, 0, err

--- a/keyserver/storage/sqlite3/key_changes_table.go
+++ b/keyserver/storage/sqlite3/key_changes_table.go
@@ -83,6 +83,7 @@ func (s *keyChangesStatements) SelectKeyChanges(
 	if toOffset == sarama.OffsetNewest {
 		toOffset = math.MaxInt64
 	}
+	latestOffset = fromOffset
 	rows, err := s.selectKeyChangesStmt.QueryContext(ctx, partition, fromOffset, toOffset)
 	if err != nil {
 		return nil, 0, err


### PR DESCRIPTION
`SelectKeyChanges` was only setting `latestOffset` if there was more one or more keys, but not if there were zero keys changed. `latestOffset` was put into the `NextBatch` token, which is why the offset kept alternating and being set back to zero.

This sets the `latestOffset` to the `fromOffset` initially, so that if no keys are returned, we keep the same offset in the `NextBatch`.

This *should* fix #1625.