### PR TITLE
Don't use request context for input room event queued tasks

### DIFF
--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -116,7 +116,7 @@ func (r *Inputer) WriteOutputEvents(roomID string, updates []api.OutputEvent) er
 
 // InputRoomEvents implements api.RoomserverInternalAPI
 func (r *Inputer) InputRoomEvents(
-	ctx context.Context,
+	_ context.Context,
 	request *api.InputRoomEventsRequest,
 	response *api.InputRoomEventsResponse,
 ) {
@@ -148,7 +148,7 @@ func (r *Inputer) InputRoomEvents(
 		// the wait group, so that the worker can notify us when this specific
 		// task has been finished.
 		tasks[i] = &inputTask{
-			ctx:   ctx,
+			ctx:   context.Background(),
 			event: &request.InputRoomEvents[i],
 			wg:    wg,
 		}


### PR DESCRIPTION
If the roomserver receives the task successfully then we shouldn't pass through the request context, otherwise database writes will fail and the effort is for nothing.

This should fix #1630.