### PR TITLE
More sane next batch handling, typing notification tweaks, give invites their own stream position, device list fix

### DIFF
--- a/keyserver/storage/postgres/key_changes_table.go
+++ b/keyserver/storage/postgres/key_changes_table.go
@@ -82,6 +82,7 @@ func (s *keyChangesStatements) SelectKeyChanges(
 	if toOffset == sarama.OffsetNewest {
 		toOffset = math.MaxInt64
 	}
+	latestOffset = fromOffset
 	rows, err := s.selectKeyChangesStmt.QueryContext(ctx, partition, fromOffset, toOffset)
 	if err != nil {
 		return nil, 0, err

--- a/keyserver/storage/sqlite3/key_changes_table.go
+++ b/keyserver/storage/sqlite3/key_changes_table.go
@@ -83,6 +83,7 @@ func (s *keyChangesStatements) SelectKeyChanges(
 	if toOffset == sarama.OffsetNewest {
 		toOffset = math.MaxInt64
 	}
+	latestOffset = fromOffset
 	rows, err := s.selectKeyChangesStmt.QueryContext(ctx, partition, fromOffset, toOffset)
 	if err != nil {
 		return nil, 0, err

--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -116,7 +116,7 @@ func (r *Inputer) WriteOutputEvents(roomID string, updates []api.OutputEvent) er
 
 // InputRoomEvents implements api.RoomserverInternalAPI
 func (r *Inputer) InputRoomEvents(
-	ctx context.Context,
+	_ context.Context,
 	request *api.InputRoomEventsRequest,
 	response *api.InputRoomEventsResponse,
 ) {
@@ -148,7 +148,7 @@ func (r *Inputer) InputRoomEvents(
 		// the wait group, so that the worker can notify us when this specific
 		// task has been finished.
 		tasks[i] = &inputTask{
-			ctx:   ctx,
+			ctx:   context.Background(),
 			event: &request.InputRoomEvents[i],
 			wg:    wg,
 		}

--- a/syncapi/consumers/eduserver_receipts.go
+++ b/syncapi/consumers/eduserver_receipts.go
@@ -88,7 +88,7 @@ func (s *OutputReceiptEventConsumer) onMessage(msg *sarama.ConsumerMessage) erro
 		return err
 	}
 	// update stream position
-	s.notifier.OnNewReceipt(types.StreamingToken{ReceiptPosition: streamPos})
+	s.notifier.OnNewReceipt(output.RoomID, types.StreamingToken{ReceiptPosition: streamPos})
 
 	return nil
 }

--- a/syncapi/consumers/eduserver_sendtodevice.go
+++ b/syncapi/consumers/eduserver_sendtodevice.go
@@ -94,10 +94,8 @@ func (s *OutputSendToDeviceEventConsumer) onMessage(msg *sarama.ConsumerMessage)
 		"event_type": output.Type,
 	}).Info("sync API received send-to-device event from EDU server")
 
-	streamPos := s.db.AddSendToDevice()
-
-	_, err = s.db.StoreNewSendForDeviceMessage(
-		context.TODO(), streamPos, output.UserID, output.DeviceID, output.SendToDeviceEvent,
+	streamPos, err := s.db.StoreNewSendForDeviceMessage(
+		context.TODO(), output.UserID, output.DeviceID, output.SendToDeviceEvent,
 	)
 	if err != nil {
 		log.WithError(err).Errorf("failed to store send-to-device message")

--- a/syncapi/consumers/eduserver_typing.go
+++ b/syncapi/consumers/eduserver_typing.go
@@ -64,12 +64,7 @@ func NewOutputTypingEventConsumer(
 // Start consuming from EDU api
 func (s *OutputTypingEventConsumer) Start() error {
 	s.db.SetTypingTimeoutCallback(func(userID, roomID string, latestSyncPosition int64) {
-		s.notifier.OnNewEvent(
-			nil, roomID, nil,
-			types.StreamingToken{
-				TypingPosition: types.StreamPosition(latestSyncPosition),
-			},
-		)
+		s.notifier.OnNewTyping(roomID, types.StreamingToken{TypingPosition: types.StreamPosition(latestSyncPosition)})
 	})
 
 	return s.typingConsumer.Start()
@@ -97,6 +92,6 @@ func (s *OutputTypingEventConsumer) onMessage(msg *sarama.ConsumerMessage) error
 		typingPos = s.db.RemoveTypingUser(typingEvent.UserID, typingEvent.RoomID)
 	}
 
-	s.notifier.OnNewEvent(nil, output.Event.RoomID, nil, types.StreamingToken{TypingPosition: typingPos})
+	s.notifier.OnNewTyping(output.Event.RoomID, types.StreamingToken{TypingPosition: typingPos})
 	return nil
 }

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -275,14 +275,14 @@ func (s *OutputRoomEventConsumer) onNewInviteEvent(
 		}).Panicf("roomserver output log: write invite failure")
 		return nil
 	}
-	s.notifier.OnNewInvite(types.StreamingToken{PDUPosition: pduPos}, *msg.Event.StateKey())
+	s.notifier.OnNewInvite(types.StreamingToken{InvitePosition: pduPos}, *msg.Event.StateKey())
 	return nil
 }
 
 func (s *OutputRoomEventConsumer) onRetireInviteEvent(
 	ctx context.Context, msg api.OutputRetireInviteEvent,
 ) error {
-	sp, err := s.db.RetireInviteEvent(ctx, msg.EventID)
+	pduPos, err := s.db.RetireInviteEvent(ctx, msg.EventID)
 	if err != nil {
 		// panic rather than continue with an inconsistent database
 		log.WithFields(log.Fields{
@@ -293,7 +293,7 @@ func (s *OutputRoomEventConsumer) onRetireInviteEvent(
 	}
 	// Notify any active sync requests that the invite has been retired.
 	// Invites share the same stream counter as PDUs
-	s.notifier.OnNewEvent(nil, "", []string{msg.TargetUserID}, types.StreamingToken{PDUPosition: sp})
+	s.notifier.OnNewInvite(types.StreamingToken{InvitePosition: pduPos}, msg.TargetUserID)
 	return nil
 }
 

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -259,6 +259,12 @@ func (s *OutputRoomEventConsumer) notifyJoinedPeeks(ctx context.Context, ev *gom
 func (s *OutputRoomEventConsumer) onNewInviteEvent(
 	ctx context.Context, msg api.OutputNewInviteEvent,
 ) error {
+	if msg.Event.StateKey() == nil {
+		log.WithFields(log.Fields{
+			"event": string(msg.Event.JSON()),
+		}).Panicf("roomserver output log: invite has no state key")
+		return nil
+	}
 	pduPos, err := s.db.AddInviteEvent(ctx, msg.Event)
 	if err != nil {
 		// panic rather than continue with an inconsistent database
@@ -269,7 +275,7 @@ func (s *OutputRoomEventConsumer) onNewInviteEvent(
 		}).Panicf("roomserver output log: write invite failure")
 		return nil
 	}
-	s.notifier.OnNewEvent(msg.Event, "", nil, types.StreamingToken{PDUPosition: pduPos})
+	s.notifier.OnNewInvite(types.StreamingToken{PDUPosition: pduPos}, *msg.Event.StateKey())
 	return nil
 }
 

--- a/syncapi/internal/keychange.go
+++ b/syncapi/internal/keychange.go
@@ -134,7 +134,7 @@ func DeviceListCatchup(
 		Partition: queryRes.Partition,
 		Offset:    queryRes.Offset,
 	})
-	res.NextBatch = to.String()
+	res.NextBatch = res.NextBatch.WithUpdates(to)
 
 	return hasNew, nil
 }

--- a/syncapi/internal/keychange.go
+++ b/syncapi/internal/keychange.go
@@ -131,7 +131,7 @@ func DeviceListCatchup(
 	to.DeviceListPosition = types.LogPosition{
 		Partition: queryRes.Partition,
 		Offset:    queryRes.Offset,
-	})
+	}
 	res.NextBatch.ApplyUpdates(to)
 
 	return hasNew, nil

--- a/syncapi/internal/keychange.go
+++ b/syncapi/internal/keychange.go
@@ -134,7 +134,7 @@ func DeviceListCatchup(
 		Partition: queryRes.Partition,
 		Offset:    queryRes.Offset,
 	})
-	res.NextBatch = res.NextBatch.WithUpdates(to)
+	res.NextBatch.ApplyUpdates(to)
 
 	return hasNew, nil
 }

--- a/syncapi/storage/interface.go
+++ b/syncapi/storage/interface.go
@@ -130,9 +130,9 @@ type Database interface {
 	//      can be deleted altogether by CleanSendToDeviceUpdates
 	// The token supplied should be the current requested sync token, e.g. from the "since"
 	// parameter.
-	SendToDeviceUpdatesForSync(ctx context.Context, userID, deviceID string, token types.StreamingToken) (events []types.SendToDeviceEvent, changes []types.SendToDeviceNID, deletions []types.SendToDeviceNID, err error)
+	SendToDeviceUpdatesForSync(ctx context.Context, userID, deviceID string, token types.StreamingToken) (pos types.StreamPosition, events []types.SendToDeviceEvent, changes []types.SendToDeviceNID, deletions []types.SendToDeviceNID, err error)
 	// StoreNewSendForDeviceMessage stores a new send-to-device event for a user's device.
-	StoreNewSendForDeviceMessage(ctx context.Context, streamPos types.StreamPosition, userID, deviceID string, event gomatrixserverlib.SendToDeviceEvent) (types.StreamPosition, error)
+	StoreNewSendForDeviceMessage(ctx context.Context, userID, deviceID string, event gomatrixserverlib.SendToDeviceEvent) (types.StreamPosition, error)
 	// CleanSendToDeviceUpdates will update or remove any send-to-device updates based on the
 	// result to a previous call to SendDeviceUpdatesForSync. This is separate as it allows
 	// SendToDeviceUpdatesForSync to be called multiple times if needed (e.g. before and after

--- a/syncapi/storage/shared/syncserver.go
+++ b/syncapi/storage/shared/syncserver.go
@@ -629,7 +629,6 @@ func (d *Database) addReceiptDeltaToResponse(
 			}
 			read.User[receipt.UserID] = eduAPI.ReceiptTS{TS: receipt.Timestamp}
 			content[receipt.EventID] = read
-			res.NextBatch.ReceiptPosition++
 		}
 		ev.Content, err = json.Marshal(content)
 		if err != nil {

--- a/syncapi/storage/shared/syncserver.go
+++ b/syncapi/storage/shared/syncserver.go
@@ -580,9 +580,9 @@ func (d *Database) addTypingDeltaToResponse(
 				jr = *types.NewJoinResponse()
 			}
 			jr.Ephemeral.Events = append(jr.Ephemeral.Events, ev)
-			res.NextBatch.TypingPosition++
 			res.Rooms.Join[roomID] = jr
 		}
+		res.NextBatch.TypingPosition = types.StreamPosition(d.EDUCache.GetLatestSyncPosition())
 	}
 	return nil
 }

--- a/syncapi/storage/shared/syncserver.go
+++ b/syncapi/storage/shared/syncserver.go
@@ -880,14 +880,14 @@ func (d *Database) getJoinResponseForCompleteSync(
 
 	// Retrieve the backward topology position, i.e. the position of the
 	// oldest event in the room's topology.
-	var prevBatch types.TopologyToken
+	var prevBatch *types.TopologyToken
 	if len(recentStreamEvents) > 0 {
 		var backwardTopologyPos, backwardStreamPos types.StreamPosition
 		backwardTopologyPos, backwardStreamPos, err = d.Topology.SelectPositionInTopology(ctx, txn, recentStreamEvents[0].EventID())
 		if err != nil {
 			return
 		}
-		prevBatch = types.TopologyToken{
+		prevBatch = &types.TopologyToken{
 			Depth:       backwardTopologyPos,
 			PDUPosition: backwardStreamPos,
 		}
@@ -1028,7 +1028,7 @@ func (d *Database) addRoomDeltaToResponse(
 	case gomatrixserverlib.Join:
 		jr := types.NewJoinResponse()
 
-		jr.Timeline.PrevBatch = prevBatch
+		jr.Timeline.PrevBatch = &prevBatch
 		jr.Timeline.Events = gomatrixserverlib.HeaderedToClientEvents(recentEvents, gomatrixserverlib.FormatSync)
 		jr.Timeline.Limited = limited
 		jr.State.Events = gomatrixserverlib.HeaderedToClientEvents(delta.stateEvents, gomatrixserverlib.FormatSync)
@@ -1036,7 +1036,7 @@ func (d *Database) addRoomDeltaToResponse(
 	case gomatrixserverlib.Peek:
 		jr := types.NewJoinResponse()
 
-		jr.Timeline.PrevBatch = prevBatch
+		jr.Timeline.PrevBatch = &prevBatch
 		jr.Timeline.Events = gomatrixserverlib.HeaderedToClientEvents(recentEvents, gomatrixserverlib.FormatSync)
 		jr.Timeline.Limited = limited
 		jr.State.Events = gomatrixserverlib.HeaderedToClientEvents(delta.stateEvents, gomatrixserverlib.FormatSync)
@@ -1047,7 +1047,7 @@ func (d *Database) addRoomDeltaToResponse(
 		// TODO: recentEvents may contain events that this user is not allowed to see because they are
 		//       no longer in the room.
 		lr := types.NewLeaveResponse()
-		lr.Timeline.PrevBatch = prevBatch
+		lr.Timeline.PrevBatch = &prevBatch
 		lr.Timeline.Events = gomatrixserverlib.HeaderedToClientEvents(recentEvents, gomatrixserverlib.FormatSync)
 		lr.Timeline.Limited = false // TODO: if len(events) >= numRecents + 1 and then set limited:true
 		lr.State.Events = gomatrixserverlib.HeaderedToClientEvents(delta.stateEvents, gomatrixserverlib.FormatSync)

--- a/syncapi/storage/shared/syncserver.go
+++ b/syncapi/storage/shared/syncserver.go
@@ -575,6 +575,7 @@ func (d *Database) addTypingDeltaToResponse(
 				jr = *types.NewJoinResponse()
 			}
 			jr.Ephemeral.Events = append(jr.Ephemeral.Events, ev)
+			res.NextBatch.TypingPosition++
 			res.Rooms.Join[roomID] = jr
 		}
 	}
@@ -630,6 +631,7 @@ func (d *Database) addReceiptDeltaToResponse(
 		}
 
 		jr.Ephemeral.Events = append(jr.Ephemeral.Events, ev)
+		res.NextBatch.ReceiptPosition++
 		res.Rooms.Join[roomID] = jr
 	}
 
@@ -686,7 +688,7 @@ func (d *Database) IncrementalSync(
 	numRecentEventsPerRoom int,
 	wantFullState bool,
 ) (*types.Response, error) {
-	res.NextBatch = res.NextBatch.WithUpdates(toPos)
+	res.NextBatch = fromPos.WithUpdates(toPos)
 
 	var joinedRoomIDs []string
 	var err error
@@ -778,7 +780,7 @@ func (d *Database) getResponseWithPDUsForCompleteSync(
 		To:   toPos.PDUPosition,
 	}
 
-	res.NextBatch = res.NextBatch.WithUpdates(toPos)
+	res.NextBatch.ApplyUpdates(toPos)
 
 	// Extract room state and recent events for all rooms the user is joined to.
 	joinedRoomIDs, err = d.CurrentRoomState.SelectRoomIDsWithMembership(ctx, txn, userID, gomatrixserverlib.Join)

--- a/syncapi/storage/shared/syncserver.go
+++ b/syncapi/storage/shared/syncserver.go
@@ -629,6 +629,7 @@ func (d *Database) addReceiptDeltaToResponse(
 			}
 			read.User[receipt.UserID] = eduAPI.ReceiptTS{TS: receipt.Timestamp}
 			content[receipt.EventID] = read
+			res.NextBatch.ReceiptPosition++
 		}
 		ev.Content, err = json.Marshal(content)
 		if err != nil {
@@ -636,7 +637,6 @@ func (d *Database) addReceiptDeltaToResponse(
 		}
 
 		jr.Ephemeral.Events = append(jr.Ephemeral.Events, ev)
-		res.NextBatch.ReceiptPosition++
 		res.Rooms.Join[roomID] = jr
 	}
 

--- a/syncapi/storage/shared/syncserver.go
+++ b/syncapi/storage/shared/syncserver.go
@@ -629,6 +629,7 @@ func (d *Database) addReceiptDeltaToResponse(
 			}
 			read.User[receipt.UserID] = eduAPI.ReceiptTS{TS: receipt.Timestamp}
 			content[receipt.EventID] = read
+			res.NextBatch.ReceiptPosition++
 		}
 		ev.Content, err = json.Marshal(content)
 		if err != nil {

--- a/syncapi/storage/storage_test.go
+++ b/syncapi/storage/storage_test.go
@@ -228,7 +228,7 @@ func TestSyncResponse(t *testing.T) {
 				ReceiptPosition:      latest.ReceiptPosition,
 				SendToDevicePosition: latest.SendToDevicePosition,
 			}
-			if res.NextBatch != next.String() {
+			if res.NextBatch.String() != next.String() {
 				st.Errorf("NextBatch got %s want %s", res.NextBatch, next.String())
 			}
 			roomRes, ok := res.Rooms.Join[testRoomID]
@@ -266,7 +266,7 @@ func TestGetEventsInRangeWithPrevBatch(t *testing.T) {
 	// returns the last event "Message 10"
 	assertEventsEqual(t, "IncrementalSync Timeline", false, roomRes.Timeline.Events, reversed(events[len(events)-1:]))
 
-	prev := roomRes.Timeline.PrevBatch
+	prev := roomRes.Timeline.PrevBatch.String()
 	if prev == "" {
 		t.Fatalf("IncrementalSync expected prev_batch token")
 	}
@@ -666,12 +666,8 @@ func TestInviteBehaviour(t *testing.T) {
 	assertInvitedToRooms(t, res, []string{inviteRoom2})
 
 	// a sync after we have received both invites should result in a leave for the retired room
-	beforeRetireTok, err := types.NewStreamTokenFromString(beforeRetireRes.NextBatch)
-	if err != nil {
-		t.Fatalf("NewStreamTokenFromString cannot parse next batch '%s' : %s", beforeRetireRes.NextBatch, err)
-	}
 	res = types.NewResponse()
-	res, err = db.IncrementalSync(ctx, res, testUserDeviceA, beforeRetireTok, latest, 0, false)
+	res, err = db.IncrementalSync(ctx, res, testUserDeviceA, beforeRetireRes.NextBatch, latest, 0, false)
 	if err != nil {
 		t.Fatalf("IncrementalSync failed: %s", err)
 	}

--- a/syncapi/storage/storage_test.go
+++ b/syncapi/storage/storage_test.go
@@ -539,7 +539,7 @@ func TestSendToDeviceBehaviour(t *testing.T) {
 
 	// At this point there should be no messages. We haven't sent anything
 	// yet.
-	events, updates, deletions, err := db.SendToDeviceUpdatesForSync(ctx, "alice", "one", types.StreamingToken{})
+	_, events, updates, deletions, err := db.SendToDeviceUpdatesForSync(ctx, "alice", "one", types.StreamingToken{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -552,7 +552,7 @@ func TestSendToDeviceBehaviour(t *testing.T) {
 	}
 
 	// Try sending a message.
-	streamPos, err := db.StoreNewSendForDeviceMessage(ctx, types.StreamPosition(0), "alice", "one", gomatrixserverlib.SendToDeviceEvent{
+	streamPos, err := db.StoreNewSendForDeviceMessage(ctx, "alice", "one", gomatrixserverlib.SendToDeviceEvent{
 		Sender:  "bob",
 		Type:    "m.type",
 		Content: json.RawMessage("{}"),
@@ -564,7 +564,7 @@ func TestSendToDeviceBehaviour(t *testing.T) {
 	// At this point we should get exactly one message. We're sending the sync position
 	// that we were given from the update and the send-to-device update will be updated
 	// in the database to reflect that this was the sync position we sent the message at.
-	events, updates, deletions, err = db.SendToDeviceUpdatesForSync(ctx, "alice", "one", types.StreamingToken{SendToDevicePosition: streamPos})
+	_, events, updates, deletions, err = db.SendToDeviceUpdatesForSync(ctx, "alice", "one", types.StreamingToken{SendToDevicePosition: streamPos})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -579,7 +579,7 @@ func TestSendToDeviceBehaviour(t *testing.T) {
 	// At this point we should still have one message because we haven't progressed the
 	// sync position yet. This is equivalent to the client failing to /sync and retrying
 	// with the same position.
-	events, updates, deletions, err = db.SendToDeviceUpdatesForSync(ctx, "alice", "one", types.StreamingToken{SendToDevicePosition: streamPos})
+	_, events, updates, deletions, err = db.SendToDeviceUpdatesForSync(ctx, "alice", "one", types.StreamingToken{SendToDevicePosition: streamPos})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -593,7 +593,7 @@ func TestSendToDeviceBehaviour(t *testing.T) {
 
 	// At this point we should now have no updates, because we've progressed the sync
 	// position. Therefore the update from before will not be sent again.
-	events, updates, deletions, err = db.SendToDeviceUpdatesForSync(ctx, "alice", "one", types.StreamingToken{SendToDevicePosition: streamPos + 1})
+	_, events, updates, deletions, err = db.SendToDeviceUpdatesForSync(ctx, "alice", "one", types.StreamingToken{SendToDevicePosition: streamPos + 1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -607,7 +607,7 @@ func TestSendToDeviceBehaviour(t *testing.T) {
 
 	// At this point we should still have no updates, because no new updates have been
 	// sent.
-	events, updates, deletions, err = db.SendToDeviceUpdatesForSync(ctx, "alice", "one", types.StreamingToken{SendToDevicePosition: streamPos + 2})
+	_, events, updates, deletions, err = db.SendToDeviceUpdatesForSync(ctx, "alice", "one", types.StreamingToken{SendToDevicePosition: streamPos + 2})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/syncapi/storage/tables/interface.go
+++ b/syncapi/storage/tables/interface.go
@@ -160,6 +160,6 @@ type Filter interface {
 
 type Receipts interface {
 	UpsertReceipt(ctx context.Context, txn *sql.Tx, roomId, receiptType, userId, eventId string, timestamp gomatrixserverlib.Timestamp) (pos types.StreamPosition, err error)
-	SelectRoomReceiptsAfter(ctx context.Context, roomIDs []string, streamPos types.StreamPosition) ([]eduAPI.OutputReceiptEvent, error)
+	SelectRoomReceiptsAfter(ctx context.Context, roomIDs []string, streamPos types.StreamPosition) (types.StreamPosition, []eduAPI.OutputReceiptEvent, error)
 	SelectMaxReceiptID(ctx context.Context, txn *sql.Tx) (id int64, err error)
 }

--- a/syncapi/storage/tables/interface.go
+++ b/syncapi/storage/tables/interface.go
@@ -146,8 +146,8 @@ type BackwardsExtremities interface {
 // sync parameter isn't later then we will keep including the updates in the
 // sync response, as the client is seemingly trying to repeat the same /sync.
 type SendToDevice interface {
-	InsertSendToDeviceMessage(ctx context.Context, txn *sql.Tx, userID, deviceID, content string) (err error)
-	SelectSendToDeviceMessages(ctx context.Context, txn *sql.Tx, userID, deviceID string) (events []types.SendToDeviceEvent, err error)
+	InsertSendToDeviceMessage(ctx context.Context, txn *sql.Tx, userID, deviceID, content string) (pos types.StreamPosition, err error)
+	SelectSendToDeviceMessages(ctx context.Context, txn *sql.Tx, userID, deviceID string) (lastPos types.StreamPosition, events []types.SendToDeviceEvent, err error)
 	UpdateSentSendToDeviceMessages(ctx context.Context, txn *sql.Tx, token string, nids []types.SendToDeviceNID) (err error)
 	DeleteSendToDeviceMessages(ctx context.Context, txn *sql.Tx, nids []types.SendToDeviceNID) (err error)
 	CountSendToDeviceMessages(ctx context.Context, txn *sql.Tx, userID, deviceID string) (count int, err error)

--- a/syncapi/sync/notifier.go
+++ b/syncapi/sync/notifier.go
@@ -193,6 +193,16 @@ func (n *Notifier) OnNewKeyChange(
 	n.wakeupUsers([]string{wakeUserID}, nil, n.currPos)
 }
 
+func (n *Notifier) OnNewInvite(
+	posUpdate types.StreamingToken, wakeUserID string,
+) {
+	n.streamLock.Lock()
+	defer n.streamLock.Unlock()
+
+	n.currPos.ApplyUpdates(posUpdate)
+	n.wakeupUsers([]string{wakeUserID}, nil, n.currPos)
+}
+
 // GetListener returns a UserStreamListener that can be used to wait for
 // updates for a user. Must be closed.
 // notify for anything before sincePos

--- a/syncapi/sync/notifier.go
+++ b/syncapi/sync/notifier.go
@@ -77,9 +77,8 @@ func (n *Notifier) OnNewEvent(
 	// This needs to be done PRIOR to waking up users as they will read this value.
 	n.streamLock.Lock()
 	defer n.streamLock.Unlock()
-	latestPos := n.currPos.WithUpdates(posUpdate)
-	n.currPos = latestPos
 
+	n.currPos.ApplyUpdates(posUpdate)
 	n.removeEmptyUserStreams()
 
 	if ev != nil {
@@ -113,11 +112,11 @@ func (n *Notifier) OnNewEvent(
 			}
 		}
 
-		n.wakeupUsers(usersToNotify, peekingDevicesToNotify, latestPos)
+		n.wakeupUsers(usersToNotify, peekingDevicesToNotify, n.currPos)
 	} else if roomID != "" {
-		n.wakeupUsers(n.joinedUsers(roomID), n.PeekingDevices(roomID), latestPos)
+		n.wakeupUsers(n.joinedUsers(roomID), n.PeekingDevices(roomID), n.currPos)
 	} else if len(userIDs) > 0 {
-		n.wakeupUsers(userIDs, nil, latestPos)
+		n.wakeupUsers(userIDs, nil, n.currPos)
 	} else {
 		log.WithFields(log.Fields{
 			"posUpdate": posUpdate.String,
@@ -155,10 +154,9 @@ func (n *Notifier) OnNewSendToDevice(
 ) {
 	n.streamLock.Lock()
 	defer n.streamLock.Unlock()
-	latestPos := n.currPos.WithUpdates(posUpdate)
-	n.currPos = latestPos
 
-	n.wakeupUserDevice(userID, deviceIDs, latestPos)
+	n.currPos.ApplyUpdates(posUpdate)
+	n.wakeupUserDevice(userID, deviceIDs, n.currPos)
 }
 
 // OnNewReceipt updates the current position
@@ -168,10 +166,9 @@ func (n *Notifier) OnNewTyping(
 ) {
 	n.streamLock.Lock()
 	defer n.streamLock.Unlock()
-	latestPos := n.currPos.WithUpdates(posUpdate)
-	n.currPos = latestPos
 
-	n.wakeupUsers(n.joinedUsers(roomID), nil, latestPos)
+	n.currPos.ApplyUpdates(posUpdate)
+	n.wakeupUsers(n.joinedUsers(roomID), nil, n.currPos)
 }
 
 // OnNewReceipt updates the current position
@@ -181,10 +178,9 @@ func (n *Notifier) OnNewReceipt(
 ) {
 	n.streamLock.Lock()
 	defer n.streamLock.Unlock()
-	latestPos := n.currPos.WithUpdates(posUpdate)
-	n.currPos = latestPos
 
-	n.wakeupUsers(n.joinedUsers(roomID), nil, latestPos)
+	n.currPos.ApplyUpdates(posUpdate)
+	n.wakeupUsers(n.joinedUsers(roomID), nil, n.currPos)
 }
 
 func (n *Notifier) OnNewKeyChange(
@@ -192,9 +188,9 @@ func (n *Notifier) OnNewKeyChange(
 ) {
 	n.streamLock.Lock()
 	defer n.streamLock.Unlock()
-	latestPos := n.currPos.WithUpdates(posUpdate)
-	n.currPos = latestPos
-	n.wakeupUsers([]string{wakeUserID}, nil, latestPos)
+
+	n.currPos.ApplyUpdates(posUpdate)
+	n.wakeupUsers([]string{wakeUserID}, nil, n.currPos)
 }
 
 // GetListener returns a UserStreamListener that can be used to wait for

--- a/syncapi/sync/notifier.go
+++ b/syncapi/sync/notifier.go
@@ -162,13 +162,29 @@ func (n *Notifier) OnNewSendToDevice(
 }
 
 // OnNewReceipt updates the current position
-func (n *Notifier) OnNewReceipt(
+func (n *Notifier) OnNewTyping(
+	roomID string,
 	posUpdate types.StreamingToken,
 ) {
 	n.streamLock.Lock()
 	defer n.streamLock.Unlock()
 	latestPos := n.currPos.WithUpdates(posUpdate)
 	n.currPos = latestPos
+
+	n.wakeupUsers(n.joinedUsers(roomID), nil, latestPos)
+}
+
+// OnNewReceipt updates the current position
+func (n *Notifier) OnNewReceipt(
+	roomID string,
+	posUpdate types.StreamingToken,
+) {
+	n.streamLock.Lock()
+	defer n.streamLock.Unlock()
+	latestPos := n.currPos.WithUpdates(posUpdate)
+	n.currPos = latestPos
+
+	n.wakeupUsers(n.joinedUsers(roomID), nil, latestPos)
 }
 
 func (n *Notifier) OnNewKeyChange(

--- a/syncapi/sync/notifier_test.go
+++ b/syncapi/sync/notifier_test.go
@@ -335,7 +335,7 @@ func waitForEvents(n *Notifier, req syncRequest) (types.StreamingToken, error) {
 		return types.StreamingToken{}, fmt.Errorf(
 			"waitForEvents timed out waiting for %s (pos=%v)", req.device.UserID, req.since,
 		)
-	case <-listener.GetNotifyChannel(*req.since):
+	case <-listener.GetNotifyChannel(req.since):
 		p := listener.GetSyncPosition()
 		return p, nil
 	}
@@ -365,7 +365,7 @@ func newTestSyncRequest(userID, deviceID string, since types.StreamingToken) syn
 			ID:     deviceID,
 		},
 		timeout:       1 * time.Minute,
-		since:         &since,
+		since:         since,
 		wantFullState: false,
 		limit:         DefaultTimelineLimit,
 		log:           util.GetLogger(context.TODO()),

--- a/syncapi/sync/request.go
+++ b/syncapi/sync/request.go
@@ -46,7 +46,7 @@ type syncRequest struct {
 	device        userapi.Device
 	limit         int
 	timeout       time.Duration
-	since         *types.StreamingToken // nil means that no since token was supplied
+	since         types.StreamingToken // nil means that no since token was supplied
 	wantFullState bool
 	log           *log.Entry
 }
@@ -55,17 +55,13 @@ func newSyncRequest(req *http.Request, device userapi.Device, syncDB storage.Dat
 	timeout := getTimeout(req.URL.Query().Get("timeout"))
 	fullState := req.URL.Query().Get("full_state")
 	wantFullState := fullState != "" && fullState != "false"
-	var since *types.StreamingToken
-	sinceStr := req.URL.Query().Get("since")
+	since, sinceStr := types.StreamingToken{}, req.URL.Query().Get("since")
 	if sinceStr != "" {
-		tok, err := types.NewStreamTokenFromString(sinceStr)
+		var err error
+		since, err = types.NewStreamTokenFromString(sinceStr)
 		if err != nil {
 			return nil, err
 		}
-		since = &tok
-	}
-	if since == nil {
-		since = &types.StreamingToken{}
 	}
 	timelineLimit := DefaultTimelineLimit
 	// TODO: read from stored filters too

--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -325,7 +325,6 @@ func (rp *RequestPool) currentSyncForUser(req syncRequest, latestPos types.Strea
 		// Add the updates into the sync response.
 		for _, event := range events {
 			res.ToDevice.Events = append(res.ToDevice.Events, event.SendToDeviceEvent)
-			res.NextBatch.SendToDevicePosition++
 		}
 	}
 

--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -294,8 +294,8 @@ func (rp *RequestPool) currentSyncForUser(req syncRequest, latestPos types.Strea
 		// Add the updates into the sync response.
 		for _, event := range events {
 			res.ToDevice.Events = append(res.ToDevice.Events, event.SendToDeviceEvent)
+			res.NextBatch.SendToDevicePosition++
 		}
-		res.NextBatch.SendToDevicePosition++
 	}
 
 	return res, err

--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -295,13 +295,7 @@ func (rp *RequestPool) currentSyncForUser(req syncRequest, latestPos types.Strea
 		for _, event := range events {
 			res.ToDevice.Events = append(res.ToDevice.Events, event.SendToDeviceEvent)
 		}
-
-		// Get the next_batch from the sync response and increase the
-		// EDU counter.
-		if pos, perr := types.NewStreamTokenFromString(res.NextBatch); perr == nil {
-			pos.SendToDevicePosition++
-			res.NextBatch = pos.String()
-		}
+		res.NextBatch.SendToDevicePosition++
 	}
 
 	return res, err

--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -427,7 +427,7 @@ func (rp *RequestPool) appendAccountData(
 // or timeout=0, or full_state=true, in any of the cases the request should
 // return immediately.
 func (rp *RequestPool) shouldReturnImmediately(syncReq *syncRequest) bool {
-	if syncReq.since == nil || syncReq.timeout == 0 || syncReq.wantFullState {
+	if syncReq.since.IsEmpty() || syncReq.timeout == 0 || syncReq.wantFullState {
 		return true
 	}
 	waiting, werr := rp.db.SendToDeviceUpdatesWaiting(context.TODO(), syncReq.device.UserID, syncReq.device.ID)

--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -191,7 +191,6 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request, device *userapi.
 		// Wait for notifier to wake us up
 		case <-userStreamListener.GetNotifyChannel(sincePos):
 			currPos = userStreamListener.GetSyncPosition()
-			sincePos = currPos
 		// Or for timeout to expire
 		case <-timer.C:
 			// We just need to ensure we get out of the select after reaching the

--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -325,6 +325,7 @@ func (rp *RequestPool) currentSyncForUser(req syncRequest, latestPos types.Strea
 		// Add the updates into the sync response.
 		for _, event := range events {
 			res.ToDevice.Events = append(res.ToDevice.Events, event.SendToDeviceEvent)
+			res.NextBatch.SendToDevicePosition++
 		}
 	}
 

--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -278,7 +278,7 @@ func (rp *RequestPool) currentSyncForUser(req syncRequest, latestPos types.Strea
 	res := types.NewResponse()
 
 	// See if we have any new tasks to do for the send-to-device messaging.
-	events, updates, deletions, err := rp.db.SendToDeviceUpdatesForSync(req.ctx, req.device.UserID, req.device.ID, req.since)
+	lastPos, events, updates, deletions, err := rp.db.SendToDeviceUpdatesForSync(req.ctx, req.device.UserID, req.device.ID, req.since)
 	if err != nil {
 		return nil, fmt.Errorf("rp.db.SendToDeviceUpdatesForSync: %w", err)
 	}
@@ -324,10 +324,10 @@ func (rp *RequestPool) currentSyncForUser(req syncRequest, latestPos types.Strea
 		// Add the updates into the sync response.
 		for _, event := range events {
 			res.ToDevice.Events = append(res.ToDevice.Events, event.SendToDeviceEvent)
-			res.NextBatch.SendToDevicePosition++
 		}
 	}
 
+	res.NextBatch.SendToDevicePosition = lastPos
 	return res, err
 }
 

--- a/syncapi/types/types.go
+++ b/syncapi/types/types.go
@@ -113,6 +113,17 @@ type StreamingToken struct {
 	Logs                 map[string]*LogPosition
 }
 
+// This will be used as a fallback by json.Marshal.
+func (t *StreamingToken) MarshalText() ([]byte, error) {
+	return []byte(t.String()), nil
+}
+
+// This will be used as a fallback by json.Unmarshal.
+func (t *StreamingToken) UnmarshalText(text []byte) (err error) {
+	*t, err = NewStreamTokenFromString(string(text))
+	return err
+}
+
 func (t *StreamingToken) SetLog(name string, lp *LogPosition) {
 	if t.Logs == nil {
 		t.Logs = make(map[string]*LogPosition)
@@ -203,6 +214,17 @@ func (t *StreamingToken) WithUpdates(other StreamingToken) (ret StreamingToken) 
 type TopologyToken struct {
 	Depth       StreamPosition
 	PDUPosition StreamPosition
+}
+
+// This will be used as a fallback by json.Marshal.
+func (t *TopologyToken) MarshalText() ([]byte, error) {
+	return []byte(t.String()), nil
+}
+
+// This will be used as a fallback by json.Unmarshal.
+func (t *TopologyToken) UnmarshalText(text []byte) (err error) {
+	*t, err = NewTopologyTokenFromString(string(text))
+	return err
 }
 
 func (t *TopologyToken) StreamToken() StreamingToken {
@@ -331,7 +353,7 @@ type PrevEventRef struct {
 
 // Response represents a /sync API response. See https://matrix.org/docs/spec/client_server/r0.2.0.html#get-matrix-client-r0-sync
 type Response struct {
-	NextBatch   string `json:"next_batch"`
+	NextBatch   StreamingToken `json:"next_batch"`
 	AccountData struct {
 		Events []gomatrixserverlib.ClientEvent `json:"events"`
 	} `json:"account_data,omitempty"`
@@ -395,7 +417,7 @@ type JoinResponse struct {
 	Timeline struct {
 		Events    []gomatrixserverlib.ClientEvent `json:"events"`
 		Limited   bool                            `json:"limited"`
-		PrevBatch string                          `json:"prev_batch"`
+		PrevBatch TopologyToken                   `json:"prev_batch"`
 	} `json:"timeline"`
 	Ephemeral struct {
 		Events []gomatrixserverlib.ClientEvent `json:"events"`
@@ -453,7 +475,7 @@ type LeaveResponse struct {
 	Timeline struct {
 		Events    []gomatrixserverlib.ClientEvent `json:"events"`
 		Limited   bool                            `json:"limited"`
-		PrevBatch string                          `json:"prev_batch"`
+		PrevBatch TopologyToken                   `json:"prev_batch"`
 	} `json:"timeline"`
 }
 

--- a/syncapi/types/types.go
+++ b/syncapi/types/types.go
@@ -116,6 +116,17 @@ type StreamingToken struct {
 	DeviceListPosition   LogPosition
 }
 
+// This will be used as a fallback by json.Marshal.
+func (s StreamingToken) MarshalText() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
+// This will be used as a fallback by json.Unmarshal.
+func (s *StreamingToken) UnmarshalText(text []byte) (err error) {
+	*s, err = NewStreamTokenFromString(string(text))
+	return err
+}
+
 func (t StreamingToken) String() string {
 	posStr := fmt.Sprintf(
 		"s%d_%d_%d_%d",

--- a/syncapi/types/types.go
+++ b/syncapi/types/types.go
@@ -114,7 +114,7 @@ type StreamingToken struct {
 }
 
 // This will be used as a fallback by json.Marshal.
-func (t *StreamingToken) MarshalText() ([]byte, error) {
+func (t StreamingToken) MarshalText() ([]byte, error) {
 	return []byte(t.String()), nil
 }
 
@@ -222,7 +222,7 @@ type TopologyToken struct {
 }
 
 // This will be used as a fallback by json.Marshal.
-func (t *TopologyToken) MarshalText() ([]byte, error) {
+func (t TopologyToken) MarshalText() ([]byte, error) {
 	return []byte(t.String()), nil
 }
 
@@ -422,7 +422,7 @@ type JoinResponse struct {
 	Timeline struct {
 		Events    []gomatrixserverlib.ClientEvent `json:"events"`
 		Limited   bool                            `json:"limited"`
-		PrevBatch TopologyToken                   `json:"prev_batch"`
+		PrevBatch *TopologyToken                  `json:"prev_batch,omitempty"`
 	} `json:"timeline"`
 	Ephemeral struct {
 		Events []gomatrixserverlib.ClientEvent `json:"events"`
@@ -480,7 +480,7 @@ type LeaveResponse struct {
 	Timeline struct {
 		Events    []gomatrixserverlib.ClientEvent `json:"events"`
 		Limited   bool                            `json:"limited"`
-		PrevBatch TopologyToken                   `json:"prev_batch"`
+		PrevBatch *TopologyToken                  `json:"prev_batch,omitempty"`
 	} `json:"timeline"`
 }
 

--- a/syncapi/types/types_test.go
+++ b/syncapi/types/types_test.go
@@ -42,10 +42,10 @@ func TestNewSyncTokenWithLogs(t *testing.T) {
 
 func TestSyncTokens(t *testing.T) {
 	shouldPass := map[string]string{
-		"s4_0_0_0":        StreamingToken{4, 0, 0, 0, LogPosition{}}.String(),
-		"s3_1_0_0.dl-1-2": StreamingToken{3, 1, 0, 0, LogPosition{1, 2}}.String(),
-		"s3_1_2_3":        StreamingToken{3, 1, 2, 3, LogPosition{}}.String(),
-		"t3_1":            TopologyToken{3, 1}.String(),
+		"s4_0_0_0_0":        StreamingToken{4, 0, 0, 0, 0, LogPosition{}}.String(),
+		"s3_1_0_0_0.dl-1-2": StreamingToken{3, 1, 0, 0, 0, LogPosition{1, 2}}.String(),
+		"s3_1_2_3_5":        StreamingToken{3, 1, 2, 3, 5, LogPosition{}}.String(),
+		"t3_1":              TopologyToken{3, 1}.String(),
 	}
 
 	for a, b := range shouldPass {

--- a/syncapi/types/types_test.go
+++ b/syncapi/types/types_test.go
@@ -10,10 +10,10 @@ import (
 
 func TestNewSyncTokenWithLogs(t *testing.T) {
 	tests := map[string]*StreamingToken{
-		"s4_0_0_0": {
+		"s4_0_0_0_0": {
 			PDUPosition: 4,
 		},
-		"s4_0_0_0.dl-0-123": {
+		"s4_0_0_0_0.dl-0-123": {
 			PDUPosition: 4,
 			DeviceListPosition: LogPosition{
 				Partition: 0,

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -141,18 +141,14 @@ New users appear in /keys/changes
 Local delete device changes appear in v2 /sync
 Local new device changes appear in v2 /sync
 Local update device changes appear in v2 /sync
-Users receive device_list updates for their own devices
 Get left notifs for other users in sync and /keys/changes when user leaves
 Local device key changes get to remote servers
 Local device key changes get to remote servers with correct prev_id
 Server correctly handles incoming m.device_list_update
-Device deletion propagates over federation
 If remote user leaves room, changes device and rejoins we see update in sync
 If remote user leaves room, changes device and rejoins we see update in /keys/changes
 If remote user leaves room we no longer receive device updates
 If a device list update goes missing, the server resyncs on the next one
-Get left notifs in sync and /keys/changes when other user leaves
-Can query remote device keys using POST after notification
 Server correctly resyncs when client query keys and there is no remote cache
 Server correctly resyncs when server leaves and rejoins a room
 Device list doesn't change if remote server is down


### PR DESCRIPTION
This PR does a few things:

- Replaces a few places where we'd bounce backwards and forwards between `string` and `types.StreamPosition` with a single `NextBatch` stream position which gets marshalled to/from text as needed by the JSON marshaller/unmarshaller
- Tweaks the typing code so it's a bit cleaner and so that the server restarting doesn't break typing notifications until the cache is cleared
- Invites now have their own stream position instead of abusing the PDU one
- Adds the device list fix from #1632 for good measure