### PR TITLE
De-map device list positions in streaming tokens

### DIFF
--- a/syncapi/consumers/keychange.go
+++ b/syncapi/consumers/keychange.go
@@ -23,7 +23,6 @@ import (
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/keyserver/api"
 	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
-	syncinternal "github.com/matrix-org/dendrite/syncapi/internal"
 	"github.com/matrix-org/dendrite/syncapi/storage"
 	syncapi "github.com/matrix-org/dendrite/syncapi/sync"
 	"github.com/matrix-org/dendrite/syncapi/types"
@@ -115,11 +114,9 @@ func (s *OutputKeyChangeEventConsumer) onMessage(msg *sarama.ConsumerMessage) er
 	}
 	// TODO: f.e queryRes.UserIDsToCount : notify users by waking up streams
 	posUpdate := types.StreamingToken{
-		Logs: map[string]*types.LogPosition{
-			syncinternal.DeviceListLogName: {
-				Offset:    msg.Offset,
-				Partition: msg.Partition,
-			},
+		DeviceListPosition: types.LogPosition{
+			Offset:    msg.Offset,
+			Partition: msg.Partition,
 		},
 	}
 	for userID := range queryRes.UserIDsToCount {

--- a/syncapi/internal/keychange.go
+++ b/syncapi/internal/keychange.go
@@ -79,7 +79,7 @@ func DeviceListCatchup(
 	}
 	var toOffset int64
 	toOffset = sarama.OffsetNewest
-	if toLog := to.DeviceListPosition; toLog.Offset > 0 {
+	if toLog := to.DeviceListPosition; toLog.Partition == partition && toLog.Offset > 0 {
 		toOffset = toLog.Offset
 	}
 	var queryRes api.QueryKeyChangesResponse

--- a/syncapi/internal/keychange.go
+++ b/syncapi/internal/keychange.go
@@ -73,8 +73,10 @@ func DeviceListCatchup(
 	offset = sarama.OffsetOldest
 	// Extract partition/offset from sync token
 	// TODO: In a world where keyserver is sharded there will be multiple partitions and hence multiple QueryKeyChanges to make.
-	partition = from.DeviceListPosition.Partition
-	offset = from.DeviceListPosition.Offset
+	if !from.DeviceListPosition.IsEmpty() {
+		partition = from.DeviceListPosition.Partition
+		offset = from.DeviceListPosition.Offset
+	}
 	var toOffset int64
 	toOffset = sarama.OffsetNewest
 	if toLog := to.DeviceListPosition; toLog.Offset > 0 {

--- a/syncapi/internal/keychange.go
+++ b/syncapi/internal/keychange.go
@@ -73,15 +73,11 @@ func DeviceListCatchup(
 	offset = sarama.OffsetOldest
 	// Extract partition/offset from sync token
 	// TODO: In a world where keyserver is sharded there will be multiple partitions and hence multiple QueryKeyChanges to make.
-	logOffset := from.Log(DeviceListLogName)
-	if logOffset != nil {
-		partition = logOffset.Partition
-		offset = logOffset.Offset
-	}
+	partition = from.DeviceListPosition.Partition
+	offset = from.DeviceListPosition.Offset
 	var toOffset int64
 	toOffset = sarama.OffsetNewest
-	toLog := to.Log(DeviceListLogName)
-	if toLog != nil && toLog.Offset > 0 {
+	if toLog := to.DeviceListPosition; toLog.Offset > 0 {
 		toOffset = toLog.Offset
 	}
 	var queryRes api.QueryKeyChangesResponse
@@ -130,10 +126,10 @@ func DeviceListCatchup(
 		}
 	}
 	// set the new token
-	to.SetLog(DeviceListLogName, &types.LogPosition{
+	to.DeviceListPosition = types.LogPosition{
 		Partition: queryRes.Partition,
 		Offset:    queryRes.Offset,
-	})
+	}
 	res.NextBatch = to.String()
 
 	return hasNew, nil

--- a/syncapi/internal/keychange_test.go
+++ b/syncapi/internal/keychange_test.go
@@ -18,11 +18,9 @@ var (
 	syncingUser = "@alice:localhost"
 	emptyToken  = types.StreamingToken{}
 	newestToken = types.StreamingToken{
-		Logs: map[string]*types.LogPosition{
-			DeviceListLogName: {
-				Offset:    sarama.OffsetNewest,
-				Partition: 0,
-			},
+		DeviceListPosition: types.LogPosition{
+			Offset:    sarama.OffsetNewest,
+			Partition: 0,
 		},
 	}
 )

--- a/syncapi/types/types_test.go
+++ b/syncapi/types/types_test.go
@@ -12,28 +12,12 @@ func TestNewSyncTokenWithLogs(t *testing.T) {
 	tests := map[string]*StreamingToken{
 		"s4_0_0_0": {
 			PDUPosition: 4,
-			Logs:        make(map[string]*LogPosition),
 		},
 		"s4_0_0_0.dl-0-123": {
 			PDUPosition: 4,
-			Logs: map[string]*LogPosition{
-				"dl": {
-					Partition: 0,
-					Offset:    123,
-				},
-			},
-		},
-		"s4_0_0_0.ab-1-14419482332.dl-0-123": {
-			PDUPosition: 4,
-			Logs: map[string]*LogPosition{
-				"ab": {
-					Partition: 1,
-					Offset:    14419482332,
-				},
-				"dl": {
-					Partition: 0,
-					Offset:    123,
-				},
+			DeviceListPosition: LogPosition{
+				Partition: 0,
+				Offset:    123,
 			},
 		},
 	}
@@ -58,10 +42,10 @@ func TestNewSyncTokenWithLogs(t *testing.T) {
 
 func TestSyncTokens(t *testing.T) {
 	shouldPass := map[string]string{
-		"s4_0_0_0": StreamingToken{4, 0, 0, 0, nil}.String(),
-		"s3_1_0_0": StreamingToken{3, 1, 0, 0, nil}.String(),
-		"s3_1_2_3": StreamingToken{3, 1, 2, 3, nil}.String(),
-		"t3_1":     TopologyToken{3, 1}.String(),
+		"s4_0_0_0":        StreamingToken{4, 0, 0, 0, LogPosition{}}.String(),
+		"s3_1_0_0.dl-1-2": StreamingToken{3, 1, 0, 0, LogPosition{1, 2}}.String(),
+		"s3_1_2_3":        StreamingToken{3, 1, 2, 3, LogPosition{}}.String(),
+		"t3_1":            TopologyToken{3, 1}.String(),
 	}
 
 	for a, b := range shouldPass {


### PR DESCRIPTION
This removes the map from the `StreamPosition` which should fix #1633.