### PR TITLE
Add RoomInfo cache, remove RoomServerRoomNIDsCache

### DIFF
--- a/internal/caching/cache_roominfo.go
+++ b/internal/caching/cache_roominfo.go
@@ -4,6 +4,14 @@ import (
 	"github.com/matrix-org/dendrite/roomserver/types"
 )
 
+// WARNING: This cache is mutable because it's entirely possible that
+// the IsStub or StateSnaphotNID fields can change, even though the
+// room version and room NID fields will not. This is only safe because
+// the RoomInfoCache is used ONLY within the roomserver and because it
+// will be kept up-to-date by the latest events updater. It MUST NOT be
+// used from other components as we currently have no way to invalidate
+// the cache in downstream components.
+
 const (
 	RoomInfoCacheName       = "roominfo"
 	RoomInfoCacheMaxEntries = 1024
@@ -11,12 +19,15 @@ const (
 )
 
 // RoomInfosCache contains the subset of functions needed for
-// a room Info cache.
+// a room Info cache. It must only be used from the roomserver only
+// It is not safe for use from other components.
 type RoomInfoCache interface {
 	GetRoomInfo(roomID string) (roomInfo types.RoomInfo, ok bool)
 	StoreRoomInfo(roomID string, roomInfo types.RoomInfo)
 }
 
+// GetRoomInfo must only be called from the roomserver only. It is not
+// safe for use from other components.
 func (c Caches) GetRoomInfo(roomID string) (types.RoomInfo, bool) {
 	val, found := c.RoomInfos.Get(roomID)
 	if found && val != nil {
@@ -27,6 +38,8 @@ func (c Caches) GetRoomInfo(roomID string) (types.RoomInfo, bool) {
 	return types.RoomInfo{}, false
 }
 
+// StoreRoomInfo must only be called from the roomserver only. It is not
+// safe for use from other components.
 func (c Caches) StoreRoomInfo(roomID string, roomInfo types.RoomInfo) {
 	c.RoomInfos.Set(roomID, roomInfo)
 }

--- a/internal/caching/cache_roominfo.go
+++ b/internal/caching/cache_roominfo.go
@@ -1,0 +1,32 @@
+package caching
+
+import (
+	"github.com/matrix-org/dendrite/roomserver/types"
+)
+
+const (
+	RoomInfoCacheName       = "roominfo"
+	RoomInfoCacheMaxEntries = 1024
+	RoomInfoCacheMutable    = true
+)
+
+// RoomInfosCache contains the subset of functions needed for
+// a room Info cache.
+type RoomInfoCache interface {
+	GetRoomInfo(roomID string) (roomInfo types.RoomInfo, ok bool)
+	StoreRoomInfo(roomID string, roomInfo types.RoomInfo)
+}
+
+func (c Caches) GetRoomInfo(roomID string) (types.RoomInfo, bool) {
+	val, found := c.RoomInfos.Get(roomID)
+	if found && val != nil {
+		if roomInfo, ok := val.(types.RoomInfo); ok {
+			return roomInfo, true
+		}
+	}
+	return types.RoomInfo{}, false
+}
+
+func (c Caches) StoreRoomInfo(roomID string, roomInfo types.RoomInfo) {
+	c.RoomInfos.Set(roomID, roomInfo)
+}

--- a/internal/caching/cache_roomservernids.go
+++ b/internal/caching/cache_roomservernids.go
@@ -15,10 +15,6 @@ const (
 	RoomServerEventTypeNIDsCacheMaxEntries = 64
 	RoomServerEventTypeNIDsCacheMutable    = false
 
-	RoomServerRoomNIDsCacheName       = "roomserver_room_nids"
-	RoomServerRoomNIDsCacheMaxEntries = 1024
-	RoomServerRoomNIDsCacheMutable    = false
-
 	RoomServerRoomIDsCacheName       = "roomserver_room_ids"
 	RoomServerRoomIDsCacheMaxEntries = 1024
 	RoomServerRoomIDsCacheMutable    = false
@@ -27,6 +23,7 @@ const (
 type RoomServerCaches interface {
 	RoomServerNIDsCache
 	RoomVersionCache
+	RoomInfoCache
 }
 
 // RoomServerNIDsCache contains the subset of functions needed for
@@ -37,9 +34,6 @@ type RoomServerNIDsCache interface {
 
 	GetRoomServerEventTypeNID(eventType string) (types.EventTypeNID, bool)
 	StoreRoomServerEventTypeNID(eventType string, nid types.EventTypeNID)
-
-	GetRoomServerRoomNID(roomID string) (types.RoomNID, bool)
-	StoreRoomServerRoomNID(roomID string, nid types.RoomNID)
 
 	GetRoomServerRoomID(roomNID types.RoomNID) (string, bool)
 	StoreRoomServerRoomID(roomNID types.RoomNID, roomID string)
@@ -73,21 +67,6 @@ func (c Caches) StoreRoomServerEventTypeNID(eventType string, nid types.EventTyp
 	c.RoomServerEventTypeNIDs.Set(eventType, nid)
 }
 
-func (c Caches) GetRoomServerRoomNID(roomID string) (types.RoomNID, bool) {
-	val, found := c.RoomServerRoomNIDs.Get(roomID)
-	if found && val != nil {
-		if roomNID, ok := val.(types.RoomNID); ok {
-			return roomNID, true
-		}
-	}
-	return 0, false
-}
-
-func (c Caches) StoreRoomServerRoomNID(roomID string, roomNID types.RoomNID) {
-	c.RoomServerRoomNIDs.Set(roomID, roomNID)
-	c.RoomServerRoomIDs.Set(strconv.Itoa(int(roomNID)), roomID)
-}
-
 func (c Caches) GetRoomServerRoomID(roomNID types.RoomNID) (string, bool) {
 	val, found := c.RoomServerRoomIDs.Get(strconv.Itoa(int(roomNID)))
 	if found && val != nil {
@@ -99,5 +78,5 @@ func (c Caches) GetRoomServerRoomID(roomNID types.RoomNID) (string, bool) {
 }
 
 func (c Caches) StoreRoomServerRoomID(roomNID types.RoomNID, roomID string) {
-	c.StoreRoomServerRoomNID(roomID, roomNID)
+	c.RoomServerRoomIDs.Set(strconv.Itoa(int(roomNID)), roomID)
 }

--- a/internal/caching/caches.go
+++ b/internal/caching/caches.go
@@ -10,6 +10,7 @@ type Caches struct {
 	RoomServerEventTypeNIDs Cache // RoomServerNIDsCache
 	RoomServerRoomNIDs      Cache // RoomServerNIDsCache
 	RoomServerRoomIDs       Cache // RoomServerNIDsCache
+	RoomInfos               Cache // RoomInfoCache
 	FederationEvents        Cache // FederationEventsCache
 }
 

--- a/roomserver/storage/shared/latest_events_updater.go
+++ b/roomserver/storage/shared/latest_events_updater.go
@@ -105,6 +105,13 @@ func (u *LatestEventsUpdater) SetLatestEvents(
 		if err := u.d.RoomsTable.UpdateLatestEventNIDs(u.ctx, txn, roomNID, eventNIDs, lastEventNIDSent, currentStateSnapshotNID); err != nil {
 			return fmt.Errorf("u.d.RoomsTable.updateLatestEventNIDs: %w", err)
 		}
+		if roomID, ok := u.d.Cache.GetRoomServerRoomID(roomNID); ok {
+			if roomInfo, ok := u.d.Cache.GetRoomInfo(roomID); ok {
+				roomInfo.StateSnapshotNID = currentStateSnapshotNID
+				roomInfo.IsStub = false
+				u.d.Cache.StoreRoomInfo(roomID, roomInfo)
+			}
+		}
 		return nil
 	})
 }

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -128,7 +128,7 @@ func (d *Database) RoomInfo(ctx context.Context, roomID string) (*types.RoomInfo
 		return &roomInfo, nil
 	}
 	roomInfo, err := d.RoomsTable.SelectRoomInfo(ctx, roomID)
-	if err == nil {
+	if err == nil && roomInfo != nil {
 		d.Cache.StoreRoomServerRoomID(roomInfo.RoomNID, roomID)
 		d.Cache.StoreRoomInfo(roomID, *roomInfo)
 	}


### PR DESCRIPTION
This adds a cache for `types.RoomInfo` in the roomserver, and removes the `RoomServerRoomNIDsCache` since `RoomInfoCache` covers the same use-case.

I've deliberately not done anything with the `RoomVersionCache` in this PR because it needs a bit more thought - the main place that the `RoomVersionCache` helps us is in polylith mode, hence why it's mostly handled at the API boundaries and not internally within the roomserver.