### PR TITLE
Add health check endpoint

### DIFF
--- a/setup/base.go
+++ b/setup/base.go
@@ -26,6 +26,7 @@ import (
 	"github.com/matrix-org/dendrite/internal/caching"
 	"github.com/matrix-org/dendrite/internal/httputil"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/util"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
@@ -310,6 +311,17 @@ func (b *BaseDendrite) SetupAndServeHTTP(
 			Handler: h2c.NewHandler(internalRouter, internalH2S),
 		}
 	}
+
+	externalRouter.Handle("/health",
+		httputil.MakeExternalAPI("health", func(req *http.Request) util.JSONResponse {
+			return util.JSONResponse{
+				Code: http.StatusOK,
+				JSON: struct {
+					Versions bool `json:"success"`
+				}{true},
+			}
+		}),
+	).Methods(http.MethodGet)
 
 	internalRouter.PathPrefix(httputil.InternalPathPrefix).Handler(b.InternalAPIMux)
 	if b.Cfg.Global.Metrics.Enabled {

--- a/setup/base.go
+++ b/setup/base.go
@@ -317,7 +317,7 @@ func (b *BaseDendrite) SetupAndServeHTTP(
 			return util.JSONResponse{
 				Code: http.StatusOK,
 				JSON: struct {
-					Versions bool `json:"success"`
+					Success bool `json:"success"`
 				}{true},
 			}
 		}),


### PR DESCRIPTION
Add health check (`/health`) endpoint, http://localhost:8008/health

Fix https://github.com/matrix-org/dendrite/issues/1668



## Dev notes


 - [`setup/base.go`](https://github.com/matrix-org/dendrite/blob/4a0461378ad0d0af2ba701fb07dea505be469c92/setup/base.go#L279-L282)
 - [`/_matrix/client/versions`](https://github.com/matrix-org/dendrite/blob/4a0461378ad0d0af2ba701fb07dea505be469c92/clientapi/routing/routing.go#L65-L82)


---


```
./build.sh && ./bin/dendrite-demo-libp2p --port 8085
```

 - http://localhost:8085/api/health
 - http://localhost:8085/_matrix/client/health


```
./build.sh && sudo ./bin/dendrite-monolith-server --tls-cert server.crt --tls-key server.key --config dendrite.yaml -http-bind-address :8009
```

 - http://localhost:8009/api/health
 - http://localhost:8009/_matrix/client/health


---

In [`setup/base.go` -> `SetupAndServeHTTP`](https://github.com/matrix-org/dendrite/blob/4a0461378ad0d0af2ba701fb07dea505be469c92/setup/base.go#L279-L282). But `SetupAndServeHTTP` function never gets called in `./bin/dendrite-demo-libp2p` so the health checks aren't available. But this does work for normal monolith (`/api/health`, `/_matrix/client/health`).
```go
b.InternalAPIMux.HandleFunc("/health", func(w http.ResponseWriter, req *http.Request) {
		fmt.Println("health hit1")
		w.WriteHeader(200)
	}).Methods(http.MethodGet)

	b.PublicClientAPIMux.HandleFunc("/health", func(w http.ResponseWriter, req *http.Request) {
		fmt.Println("health hit2")
		w.WriteHeader(200)
	}).Methods(http.MethodGet)

externalRouter.Handle("/health", httputil.MakeInternalAPI("Health", func(req *http.Request) util.JSONResponse {
		return util.JSONResponse{
			Code: http.StatusOK,
			JSON: struct {
				Versions bool `json:"success"`
			}{true},
		}
	}),
	)
```


---


Next to [`/_matrix/client/versions`](https://github.com/matrix-org/dendrite/blob/4a0461378ad0d0af2ba701fb07dea505be469c92/clientapi/routing/routing.go#L65-L82). Adds to `/_matrix/client/health`
```go
publicAPIMux.Handle("/health",
		httputil.MakeExternalAPI("health", func(req *http.Request) util.JSONResponse {
			return util.JSONResponse{
				Code: http.StatusOK,
				JSON: struct {
					Versions bool `json:"success"`
				}{true},
			}
		}),
	).Methods(http.MethodGet)
```





### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `Your Name <your@email.example.org>`
