### PR TITLE
Re-add the appservice alias query on unknown alias

### DIFF
--- a/appservice/api/query.go
+++ b/appservice/api/query.go
@@ -20,9 +20,9 @@ package api
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
-	"github.com/matrix-org/dendrite/internal/eventutil"
 	"github.com/matrix-org/dendrite/userapi/storage/accounts"
 	"github.com/matrix-org/gomatrixserverlib"
 )
@@ -109,7 +109,7 @@ func RetrieveUserProfile(
 
 	// If no user exists, return
 	if !userResp.UserIDExists {
-		return nil, eventutil.ErrProfileNoExists
+		return nil, errors.New("no known profile for given user ID")
 	}
 
 	// Try to query the user from the local database again

--- a/build/gobind/monolith.go
+++ b/build/gobind/monolith.go
@@ -130,6 +130,7 @@ func (m *DendriteMonolith) Start() {
 	)
 
 	asAPI := appservice.NewInternalAPI(base, userAPI, rsAPI)
+	rsAPI.SetAppserviceAPI(asAPI)
 
 	ygg.SetSessionFunc(func(address string) {
 		req := &api.PerformServersAliveRequest{

--- a/cmd/dendrite-demo-libp2p/main.go
+++ b/cmd/dendrite-demo-libp2p/main.go
@@ -161,6 +161,7 @@ func main() {
 		&base.Base, cache.New(), userAPI,
 	)
 	asAPI := appservice.NewInternalAPI(&base.Base, userAPI, rsAPI)
+	rsAPI.SetAppserviceAPI(asAPI)
 	fsAPI := federationsender.NewInternalAPI(
 		&base.Base, federation, rsAPI, keyRing,
 	)

--- a/cmd/dendrite-demo-yggdrasil/main.go
+++ b/cmd/dendrite-demo-yggdrasil/main.go
@@ -113,6 +113,7 @@ func main() {
 	)
 
 	asAPI := appservice.NewInternalAPI(base, userAPI, rsAPI)
+	rsAPI.SetAppserviceAPI(asAPI)
 	fsAPI := federationsender.NewInternalAPI(
 		base, federation, rsAPI, keyRing,
 	)

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -126,6 +126,7 @@ func main() {
 		appservice.AddInternalRoutes(base.InternalAPIMux, asAPI)
 		asAPI = base.AppserviceHTTPClient()
 	}
+	rsAPI.SetAppserviceAPI(asAPI)
 
 	monolith := setup.Monolith{
 		Config:    base.Cfg,

--- a/cmd/dendrite-polylith-multi/personalities/roomserver.go
+++ b/cmd/dendrite-polylith-multi/personalities/roomserver.go
@@ -24,9 +24,11 @@ func RoomServer(base *setup.BaseDendrite, cfg *config.Dendrite) {
 	serverKeyAPI := base.SigningKeyServerHTTPClient()
 	keyRing := serverKeyAPI.KeyRing()
 
+	asAPI := base.AppserviceHTTPClient()
 	fsAPI := base.FederationSenderHTTPClient()
 	rsAPI := roomserver.NewInternalAPI(base, keyRing)
 	rsAPI.SetFederationSenderAPI(fsAPI)
+	rsAPI.SetAppserviceAPI(asAPI)
 	roomserver.AddInternalRoutes(base.InternalAPIMux, rsAPI)
 
 	base.SetupAndServeHTTP(

--- a/cmd/dendritejs/main.go
+++ b/cmd/dendritejs/main.go
@@ -207,6 +207,7 @@ func main() {
 	asQuery := appservice.NewInternalAPI(
 		base, userAPI, rsAPI,
 	)
+	rsAPI.SetAppserviceAPI(asQuery)
 	fedSenderAPI := federationsender.NewInternalAPI(base, federation, rsAPI, &keyRing)
 	rsAPI.SetFederationSenderAPI(fedSenderAPI)
 	p2pPublicRoomProvider := NewLibP2PPublicRoomsProvider(node, fedSenderAPI, federation)

--- a/roomserver/api/api.go
+++ b/roomserver/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 
+	asAPI "github.com/matrix-org/dendrite/appservice/api"
 	fsAPI "github.com/matrix-org/dendrite/federationsender/api"
 )
 
@@ -11,6 +12,7 @@ type RoomserverInternalAPI interface {
 	// needed to avoid chicken and egg scenario when setting up the
 	// interdependencies between the roomserver and other input APIs
 	SetFederationSenderAPI(fsAPI fsAPI.FederationSenderInternalAPI)
+	SetAppserviceAPI(asAPI asAPI.AppServiceQueryAPI)
 
 	InputRoomEvents(
 		ctx context.Context,

--- a/roomserver/api/api_trace.go
+++ b/roomserver/api/api_trace.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	asAPI "github.com/matrix-org/dendrite/appservice/api"
 	fsAPI "github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/util"
 )
@@ -17,6 +18,10 @@ type RoomserverInternalAPITrace struct {
 
 func (t *RoomserverInternalAPITrace) SetFederationSenderAPI(fsAPI fsAPI.FederationSenderInternalAPI) {
 	t.Impl.SetFederationSenderAPI(fsAPI)
+}
+
+func (t *RoomserverInternalAPITrace) SetAppserviceAPI(asAPI asAPI.AppServiceQueryAPI) {
+	t.Impl.SetAppserviceAPI(asAPI)
 }
 
 func (t *RoomserverInternalAPITrace) InputRoomEvents(

--- a/roomserver/internal/alias.go
+++ b/roomserver/internal/alias.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
+
+	asAPI "github.com/matrix-org/dendrite/appservice/api"
 )
 
 // RoomserverInternalAPIDatabase has the storage APIs needed to implement the alias API.
@@ -90,17 +92,13 @@ func (r *RoomserverInternalAPI) GetRoomIDForAlias(
 		return err
 	}
 
-	/*
-		TODO: Why is this here? It creates an unnecessary dependency
-		from the roomserver to the appservice component, which should be
-		altogether optional.
-
+	if r.asAPI != nil { // appservice component is wired in
 		if roomID == "" {
 			// No room found locally, try our application services by making a call to
 			// the appservice component
-			aliasReq := appserviceAPI.RoomAliasExistsRequest{Alias: request.Alias}
-			var aliasResp appserviceAPI.RoomAliasExistsResponse
-			if err = r.AppserviceAPI.RoomAliasExists(ctx, &aliasReq, &aliasResp); err != nil {
+			aliasReq := asAPI.RoomAliasExistsRequest{Alias: request.Alias}
+			var aliasResp asAPI.RoomAliasExistsResponse
+			if err = r.asAPI.RoomAliasExists(ctx, &aliasReq, &aliasResp); err != nil {
 				return err
 			}
 
@@ -111,7 +109,7 @@ func (r *RoomserverInternalAPI) GetRoomIDForAlias(
 				}
 			}
 		}
-	*/
+	}
 
 	response.RoomID = roomID
 	return nil

--- a/roomserver/internal/api.go
+++ b/roomserver/internal/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/Shopify/sarama"
+	asAPI "github.com/matrix-org/dendrite/appservice/api"
 	fsAPI "github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/dendrite/internal/caching"
 	"github.com/matrix-org/dendrite/roomserver/acls"
@@ -35,6 +36,7 @@ type RoomserverInternalAPI struct {
 	ServerName             gomatrixserverlib.ServerName
 	KeyRing                gomatrixserverlib.JSONVerifier
 	fsAPI                  fsAPI.FederationSenderInternalAPI
+	asAPI                  asAPI.AppServiceQueryAPI
 	OutputRoomEventTopic   string // Kafka topic for new output room events
 	PerspectiveServerNames []gomatrixserverlib.ServerName
 }
@@ -124,6 +126,10 @@ func (r *RoomserverInternalAPI) SetFederationSenderAPI(fsAPI fsAPI.FederationSen
 	r.Forgetter = &perform.Forgetter{
 		DB: r.DB,
 	}
+}
+
+func (r *RoomserverInternalAPI) SetAppserviceAPI(asAPI asAPI.AppServiceQueryAPI) {
+	r.asAPI = asAPI
 }
 
 func (r *RoomserverInternalAPI) PerformInvite(

--- a/roomserver/inthttp/client.go
+++ b/roomserver/inthttp/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
+	asAPI "github.com/matrix-org/dendrite/appservice/api"
 	fsInputAPI "github.com/matrix-org/dendrite/federationsender/api"
 	"github.com/matrix-org/dendrite/internal/caching"
 	"github.com/matrix-org/dendrite/internal/httputil"
@@ -82,6 +83,10 @@ func NewRoomserverClient(
 
 // SetFederationSenderInputAPI no-ops in HTTP client mode as there is no chicken/egg scenario
 func (h *httpRoomserverInternalAPI) SetFederationSenderAPI(fsAPI fsInputAPI.FederationSenderInternalAPI) {
+}
+
+// SetAppserviceAPI no-ops in HTTP client mode as there is no chicken/egg scenario
+func (h *httpRoomserverInternalAPI) SetAppserviceAPI(asAPI asAPI.AppServiceQueryAPI) {
 }
 
 // SetRoomAlias implements RoomserverAliasAPI


### PR DESCRIPTION
At the time I commented this out during a roomserver API refactor because it wasn't obvious what it did and it created an import cycle. I've now restored it to close #1655.