### PR TITLE
Reduce database impact on getStateDeltas

### DIFF
--- a/syncapi/storage/postgres/output_room_events_table.go
+++ b/syncapi/storage/postgres/output_room_events_table.go
@@ -103,7 +103,7 @@ const updateEventJSONSQL = "" +
 	"UPDATE syncapi_output_room_events SET headered_event_json=$1 WHERE event_id=$2"
 
 const selectCountStateChangesInRangeSQL = "" +
-	"SELECT COUNT(*), MIN(id), MAX(id) FROM syncapi_output_room_events" +
+	"SELECT COUNT(id), COALESCE(MIN(id), 0) AS min, COALESCE(MAX(id), 0) AS max FROM syncapi_output_room_events" +
 	" WHERE (id > $1 AND id <= $2) AND (cardinality (add_state_ids) > 0 OR cardinality (remove_state_ids) > 0)"
 
 // In order for us to apply the state updates correctly, rows need to be ordered in the order they were received (id).

--- a/syncapi/storage/postgres/output_room_events_table.go
+++ b/syncapi/storage/postgres/output_room_events_table.go
@@ -106,7 +106,7 @@ const updateEventJSONSQL = "" +
 const selectStateInRangeSQL = "" +
 	"SELECT id, headered_event_json, exclude_from_sync, add_state_ids, remove_state_ids" +
 	" FROM syncapi_output_room_events" +
-	" WHERE (id > $1 AND id <= $2) AND (add_state_ids IS NOT NULL OR remove_state_ids IS NOT NULL)" +
+	" WHERE (id > $1 AND id <= $2) AND (cardinality (add_state_ids) > 0 OR cardinality (remove_state_ids) > 0)" +
 	" AND ( $3::text[] IS NULL OR     sender  = ANY($3)  )" +
 	" AND ( $4::text[] IS NULL OR NOT(sender  = ANY($4)) )" +
 	" AND ( $5::text[] IS NULL OR     type LIKE ANY($5)  )" +

--- a/syncapi/storage/shared/syncserver.go
+++ b/syncapi/storage/shared/syncserver.go
@@ -1182,8 +1182,17 @@ func (d *Database) getStateDeltas(
 	// - Get all CURRENTLY joined rooms, and add them to 'joined' block.
 	var deltas []stateDelta
 
+	// work out if any state changed, and if so, within which ranges
+	count, nr, err := d.OutputEvents.SelectCountStateChangesInRange(ctx, txn, r)
+	if err != nil {
+		return nil, nil, err
+	}
+	if count == 0 {
+		return nil, nil, nil
+	}
+
 	// get all the state events ever (i.e. for all available rooms) between these two positions
-	stateNeeded, eventMap, err := d.OutputEvents.SelectStateInRange(ctx, txn, r, stateFilter)
+	stateNeeded, eventMap, err := d.OutputEvents.SelectStateInRange(ctx, txn, nr, stateFilter)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/syncapi/storage/sqlite3/output_room_events_table.go
+++ b/syncapi/storage/sqlite3/output_room_events_table.go
@@ -92,7 +92,7 @@ const updateEventJSONSQL = "" +
 */
 
 const selectCountStateChangesInRangeSQL = "" +
-	"SELECT COUNT(*), coalesce(MIN(id), 0) AS min, coalesce(MAX(id), 0) AS max FROM syncapi_output_room_events" +
+	"SELECT COUNT(*), MIN(id), MAX(id) AS max FROM syncapi_output_room_events" +
 	" WHERE (id > $1 AND id <= $2) AND ((add_state_ids IS NULL OR add_state_ids = '') OR (remove_state_ids IS NULL OR remove_state_ids = ''))"
 
 const selectStateInRangeSQL = "" +

--- a/syncapi/storage/sqlite3/output_room_events_table.go
+++ b/syncapi/storage/sqlite3/output_room_events_table.go
@@ -92,7 +92,7 @@ const updateEventJSONSQL = "" +
 */
 
 const selectCountStateChangesInRangeSQL = "" +
-	"SELECT COUNT(*), MIN(id), MAX(id) FROM syncapi_output_room_events" +
+	"SELECT COUNT(*), coalesce(MIN(id), 0) AS min, coalesce(MAX(id), 0) AS max FROM syncapi_output_room_events" +
 	" WHERE (id > $1 AND id <= $2) AND ((add_state_ids IS NULL OR add_state_ids = '') OR (remove_state_ids IS NULL OR remove_state_ids = ''))"
 
 const selectStateInRangeSQL = "" +

--- a/syncapi/storage/tables/interface.go
+++ b/syncapi/storage/tables/interface.go
@@ -51,6 +51,7 @@ type Peeks interface {
 
 type Events interface {
 	SelectStateInRange(ctx context.Context, txn *sql.Tx, r types.Range, stateFilter *gomatrixserverlib.StateFilter) (map[string]map[string]bool, map[string]types.StreamEvent, error)
+	SelectCountStateChangesInRange(ctx context.Context, txn *sql.Tx, r types.Range) (int, types.Range, error)
 	SelectMaxEventID(ctx context.Context, txn *sql.Tx) (id int64, err error)
 	InsertEvent(ctx context.Context, txn *sql.Tx, event *gomatrixserverlib.HeaderedEvent, addState, removeState []string, transactionID *api.TransactionID, excludeFromSync bool) (streamPos types.StreamPosition, err error)
 	// SelectRecentEvents returns events between the two stream positions: exclusive of low and inclusive of high.


### PR DESCRIPTION
This performs a simpler query first to work out the smallest range to satisfy the state deltas, if there are indeed any at all.