### PR TITLE
Ensure appservices can auth as users in their namespaces

### DIFF
--- a/userapi/internal/api.go
+++ b/userapi/internal/api.go
@@ -389,9 +389,10 @@ func (a *UserInternalAPI) queryAppServiceToken(ctx context.Context, token, appSe
 
 	if localpart != "" { // AS is masquerading as another user
 		// Verify that the user is registered
-		_, err := a.AccountDB.GetAccountByLocalpart(ctx, localpart)
-		// Verify that the account belongs to the appservice user namespaces
-		if err == nil && appService.IsInterestedInUserID(appServiceUserID) {
+		account, err := a.AccountDB.GetAccountByLocalpart(ctx, localpart)
+		// Verify that the account exists and either appServiceID matches or
+		// it belongs to the appservice user namespaces
+		if err == nil && (account.AppServiceID == appService.ID || appService.IsInterestedInUserID(appServiceUserID)) {
 			// Set the userID of dummy device
 			dev.UserID = appServiceUserID
 			return &dev, nil

--- a/userapi/internal/api.go
+++ b/userapi/internal/api.go
@@ -389,9 +389,9 @@ func (a *UserInternalAPI) queryAppServiceToken(ctx context.Context, token, appSe
 
 	if localpart != "" { // AS is masquerading as another user
 		// Verify that the user is registered
-		account, err := a.AccountDB.GetAccountByLocalpart(ctx, localpart)
-		// Verify that account exists & appServiceID matches
-		if err == nil && account.AppServiceID == appService.ID {
+		_, err := a.AccountDB.GetAccountByLocalpart(ctx, localpart)
+		// Verify that the account belongs to the appservice user namespaces
+		if err == nil && appService.IsInterestedInUserID(appServiceUserID) {
 			// Set the userID of dummy device
 			dev.UserID = appServiceUserID
 			return &dev, nil


### PR DESCRIPTION
Currently in Dendrite appservices can only auth as a user if the user was created by said appservice. This does not align with the appservices spec which specifically says:

> The application service may specify the virtual user to act as through use of a user_id query string parameter on the request. The user specified in the query string must be covered by one of the application service’s user namespaces.

https://matrix.org/docs/spec/application_service/r0.1.2#identity-assertion

In the case that a user has been created for example via manual registration but belongs to an appservice namespace, the current functionality does not allow appservices to auth as them. This PR fixes that by replacing the appservice ID check with a check against the appservice namespace.

This also matches Synapse functionality, which I confirmed to allow appservices to auth as a user in their namespace, irregardless of how the user was registered.

Signed-off-by: `Jason Robinson <mail@jasonrobinson.me>`
