### PR TITLE
Sync refactor fixes

### DIFF
--- a/syncapi/consumers/clientapi.go
+++ b/syncapi/consumers/clientapi.go
@@ -95,8 +95,9 @@ func (s *OutputClientDataConsumer) onMessage(msg *sarama.ConsumerMessage) error 
 		}).Panicf("could not save account data")
 	}
 
-	s.stream.Advance(streamPos)
-	s.notifier.OnNewAccountData(string(msg.Key), types.StreamingToken{AccountDataPosition: streamPos})
+	if s.stream.Advance(streamPos) {
+		s.notifier.OnNewAccountData(string(msg.Key), types.StreamingToken{AccountDataPosition: streamPos})
+	}
 
 	return nil
 }

--- a/syncapi/consumers/eduserver_receipts.go
+++ b/syncapi/consumers/eduserver_receipts.go
@@ -90,8 +90,9 @@ func (s *OutputReceiptEventConsumer) onMessage(msg *sarama.ConsumerMessage) erro
 		return err
 	}
 
-	s.stream.Advance(streamPos)
-	s.notifier.OnNewReceipt(output.RoomID, types.StreamingToken{ReceiptPosition: streamPos})
+	if s.stream.Advance(streamPos) {
+		s.notifier.OnNewReceipt(output.RoomID, types.StreamingToken{ReceiptPosition: streamPos})
+	}
 
 	return nil
 }

--- a/syncapi/consumers/eduserver_sendtodevice.go
+++ b/syncapi/consumers/eduserver_sendtodevice.go
@@ -105,12 +105,13 @@ func (s *OutputSendToDeviceEventConsumer) onMessage(msg *sarama.ConsumerMessage)
 		return err
 	}
 
-	s.stream.Advance(streamPos)
-	s.notifier.OnNewSendToDevice(
-		output.UserID,
-		[]string{output.DeviceID},
-		types.StreamingToken{SendToDevicePosition: streamPos},
-	)
+	if s.stream.Advance(streamPos) {
+		s.notifier.OnNewSendToDevice(
+			output.UserID,
+			[]string{output.DeviceID},
+			types.StreamingToken{SendToDevicePosition: streamPos},
+		)
+	}
 
 	return nil
 }

--- a/syncapi/consumers/eduserver_typing.go
+++ b/syncapi/consumers/eduserver_typing.go
@@ -101,8 +101,9 @@ func (s *OutputTypingEventConsumer) onMessage(msg *sarama.ConsumerMessage) error
 		)
 	}
 
-	s.stream.Advance(typingPos)
-	s.notifier.OnNewTyping(output.Event.RoomID, types.StreamingToken{TypingPosition: typingPos})
+	if s.stream.Advance(typingPos) {
+		s.notifier.OnNewTyping(output.Event.RoomID, types.StreamingToken{TypingPosition: typingPos})
+	}
 
 	return nil
 }

--- a/syncapi/consumers/eduserver_typing.go
+++ b/syncapi/consumers/eduserver_typing.go
@@ -15,6 +15,7 @@
 package consumers
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/Shopify/sarama"
@@ -24,6 +25,7 @@ import (
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/dendrite/syncapi/notifier"
 	"github.com/matrix-org/dendrite/syncapi/storage"
+	"github.com/matrix-org/dendrite/syncapi/streams"
 	"github.com/matrix-org/dendrite/syncapi/types"
 	log "github.com/sirupsen/logrus"
 )
@@ -32,7 +34,7 @@ import (
 type OutputTypingEventConsumer struct {
 	typingConsumer *internal.ContinualConsumer
 	eduCache       *cache.EDUCache
-	stream         types.StreamProvider
+	streams        *streams.Streams
 	notifier       *notifier.Notifier
 }
 
@@ -44,7 +46,7 @@ func NewOutputTypingEventConsumer(
 	store storage.Database,
 	eduCache *cache.EDUCache,
 	notifier *notifier.Notifier,
-	stream types.StreamProvider,
+	streams *streams.Streams,
 ) *OutputTypingEventConsumer {
 
 	consumer := internal.ContinualConsumer{
@@ -58,7 +60,7 @@ func NewOutputTypingEventConsumer(
 		typingConsumer: &consumer,
 		eduCache:       eduCache,
 		notifier:       notifier,
-		stream:         stream,
+		streams:        streams,
 	}
 
 	consumer.ProcessMessage = s.onMessage
@@ -101,8 +103,8 @@ func (s *OutputTypingEventConsumer) onMessage(msg *sarama.ConsumerMessage) error
 		)
 	}
 
-	if s.stream.Advance(typingPos) {
-		s.notifier.OnNewTyping(output.Event.RoomID, types.StreamingToken{TypingPosition: typingPos})
+	if s.streams.TypingStreamProvider.Advance(typingPos) {
+		s.notifier.OnNewTyping(output.Event.RoomID, s.streams.Latest(context.Background()))
 	}
 
 	return nil

--- a/syncapi/consumers/keychange.go
+++ b/syncapi/consumers/keychange.go
@@ -122,9 +122,10 @@ func (s *OutputKeyChangeEventConsumer) onMessage(msg *sarama.ConsumerMessage) er
 		Partition: msg.Partition,
 	}
 
-	s.stream.Advance(posUpdate)
-	for userID := range queryRes.UserIDsToCount {
-		s.notifier.OnNewKeyChange(types.StreamingToken{DeviceListPosition: posUpdate}, userID, output.UserID)
+	if s.stream.Advance(posUpdate) {
+		for userID := range queryRes.UserIDsToCount {
+			s.notifier.OnNewKeyChange(types.StreamingToken{DeviceListPosition: posUpdate}, userID, output.UserID)
+		}
 	}
 
 	return nil

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -186,8 +186,9 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 		return err
 	}
 
-	s.pduStream.Advance(pduPos)
-	s.notifier.OnNewEvent(ev, ev.RoomID(), nil, types.StreamingToken{PDUPosition: pduPos})
+	if s.pduStream.Advance(pduPos) {
+		s.notifier.OnNewEvent(ev, ev.RoomID(), nil, types.StreamingToken{PDUPosition: pduPos})
+	}
 
 	return nil
 }
@@ -226,8 +227,9 @@ func (s *OutputRoomEventConsumer) onOldRoomEvent(
 		return err
 	}
 
-	s.pduStream.Advance(pduPos)
-	s.notifier.OnNewEvent(ev, ev.RoomID(), nil, types.StreamingToken{PDUPosition: pduPos})
+	if s.pduStream.Advance(pduPos) {
+		s.notifier.OnNewEvent(ev, ev.RoomID(), nil, types.StreamingToken{PDUPosition: pduPos})
+	}
 
 	return nil
 }
@@ -283,8 +285,9 @@ func (s *OutputRoomEventConsumer) onNewInviteEvent(
 		return nil
 	}
 
-	s.inviteStream.Advance(pduPos)
-	s.notifier.OnNewInvite(types.StreamingToken{InvitePosition: pduPos}, *msg.Event.StateKey())
+	if s.inviteStream.Advance(pduPos) {
+		s.notifier.OnNewInvite(types.StreamingToken{InvitePosition: pduPos}, *msg.Event.StateKey())
+	}
 
 	return nil
 }
@@ -303,8 +306,9 @@ func (s *OutputRoomEventConsumer) onRetireInviteEvent(
 	}
 
 	// Notify any active sync requests that the invite has been retired.
-	s.inviteStream.Advance(pduPos)
-	s.notifier.OnNewInvite(types.StreamingToken{InvitePosition: pduPos}, msg.TargetUserID)
+	if s.inviteStream.Advance(pduPos) {
+		s.notifier.OnNewInvite(types.StreamingToken{InvitePosition: pduPos}, msg.TargetUserID)
+	}
 
 	return nil
 }
@@ -324,8 +328,9 @@ func (s *OutputRoomEventConsumer) onNewPeek(
 	// tell the notifier about the new peek so it knows to wake up new devices
 	// TODO: This only works because the peeks table is reusing the same
 	// index as PDUs, but we should fix this
-	s.pduStream.Advance(sp)
-	s.notifier.OnNewPeek(msg.RoomID, msg.UserID, msg.DeviceID, types.StreamingToken{PDUPosition: sp})
+	if s.pduStream.Advance(sp) {
+		s.notifier.OnNewPeek(msg.RoomID, msg.UserID, msg.DeviceID, types.StreamingToken{PDUPosition: sp})
+	}
 
 	return nil
 }
@@ -345,8 +350,9 @@ func (s *OutputRoomEventConsumer) onRetirePeek(
 	// tell the notifier about the new peek so it knows to wake up new devices
 	// TODO: This only works because the peeks table is reusing the same
 	// index as PDUs, but we should fix this
-	s.pduStream.Advance(sp)
-	s.notifier.OnRetirePeek(msg.RoomID, msg.UserID, msg.DeviceID, types.StreamingToken{PDUPosition: sp})
+	if s.pduStream.Advance(sp) {
+		s.notifier.OnRetirePeek(msg.RoomID, msg.UserID, msg.DeviceID, types.StreamingToken{PDUPosition: sp})
+	}
 
 	return nil
 }

--- a/syncapi/notifier/notifier.go
+++ b/syncapi/notifier/notifier.go
@@ -36,7 +36,7 @@ type Notifier struct {
 	// A map of RoomID => Set<UserID> : Must only be accessed by the OnNewEvent goroutine
 	roomIDToPeekingDevices map[string]peekingDeviceSet
 	// Protects currPos and userStreams.
-	streamLock *sync.Mutex
+	streamLock *sync.RWMutex
 	// The latest sync position
 	currPos types.StreamingToken
 	// A map of user_id => device_id => UserStream which can be used to wake a given user's /sync request.
@@ -54,7 +54,7 @@ func NewNotifier(currPos types.StreamingToken) *Notifier {
 		roomIDToJoinedUsers:    make(map[string]userIDSet),
 		roomIDToPeekingDevices: make(map[string]peekingDeviceSet),
 		userDeviceStreams:      make(map[string]map[string]*UserDeviceStream),
-		streamLock:             &sync.Mutex{},
+		streamLock:             &sync.RWMutex{},
 		lastCleanUpTime:        time.Now(),
 	}
 }
@@ -256,8 +256,8 @@ func (n *Notifier) Load(ctx context.Context, db storage.Database) error {
 
 // CurrentPosition returns the current sync position
 func (n *Notifier) CurrentPosition() types.StreamingToken {
-	n.streamLock.Lock()
-	defer n.streamLock.Unlock()
+	n.streamLock.RLock()
+	defer n.streamLock.RUnlock()
 
 	return n.currPos
 }

--- a/syncapi/notifier/userstream.go
+++ b/syncapi/notifier/userstream.go
@@ -89,10 +89,9 @@ func (s *UserDeviceStream) Broadcast(pos types.StreamingToken) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	s.pos = pos
+	s.pos.ApplyUpdates(pos)
 
 	close(s.signalChannel)
-
 	s.signalChannel = make(chan struct{})
 }
 

--- a/syncapi/streams/template_pstream.go
+++ b/syncapi/streams/template_pstream.go
@@ -19,13 +19,16 @@ func (p *PartitionedStreamProvider) Setup() {
 
 func (p *PartitionedStreamProvider) Advance(
 	latest types.LogPosition,
-) {
+) bool {
 	p.latestMutex.Lock()
 	defer p.latestMutex.Unlock()
 
 	if latest.IsAfter(&p.latest) {
 		p.latest = latest
+		return true
 	}
+
+	return false
 }
 
 func (p *PartitionedStreamProvider) LatestPosition(

--- a/syncapi/streams/template_stream.go
+++ b/syncapi/streams/template_stream.go
@@ -19,13 +19,16 @@ func (p *StreamProvider) Setup() {
 
 func (p *StreamProvider) Advance(
 	latest types.StreamPosition,
-) {
+) bool {
 	p.latestMutex.Lock()
 	defer p.latestMutex.Unlock()
 
 	if latest > p.latest {
 		p.latest = latest
+		return true
 	}
+
+	return false
 }
 
 func (p *StreamProvider) LatestPosition(

--- a/syncapi/syncapi.go
+++ b/syncapi/syncapi.go
@@ -64,14 +64,14 @@ func AddPublicRoutes(
 
 	keyChangeConsumer := consumers.NewOutputKeyChangeEventConsumer(
 		cfg.Matrix.ServerName, string(cfg.Matrix.Kafka.TopicFor(config.TopicOutputKeyChangeEvent)),
-		consumer, keyAPI, rsAPI, syncDB, notifier, streams.DeviceListStreamProvider,
+		consumer, keyAPI, rsAPI, syncDB, notifier, streams,
 	)
 	if err = keyChangeConsumer.Start(); err != nil {
 		logrus.WithError(err).Panicf("failed to start key change consumer")
 	}
 
 	roomConsumer := consumers.NewOutputRoomEventConsumer(
-		cfg, consumer, syncDB, notifier, streams.PDUStreamProvider,
+		cfg, consumer, syncDB, notifier, streams,
 		streams.InviteStreamProvider, rsAPI,
 	)
 	if err = roomConsumer.Start(); err != nil {
@@ -79,28 +79,28 @@ func AddPublicRoutes(
 	}
 
 	clientConsumer := consumers.NewOutputClientDataConsumer(
-		cfg, consumer, syncDB, notifier, streams.AccountDataStreamProvider,
+		cfg, consumer, syncDB, notifier, streams,
 	)
 	if err = clientConsumer.Start(); err != nil {
 		logrus.WithError(err).Panicf("failed to start client data consumer")
 	}
 
 	typingConsumer := consumers.NewOutputTypingEventConsumer(
-		cfg, consumer, syncDB, eduCache, notifier, streams.TypingStreamProvider,
+		cfg, consumer, syncDB, eduCache, notifier, streams,
 	)
 	if err = typingConsumer.Start(); err != nil {
 		logrus.WithError(err).Panicf("failed to start typing consumer")
 	}
 
 	sendToDeviceConsumer := consumers.NewOutputSendToDeviceEventConsumer(
-		cfg, consumer, syncDB, notifier, streams.SendToDeviceStreamProvider,
+		cfg, consumer, syncDB, notifier, streams,
 	)
 	if err = sendToDeviceConsumer.Start(); err != nil {
 		logrus.WithError(err).Panicf("failed to start send-to-device consumer")
 	}
 
 	receiptConsumer := consumers.NewOutputReceiptEventConsumer(
-		cfg, consumer, syncDB, notifier, streams.ReceiptStreamProvider,
+		cfg, consumer, syncDB, notifier, streams,
 	)
 	if err = receiptConsumer.Start(); err != nil {
 		logrus.WithError(err).Panicf("failed to start receipts consumer")

--- a/syncapi/types/provider.go
+++ b/syncapi/types/provider.go
@@ -28,8 +28,8 @@ type StreamProvider interface {
 	Setup()
 
 	// Advance will update the latest position of the stream based on
-	// an update and will wake callers waiting on StreamNotifyAfter.
-	Advance(latest StreamPosition)
+	// an update. It returns true if the position advanced or false otherwise.
+	Advance(latest StreamPosition) bool
 
 	// CompleteSync will update the response to include all updates as needed
 	// for a complete sync. It will always return immediately.
@@ -46,7 +46,7 @@ type StreamProvider interface {
 
 type PartitionedStreamProvider interface {
 	Setup()
-	Advance(latest LogPosition)
+	Advance(latest LogPosition) bool
 	CompleteSync(ctx context.Context, req *SyncRequest) LogPosition
 	IncrementalSync(ctx context.Context, req *SyncRequest, from, to LogPosition) LogPosition
 	LatestPosition(ctx context.Context) LogPosition


### PR DESCRIPTION
It turns out that it makes sense for each of the consumers to have access to `*streams.Streams` after all, because then we can send the *absolutely latest* stream token for all streams, rather than just delta-ing based on the thing we just consumed from Kafka. This should hopefully fix the problem where some sync positions are advancing much slower than they should be.

We also now only hit the notifier if the stream *actually* caused a stream update.