### PR TITLE
Reduce device list GetUserDevices timeout

### DIFF
--- a/keyserver/internal/device_list_update.go
+++ b/keyserver/internal/device_list_update.go
@@ -319,7 +319,7 @@ func (u *DeviceListUpdater) worker(ch chan gomatrixserverlib.ServerName) {
 }
 
 func (u *DeviceListUpdater) processServer(serverName gomatrixserverlib.ServerName) (time.Duration, bool) {
-	requestTimeout := time.Minute // max amount of time we want to spend on each request
+	requestTimeout := time.Second * 30 // max amount of time we want to spend on each request
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 	defer cancel()
 	logger := util.GetLogger(ctx).WithField("server_name", serverName)


### PR DESCRIPTION
Synapse will give up on `/send` after 60 seconds, but we can potentially block for 60 seconds trying to handle device list updates. When that happens, the remote server will just keep sending us the same transaction over and over again, because we keep timing out.

Halfing the timeout gives us more headroom to actually respond to the transaction.