### PR TITLE
MSC2946: Use new MSC1772 format for space parents

### DIFF
--- a/setup/mscs/msc2946/msc2946.go
+++ b/setup/mscs/msc2946/msc2946.go
@@ -36,7 +36,7 @@ import (
 const (
 	ConstCreateEventContentKey = "org.matrix.msc1772.type"
 	ConstSpaceChildEventType   = "org.matrix.msc1772.space.child"
-	ConstSpaceParentEventType  = "org.matrix.msc1772.room.parent"
+	ConstSpaceParentEventType  = "org.matrix.msc1772.space.parent"
 )
 
 // SpacesRequest is the request body to POST /_matrix/client/r0/rooms/{roomID}/spaces
@@ -57,7 +57,7 @@ type SpacesResponse struct {
 	NextBatch string `json:"next_batch"`
 	// Rooms are nodes on the space graph.
 	Rooms []Room `json:"rooms"`
-	// Events are edges on the space graph, exclusively m.space.child or m.room.parent events
+	// Events are edges on the space graph, exclusively m.space.child or m.space.parent events
 	Events []gomatrixserverlib.ClientEvent `json:"events"`
 }
 
@@ -182,8 +182,8 @@ func (w *walker) walk() *SpacesResponse {
 		if !w.authorised(roomID) {
 			continue
 		}
-		// Get all `m.space.child` and `m.room.parent` state events for the room. *In addition*, get
-		// all `m.space.child` and `m.room.parent` state events which *point to* (via `state_key` or `content.room_id`)
+		// Get all `m.space.child` and `m.space.parent` state events for the room. *In addition*, get
+		// all `m.space.child` and `m.space.parent` state events which *point to* (via `state_key` or `content.room_id`)
 		// this room. This requires servers to store reverse lookups.
 		refs, err := w.references(roomID)
 		if err != nil {
@@ -196,7 +196,7 @@ func (w *walker) walk() *SpacesResponse {
 		if !w.alreadySent(roomID) {
 			pubRoom := w.publicRoomsChunk(roomID)
 			roomType := ""
-			create := w.stateEvent(roomID, "m.room.create", "")
+			create := w.stateEvent(roomID, gomatrixserverlib.MRoomCreate, "")
 			if create != nil {
 				roomType = gjson.GetBytes(create.Content(), ConstCreateEventContentKey).Str
 			}

--- a/setup/mscs/msc2946/msc2946_test.go
+++ b/setup/mscs/msc2946/msc2946_test.go
@@ -86,8 +86,7 @@ func TestMSC2946(t *testing.T) {
 		Type:     msc2946.ConstSpaceChildEventType,
 		StateKey: &room1,
 		Content: map[string]interface{}{
-			"via":     []string{"localhost"},
-			"present": true,
+			"via": []string{"localhost"},
 		},
 	})
 	rootToR2 := mustCreateEvent(t, fledglingEvent{
@@ -96,8 +95,7 @@ func TestMSC2946(t *testing.T) {
 		Type:     msc2946.ConstSpaceChildEventType,
 		StateKey: &room2,
 		Content: map[string]interface{}{
-			"via":     []string{"localhost"},
-			"present": true,
+			"via": []string{"localhost"},
 		},
 	})
 	rootToS1 := mustCreateEvent(t, fledglingEvent{
@@ -106,8 +104,7 @@ func TestMSC2946(t *testing.T) {
 		Type:     msc2946.ConstSpaceChildEventType,
 		StateKey: &subSpaceS1,
 		Content: map[string]interface{}{
-			"via":     []string{"localhost"},
-			"present": true,
+			"via": []string{"localhost"},
 		},
 	})
 	s1ToR3 := mustCreateEvent(t, fledglingEvent{
@@ -116,8 +113,7 @@ func TestMSC2946(t *testing.T) {
 		Type:     msc2946.ConstSpaceChildEventType,
 		StateKey: &room3,
 		Content: map[string]interface{}{
-			"via":     []string{"localhost"},
-			"present": true,
+			"via": []string{"localhost"},
 		},
 	})
 	s1ToR4 := mustCreateEvent(t, fledglingEvent{
@@ -126,8 +122,7 @@ func TestMSC2946(t *testing.T) {
 		Type:     msc2946.ConstSpaceChildEventType,
 		StateKey: &room4,
 		Content: map[string]interface{}{
-			"via":     []string{"localhost"},
-			"present": true,
+			"via": []string{"localhost"},
 		},
 	})
 	s1ToS2 := mustCreateEvent(t, fledglingEvent{
@@ -136,8 +131,7 @@ func TestMSC2946(t *testing.T) {
 		Type:     msc2946.ConstSpaceChildEventType,
 		StateKey: &subSpaceS2,
 		Content: map[string]interface{}{
-			"via":     []string{"localhost"},
-			"present": true,
+			"via": []string{"localhost"},
 		},
 	})
 	// This is a parent link only
@@ -145,11 +139,9 @@ func TestMSC2946(t *testing.T) {
 		RoomID:   room5,
 		Sender:   alice,
 		Type:     msc2946.ConstSpaceParentEventType,
-		StateKey: &empty,
+		StateKey: &subSpaceS2,
 		Content: map[string]interface{}{
-			"room_id": subSpaceS2,
-			"via":     []string{"localhost"},
-			"present": true,
+			"via": []string{"localhost"},
 		},
 	})
 	// history visibility for R4

--- a/setup/mscs/msc2946/storage.go
+++ b/setup/mscs/msc2946/storage.go
@@ -22,7 +22,6 @@ import (
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/gomatrixserverlib"
-	"github.com/tidwall/gjson"
 )
 
 var (
@@ -175,7 +174,7 @@ func SpaceTarget(he *gomatrixserverlib.HeaderedEvent) string {
 	}
 	switch he.Type() {
 	case ConstSpaceParentEventType:
-		return gjson.GetBytes(he.Content(), "room_id").Str
+		return *he.StateKey()
 	case ConstSpaceChildEventType:
 		return *he.StateKey()
 	}


### PR DESCRIPTION
Namely that the room ID has moved from `content.room_id` to `state_key` and the event type has changed names.