### PR TITLE
WIP - docs: Add key generation without go

### DIFF
--- a/build/docker/README.md
+++ b/build/docker/README.md
@@ -34,13 +34,33 @@ runtime config should come from. The mounted folder must contain:
 - `server.crt` certificate file
 - `server.key` private key file for the above certificate
 
-To generate keys:
+**To generate keys:**  
+With Go installed on the host
 
 ```
+mkdir keys
 go run github.com/matrix-org/dendrite/cmd/generate-keys \
-  --private-key=matrix_key.pem \
-  --tls-cert=server.crt \
-  --tls-key=server.key
+  --private-key=keys/matrix_key.pem \
+  --tls-cert=keys/server.crt \
+  --tls-key=keys/server.key
+```
+
+Without Go on the host, with monolith deployment
+
+```
+docker-compose run --entrypoint generate-keys monolith \
+  --private-key=/keys/matrix_key.pem \
+  --tls-cert=/keys/server.crt \
+  --tls-key=/keys/server.key
+```
+
+Without Go on the host, with polylith deployment
+
+```
+docker-compose run --entrypoint generate-keys key_server \
+  --private-key=/keys/matrix_key.pem \
+  --tls-cert=/keys/server.crt \
+  --tls-key=/keys/server.key
 ```
 
 ## Starting Dendrite as a monolith deployment

--- a/build/docker/docker-compose.monolith.yml
+++ b/build/docker/docker-compose.monolith.yml
@@ -4,14 +4,15 @@ services:
     hostname: monolith
     image: matrixdotorg/dendrite-monolith:latest
     command: [
-      "--tls-cert=server.crt",
-      "--tls-key=server.key"
+      "--tls-cert=/keys/server.crt",
+      "--tls-key=/keys/server.key"
     ]
     ports:
       - 8008:8008
       - 8448:8448
     volumes:
       - ./config:/etc/dendrite
+      - ./keys:/keys
     networks:
       - internal
 

--- a/build/docker/docker-compose.polylith.yml
+++ b/build/docker/docker-compose.polylith.yml
@@ -69,6 +69,7 @@ services:
     command: keyserver
     volumes:
       - ./config:/etc/dendrite
+      - ./keys:/keys
     networks:
         - internal
 


### PR DESCRIPTION
Hi

There is no need to have Go installed on the host server, the `generate-keys` command can be run inside the Dendrite container, I updated the instructions accordingly. For this to work I added a Docker volume `keys` to the docker-compose example files.

It is still WIP as I do not know Dendrite components well enough to all polylith containers. Which ones should be concerned?

Thank you
Oliv'


### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [N/A ] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x ] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: Olivier Gimenez <oliv4945@gmail.com>