### PR TITLE
Use go build instead of go install

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,13 +17,6 @@ else
     export FLAGS=""
 fi
 
-for pkg in ./cmd/*; do
-    if [[ -d "$pkg" && ! -L "$pkg" ]]; then
-        # https://unix.stackexchange.com/a/94307/125869 
-        pkg_x="$(basename -- "$pkg"; echo .)"
-        base="${pkg_x%??}"
-        CGO_ENABLED=1 go build -trimpath -ldflags "$FLAGS" -v -o "./bin/$base" "./cmd/$base"
-    fi
-done
+CGO_ENABLED=1 go build -trimpath -ldflags "$FLAGS" -v -o "bin/" ./cmd/...
 
 CGO_ENABLED=0 GOOS=js GOARCH=wasm go build -trimpath -ldflags "$FLAGS" -o bin/main.wasm ./cmd/dendritejs

--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,13 @@ else
     export FLAGS=""
 fi
 
-go install -trimpath -ldflags "$FLAGS" -v $PWD/`dirname $0`/cmd/...
+for pkg in ./cmd/*; do
+    if [[ -d "$pkg" && ! -L "$pkg" ]]; then
+        # https://unix.stackexchange.com/a/94307/125869 
+        pkg_x="$(basename -- "$pkg"; echo .)"
+        base="${pkg_x%??}"
+        CGO_ENABLED=1 go build -trimpath -ldflags "$FLAGS" -v -o "./bin/$base" "./cmd/$base"
+    fi
+done
 
-GOOS=js GOARCH=wasm go build -trimpath -ldflags "$FLAGS" -o bin/main.wasm ./cmd/dendritejs
+CGO_ENABLED=0 GOOS=js GOARCH=wasm go build -trimpath -ldflags "$FLAGS" -o bin/main.wasm ./cmd/dendritejs


### PR DESCRIPTION
`go install` doesn't like to cross-compile things. (Try running build.sh with `GOARCH` set to something other than what it "should" be.)

With `go build`, it appears that cross-compilation is really, really straightforward. Simply install a compiler for your target platform and set `GOARCH` and `CC` accordingly.

I need to test the produced binaries on a real ARM chip, but this approach does seem to work. (Go is rather new to me, so I'm flying by the seat of my pants here.)

See also #1613, also in the vein of "making ARM easier"

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `Caleb Xavier Berger <caleb.x.berger@gmail.com>`
