### PR TITLE
Fix integer overflow in device_list_update.go

### DIFF
--- a/keyserver/internal/device_list_update.go
+++ b/keyserver/internal/device_list_update.go
@@ -245,7 +245,7 @@ func (u *DeviceListUpdater) notifyWorkers(userID string) {
 	}
 	hash := fnv.New32a()
 	_, _ = hash.Write([]byte(remoteServer))
-	index := int(hash.Sum32()) % len(u.workerChans)
+	index := int(int64(hash.Sum32()) % int64(len(u.workerChans)))
 
 	ch := u.assignChannel(userID)
 	u.workerChans[index] <- remoteServer


### PR DESCRIPTION
Fix #1511
On 32-bits systems, int(hash.Sum32()) can be negative.
This makes the computation of array indices using modulo invalid, crashing dendrite.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `Loïck Bonniot <git@lesterpig.com>`
