### PR TITLE
Don't panic if duplicate event_id in syncapi_output_room_events_topology

### DIFF
--- a/syncapi/storage/postgres/output_room_events_topology_table.go
+++ b/syncapi/storage/postgres/output_room_events_topology_table.go
@@ -44,8 +44,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS syncapi_event_topological_position_idx ON sync
 const insertEventInTopologySQL = "" +
 	"INSERT INTO syncapi_output_room_events_topology (event_id, topological_position, room_id, stream_position)" +
 	" VALUES ($1, $2, $3, $4)" +
-	" ON CONFLICT (topological_position, stream_position, room_id) DO UPDATE SET event_id = $1" +
-	" ON CONFLICT (event_id) DO NOTHING" +
+	" ON CONFLICT DO NOTHING" +
 	" RETURNING topological_position"
 
 const selectEventIDsInRangeASCSQL = "" +

--- a/syncapi/storage/postgres/output_room_events_topology_table.go
+++ b/syncapi/storage/postgres/output_room_events_topology_table.go
@@ -45,7 +45,7 @@ const insertEventInTopologySQL = "" +
 	"INSERT INTO syncapi_output_room_events_topology (event_id, topological_position, room_id, stream_position)" +
 	" VALUES ($1, $2, $3, $4)" +
 	" ON CONFLICT (topological_position, stream_position, room_id) DO UPDATE SET event_id = $1" +
-	" ON CONFLICT (event_id) DO NOTHING"
+	" ON CONFLICT (event_id) DO NOTHING" +
 	" RETURNING topological_position"
 
 const selectEventIDsInRangeASCSQL = "" +

--- a/syncapi/storage/postgres/output_room_events_topology_table.go
+++ b/syncapi/storage/postgres/output_room_events_topology_table.go
@@ -45,6 +45,7 @@ const insertEventInTopologySQL = "" +
 	"INSERT INTO syncapi_output_room_events_topology (event_id, topological_position, room_id, stream_position)" +
 	" VALUES ($1, $2, $3, $4)" +
 	" ON CONFLICT (topological_position, stream_position, room_id) DO UPDATE SET event_id = $1" +
+	" ON CONFLICT (event_id) DO NOTHING"
 	" RETURNING topological_position"
 
 const selectEventIDsInRangeASCSQL = "" +


### PR DESCRIPTION
This should fix #1725. We already seem to avoid this problem in SQLite so not sure why we didn't on Postgres.