### PR TITLE
Complete sync performance

### DIFF
--- a/syncapi/streams/stream_devicelist.go
+++ b/syncapi/streams/stream_devicelist.go
@@ -19,7 +19,7 @@ func (p *DeviceListStreamProvider) CompleteSync(
 	ctx context.Context,
 	req *types.SyncRequest,
 ) types.LogPosition {
-	return p.IncrementalSync(ctx, req, types.LogPosition{}, p.LatestPosition(ctx))
+	return p.LatestPosition(ctx)
 }
 
 func (p *DeviceListStreamProvider) IncrementalSync(

--- a/syncapi/streams/stream_pdu.go
+++ b/syncapi/streams/stream_pdu.go
@@ -11,8 +11,14 @@ import (
 	"go.uber.org/atomic"
 )
 
-const PDU_STREAM_QUEUESIZE = 2048
+// The max number of per-room goroutines to have running.
+// Too high and this will consume lots of CPU, too low and complete
+// sync responses will take longer to process.
 const PDU_STREAM_WORKERS = 256
+
+// The maximum number of tasks that can be queued in total before
+// backpressure will build up and the rests will start to block.
+const PDU_STREAM_QUEUESIZE = PDU_STREAM_WORKERS * 8
 
 type PDUStreamProvider struct {
 	StreamProvider

--- a/syncapi/streams/stream_pdu.go
+++ b/syncapi/streams/stream_pdu.go
@@ -2,6 +2,7 @@ package streams
 
 import (
 	"context"
+	"sync"
 
 	"github.com/matrix-org/dendrite/syncapi/types"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
@@ -54,7 +55,7 @@ func (p *PDUStreamProvider) CompleteSync(
 	// Build up a /sync response. Add joined rooms.
 	var reqMutex sync.Mutex
 	var reqWaitGroup sync.WaitGroup
-	reqWaitGroup.add(len(joinedRooms))
+	reqWaitGroup.Add(len(joinedRooms))
 	for _, roomID := range joinedRoomIDs {
 		go func() {
 			defer reqWaitGroup.Done()
@@ -64,7 +65,7 @@ func (p *PDUStreamProvider) CompleteSync(
 			)
 			if err != nil {
 				req.Log.WithError(err).Error("p.getJoinResponseForCompleteSync failed")
-				return from
+				return //from
 			}
 			reqMutex.Lock()
 			defer reqMutex.Unlock()

--- a/syncapi/streams/stream_pdu.go
+++ b/syncapi/streams/stream_pdu.go
@@ -55,9 +55,9 @@ func (p *PDUStreamProvider) CompleteSync(
 	// Build up a /sync response. Add joined rooms.
 	var reqMutex sync.Mutex
 	var reqWaitGroup sync.WaitGroup
-	reqWaitGroup.Add(len(joinedRooms))
+	reqWaitGroup.Add(len(joinedRoomIDs))
 	for _, roomID := range joinedRoomIDs {
-		go func() {
+		go func(roomID string) {
 			defer reqWaitGroup.Done()
 			var jr *types.JoinResponse
 			jr, err = p.getJoinResponseForCompleteSync(
@@ -71,7 +71,7 @@ func (p *PDUStreamProvider) CompleteSync(
 			defer reqMutex.Unlock()
 			req.Response.Rooms.Join[roomID] = *jr
 			req.Rooms[roomID] = gomatrixserverlib.Join
-		}()
+		}(roomID)
 	}
 
 	// Add peeked rooms.

--- a/syncapi/streams/stream_pdu.go
+++ b/syncapi/streams/stream_pdu.go
@@ -11,8 +11,8 @@ import (
 	"go.uber.org/atomic"
 )
 
-const COMPLETE_SYNC_QUEUE = 2048
-const COMPLETE_SYNC_WORKERS = 256
+const PDU_STREAM_QUEUESIZE = 2048
+const PDU_STREAM_WORKERS = 256
 
 type PDUStreamProvider struct {
 	StreamProvider
@@ -34,17 +34,16 @@ func (p *PDUStreamProvider) worker() {
 }
 
 func (p *PDUStreamProvider) queue(f func()) {
-	p.tasks <- f
-	if p.workers.Load() < COMPLETE_SYNC_WORKERS {
+	if p.workers.Load() < PDU_STREAM_WORKERS {
 		p.workers.Inc()
 		go p.worker()
 	}
+	p.tasks <- f
 }
 
 func (p *PDUStreamProvider) Setup() {
 	p.StreamProvider.Setup()
-
-	p.tasks = make(chan func(), COMPLETE_SYNC_QUEUE)
+	p.tasks = make(chan func(), PDU_STREAM_QUEUESIZE)
 
 	p.latestMutex.Lock()
 	defer p.latestMutex.Unlock()

--- a/syncapi/streams/stream_typing.go
+++ b/syncapi/streams/stream_typing.go
@@ -18,7 +18,7 @@ func (p *TypingStreamProvider) CompleteSync(
 	ctx context.Context,
 	req *types.SyncRequest,
 ) types.StreamPosition {
-	return p.IncrementalSync(ctx, req, 0, p.LatestPosition(ctx))
+	return p.LatestPosition(ctx)
 }
 
 func (p *TypingStreamProvider) IncrementalSync(

--- a/syncapi/streams/stream_typing.go
+++ b/syncapi/streams/stream_typing.go
@@ -18,7 +18,7 @@ func (p *TypingStreamProvider) CompleteSync(
 	ctx context.Context,
 	req *types.SyncRequest,
 ) types.StreamPosition {
-	return p.LatestPosition(ctx)
+	return p.IncrementalSync(ctx, req, 0, p.LatestPosition(ctx))
 }
 
 func (p *TypingStreamProvider) IncrementalSync(


### PR DESCRIPTION
This improves complete sync performance by:

* Adding a global pool of 256 workers into the PDU stream provider and handling rooms in parallel
* Not sending device list updates when not needed