### PR TITLE
Remove redundant membership check

### DIFF
--- a/roomserver/internal/input/input_membership.go
+++ b/roomserver/internal/input/input_membership.go
@@ -107,13 +107,6 @@ func (r *Inputer) updateMembership(
 		return updates, nil
 	}
 
-	if add == nil {
-		// This can happen when we have rejoined a room and suddenly we have a
-		// divergence between the former state and the new one. We don't want to
-		// act on removals and apparently there are no adds, so stop here.
-		return updates, nil
-	}
-
 	mu, err := updater.MembershipUpdater(targetUserNID, r.isLocalTarget(add))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This check was added quite early on when there were problems with the forward extremities and room state, so the check stopped the membership table getting mangled when Dendrite was unexpectedly trying to nuke lots of room state.

I no longer think this is needed now that the room state stuff is largely better, and probably is the result of why the membership table can get out of sync on odd occasions.