### PR TITLE
Gradually evict oldest cache entries

### DIFF
--- a/internal/caching/impl_inmemorylru.go
+++ b/internal/caching/impl_inmemorylru.go
@@ -93,7 +93,12 @@ func cacheCleaner(caches ...*InMemoryLRUCachePartition) {
 	for {
 		time.Sleep(time.Minute)
 		for _, cache := range caches {
-			cache.lru.RemoveOldest()
+			// Hold onto the last 10% of the cache entries, since
+			// otherwise a quiet period might cause us to evict all
+			// cache entries entirely.
+			if cache.lru.Len() > cache.maxEntries/10 {
+				cache.lru.RemoveOldest()
+			}
 		}
 	}
 }


### PR DESCRIPTION
Right now, when a cache grows, it never ever shrinks again, so the baseline memory usage of the Dendrite process creeps up over time.

This PR just ticks over once per minute and evicts the oldest item from each cache, so we have a chance to reclaim some of that memory for things that haven't been hit in a while.