### PR TITLE
Don't hold destination queues in memory forever

### DIFF
--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -159,10 +159,6 @@ func (oq *destinationQueue) sendEDU(event *gomatrixserverlib.EDU, receipt *share
 // then we will interrupt the backoff, causing any federation
 // requests to retry.
 func (oq *destinationQueue) wakeQueueIfNeeded() {
-	// If the destination is blacklisted then do nothing.
-	if _, blacklisted := oq.statistics.BackoffInfo(); blacklisted {
-		return
-	}
 	// If we are backing off then interrupt the backoff.
 	if oq.backingOff.CAS(true, false) {
 		oq.interruptBackoff <- true

--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -247,6 +247,7 @@ func (oq *destinationQueue) backgroundSend() {
 	}
 	destinationQueueRunning.Inc()
 	defer destinationQueueRunning.Dec()
+	defer oq.queues.clearQueue(oq.destination)
 	defer oq.running.Store(false)
 
 	// Mark the queue as overflowed, so we will consult the database
@@ -271,7 +272,6 @@ func (oq *destinationQueue) backgroundSend() {
 			// The worker is idle so stop the goroutine. It'll get
 			// restarted automatically the next time we have an event to
 			// send.
-			oq.queues.clearQueue(oq.destination)
 			return
 		}
 

--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -46,6 +46,7 @@ const (
 // ensures that only one request is in flight to a given destination
 // at a time.
 type destinationQueue struct {
+	queues             *OutgoingQueues
 	db                 storage.Database
 	process            *process.ProcessContext
 	signing            *SigningInfo
@@ -270,6 +271,7 @@ func (oq *destinationQueue) backgroundSend() {
 			// The worker is idle so stop the goroutine. It'll get
 			// restarted automatically the next time we have an event to
 			// send.
+			oq.queues.clearQueue(oq.destination)
 			return
 		}
 

--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -247,7 +247,7 @@ func (oq *destinationQueue) backgroundSend() {
 	}
 	destinationQueueRunning.Inc()
 	defer destinationQueueRunning.Dec()
-	defer oq.queues.clearQueue(oq.destination)
+	defer oq.queues.clearQueue(oq)
 	defer oq.running.Store(false)
 
 	// Mark the queue as overflowed, so we will consult the database

--- a/federationsender/queue/destinationqueue.go
+++ b/federationsender/queue/destinationqueue.go
@@ -159,6 +159,10 @@ func (oq *destinationQueue) sendEDU(event *gomatrixserverlib.EDU, receipt *share
 // then we will interrupt the backoff, causing any federation
 // requests to retry.
 func (oq *destinationQueue) wakeQueueIfNeeded() {
+	// If the destination is blacklisted then do nothing.
+	if _, blacklisted := oq.statistics.BackoffInfo(); blacklisted {
+		return
+	}
 	// If we are backing off then interrupt the backoff.
 	if oq.backingOff.CAS(true, false) {
 		oq.interruptBackoff <- true

--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -167,6 +167,7 @@ func (oqs *OutgoingQueues) getQueue(destination gomatrixserverlib.ServerName) *d
 			signing:          oqs.signing,
 		}
 		oqs.queues[destination] = oq
+		oq.wakeQueueIfNeeded()
 	}
 	return oq
 }

--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -171,15 +171,14 @@ func (oqs *OutgoingQueues) getQueue(destination gomatrixserverlib.ServerName) *d
 	return oq
 }
 
-func (oqs *OutgoingQueues) clearQueue(destination gomatrixserverlib.ServerName) {
+func (oqs *OutgoingQueues) clearQueue(oq *destinationQueue) {
 	oqs.queuesMutex.Lock()
 	defer oqs.queuesMutex.Unlock()
-	if oq, ok := oqs.queues[destination]; ok {
-		close(oq.notify)
-		close(oq.interruptBackoff)
-		delete(oqs.queues, destination)
-		destinationQueueTotal.Dec()
-	}
+
+	close(oq.notify)
+	close(oq.interruptBackoff)
+	delete(oqs.queues, oq.destination)
+	destinationQueueTotal.Dec()
 }
 
 type ErrorFederationDisabled struct {

--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -183,6 +183,8 @@ func (oqs *OutgoingQueues) clearQueue(destination gomatrixserverlib.ServerName) 
 	case oq.backingOff.Load():
 		return
 	}
+	close(oq.notify)
+	close(oq.interruptBackoff)
 	delete(oqs.queues, destination)
 	destinationQueueTotal.Dec()
 }

--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -148,13 +148,13 @@ type queuedEDU struct {
 }
 
 func (oqs *OutgoingQueues) getQueue(destination gomatrixserverlib.ServerName) *destinationQueue {
-	if _, blacklisted := oqs.statistics.ForServer(destination).BackoffInfo(); blacklisted {
+	if oqs.statistics.ForServer(destination).Blacklisted() {
 		return nil
 	}
 	oqs.queuesMutex.Lock()
 	defer oqs.queuesMutex.Unlock()
-	oq := oqs.queues[destination]
-	if oq == nil {
+	oq, ok := oqs.queues[destination]
+	if !ok {
 		destinationQueueTotal.Inc()
 		oq = &destinationQueue{
 			queues:           oqs,

--- a/federationsender/queue/queue.go
+++ b/federationsender/queue/queue.go
@@ -174,9 +174,8 @@ func (oqs *OutgoingQueues) getQueue(destination gomatrixserverlib.ServerName) *d
 
 func (oqs *OutgoingQueues) clearQueues() {
 	oqs.queuesMutex.Lock()
-	queues := oqs.queues
-	oqs.queuesMutex.Unlock()
-	for _, q := range queues {
+	defer oqs.queuesMutex.Unlock()
+	for _, q := range oqs.queues {
 		oqs.clearQueue(q)
 	}
 	time.AfterFunc(time.Minute, oqs.clearQueues)
@@ -191,7 +190,6 @@ func (oqs *OutgoingQueues) clearQueue(oq *destinationQueue) {
 	case oq.backingOff.Load():
 		return
 	}
-
 	close(oq.notify)
 	close(oq.interruptBackoff)
 	delete(oqs.queues, oq.destination)


### PR DESCRIPTION
 Today, once a queue is started, the struct is held forever, which increases the baseline memory usage of Dendrite.

This PR updates the destination queues in the federation sender so that we clear them from memory unless the queue is actually running or backing off.