### PR TITLE
Don't return error when account conflict is handled gracefully

### DIFF
--- a/userapi/internal/api.go
+++ b/userapi/internal/api.go
@@ -87,7 +87,7 @@ func (a *UserInternalAPI) PerformAccountCreation(ctx context.Context, req *api.P
 			ServerName:   a.ServerName,
 			UserID:       fmt.Sprintf("@%s:%s", req.Localpart, a.ServerName),
 		}
-		return err
+		return nil
 	}
 
 	if err = a.AccountDB.SetDisplayName(ctx, req.Localpart, req.Localpart); err != nil {


### PR DESCRIPTION
I suspect this will be sufficient to fix #1780. I've tested it locally with SQLite and it still successfully handles duplicate account registration properly.