### PR TITLE
Add CORS to nginx config

### DIFF
--- a/docs/nginx/monolith-sample.conf
+++ b/docs/nginx/monolith-sample.conf
@@ -16,6 +16,9 @@ server {
     }
 
     location /.well-known/matrix/client {
+        # If your sever_name here doesn't match your matrix homeserver URL
+        # (e.g. hostname.com as server_name and matrix.hostname.com as homeserver URL)
+        # add_header Access-Control-Allow-Origin '*';
         return 200 '{ "m.homeserver": { "base_url": "https://my.hostname.com" } }';
     }
 

--- a/docs/nginx/polylith-sample.conf
+++ b/docs/nginx/polylith-sample.conf
@@ -16,6 +16,9 @@ server {
     }
 
     location /.well-known/matrix/client {
+        # If your sever_name here doesn't match your matrix homeserver URL
+        # (e.g. hostname.com as server_name and matrix.hostname.com as homeserver URL)
+        # add_header Access-Control-Allow-Origin '*';
         return 200 '{ "m.homeserver": { "base_url": "https://my.hostname.com" } }';
     }
 


### PR DESCRIPTION
Without this entry, setups where users have the homeserver on the URL
matrix.myurl.com but want the servername to be myurl.com don't work by default
since clients like element.io can't connect to the homeserver