### PR TITLE
Fix database default connection limits for CI

### DIFF
--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -240,7 +240,7 @@ media_api:
     listen: http://[::]:8074
   database:
     connection_string: file:mediaapi.db
-    max_open_conns: 10
+    max_open_conns: 5
     max_idle_conns: 2
     conn_max_lifetime: -1
 
@@ -278,7 +278,7 @@ mscs:
   mscs: []
   database:
     connection_string: file:mscs.db
-    max_open_conns: 10
+    max_open_conns: 5
     max_idle_conns: 2
     conn_max_lifetime: -1
 

--- a/setup/config/config_appservice.go
+++ b/setup/config/config_appservice.go
@@ -43,7 +43,7 @@ type AppServiceAPI struct {
 func (c *AppServiceAPI) Defaults() {
 	c.InternalAPI.Listen = "http://localhost:7777"
 	c.InternalAPI.Connect = "http://localhost:7777"
-	c.Database.Defaults()
+	c.Database.Defaults(10)
 	c.Database.ConnectionString = "file:appservice.db"
 }
 

--- a/setup/config/config_federationsender.go
+++ b/setup/config/config_federationsender.go
@@ -25,7 +25,7 @@ type FederationSender struct {
 func (c *FederationSender) Defaults() {
 	c.InternalAPI.Listen = "http://localhost:7775"
 	c.InternalAPI.Connect = "http://localhost:7775"
-	c.Database.Defaults()
+	c.Database.Defaults(10)
 	c.Database.ConnectionString = "file:federationsender.db"
 
 	c.FederationMaxRetries = 16

--- a/setup/config/config_global.go
+++ b/setup/config/config_global.go
@@ -122,8 +122,8 @@ type DatabaseOptions struct {
 	ConnMaxLifetimeSeconds int `yaml:"conn_max_lifetime"`
 }
 
-func (c *DatabaseOptions) Defaults() {
-	c.MaxOpenConnections = 100
+func (c *DatabaseOptions) Defaults(conns int) {
+	c.MaxOpenConnections = conns
 	c.MaxIdleConnections = 2
 	c.ConnMaxLifetimeSeconds = -1
 }

--- a/setup/config/config_kafka.go
+++ b/setup/config/config_kafka.go
@@ -36,7 +36,7 @@ func (k *Kafka) TopicFor(name string) string {
 
 func (c *Kafka) Defaults() {
 	c.UseNaffka = true
-	c.Database.Defaults()
+	c.Database.Defaults(10)
 	c.Addresses = []string{"localhost:2181"}
 	c.Database.ConnectionString = DataSource("file:naffka.db")
 	c.TopicPrefix = "Dendrite"

--- a/setup/config/config_keyserver.go
+++ b/setup/config/config_keyserver.go
@@ -11,7 +11,7 @@ type KeyServer struct {
 func (c *KeyServer) Defaults() {
 	c.InternalAPI.Listen = "http://localhost:7779"
 	c.InternalAPI.Connect = "http://localhost:7779"
-	c.Database.Defaults()
+	c.Database.Defaults(10)
 	c.Database.ConnectionString = "file:keyserver.db"
 }
 

--- a/setup/config/config_mediaapi.go
+++ b/setup/config/config_mediaapi.go
@@ -39,7 +39,7 @@ func (c *MediaAPI) Defaults() {
 	c.InternalAPI.Listen = "http://localhost:7774"
 	c.InternalAPI.Connect = "http://localhost:7774"
 	c.ExternalAPI.Listen = "http://[::]:8074"
-	c.Database.Defaults()
+	c.Database.Defaults(5)
 	c.Database.ConnectionString = "file:mediaapi.db"
 
 	defaultMaxFileSizeBytes := FileSizeBytes(10485760)

--- a/setup/config/config_mscs.go
+++ b/setup/config/config_mscs.go
@@ -14,7 +14,7 @@ type MSCs struct {
 }
 
 func (c *MSCs) Defaults() {
-	c.Database.Defaults()
+	c.Database.Defaults(5)
 	c.Database.ConnectionString = "file:mscs.db"
 }
 

--- a/setup/config/config_roomserver.go
+++ b/setup/config/config_roomserver.go
@@ -11,7 +11,7 @@ type RoomServer struct {
 func (c *RoomServer) Defaults() {
 	c.InternalAPI.Listen = "http://localhost:7770"
 	c.InternalAPI.Connect = "http://localhost:7770"
-	c.Database.Defaults()
+	c.Database.Defaults(10)
 	c.Database.ConnectionString = "file:roomserver.db"
 }
 

--- a/setup/config/config_signingkeyserver.go
+++ b/setup/config/config_signingkeyserver.go
@@ -22,7 +22,7 @@ type SigningKeyServer struct {
 func (c *SigningKeyServer) Defaults() {
 	c.InternalAPI.Listen = "http://localhost:7780"
 	c.InternalAPI.Connect = "http://localhost:7780"
-	c.Database.Defaults()
+	c.Database.Defaults(10)
 	c.Database.ConnectionString = "file:signingkeyserver.db"
 }
 

--- a/setup/config/config_syncapi.go
+++ b/setup/config/config_syncapi.go
@@ -15,7 +15,7 @@ func (c *SyncAPI) Defaults() {
 	c.InternalAPI.Listen = "http://localhost:7773"
 	c.InternalAPI.Connect = "http://localhost:7773"
 	c.ExternalAPI.Listen = "http://localhost:8073"
-	c.Database.Defaults()
+	c.Database.Defaults(10)
 	c.Database.ConnectionString = "file:syncapi.db"
 }
 

--- a/setup/config/config_userapi.go
+++ b/setup/config/config_userapi.go
@@ -16,8 +16,8 @@ type UserAPI struct {
 func (c *UserAPI) Defaults() {
 	c.InternalAPI.Listen = "http://localhost:7781"
 	c.InternalAPI.Connect = "http://localhost:7781"
-	c.AccountDatabase.Defaults()
-	c.DeviceDatabase.Defaults()
+	c.AccountDatabase.Defaults(10)
+	c.DeviceDatabase.Defaults(10)
 	c.AccountDatabase.ConnectionString = "file:userapi_accounts.db"
 	c.DeviceDatabase.ConnectionString = "file:userapi_devices.db"
 }


### PR DESCRIPTION
We seemingly did a reasonable job at fixing this in `dendrite-config.yaml` but not in the `generate-config` defaults, so CI was exceeding the 100 configured connections for Postgres.