### PR TITLE
Inhibit login for AS users

### DIFF
--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -725,7 +725,7 @@ func handleApplicationServiceRegistration(
 	// application service registration is entirely separate.
 	return completeRegistration(
 		req.Context(), userAPI, r.Username, "", appserviceID, req.RemoteAddr, req.UserAgent(),
-		r.InhibitLogin, r.InitialDisplayName, r.DeviceID,
+		true, r.InitialDisplayName, r.DeviceID,
 	)
 }
 


### PR DESCRIPTION
As per matrix-org/matrix-doc#2917, so that we don't go creating access tokens for those users.