### PR TITLE
device lists: backoff for longer if the wrong error type is returned

### DIFF
--- a/keyserver/internal/device_list_update.go
+++ b/keyserver/internal/device_list_update.go
@@ -347,6 +347,9 @@ func (u *DeviceListUpdater) processServer(serverName gomatrixserverlib.ServerNam
 				} else if fcerr.Blacklisted {
 					waitTime = time.Hour * 8
 				}
+			} else {
+				waitTime = time.Hour
+				logger.WithError(err).Warn("GetUserDevices returned unknown error type")
 			}
 			hasFailures = true
 			continue


### PR DESCRIPTION
I've noticed that sometimes the device list updater retries blacklisted servers every 2s (which is the default `waitTime`) - now we will default to 1 hour if the type assertion fails. Log when this happens so we can figure out why/if this even does anything.