### PR TITLE
Document need for max-body-size change in reverse proxy as well

### DIFF
--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -248,7 +248,8 @@ media_api:
   base_path: ./media_store
 
   # The maximum allowed file size (in bytes) for media uploads to this homeserver
-  # (0 = unlimited).
+  # (0 = unlimited). If using a reverse proxy, ensure it allows requests at
+  # least this large (e.g. client_max_body_size in nginx.)
   max_file_size_bytes: 10485760
 
   # Whether to dynamically generate thumbnails if needed.


### PR DESCRIPTION
Just changing the Media API's `max_file_size_bytes` isn't enough if Dendrite is running behind a proxy; document the need for a proxy config change in the place the admin is most likely to notice it.

### Pull Request Checklist

* [x] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: Tim McCormack <cortex@brainonfire.net>