### PR TITLE
Move room mutex in federation API

### DIFF
--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -498,8 +498,6 @@ func (t *txnReq) getServers(ctx context.Context, roomID string) []gomatrixserver
 }
 
 func (t *txnReq) processEvent(ctx context.Context, e *gomatrixserverlib.Event) error {
-	t.roomsMu.Lock(e.RoomID())
-	defer t.roomsMu.Unlock(e.RoomID())
 	logger := util.GetLogger(ctx).WithField("event_id", e.EventID()).WithField("room_id", e.RoomID())
 	t.work = "" // reset from previous event
 
@@ -718,7 +716,9 @@ func (t *txnReq) processEventWithMissingState(
 			respStates[i] = states[i].RespState
 		}
 		// There's more than one previous state - run them all through state res
+		t.roomsMu.Lock(e.RoomID())
 		resolvedState, err = t.resolveStatesAndCheck(gmectx, roomVersion, respStates, backwardsExtremity)
+		t.roomsMu.Unlock(e.RoomID())
 		if err != nil {
 			util.GetLogger(ctx).WithError(err).Errorf("Failed to resolve state conflicts for event %s", backwardsExtremity.EventID())
 			return err

--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -621,8 +621,6 @@ func checkAllowedByState(e *gomatrixserverlib.Event, stateEvents []*gomatrixserv
 func (t *txnReq) processEventWithMissingState(
 	ctx context.Context, e *gomatrixserverlib.Event, roomVersion gomatrixserverlib.RoomVersion,
 ) error {
-	t.roomsMu.Lock(e.RoomID())
-	defer t.roomsMu.Unlock(e.RoomID())
 	// Do this with a fresh context, so that we keep working even if the
 	// original request times out. With any luck, by the time the remote
 	// side retries, we'll have fetched the missing state.
@@ -718,7 +716,9 @@ func (t *txnReq) processEventWithMissingState(
 			respStates[i] = states[i].RespState
 		}
 		// There's more than one previous state - run them all through state res
+		t.roomsMu.Lock(e.RoomID())
 		resolvedState, err = t.resolveStatesAndCheck(gmectx, roomVersion, respStates, backwardsExtremity)
+		t.roomsMu.Unlock(e.RoomID())
 		if err != nil {
 			util.GetLogger(ctx).WithError(err).Errorf("Failed to resolve state conflicts for event %s", backwardsExtremity.EventID())
 			return err


### PR DESCRIPTION
This moves the mutex to surround `resolveStatesAndCheck`, otherwise we will end up stacking up lots of goroutines for events that don't require state resolution.