### PR TITLE
Remove the Content-Length requirement on upload request

### DIFF
--- a/mediaapi/routing/upload.go
+++ b/mediaapi/routing/upload.go
@@ -221,12 +221,6 @@ func (r *uploadRequest) doUpload(
 
 // Validate validates the uploadRequest fields
 func (r *uploadRequest) Validate(maxFileSizeBytes config.FileSizeBytes) *util.JSONResponse {
-	if r.MediaMetadata.FileSizeBytes < 1 {
-		return &util.JSONResponse{
-			Code: http.StatusLengthRequired,
-			JSON: jsonerror.Unknown("HTTP Content-Length request header must be greater than zero."),
-		}
-	}
 	if maxFileSizeBytes > 0 && r.MediaMetadata.FileSizeBytes > types.FileSizeBytes(maxFileSizeBytes) {
 		return &util.JSONResponse{
 			Code: http.StatusRequestEntityTooLarge,

--- a/mediaapi/routing/upload.go
+++ b/mediaapi/routing/upload.go
@@ -158,8 +158,8 @@ func (r *uploadRequest) doUpload(
 		}
 	}
 
-	// If Content-Length header is not set, check if temp file size exceeds max file size configuration
-	if r.MediaMetadata.FileSizeBytes < 1 && bytesWritten > types.FileSizeBytes(*cfg.MaxFileSizeBytes) {
+	// Check if temp file size exceeds max file size configuration
+	if bytesWritten > types.FileSizeBytes(*cfg.MaxFileSizeBytes) {
 		fileutils.RemoveDir(tmpDir, r.Logger) // delete temp file
 		return requestEntityTooLargeJSONResponse(*cfg.MaxFileSizeBytes)
 	}

--- a/mediaapi/routing/upload.go
+++ b/mediaapi/routing/upload.go
@@ -158,6 +158,12 @@ func (r *uploadRequest) doUpload(
 		}
 	}
 
+	// If Content-Length header is not set, check if temp file size exceeds max file size configuration
+	if r.MediaMetadata.FileSizeBytes < 1 && bytesWritten > types.FileSizeBytes(*cfg.MaxFileSizeBytes) {
+		fileutils.RemoveDir(tmpDir, r.Logger) // delete temp file
+		return requestEntityTooLargeJSONResponse(*cfg.MaxFileSizeBytes)
+	}
+
 	// Look up the media by the file hash. If we already have the file but under a
 	// different media ID then we won't upload the file again - instead we'll just
 	// add a new metadata entry that refers to the same file.
@@ -219,13 +225,17 @@ func (r *uploadRequest) doUpload(
 	)
 }
 
+func requestEntityTooLargeJSONResponse(maxFileSizeBytes config.FileSizeBytes) *util.JSONResponse {
+	return &util.JSONResponse{
+		Code: http.StatusRequestEntityTooLarge,
+		JSON: jsonerror.Unknown(fmt.Sprintf("HTTP Content-Length is greater than the maximum allowed upload size (%v).", maxFileSizeBytes)),
+	}
+}
+
 // Validate validates the uploadRequest fields
 func (r *uploadRequest) Validate(maxFileSizeBytes config.FileSizeBytes) *util.JSONResponse {
 	if maxFileSizeBytes > 0 && r.MediaMetadata.FileSizeBytes > types.FileSizeBytes(maxFileSizeBytes) {
-		return &util.JSONResponse{
-			Code: http.StatusRequestEntityTooLarge,
-			JSON: jsonerror.Unknown(fmt.Sprintf("HTTP Content-Length is greater than the maximum allowed upload size (%v).", maxFileSizeBytes)),
-		}
+		return requestEntityTooLargeJSONResponse(maxFileSizeBytes)
 	}
 	// TODO: Check if the Content-Type is a valid type?
 	if r.MediaMetadata.ContentType == "" {


### PR DESCRIPTION
The requirement for Content-Length header in upload requests can be relaxed because we can fallback to temporary file size to make sure it does not exceed the configured max content size.

Resolves #1825

Signed-off-by: `Frantisek Hetes f.hetes@gmail.com`
