### PR TITLE
Remove the 'Content-Type' request header requirement

### DIFF
--- a/mediaapi/routing/upload.go
+++ b/mediaapi/routing/upload.go
@@ -233,13 +233,6 @@ func (r *uploadRequest) Validate(maxFileSizeBytes config.FileSizeBytes) *util.JS
 			JSON: jsonerror.Unknown(fmt.Sprintf("HTTP Content-Length is greater than the maximum allowed upload size (%v).", maxFileSizeBytes)),
 		}
 	}
-	// TODO: Check if the Content-Type is a valid type?
-	if r.MediaMetadata.ContentType == "" {
-		return &util.JSONResponse{
-			Code: http.StatusBadRequest,
-			JSON: jsonerror.Unknown("HTTP Content-Type request header must be set."),
-		}
-	}
 	if strings.HasPrefix(string(r.MediaMetadata.UploadName), "~") {
 		return &util.JSONResponse{
 			Code: http.StatusBadRequest,


### PR DESCRIPTION
### Pull Request Checklist

The requirement for `Content-Type` header in upload requests does not seem to be necessary for the request so succeed and it's removal allows the iOS Matrix client SDK to upload video content.

Resolves #1833 

Signed-off-by: `Frantisek Hetes f.hetes@gmail.com`
