### PR TITLE
Appservice config: handle regexp parsing errors

### DIFF
--- a/setup/config/config_appservice.go
+++ b/setup/config/config_appservice.go
@@ -226,7 +226,6 @@ func setupRegexps(asAPI *AppServiceAPI, derived *Derived) (err error) {
 			case "aliases":
 				err = appendExclusiveNamespaceRegexs(&exclusiveAliasStrings, namespaceSlice)
 			}
-
 			if err != nil {
 				return fmt.Errorf("invalid regex in appservice %q, namespace %q: %w", appservice.ID, key, err)
 			}


### PR DESCRIPTION
This pull request adds the missing error checks for parsing AppService configs. Prior to this change, regexp usage would result in a server segfault.

### Pull Request Checklist

* [x] `sytest-whitelist` not applicable.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off).

Signed-off-by: `diamondburned <datutbrus@gmail.com>`
