### PR TITLE
Implement registering with an email support

### DIFF
--- a/clientapi/auth/authtypes/flow.go
+++ b/clientapi/auth/authtypes/flow.go
@@ -17,5 +17,5 @@ package authtypes
 // Flow represents one possible way that the client can authenticate a request.
 // https://matrix.org/docs/spec/client_server/r0.3.0.html#user-interactive-authentication-api
 type Flow struct {
-	Stages []LoginType `json:"stages" yaml:"stages`
+	Stages []LoginType `json:"stages" yaml:"stages"`
 }

--- a/clientapi/auth/authtypes/flow.go
+++ b/clientapi/auth/authtypes/flow.go
@@ -17,5 +17,5 @@ package authtypes
 // Flow represents one possible way that the client can authenticate a request.
 // https://matrix.org/docs/spec/client_server/r0.3.0.html#user-interactive-authentication-api
 type Flow struct {
-	Stages []LoginType `json:"stages"`
+	Stages []LoginType `json:"stages" yaml:"stages`
 }

--- a/clientapi/auth/authtypes/interactive_auth.go
+++ b/clientapi/auth/authtypes/interactive_auth.go
@@ -1,0 +1,27 @@
+// Copyright Piotr Kozimor <piotr.kozimor@globekeeper.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authtypes
+
+type InteractiveAuth struct {
+	// Flows is a slice of flows, which represent one possible way that the client can authenticate a request.
+	// http://matrix.org/docs/spec/HEAD/client_server/r0.3.0.html#user-interactive-authentication-api
+	// As long as the generated flows only rely on config file options,
+	// we can generate them on startup and store them until needed
+	Flows []Flow `json:"flows"`
+
+	// Params that need to be returned to the client during
+	// registration in order to complete registration stages.
+	Params map[string]interface{} `json:"params"`
+}

--- a/clientapi/auth/authtypes/logintypes.go
+++ b/clientapi/auth/authtypes/logintypes.go
@@ -10,4 +10,5 @@ const (
 	LoginTypeSharedSecret       = "org.matrix.login.shared_secret"
 	LoginTypeRecaptcha          = "m.login.recaptcha"
 	LoginTypeApplicationService = "m.login.application_service"
+	LoginTypeEmailIdentity      = "m.login.email.identity"
 )

--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -823,7 +823,7 @@ func checkAndCompleteFlow(
 	cfg *config.ClientAPI,
 	userAPI userapi.UserInternalAPI,
 ) util.JSONResponse {
-	if checkFlowCompleted(flow, cfg.Derived.Registration.Flows) {
+	if checkFlowCompleted(flow, cfg.Registration.Flows) {
 		// This flow was completed, registration can continue
 		return completeRegistration(
 			req.Context(), userAPI, r.Username, r.Password, "", req.RemoteAddr, req.UserAgent(),
@@ -836,7 +836,7 @@ func checkAndCompleteFlow(
 	return util.JSONResponse{
 		Code: http.StatusUnauthorized,
 		JSON: newUserInteractiveResponse(sessionID,
-			cfg.Derived.Registration.Flows, cfg.Derived.Registration.Params),
+			cfg.Registration.Flows, cfg.Registration.Params),
 	}
 }
 

--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -356,7 +356,7 @@ func validateEmailIdentity(
 	cred *threepidCreds,
 ) *util.JSONResponse {
 	url := fmt.Sprintf(
-		"https://%s/_matrix/identity/v2/3pid/getValidated3pid",
+		"https://%s/_matrix/identity/api/v1/3pid/getValidated3pid",
 		cred.IdServer)
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
@@ -1156,14 +1156,13 @@ func requestEmailTokenFromIdServer(
 		ctx,
 		"POST",
 		fmt.Sprintf(
-			"https://%s/_matrix/identity/v2/validate/email/requestToken",
+			"https://%s/_matrix/identity/api/v1/validate/email/requestToken",
 			idServer),
 		&b)
 	if err != nil {
 		util.GetLogger(ctx).WithError(err).Error("http.NewRequestWithContext failed")
 		return jsonerror.InternalServerError()
 	}
-	idReq.Header.Add("Authentication", "Bearer "+idAccessToken)
 	idReq.Header.Add("Content-Type", "application/json")
 	idResp, err := client.Do(idReq)
 	if err != nil {

--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -348,7 +348,12 @@ func validateEmailIdentity(
 			JSON: jsonerror.Unknown("failed conecting to identity server"),
 		}
 	}
-	defer resp.Body.Close()
+	defer func() {
+		err = resp.Body.Close()
+		if err != nil {
+			util.GetLogger(ctx).WithError(err).Error("validateEmailIdentity: unable to close response body")
+		}
+	}()
 	switch resp.StatusCode {
 	case 404:
 		return &util.JSONResponse{

--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -1153,8 +1153,8 @@ func requestEmailTokenFromIdServer(
 		util.GetLogger(ctx).WithError(err).Error("enc.Encode failed")
 		return jsonerror.InternalServerError()
 	}
-	idReq, err := http.NewRequest(
-		// ctx,
+	idReq, err := http.NewRequestWithContext(
+		ctx,
 		"POST",
 		fmt.Sprintf(
 			"https://%s/_matrix/identity/v2/validate/email/requestToken",
@@ -1166,8 +1166,6 @@ func requestEmailTokenFromIdServer(
 	}
 	idReq.Header.Add("Authentication", "Bearer "+idAccessToken)
 	idReq.Header.Add("Content-Type", "application/json")
-	// util.GetLogger(ctx).WithError(err).Warnf("buffer %s")
-	// io.Copy(os.Stdout, &b)
 	idResp, err := client.Do(idReq)
 	if err != nil {
 		util.GetLogger(ctx).WithError(err).Errorf("failed to connect to identity server %s", idServer)

--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -769,7 +769,7 @@ func handleRegistrationFlow(
 		if err := validateEmailIdentity(req.Context(), r.Auth.ThreePidCreds); err != nil {
 			return *err
 		}
-		AddCompletedSessionStage(sessionID, authtypes.LoginTypeApplicationService)
+		AddCompletedSessionStage(sessionID, authtypes.LoginTypeEmailIdentity)
 
 	case "":
 		// An empty auth type means that we want to fetch the available

--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -354,7 +354,6 @@ func validateRecaptcha(
 func validateEmailIdentity(
 	ctx context.Context,
 	cred *threepidCreds,
-	// cfg *config.ClientAPI,
 ) *util.JSONResponse {
 	url := fmt.Sprintf(
 		"https://%s/_matrix/identity/v2/3pid/getValidated3pid",

--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -144,15 +144,6 @@ type registerRequest struct {
 	Type authtypes.LoginType `json:"type"`
 }
 
-type registerEmailRequestTokenRequest struct {
-	ClientSecret  string `json:"client_secret"`
-	Email         string `json:"email"`
-	IdAccessToken string `json:"id_access_token,omitempty"`
-	IdServer      string `json:"id_server,omitempty"`
-	NextLink      string `json:"next_link"`
-	SendAttempt   int    `json:"send_attempt"`
-}
-
 type authDict struct {
 	Type    authtypes.LoginType         `json:"type"`
 	Session string                      `json:"session"`
@@ -199,11 +190,6 @@ type recaptchaResponse struct {
 	ChallengeTS time.Time `json:"challenge_ts"`
 	Hostname    string    `json:"hostname"`
 	ErrorCodes  []int     `json:"error-codes"`
-}
-
-// server response for
-type registerEmailRequestTokenResponse struct {
-	Sid string `json:"sid"`
 }
 
 // validateUsername returns an error response if the username is invalid

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -312,6 +312,13 @@ func Setup(
 		return RegisterAvailable(req, cfg, accountDB)
 	})).Methods(http.MethodGet, http.MethodOptions)
 
+	r0mux.Handle("/register/email/requestToken", httputil.MakeExternalAPI("registerEmailRequestToken", func(req *http.Request) util.JSONResponse {
+		if r := rateLimits.rateLimit(req); r != nil {
+			return *r
+		}
+		return RegisterEmailRequestToken(req, cfg)
+	})).Methods(http.MethodPost, http.MethodOptions)
+
 	r0mux.Handle("/directory/room/{roomAlias}",
 		httputil.MakeExternalAPI("directory_room", func(req *http.Request) util.JSONResponse {
 			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -312,13 +312,6 @@ func Setup(
 		return RegisterAvailable(req, cfg, accountDB)
 	})).Methods(http.MethodGet, http.MethodOptions)
 
-	r0mux.Handle("/register/email/requestToken", httputil.MakeExternalAPI("registerEmailRequestToken", func(req *http.Request) util.JSONResponse {
-		if r := rateLimits.rateLimit(req); r != nil {
-			return *r
-		}
-		return RegisterEmailRequestToken(req, cfg)
-	})).Methods(http.MethodPost, http.MethodOptions)
-
 	r0mux.Handle("/directory/room/{roomAlias}",
 		httputil.MakeExternalAPI("directory_room", func(req *http.Request) util.JSONResponse {
 			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))

--- a/clientapi/threepid/threepid.go
+++ b/clientapi/threepid/threepid.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/setup/config"
+	"github.com/matrix-org/util"
 )
 
 // EmailAssociationRequest represents the request defined at https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-register-email-requesttoken
@@ -92,7 +93,12 @@ func CreateSession(
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		err = resp.Body.Close()
+		if err != nil {
+			util.GetLogger(ctx).WithError(err).Error("CreateSession: unable to close response body")
+		}
+	}()
 
 	// Error if the status isn't OK
 	if resp.StatusCode != http.StatusOK {
@@ -131,7 +137,12 @@ func CheckAssociation(
 	if err != nil {
 		return false, "", "", err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		err = resp.Body.Close()
+		if err != nil {
+			util.GetLogger(ctx).WithError(err).Error("CheckAssociation: unable to close response body")
+		}
+	}()
 	var respBody struct {
 		Medium      string `json:"medium"`
 		ValidatedAt int64  `json:"validated_at"`

--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -140,7 +140,14 @@ client_api:
     connect: http://localhost:7771
   external_api:
     listen: http://[::]:8071
-
+  registration:
+    flows:
+      - stages:
+        - m.login.email.identity
+  login:
+    flows:
+      - stages:
+        - m.login.password
   # Prevents new users from being able to register on this homeserver, except when
   # using the registration shared secret below.
   registration_disabled: false

--- a/setup/config/config_clientapi.go
+++ b/setup/config/config_clientapi.go
@@ -11,6 +11,9 @@ type ClientAPI struct {
 	Matrix  *Global  `yaml:"-"`
 	Derived *Derived `yaml:"-"` // TODO: Nuke Derived from orbit
 
+	// The path to file of custom CA certificate to be added to root CA
+	CustomCaPath string `yaml:"custom_ca_path"`
+
 	InternalAPI InternalAPIOptions `yaml:"internal_api"`
 	ExternalAPI ExternalAPIOptions `yaml:"external_api"`
 

--- a/setup/config/config_clientapi.go
+++ b/setup/config/config_clientapi.go
@@ -3,6 +3,8 @@ package config
 import (
 	"fmt"
 	"time"
+
+	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 )
 
 type ClientAPI struct {
@@ -34,6 +36,13 @@ type ClientAPI struct {
 
 	// TURN options
 	TURN TURN `yaml:"turn"`
+
+	// Allowable flows for registration
+	// https://spec.matrix.org/unstable/client-server-api/#get_matrixclientr0login
+	Registration authtypes.InteractiveAuth `yaml:"registration"`
+	// Allowable flows for login
+	// https://spec.matrix.org/unstable/client-server-api/#post_matrixclientr0register
+	Login authtypes.InteractiveAuth `yaml:"login"`
 
 	// Rate-limiting options
 	RateLimiting RateLimiting `yaml:"rate_limiting"`

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -71,6 +71,7 @@ GET /rooms/:room_id/joined_members fetches my membership
 Both GET and PUT work
 POST /rooms/:room_id/read_markers can create read marker
 User signups are forbidden from starting with '_'
+Can register using an email address via identity server
 Request to logout with invalid an access token is rejected
 Request to logout without an access token is rejected
 Room creation reports m.room.create to myself


### PR DESCRIPTION
Support for registration via email sent by **identity server**. Resolves #1298, but there is a catch.
Test case `Can register using an email address` validates registration when dendrite itself sends verification email. In this PR dendrite sends `/_matrix/identity/v2/validate/email/requestToken` request to identity server (which will trigger sending email). New test case must be implemented in sytest. Proposed name: `Can register using an email address via identity server`

Allowable authentication flows must be passed via config file. This PR setups following convention (at the same time putting step towards removing `Derived`):
```yaml
client_api:
  registration:
    flows:
      - stages:
        - m.login.email.identity
  login:
    flows:
      - stages:
        - m.login.password
``` 

What's left to do?
* [x] Authenticate requests to identity server - I leave it **with no authentication** using V1 Identity API
* [x] Verify identity server certificates - there is configuration to add custom CA to system certificate pool.
* [x] Implement test case in sytest - [PR](https://github.com/matrix-org/sytest/pull/1034)

### Pull Request Checklist

* [x] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `Piotr Kozimor <p1996k@gmail.com>`
