### PR TITLE
Update MSC2946 implementation for stable spaces

### DIFF
--- a/setup/mscs/msc2946/msc2946.go
+++ b/setup/mscs/msc2946/msc2946.go
@@ -39,9 +39,9 @@ import (
 )
 
 const (
-	ConstCreateEventContentKey = "org.matrix.msc1772.type"
-	ConstSpaceChildEventType   = "org.matrix.msc1772.space.child"
-	ConstSpaceParentEventType  = "org.matrix.msc1772.space.parent"
+	ConstCreateEventContentKey = "type"
+	ConstSpaceChildEventType   = "m.space.child"
+	ConstSpaceParentEventType  = "m.space.parent"
 )
 
 // Defaults sets the request defaults


### PR DESCRIPTION
Now that MSC1772 passed FCP its identifiers have stabilised
This outright drops support for experimental spaces but that's what you get for being on the bleeding edge