### PR TITLE
Fix Key Generation Docs - resolves #1759

### DIFF
--- a/build/docker/README.md
+++ b/build/docker/README.md
@@ -37,11 +37,16 @@ runtime config should come from. The mounted folder must contain:
 To generate keys:
 
 ```
-go run github.com/matrix-org/dendrite/cmd/generate-keys \
-  --private-key=matrix_key.pem \
-  --tls-cert=server.crt \
-  --tls-key=server.key
+docker run --rm --entrypoint="" \
+  -v $(pwd):/mnt \
+  matrixdotorg/dendrite-monolith:latest \
+  /usr/bin/generate-keys \
+  -private-key /mnt/matrix_key.pem \
+  -tls-cert /mnt/server.crt \
+  -tls-key /mnt/server.key
 ```
+
+The key files will now exist in your current working directory, and can be mounted into place.
 
 ## Starting Dendrite as a monolith deployment
 


### PR DESCRIPTION
This fixes the issue found in #1759 which broke due to go changes. The new command allows you to generate keys with docker, and drop them in the current working directory.