### PR TITLE
Validate configured server name

### DIFF
--- a/setup/config/config_global.go
+++ b/setup/config/config_global.go
@@ -85,22 +85,22 @@ func (c *Global) Verify(configErrs *ConfigErrors, isMonolith bool) {
 		idna.VerifyDNSLength(true),
 	)
 	sn := string(c.ServerName)
-	if _, err := validator.ToUnicode(sn); err != nil {
-		if n, p, err := net.SplitHostPort(sn); err == nil {
-			// A valid port was specified but we don't care about it.
-			// If it's an IPv6 literal at this point then the [] will
-			// already have been stripped by net.SplitHostPort.
-			sn = n
-			// Check that the port number also makes sense.
-			if sp, err := strconv.Atoi(p); err != nil || sp <= 0 || sp > 65535 {
-				configErrs.Add(fmt.Sprintf("server_name %q contains an invalid port number", c.ServerName))
-			}
-		} else {
-			// If we didn't have a port then the net.SplitHostPort
-			// call will fail, leaving us with a possible []-wrapped
-			// IPv6 literal. Strip those before checking if it's valid.
-			sn = strings.Trim(sn, "[]")
+	if n, p, err := net.SplitHostPort(sn); err == nil {
+		// A valid port was specified but we don't care about it.
+		// If it's an IPv6 literal at this point then the [] will
+		// already have been stripped by net.SplitHostPort.
+		sn = n
+		// Check that the port number also makes sense.
+		if sp, err := strconv.Atoi(p); err != nil || sp <= 0 || sp > 65535 {
+			configErrs.Add(fmt.Sprintf("server_name %q contains an invalid port number", c.ServerName))
 		}
+	} else {
+		// If we didn't have a port then the net.SplitHostPort
+		// call will fail, leaving us with a possible []-wrapped
+		// IPv6 literal. Strip those before checking if it's valid.
+		sn = strings.Trim(sn, "[]")
+	}
+	if _, err := validator.ToUnicode(sn); err != nil {
 		// Check if it's a valid IP address. If the server name is a
 		// valid IPv4 or IPv6 literal then this won't return nil.
 		if net.ParseIP(sn) == nil {


### PR DESCRIPTION
Apparently it's possible to configure Dendrite with nonsense server names which will break clients and/or federation. This PR enforces IDNA validation if there's a domain name present in the `server_name` configuration option, or sufficient IP literal (and optional port) validation if not.