### PR TITLE
Use NotFound instead of Forbidden for missing account data

### DIFF
--- a/clientapi/routing/account_data.go
+++ b/clientapi/routing/account_data.go
@@ -69,7 +69,7 @@ func GetAccountData(
 
 	return util.JSONResponse{
 		Code: http.StatusNotFound,
-		JSON: jsonerror.Forbidden("data not found"),
+		JSON: jsonerror.NotFound("data not found"),
 	}
 }
 


### PR DESCRIPTION
Currently Dendrite returns HTTP 404 but with an M_FORBIDDEN error type when a client requests account data of a non-existent type. Synapse [returns M_NOT_FOUND instead](https://github.com/matrix-org/synapse/blob/4b965c862dc66c0da5d3240add70e9b5f0aa720b/synapse/rest/client/v2_alpha/account_data.py#L62). The spec [doesn't mention behaviour when not found](https://matrix.org/docs/spec/client_server/r0.6.1#get-matrix-client-r0-user-userid-account-data-type).

### Pull Request Checklist

* [ ] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `Adam Greig <adam@adamgreig.com>`
