### PR TITLE
Set MaxFileSizeBytes <= 0 to "unlimited"

### DIFF
--- a/mediaapi/routing/upload.go
+++ b/mediaapi/routing/upload.go
@@ -147,6 +147,18 @@ func (r *uploadRequest) doUpload(
 	//   r.storeFileAndMetadata(ctx, tmpDir, ...)
 	// before you return from doUpload else we will leak a temp file. We could make this nicer with a `WithTransaction` style of
 	// nested function to guarantee either storage or cleanup.
+
+	// should not happen, but prevents any int overflows
+	if cfg.MaxFileSizeBytes != nil && *cfg.MaxFileSizeBytes+1 <= 0 {
+		r.Logger.WithFields(log.Fields{
+			"MaxFileSizeBytes": *cfg.MaxFileSizeBytes + 1,
+		}).Error("Error while transferring file, configured max_file_size_bytes overflows int64")
+		return &util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.Unknown("Failed to upload"),
+		}
+	}
+
 	lr := io.LimitReader(reqReader, int64(*cfg.MaxFileSizeBytes)+1)
 	hash, bytesWritten, tmpDir, err := fileutils.WriteTempFile(ctx, lr, cfg.AbsBasePath)
 	if err != nil {

--- a/setup/config/config_mediaapi.go
+++ b/setup/config/config_mediaapi.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 )
 
 type MediaAPI struct {
@@ -57,6 +58,11 @@ func (c *MediaAPI) Verify(configErrs *ConfigErrors, isMonolith bool) {
 	checkNotEmpty(configErrs, "media_api.database.connection_string", string(c.Database.ConnectionString))
 
 	checkNotEmpty(configErrs, "media_api.base_path", string(c.BasePath))
+	// allow "unlimited" file size
+	if c.MaxFileSizeBytes != nil && *c.MaxFileSizeBytes <= 0 {
+		unlimitedSize := FileSizeBytes(math.MaxInt64)
+		c.MaxFileSizeBytes = &unlimitedSize
+	}
 	checkPositive(configErrs, "media_api.max_file_size_bytes", int64(*c.MaxFileSizeBytes))
 	checkPositive(configErrs, "media_api.max_thumbnail_generators", int64(c.MaxThumbnailGenerators))
 

--- a/setup/config/config_mediaapi.go
+++ b/setup/config/config_mediaapi.go
@@ -60,7 +60,7 @@ func (c *MediaAPI) Verify(configErrs *ConfigErrors, isMonolith bool) {
 	checkNotEmpty(configErrs, "media_api.base_path", string(c.BasePath))
 	// allow "unlimited" file size
 	if c.MaxFileSizeBytes != nil && *c.MaxFileSizeBytes <= 0 {
-		unlimitedSize := FileSizeBytes(math.MaxInt64)
+		unlimitedSize := FileSizeBytes(math.MaxInt64 - 1)
 		c.MaxFileSizeBytes = &unlimitedSize
 	}
 	checkPositive(configErrs, "media_api.max_file_size_bytes", int64(*c.MaxFileSizeBytes))


### PR DESCRIPTION
Not sure if it's the right place, but this should allow an "unlimited" file size if it's set below 0.

From #dendrite:matrix.org
> In case it's helpful, the dendrite yaml was configured to allow unlimited max file size (since nginx can handle file size), by setting maxfilesize_bytes to zero.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)
