### PR TITLE
Set MaxFileSizeBytes <= 0 to unlimited

### DIFF
--- a/mediaapi/routing/upload.go
+++ b/mediaapi/routing/upload.go
@@ -147,8 +147,17 @@ func (r *uploadRequest) doUpload(
 	//   r.storeFileAndMetadata(ctx, tmpDir, ...)
 	// before you return from doUpload else we will leak a temp file. We could make this nicer with a `WithTransaction` style of
 	// nested function to guarantee either storage or cleanup.
-	lr := io.LimitReader(reqReader, int64(*cfg.MaxFileSizeBytes)+1)
-	hash, bytesWritten, tmpDir, err := fileutils.WriteTempFile(ctx, lr, cfg.AbsBasePath)
+	if *cfg.MaxFileSizeBytes > 0 {
+		if *cfg.MaxFileSizeBytes+1 <= 0 {
+			r.Logger.WithFields(log.Fields{
+				"MaxFileSizeBytes": *cfg.MaxFileSizeBytes,
+			}).Warnf("Configured MaxFileSizeBytes overflows int64, defaulting to %d bytes", config.DefaultMaxFileSizeBytes)
+			cfg.MaxFileSizeBytes = &config.DefaultMaxFileSizeBytes
+		}
+		reqReader = io.LimitReader(reqReader, int64(*cfg.MaxFileSizeBytes)+1)
+	}
+
+	hash, bytesWritten, tmpDir, err := fileutils.WriteTempFile(ctx, reqReader, cfg.AbsBasePath)
 	if err != nil {
 		r.Logger.WithError(err).WithFields(log.Fields{
 			"MaxFileSizeBytes": *cfg.MaxFileSizeBytes,

--- a/mediaapi/routing/upload.go
+++ b/mediaapi/routing/upload.go
@@ -147,18 +147,6 @@ func (r *uploadRequest) doUpload(
 	//   r.storeFileAndMetadata(ctx, tmpDir, ...)
 	// before you return from doUpload else we will leak a temp file. We could make this nicer with a `WithTransaction` style of
 	// nested function to guarantee either storage or cleanup.
-
-	// should not happen, but prevents any int overflows
-	if cfg.MaxFileSizeBytes != nil && *cfg.MaxFileSizeBytes+1 <= 0 {
-		r.Logger.WithFields(log.Fields{
-			"MaxFileSizeBytes": *cfg.MaxFileSizeBytes + 1,
-		}).Error("Error while transferring file, configured max_file_size_bytes overflows int64")
-		return &util.JSONResponse{
-			Code: http.StatusBadRequest,
-			JSON: jsonerror.Unknown("Failed to upload"),
-		}
-	}
-
 	lr := io.LimitReader(reqReader, int64(*cfg.MaxFileSizeBytes)+1)
 	hash, bytesWritten, tmpDir, err := fileutils.WriteTempFile(ctx, lr, cfg.AbsBasePath)
 	if err != nil {

--- a/setup/config/config_mediaapi.go
+++ b/setup/config/config_mediaapi.go
@@ -35,6 +35,9 @@ type MediaAPI struct {
 	ThumbnailSizes []ThumbnailSize `yaml:"thumbnail_sizes"`
 }
 
+// DefaultMaxFileSizeBytes defines the default file size allowed in transfers
+var DefaultMaxFileSizeBytes = FileSizeBytes(10485760)
+
 func (c *MediaAPI) Defaults() {
 	c.InternalAPI.Listen = "http://localhost:7774"
 	c.InternalAPI.Connect = "http://localhost:7774"
@@ -42,8 +45,7 @@ func (c *MediaAPI) Defaults() {
 	c.Database.Defaults(5)
 	c.Database.ConnectionString = "file:mediaapi.db"
 
-	defaultMaxFileSizeBytes := FileSizeBytes(10485760)
-	c.MaxFileSizeBytes = &defaultMaxFileSizeBytes
+	c.MaxFileSizeBytes = &DefaultMaxFileSizeBytes
 	c.MaxThumbnailGenerators = 10
 	c.BasePath = "./media_store"
 }

--- a/setup/config/config_mediaapi.go
+++ b/setup/config/config_mediaapi.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"math"
 )
 
 type MediaAPI struct {
@@ -58,11 +57,6 @@ func (c *MediaAPI) Verify(configErrs *ConfigErrors, isMonolith bool) {
 	checkNotEmpty(configErrs, "media_api.database.connection_string", string(c.Database.ConnectionString))
 
 	checkNotEmpty(configErrs, "media_api.base_path", string(c.BasePath))
-	// allow "unlimited" file size
-	if c.MaxFileSizeBytes != nil && *c.MaxFileSizeBytes <= 0 {
-		unlimitedSize := FileSizeBytes(math.MaxInt64 - 1)
-		c.MaxFileSizeBytes = &unlimitedSize
-	}
 	checkPositive(configErrs, "media_api.max_file_size_bytes", int64(*c.MaxFileSizeBytes))
 	checkPositive(configErrs, "media_api.max_thumbnail_generators", int64(c.MaxThumbnailGenerators))
 


### PR DESCRIPTION
As per the comments in #1875 
Don't use a `LimitedReader` if the configured `MaxFileSizeBytes` is <= 0.
Log a warning and default to the default value, if the `MaxFileSizeBytes` overflows `int64`. Not sure if we should use the default value here or just return an error.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

