### PR TITLE
Use a custom FIFO queue for the RS input API

### DIFF
--- a/roomserver/internal/input/input_fifo.go
+++ b/roomserver/internal/input/input_fifo.go
@@ -13,7 +13,7 @@ type fifoQueue struct {
 
 func newFIFOQueue() *fifoQueue {
 	q := &fifoQueue{
-		notifs: make(chan struct{}),
+		notifs: make(chan struct{}, 1),
 	}
 	return q
 }

--- a/roomserver/internal/input/input_fifo.go
+++ b/roomserver/internal/input/input_fifo.go
@@ -1,0 +1,60 @@
+package input
+
+import (
+	"sync"
+)
+
+type fifoQueue struct {
+	frames []*inputTask
+	count  int
+	mutex  sync.Mutex
+	notifs chan struct{}
+}
+
+func newFIFOQueue() *fifoQueue {
+	q := &fifoQueue{
+		notifs: make(chan struct{}),
+	}
+	return q
+}
+
+func (q *fifoQueue) push(frame *inputTask) bool {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+	q.frames = append(q.frames, frame)
+	q.count++
+	select {
+	case q.notifs <- struct{}{}:
+	default:
+	}
+	return true
+}
+
+func (q *fifoQueue) pop() (*inputTask, bool) {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+	if q.count == 0 {
+		return nil, false
+	}
+	frame := q.frames[0]
+	q.frames[0] = nil
+	q.frames = q.frames[1:]
+	q.count--
+	if q.count == 0 {
+		// Force a GC of the underlying array, since it might have
+		// grown significantly if the queue was hammered for some reason
+		q.frames = nil
+	}
+	return frame, true
+}
+
+func (q *fifoQueue) wait() <-chan struct{} {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+	if q.count > 0 {
+		ch := make(chan struct{})
+		close(ch)
+		return ch
+	}
+	return q.notifs
+}

--- a/roomserver/internal/input/input_fifo.go
+++ b/roomserver/internal/input/input_fifo.go
@@ -29,6 +29,9 @@ func (q *fifoQueue) push(frame *inputTask) {
 	}
 }
 
+// pop returns the first item of the queue, if there is one.
+// The second return value will indicate if a task was returned.
+// You must check this value, even after calling wait().
 func (q *fifoQueue) pop() (*inputTask, bool) {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
@@ -47,6 +50,8 @@ func (q *fifoQueue) pop() (*inputTask, bool) {
 	return frame, true
 }
 
+// wait returns a channel which can be used to detect when an
+// item is waiting in the queue.
 func (q *fifoQueue) wait() <-chan struct{} {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()


### PR DESCRIPTION
Currently the RS input API queues up work for a room by using a buffered channel. The problem is that if the channel is full, we'll block the entire loop until it isn't full anymore and other work for other rooms gets stuck behind that.

This adds a custom FIFO queue (which I originally wrote for Pinecone) which will grow as needed and won't block. That way room events are always going to be queued instantly into their worker queues.