### PR TITLE
Reduce memory usage in federation /send endpoint

### DIFF
--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -503,15 +503,6 @@ func (t *txnReq) processEvent(ctx context.Context, e *gomatrixserverlib.Event) e
 		return fmt.Errorf("t.rsAPI.QueryMissingAuthPrevEvents: %w", err)
 	}
 
-	// Prepare a map of all the events we already had before this point, so
-	// that we don't send them to the roomserver again.
-	for _, eventID := range append(e.AuthEventIDs(), e.PrevEventIDs()...) {
-		t.hadEvents[eventID] = true
-	}
-	for _, eventID := range append(stateResp.MissingAuthEventIDs, stateResp.MissingPrevEventIDs...) {
-		t.hadEvents[eventID] = false
-	}
-
 	if !stateResp.RoomExists {
 		// TODO: When synapse receives a message for a room it is not in it
 		// asks the remote server for the state of the room so that it can
@@ -520,6 +511,15 @@ func (t *txnReq) processEvent(ctx context.Context, e *gomatrixserverlib.Event) e
 		// However generally speaking we should reject events for rooms we
 		// aren't a member of.
 		return roomNotFoundError{e.RoomID()}
+	}
+
+	// Prepare a map of all the events we already had before this point, so
+	// that we don't send them to the roomserver again.
+	for _, eventID := range append(e.AuthEventIDs(), e.PrevEventIDs()...) {
+		t.hadEvents[eventID] = true
+	}
+	for _, eventID := range append(stateResp.MissingAuthEventIDs, stateResp.MissingPrevEventIDs...) {
+		t.hadEvents[eventID] = false
 	}
 
 	if len(stateResp.MissingAuthEventIDs) > 0 {

--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -1029,12 +1029,13 @@ func (t *txnReq) lookupMissingStateViaState(ctx context.Context, roomID, eventID
 	if err := state.Check(ctx, t.keys, nil); err != nil {
 		return nil, err
 	}
-	// Cache the results of this state lookup.
-	for _, ev := range state.AuthEvents {
-		t.cacheAndReturn(ev.Headered(roomVersion))
+	// Cache the results of this state lookup and deduplicate anything we already
+	// have in the cache, freeing up memory.
+	for i, ev := range state.AuthEvents {
+		state.AuthEvents[i] = t.cacheAndReturn(ev.Headered(roomVersion)).Unwrap()
 	}
-	for _, ev := range state.StateEvents {
-		t.cacheAndReturn(ev.Headered(roomVersion))
+	for i, ev := range state.StateEvents {
+		state.StateEvents[i] = t.cacheAndReturn(ev.Headered(roomVersion)).Unwrap()
 	}
 	return &state, nil
 }

--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -791,7 +791,7 @@ func (t *txnReq) lookupStateAfterEvent(ctx context.Context, roomVersion gomatrix
 	default:
 		return nil, false, fmt.Errorf("t.lookupEvent: %w", err)
 	}
-	t.cacheAndReturn(h)
+	h = t.cacheAndReturn(h)
 	if h.StateKey() != nil {
 		addedToState := false
 		for i := range respState.StateEvents {
@@ -1070,8 +1070,8 @@ func (t *txnReq) lookupMissingStateViaStateIDs(ctx context.Context, roomID, even
 		return nil, err
 	}
 	for i := range queryRes.Events {
+		queryRes.Events[i] = t.cacheAndReturn(queryRes.Events[i])
 		evID := queryRes.Events[i].EventID()
-		t.cacheAndReturn(queryRes.Events[i])
 		if missing[evID] {
 			delete(missing, evID)
 		}
@@ -1235,8 +1235,7 @@ func (t *txnReq) lookupEvent(ctx context.Context, roomVersion gomatrixserverlib.
 		util.GetLogger(ctx).WithError(err).Warnf("Transaction: Couldn't validate signature of event %q", event.EventID())
 		return nil, verifySigError{event.EventID(), err}
 	}
-	h := event.Headered(roomVersion)
-	t.cacheAndReturn(h)
+	h := t.cacheAndReturn(event.Headered(roomVersion))
 	t.newEventsMutex.Lock()
 	t.newEvents[h.EventID()] = true
 	t.newEventsMutex.Unlock()

--- a/federationapi/routing/send_test.go
+++ b/federationapi/routing/send_test.go
@@ -370,7 +370,7 @@ func mustCreateTransaction(rsAPI api.RoomserverInternalAPI, fedClient txnFederat
 		keys:       &test.NopJSONVerifier{},
 		federation: fedClient,
 		haveEvents: make(map[string]*gomatrixserverlib.HeaderedEvent),
-		newEvents:  make(map[string]bool),
+		hadEvents:  make(map[string]bool),
 		roomsMu:    internal.NewMutexByRoom(),
 	}
 	t.PDUs = pdus


### PR DESCRIPTION
This PR ensures that we're aggressively using `cacheAndReturn` on all paths that bring in new events to ensure that we're a) populating the cache to begin with and b) deduplicating every time an event is already in the cache.

This reduces the memory footprint of the federation API substantially in early testing.