### PR TITLE
Asynchronous roomserver input from federation API /send

### DIFF
--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -556,6 +556,7 @@ func (t *txnReq) processEvent(ctx context.Context, e *gomatrixserverlib.Event) e
 		},
 		api.DoNotSendToOtherServers,
 		nil,
+		api.InputOptionAsync,
 	)
 }
 
@@ -598,6 +599,7 @@ withNextEvent:
 						SendAsServer: api.DoNotSendToOtherServers,
 					},
 				},
+				api.InputOptionAsync,
 			); err != nil {
 				return fmt.Errorf("api.SendEvents: %w", err)
 			}
@@ -747,6 +749,7 @@ func (t *txnReq) processEventWithMissingState(
 		resolvedState,
 		backwardsExtremity.Headered(roomVersion),
 		t.hadEvents,
+		api.InputOptionAsync,
 	)
 	if err != nil {
 		return fmt.Errorf("api.SendEventWithState: %w", err)
@@ -767,6 +770,7 @@ func (t *txnReq) processEventWithMissingState(
 		append(headeredNewEvents, e.Headered(roomVersion)),
 		api.DoNotSendToOtherServers,
 		nil,
+		api.InputOptionAsync,
 	); err != nil {
 		return fmt.Errorf("api.SendEvents: %w", err)
 	}

--- a/roomserver/api/input.go
+++ b/roomserver/api/input.go
@@ -86,6 +86,9 @@ type TransactionID struct {
 // InputRoomEventsRequest is a request to InputRoomEvents
 type InputRoomEventsRequest struct {
 	InputRoomEvents []InputRoomEvent `json:"input_room_events"`
+	// Asynchronous requests will queue up work into the roomserver and
+	// return straight away, rather than waiting for the results.
+	Asynchronous bool `json:"async"`
 }
 
 // InputRoomEventsResponse is a response to InputRoomEvents

--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -166,17 +166,19 @@ func (r *Inputer) InputRoomEvents(
 		worker.input.push(tasks[i])
 	}
 
-	// Wait for all of the workers to return results about our tasks.
-	wg.Wait()
+	if !request.Asynchronous {
+		// Wait for all of the workers to return results about our tasks.
+		wg.Wait()
 
-	// If any of the tasks returned an error, we should probably report
-	// that back to the caller.
-	for _, task := range tasks {
-		if task.err != nil {
-			response.ErrMsg = task.err.Error()
-			_, rejected := task.err.(*gomatrixserverlib.NotAllowed)
-			response.NotAllowed = rejected
-			return
+		// If any of the tasks returned an error, we should probably report
+		// that back to the caller.
+		for _, task := range tasks {
+			if task.err != nil {
+				response.ErrMsg = task.err.Error()
+				_, rejected := task.err.(*gomatrixserverlib.NotAllowed)
+				response.NotAllowed = rejected
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
I have no idea if this will improve things or make a lot of duplicate work, but this allows the RS input API to asynchronously process input events rather than blocking on the input API call.

Note that there's no persistence here yet - if the process crashes or restarts, the queued work will currently be lost.