### PR TITLE
Fix bug when rejecting invites

### DIFF
--- a/roomserver/internal/perform/perform_leave.go
+++ b/roomserver/internal/perform/perform_leave.go
@@ -102,8 +102,6 @@ func (r *Leaver) performLeaveRoomByID(
 		return nil, fmt.Errorf("Error getting membership: %w", err)
 	}
 	if membership != gomatrixserverlib.Join && membership != gomatrixserverlib.Invite {
-		// TODO: should be able to handle "invite" in this case too, if
-		// it's a case of kicking or banning or such
 		return nil, fmt.Errorf("User %q is not joined to the room (membership is %q)", req.UserID, membership)
 	}
 

--- a/roomserver/internal/perform/perform_leave.go
+++ b/roomserver/internal/perform/perform_leave.go
@@ -70,7 +70,7 @@ func (r *Leaver) performLeaveRoomByID(
 			return nil, fmt.Errorf("Sender %q is invalid", senderUser)
 		}
 		if host != r.Cfg.Matrix.ServerName {
-			return r.performRejectInvite(ctx, req, res, senderUser, eventID)
+			return r.performFederatedRejectInvite(ctx, req, res, senderUser, eventID)
 		}
 	}
 
@@ -152,7 +152,7 @@ func (r *Leaver) performLeaveRoomByID(
 	return nil, nil
 }
 
-func (r *Leaver) performRejectInvite(
+func (r *Leaver) performFederatedRejectInvite(
 	ctx context.Context,
 	req *api.PerformLeaveRequest,
 	res *api.PerformLeaveResponse, // nolint:unparam


### PR DESCRIPTION
This bit me on `dendrite.neilalexander.dev` where I was trying to reject an invite from a local user but Dendrite was trying to send a `/make_leave` over federation.