### PR TITLE
Add more optimised code path for checking if we're in a room

### DIFF
--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -573,6 +573,23 @@ func (t *txnReq) processEvent(ctx context.Context, e *gomatrixserverlib.Event) e
 	logger := util.GetLogger(ctx).WithField("event_id", e.EventID()).WithField("room_id", e.RoomID())
 	t.work = "" // reset from previous event
 
+	// Ask the roomserver if we know about the room and/or if we're joined
+	// to it. If we aren't then we won't bother processing the event.
+	joinedReq := api.QueryServerJoinedToRoomRequest{
+		RoomID: e.RoomID(),
+	}
+	var joinedRes api.QueryServerJoinedToRoomResponse
+	if err := t.rsAPI.QueryServerJoinedToRoom(ctx, &joinedReq, &joinedRes); err != nil {
+		return fmt.Errorf("t.rsAPI.QueryServerJoinedToRoom: %w", err)
+	}
+
+	if !joinedRes.RoomExists || !joinedRes.IsInRoom {
+		// We don't believe we're a member of this room, therefore there's
+		// no point in wasting work trying to figure out what to do with
+		// missing auth or prev events. Drop the event.
+		return roomNotFoundError{e.RoomID()}
+	}
+
 	// Work out if the roomserver knows everything it needs to know to auth
 	// the event. This includes the prev_events and auth_events.
 	// NOTE! This is going to include prev_events that have an empty state
@@ -587,23 +604,6 @@ func (t *txnReq) processEvent(ctx context.Context, e *gomatrixserverlib.Event) e
 	var stateResp api.QueryMissingAuthPrevEventsResponse
 	if err := t.rsAPI.QueryMissingAuthPrevEvents(ctx, &stateReq, &stateResp); err != nil {
 		return fmt.Errorf("t.rsAPI.QueryMissingAuthPrevEvents: %w", err)
-	}
-
-	if !stateResp.RoomExists {
-		// TODO: When synapse receives a message for a room it is not in it
-		// asks the remote server for the state of the room so that it can
-		// check if the remote server knows of a join "m.room.member" event
-		// that this server is unaware of.
-		// However generally speaking we should reject events for rooms we
-		// aren't a member of.
-		return roomNotFoundError{e.RoomID()}
-	}
-
-	if !stateResp.RoomJoined {
-		// We don't believe we're a member of this room anymore, therefore
-		// there's no point in wasting work trying to figure out what to do
-		// with missing auth or prev events. Silently drop the event.
-		return nil
 	}
 
 	// Prepare a map of all the events we already had before this point, so

--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -599,6 +599,13 @@ func (t *txnReq) processEvent(ctx context.Context, e *gomatrixserverlib.Event) e
 		return roomNotFoundError{e.RoomID()}
 	}
 
+	if !stateResp.RoomJoined {
+		// We don't believe we're a member of this room anymore, therefore
+		// there's no point in wasting work trying to figure out what to do
+		// with missing auth or prev events. Silently drop the event.
+		return nil
+	}
+
 	// Prepare a map of all the events we already had before this point, so
 	// that we don't send them to the roomserver again.
 	for _, eventID := range append(e.AuthEventIDs(), e.PrevEventIDs()...) {

--- a/federationapi/routing/send_test.go
+++ b/federationapi/routing/send_test.go
@@ -142,7 +142,6 @@ func (t *testRoomserverAPI) QueryMissingAuthPrevEvents(
 	response.RoomVersion = testRoomVersion
 	res := t.queryMissingAuthPrevEvents(request)
 	response.RoomExists = res.RoomExists
-	response.RoomJoined = true
 	response.MissingAuthEventIDs = res.MissingAuthEventIDs
 	response.MissingPrevEventIDs = res.MissingPrevEventIDs
 	return nil
@@ -191,7 +190,9 @@ func (t *testRoomserverAPI) QueryServerJoinedToRoom(
 	request *api.QueryServerJoinedToRoomRequest,
 	response *api.QueryServerJoinedToRoomResponse,
 ) error {
-	return fmt.Errorf("not implemented")
+	response.RoomExists = true
+	response.IsInRoom = true
+	return nil
 }
 
 // Query whether a server is allowed to see an event

--- a/federationapi/routing/send_test.go
+++ b/federationapi/routing/send_test.go
@@ -142,6 +142,7 @@ func (t *testRoomserverAPI) QueryMissingAuthPrevEvents(
 	response.RoomVersion = testRoomVersion
 	res := t.queryMissingAuthPrevEvents(request)
 	response.RoomExists = res.RoomExists
+	response.RoomJoined = true
 	response.MissingAuthEventIDs = res.MissingAuthEventIDs
 	response.MissingPrevEventIDs = res.MissingPrevEventIDs
 	return nil

--- a/roomserver/api/query.go
+++ b/roomserver/api/query.go
@@ -96,6 +96,8 @@ type QueryMissingAuthPrevEventsResponse struct {
 	// Does the room exist on this roomserver?
 	// If the room doesn't exist all other fields will be empty.
 	RoomExists bool `json:"room_exists"`
+	// Are we joined to this room locally?
+	RoomJoined bool `json:"room_joined"`
 	// The room version of the room.
 	RoomVersion gomatrixserverlib.RoomVersion `json:"room_version"`
 	// The event IDs of the auth events that we don't know locally.
@@ -182,7 +184,8 @@ type QueryServerJoinedToRoomResponse struct {
 	RoomExists bool `json:"room_exists"`
 	// True if we still believe that we are participating in the room
 	IsInRoom bool `json:"is_in_room"`
-	// List of servers that are also in the room
+	// List of servers that are also in the room. This will not be populated
+	// if the queried ServerName is the local server name.
 	ServerNames []gomatrixserverlib.ServerName `json:"server_names"`
 }
 

--- a/roomserver/api/query.go
+++ b/roomserver/api/query.go
@@ -96,8 +96,6 @@ type QueryMissingAuthPrevEventsResponse struct {
 	// Does the room exist on this roomserver?
 	// If the room doesn't exist all other fields will be empty.
 	RoomExists bool `json:"room_exists"`
-	// Are we joined to this room locally?
-	RoomJoined bool `json:"room_joined"`
 	// The room version of the room.
 	RoomVersion gomatrixserverlib.RoomVersion `json:"room_version"`
 	// The event IDs of the auth events that we don't know locally.
@@ -172,7 +170,8 @@ type QueryMembershipsForRoomResponse struct {
 
 // QueryServerJoinedToRoomRequest is a request to QueryServerJoinedToRoom
 type QueryServerJoinedToRoomRequest struct {
-	// Server name of the server to find
+	// Server name of the server to find. If not specified, we will
+	// default to checking if the local server is joined.
 	ServerName gomatrixserverlib.ServerName `json:"server_name"`
 	// ID of the room to see if we are still joined to
 	RoomID string `json:"room_id"`

--- a/roomserver/internal/api.go
+++ b/roomserver/internal/api.go
@@ -59,6 +59,7 @@ func NewRoomserverAPI(
 		Queryer: &query.Queryer{
 			DB:         roomserverDB,
 			Cache:      caches,
+			ServerName: cfg.Matrix.ServerName,
 			ServerACLs: serverACLs,
 		},
 		Inputer: &input.Inputer{

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -142,14 +142,6 @@ func (r *Queryer) QueryMissingAuthPrevEvents(
 	response.RoomExists = !info.IsStub
 	response.RoomVersion = info.RoomVersion
 
-	if response.RoomExists {
-		joined, err := r.DB.GetLocalServerInRoom(ctx, info.RoomNID)
-		if err != nil {
-			return fmt.Errorf("r.DB.GetLocalServerInRoom: %w", err)
-		}
-		response.RoomJoined = joined
-	}
-
 	for _, authEventID := range request.AuthEventIDs {
 		if nids, err := r.DB.EventNIDs(ctx, []string{authEventID}); err != nil || len(nids) == 0 {
 			response.MissingAuthEventIDs = append(response.MissingAuthEventIDs, authEventID)
@@ -337,7 +329,7 @@ func (r *Queryer) QueryServerJoinedToRoom(
 	}
 	response.RoomExists = true
 
-	if request.ServerName == r.ServerName {
+	if request.ServerName == r.ServerName || request.ServerName == "" {
 		var joined bool
 		joined, err = r.DB.GetLocalServerInRoom(ctx, info.RoomNID)
 		if err != nil {

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -142,16 +142,12 @@ func (r *Queryer) QueryMissingAuthPrevEvents(
 	response.RoomExists = !info.IsStub
 	response.RoomVersion = info.RoomVersion
 
-	joined, err := r.DB.GetLocalServerInRoom(ctx, info.RoomNID)
-	if err != nil {
-		return fmt.Errorf("r.DB.GetLocalServerInRoom: %w", err)
-	}
-	response.RoomJoined = joined
-
-	// If we're not joined to the room then there's no point in hitting
-	// the database further to work out which events we're missing.
-	if !joined {
-		return nil
+	if response.RoomExists {
+		joined, err := r.DB.GetLocalServerInRoom(ctx, info.RoomNID)
+		if err != nil {
+			return fmt.Errorf("r.DB.GetLocalServerInRoom: %w", err)
+		}
+		response.RoomJoined = joined
 	}
 
 	for _, authEventID := range request.AuthEventIDs {

--- a/roomserver/storage/interface.go
+++ b/roomserver/storage/interface.go
@@ -154,6 +154,8 @@ type Database interface {
 	GetBulkStateContent(ctx context.Context, roomIDs []string, tuples []gomatrixserverlib.StateKeyTuple, allowWildcards bool) ([]tables.StrippedEvent, error)
 	// JoinedUsersSetInRooms returns all joined users in the rooms given, along with the count of how many times they appear.
 	JoinedUsersSetInRooms(ctx context.Context, roomIDs []string) (map[string]int, error)
+	// GetLocalServerInRoom returns true if we think we're in a given room or false otherwise.
+	GetLocalServerInRoom(ctx context.Context, roomNID types.RoomNID) (bool, error)
 	// GetKnownUsers searches all users that userID knows about.
 	GetKnownUsers(ctx context.Context, userID, searchString string, limit int) ([]string, error)
 	// GetKnownRooms returns a list of all rooms we know about.

--- a/roomserver/storage/postgres/membership_table.go
+++ b/roomserver/storage/postgres/membership_table.go
@@ -130,7 +130,8 @@ var selectKnownUsersSQL = "" +
 // is expensive. The presence of a single row from this query suggests we're still in the
 // room, no rows returned suggests we aren't.
 const selectLocalServerInRoomSQL = "" +
-	"SELECT TOP 1 room_nid FROM roomserver_membership WHERE target_local = true AND membership_nid = 3 AND room_nid = $1"
+	"SELECT room_nid FROM roomserver_membership WHERE target_local = true AND membership_nid = 3 AND room_nid = $1 " +
+	"FETCH FIRST 1 ROWS ONLY"
 
 type membershipStatements struct {
 	insertMembershipStmt                            *sql.Stmt

--- a/roomserver/storage/postgres/membership_table.go
+++ b/roomserver/storage/postgres/membership_table.go
@@ -344,7 +344,7 @@ func (s *membershipStatements) SelectLocalServerInRoom(ctx context.Context, room
 		}
 		return false, err
 	}
-	defer internal.CloseAndLogIfError(ctx, rows, "SelectKnownUsers: rows.close() failed")
+	defer internal.CloseAndLogIfError(ctx, rows, "SelectLocalServerInRoom: rows.close() failed")
 	found := false
 	for rows.Next() {
 		found = true

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -1059,6 +1059,11 @@ func (d *Database) JoinedUsersSetInRooms(ctx context.Context, roomIDs []string) 
 	return result, nil
 }
 
+// GetLocalServerInRoom returns true if we think we're in a given room or false otherwise.
+func (d *Database) GetLocalServerInRoom(ctx context.Context, roomNID types.RoomNID) (bool, error) {
+	return d.MembershipTable.SelectLocalServerInRoom(ctx, roomNID)
+}
+
 // GetKnownUsers searches all users that userID knows about.
 func (d *Database) GetKnownUsers(ctx context.Context, userID, searchString string, limit int) ([]string, error) {
 	stateKeyNID, err := d.EventStateKeysTable.SelectEventStateKeyNID(ctx, nil, userID)

--- a/roomserver/storage/sqlite3/membership_table.go
+++ b/roomserver/storage/sqlite3/membership_table.go
@@ -106,7 +106,7 @@ var selectKnownUsersSQL = "" +
 // is expensive. The presence of a single row from this query suggests we're still in the
 // room, no rows returned suggests we aren't.
 const selectLocalServerInRoomSQL = "" +
-	"SELECT room_nid FROM roomserver_membership WHERE target_local = true AND membership_nid = 3 AND room_nid = $1 LIMIT 1"
+	"SELECT room_nid FROM roomserver_membership WHERE target_local = 1 AND membership_nid = 3 AND room_nid = $1 LIMIT 1"
 
 type membershipStatements struct {
 	db                                              *sql.DB

--- a/roomserver/storage/sqlite3/membership_table.go
+++ b/roomserver/storage/sqlite3/membership_table.go
@@ -100,6 +100,14 @@ var selectKnownUsersSQL = "" +
 	"  SELECT DISTINCT room_nid FROM roomserver_membership WHERE target_nid=$1 AND membership_nid = " + fmt.Sprintf("%d", tables.MembershipStateJoin) +
 	") AND membership_nid = " + fmt.Sprintf("%d", tables.MembershipStateJoin) + " AND event_state_key LIKE $2 LIMIT $3"
 
+// selectLocalServerInRoomSQL is an optimised case for checking if we, the local server,
+// are in the room by using the target_local column of the membership table. Normally when
+// we want to know if a server is in a room, we have to unmarshal the entire room state which
+// is expensive. The presence of a single row from this query suggests we're still in the
+// room, no rows returned suggests we aren't.
+const selectLocalServerInRoomSQL = "" +
+	"SELECT room_nid FROM roomserver_membership WHERE target_local = true AND membership_nid = 3 AND room_nid = $1 LIMIT 1"
+
 type membershipStatements struct {
 	db                                              *sql.DB
 	insertMembershipStmt                            *sql.Stmt
@@ -113,6 +121,7 @@ type membershipStatements struct {
 	updateMembershipStmt                            *sql.Stmt
 	selectKnownUsersStmt                            *sql.Stmt
 	updateMembershipForgetRoomStmt                  *sql.Stmt
+	selectLocalServerInRoomStmt                     *sql.Stmt
 }
 
 func createMembershipTable(db *sql.DB) error {
@@ -137,6 +146,7 @@ func prepareMembershipTable(db *sql.DB) (tables.Membership, error) {
 		{&s.selectRoomsWithMembershipStmt, selectRoomsWithMembershipSQL},
 		{&s.selectKnownUsersStmt, selectKnownUsersSQL},
 		{&s.updateMembershipForgetRoomStmt, updateMembershipForgetRoom},
+		{&s.selectLocalServerInRoomStmt, selectLocalServerInRoomSQL},
 	}.Prepare(db)
 }
 
@@ -303,4 +313,20 @@ func (s *membershipStatements) UpdateForgetMembership(
 		ctx, forget, roomNID, targetUserNID,
 	)
 	return err
+}
+
+func (s *membershipStatements) SelectLocalServerInRoom(ctx context.Context, roomNID types.RoomNID) (bool, error) {
+	rows, err := s.selectLocalServerInRoomStmt.QueryContext(ctx, roomNID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, err
+	}
+	defer internal.CloseAndLogIfError(ctx, rows, "SelectKnownUsers: rows.close() failed")
+	found := false
+	for rows.Next() {
+		found = true
+	}
+	return found, rows.Err()
 }

--- a/roomserver/storage/sqlite3/membership_table.go
+++ b/roomserver/storage/sqlite3/membership_table.go
@@ -323,7 +323,7 @@ func (s *membershipStatements) SelectLocalServerInRoom(ctx context.Context, room
 		}
 		return false, err
 	}
-	defer internal.CloseAndLogIfError(ctx, rows, "SelectKnownUsers: rows.close() failed")
+	defer internal.CloseAndLogIfError(ctx, rows, "SelectLocalServerInRoom: rows.close() failed")
 	found := false
 	for rows.Next() {
 		found = true

--- a/roomserver/storage/sqlite3/membership_table.go
+++ b/roomserver/storage/sqlite3/membership_table.go
@@ -106,7 +106,7 @@ var selectKnownUsersSQL = "" +
 // is expensive. The presence of a single row from this query suggests we're still in the
 // room, no rows returned suggests we aren't.
 const selectLocalServerInRoomSQL = "" +
-	"SELECT room_nid FROM roomserver_membership WHERE target_local = 1 AND membership_nid = 3 AND room_nid = $1 LIMIT 1"
+	"SELECT room_nid FROM roomserver_membership WHERE target_local = 1 AND membership_nid = $1 AND room_nid = $2 LIMIT 1"
 
 type membershipStatements struct {
 	db                                              *sql.DB
@@ -316,17 +316,14 @@ func (s *membershipStatements) UpdateForgetMembership(
 }
 
 func (s *membershipStatements) SelectLocalServerInRoom(ctx context.Context, roomNID types.RoomNID) (bool, error) {
-	rows, err := s.selectLocalServerInRoomStmt.QueryContext(ctx, roomNID)
+	var nid types.RoomNID
+	err := s.selectLocalServerInRoomStmt.QueryRowContext(ctx, tables.MembershipStateJoin, roomNID).Scan(&nid)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return false, nil
 		}
 		return false, err
 	}
-	defer internal.CloseAndLogIfError(ctx, rows, "SelectLocalServerInRoom: rows.close() failed")
-	found := false
-	for rows.Next() {
-		found = true
-	}
-	return found, rows.Err()
+	found := nid > 0
+	return found, nil
 }

--- a/roomserver/storage/tables/interface.go
+++ b/roomserver/storage/tables/interface.go
@@ -135,6 +135,7 @@ type Membership interface {
 	SelectJoinedUsersSetForRooms(ctx context.Context, roomNIDs []types.RoomNID) (map[types.EventStateKeyNID]int, error)
 	SelectKnownUsers(ctx context.Context, userID types.EventStateKeyNID, searchString string, limit int) ([]string, error)
 	UpdateForgetMembership(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, targetUserNID types.EventStateKeyNID, forget bool) error
+	SelectLocalServerInRoom(ctx context.Context, roomNID types.RoomNID) (bool, error)
 }
 
 type Published interface {


### PR DESCRIPTION
Asking the roomserver for all of the room state events is an expensive operation, but we don't strictly need to do that when we only care about finding out if the local server is in the room. The memberships table contains that information.

This adds a new code path for a much cheaper check using the memberships table.

It also adds code to the federation API to not bother processing events if the server thinks we aren't in the room.