### PR TITLE
Replace some helpers.IsServerCurrentlyInRoom calls with query API

### DIFF
--- a/roomserver/internal/api.go
+++ b/roomserver/internal/api.go
@@ -93,6 +93,7 @@ func (r *RoomserverInternalAPI) SetFederationSenderAPI(fsAPI fsAPI.FederationSen
 		FSAPI:      r.fsAPI,
 		RSAPI:      r,
 		Inputer:    r.Inputer,
+		Queryer:    r.Queryer,
 	}
 	r.Peeker = &perform.Peeker{
 		ServerName: r.Cfg.Matrix.ServerName,

--- a/roomserver/internal/helpers/helpers.go
+++ b/roomserver/internal/helpers/helpers.go
@@ -50,6 +50,10 @@ func UpdateToInviteMembership(
 	return updates, nil
 }
 
+// IsServerCurrentlyInRoom checks if a server is in a given room, based on the room
+// memberships. If the servername is not supplied then the local server will be
+// checked instead using a faster code path.
+// TODO: This should probably be replaced by an API call.
 func IsServerCurrentlyInRoom(ctx context.Context, db storage.Database, serverName gomatrixserverlib.ServerName, roomID string) (bool, error) {
 	info, err := db.RoomInfo(ctx, roomID)
 	if err != nil {
@@ -57,6 +61,10 @@ func IsServerCurrentlyInRoom(ctx context.Context, db storage.Database, serverNam
 	}
 	if info == nil {
 		return false, fmt.Errorf("unknown room %s", roomID)
+	}
+
+	if serverName == "" {
+		return db.GetLocalServerInRoom(ctx, info.RoomNID)
 	}
 
 	eventNIDs, err := db.GetMembershipEventNIDsForRoom(ctx, info.RoomNID, true, false)


### PR DESCRIPTION
This replaces a couple of instances where we call `helpers.IsServerCurrentlyInRoom` with calls to `query.QueryServerJoinedToRoom` instead, so we can take advantage of optimisations when querying the local server name.

The remaining user of `helpers.IsServerCurrentlyInRoom` is `ScanEventTree`, so I've left it alone for now rather than removing it altogether.