### PR TITLE
bugfix: retire invites even when we cannot talk to the remote server to make/send_leave

### DIFF
--- a/syncapi/streams/stream_invite.go
+++ b/syncapi/streams/stream_invite.go
@@ -3,7 +3,7 @@ package streams
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/hex"
+	"encoding/base64"
 	"strconv"
 	"time"
 
@@ -64,7 +64,7 @@ func (p *InviteStreamProvider) IncrementalSync(
 			h := sha256.Sum256(append([]byte(roomID), []byte(strconv.FormatInt(int64(to), 10))...))
 			lr.Timeline.Events = append(lr.Timeline.Events, gomatrixserverlib.ClientEvent{
 				// fake event ID which muxes in the to position
-				EventID:        "$" + hex.EncodeToString(h[:]),
+				EventID:        "$" + base64.RawURLEncoding.EncodeToString(h[:]),
 				OriginServerTS: gomatrixserverlib.AsTimestamp(time.Now()),
 				RoomID:         roomID,
 				Sender:         req.Device.UserID,

--- a/syncapi/streams/stream_invite.go
+++ b/syncapi/streams/stream_invite.go
@@ -2,6 +2,8 @@ package streams
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"strconv"
 	"time"
 
@@ -59,9 +61,10 @@ func (p *InviteStreamProvider) IncrementalSync(
 	for roomID := range retiredInvites {
 		if _, ok := req.Response.Rooms.Join[roomID]; !ok {
 			lr := types.NewLeaveResponse()
+			h := sha256.Sum256(append([]byte(roomID), []byte(strconv.FormatInt(int64(to), 10))...))
 			lr.Timeline.Events = append(lr.Timeline.Events, gomatrixserverlib.ClientEvent{
 				// fake event ID which muxes in the to position
-				EventID:        "$stub-retired-invite-" + roomID + "-" + strconv.FormatInt(int64(to), 10),
+				EventID:        "$" + hex.EncodeToString(h[:]),
 				OriginServerTS: gomatrixserverlib.AsTimestamp(time.Now()),
 				RoomID:         roomID,
 				Sender:         req.Device.UserID,

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -527,3 +527,6 @@ POST /_synapse/admin/v1/register with shared secret disallows symbols
 Membership event with an invalid displayname in the send_join response should not cause room join to fail
 Inbound federation rejects incorrectly-signed invite rejections
 Inbound federation can receive invite rejections
+Inbound federation can receive invite and reject when remote replies with a 403
+Inbound federation can receive invite and reject when remote replies with a 500
+Inbound federation can receive invite and reject when remote is unreachable


### PR DESCRIPTION
Also modify the leave response in /sync to include a fake event as this is ultimately
what clients (and sytest) will use to determine leave-ness.

Fixes #1743 #1727 #1828 #1873

With sytests.