### PR TITLE
Efficient /state_ids

### DIFF
--- a/federationapi/routing/state.go
+++ b/federationapi/routing/state.go
@@ -176,12 +176,3 @@ func getStateIDs(
 		AuthEventIDs:  response.AuthChainEvents,
 	}, nil
 }
-
-func getIDsFromEvent(events []*gomatrixserverlib.Event) []string {
-	IDs := make([]string, len(events))
-	for i := range events {
-		IDs[i] = events[i].EventID()
-	}
-
-	return IDs
-}

--- a/roomserver/api/api.go
+++ b/roomserver/api/api.go
@@ -75,6 +75,12 @@ type RoomserverInternalAPI interface {
 		response *QueryLatestEventsAndStateResponse,
 	) error
 
+	QueryStateAndAuthChainIDs(
+		ctx context.Context,
+		request *QueryStateAndAuthChainIDsRequest,
+		response *QueryStateAndAuthChainIDsResponse,
+	) error
+
 	// Query the state after a list of events in a room from the room server.
 	QueryStateAfterEvents(
 		ctx context.Context,

--- a/roomserver/api/api_trace.go
+++ b/roomserver/api/api_trace.go
@@ -208,6 +208,16 @@ func (t *RoomserverInternalAPITrace) QueryStateAndAuthChain(
 	return err
 }
 
+func (t *RoomserverInternalAPITrace) QueryStateAndAuthChainIDs(
+	ctx context.Context,
+	req *QueryStateAndAuthChainIDsRequest,
+	res *QueryStateAndAuthChainIDsResponse,
+) error {
+	err := t.Impl.QueryStateAndAuthChainIDs(ctx, req, res)
+	util.GetLogger(ctx).WithError(err).Infof("QueryStateAndAuthChainIDs req=%+v res=%+v", js(req), js(res))
+	return err
+}
+
 func (t *RoomserverInternalAPITrace) PerformBackfill(
 	ctx context.Context,
 	req *PerformBackfillRequest,

--- a/roomserver/api/query.go
+++ b/roomserver/api/query.go
@@ -250,6 +250,28 @@ type QueryStateAndAuthChainResponse struct {
 	AuthChainEvents []*gomatrixserverlib.HeaderedEvent `json:"auth_chain_events"`
 }
 
+// QueryStateAndAuthChainIDsRequest is a request to QueryStateAndAuthChainIDs
+type QueryStateAndAuthChainIDsRequest struct {
+	// The room ID to query the state in.
+	RoomID string `json:"room_id"`
+	// The list of prev events for the event. Used to calculate the state at
+	// the event.
+	PrevEventIDs []string `json:"prev_event_ids"`
+}
+
+// QueryStateAndAuthChainIDsResponse is a response to QueryStateAndAuthChainIDs
+type QueryStateAndAuthChainIDsResponse struct {
+	// Does the room exist on this roomserver?
+	// If the room doesn't exist this will be false and StateEvents will be empty.
+	RoomExists bool `json:"room_exists"`
+	// The room version of the room.
+	RoomVersion gomatrixserverlib.RoomVersion `json:"room_version"`
+	// The state and auth chain event IDs that were requested.
+	// The lists will be in an arbitrary order.
+	StateEvents     []string `json:"state_event_ids"`
+	AuthChainEvents []string `json:"auth_chain_event_ids"`
+}
+
 // QueryRoomVersionCapabilitiesRequest asks for the default room version
 type QueryRoomVersionCapabilitiesRequest struct{}
 

--- a/roomserver/inthttp/client.go
+++ b/roomserver/inthttp/client.go
@@ -47,6 +47,7 @@ const (
 	RoomserverQueryServerAllowedToSeeEventPath = "/roomserver/queryServerAllowedToSeeEvent"
 	RoomserverQueryMissingEventsPath           = "/roomserver/queryMissingEvents"
 	RoomserverQueryStateAndAuthChainPath       = "/roomserver/queryStateAndAuthChain"
+	RoomserverQueryStateAndAuthChainIDsPath    = "/roomserver/queryStateAndAuthChainIDs"
 	RoomserverQueryRoomVersionCapabilitiesPath = "/roomserver/queryRoomVersionCapabilities"
 	RoomserverQueryRoomVersionForRoomPath      = "/roomserver/queryRoomVersionForRoom"
 	RoomserverQueryPublishedRoomsPath          = "/roomserver/queryPublishedRooms"
@@ -414,6 +415,19 @@ func (h *httpRoomserverInternalAPI) QueryStateAndAuthChain(
 	defer span.Finish()
 
 	apiURL := h.roomserverURL + RoomserverQueryStateAndAuthChainPath
+	return httputil.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+}
+
+// QueryStateAndAuthChainIDs implements RoomserverQueryAPI
+func (h *httpRoomserverInternalAPI) QueryStateAndAuthChainIDs(
+	ctx context.Context,
+	request *api.QueryStateAndAuthChainIDsRequest,
+	response *api.QueryStateAndAuthChainIDsResponse,
+) error {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "QueryStateAndAuthChainIDs")
+	defer span.Finish()
+
+	apiURL := h.roomserverURL + RoomserverQueryStateAndAuthChainIDsPath
 	return httputil.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 }
 

--- a/roomserver/inthttp/server.go
+++ b/roomserver/inthttp/server.go
@@ -262,6 +262,20 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 		}),
 	)
 	internalAPIMux.Handle(
+		RoomserverQueryStateAndAuthChainIDsPath,
+		httputil.MakeInternalAPI("queryStateAndAuthChainIDs", func(req *http.Request) util.JSONResponse {
+			var request api.QueryStateAndAuthChainIDsRequest
+			var response api.QueryStateAndAuthChainIDsResponse
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.ErrorResponse(err)
+			}
+			if err := r.QueryStateAndAuthChainIDs(req.Context(), &request, &response); err != nil {
+				return util.ErrorResponse(err)
+			}
+			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
+		}),
+	)
+	internalAPIMux.Handle(
 		RoomserverPerformBackfillPath,
 		httputil.MakeInternalAPI("PerformBackfill", func(req *http.Request) util.JSONResponse {
 			var request api.PerformBackfillRequest

--- a/roomserver/storage/interface.go
+++ b/roomserver/storage/interface.go
@@ -87,6 +87,8 @@ type Database interface {
 	// Lookup the event IDs for a batch of event numeric IDs.
 	// Returns an error if the retrieval went wrong.
 	EventIDs(ctx context.Context, eventNIDs []types.EventNID) (map[types.EventNID]string, error)
+	// AuthEventNIDs returns the auth event NIDs for the given events.
+	AuthEventNIDs(ctx context.Context, events []types.EventNID) (types.EventNIDs, error)
 	// Look up the latest events in a room in preparation for an update.
 	// The RoomRecentEventsUpdater must have Commit or Rollback called on it if this doesn't return an error.
 	// Returns the latest events in the room and the last eventID sent to the log along with an updater.

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -292,6 +292,22 @@ func (d *Database) StateEntries(
 	return lists, nil
 }
 
+func (d *Database) AuthEventNIDs(
+	ctx context.Context, events []types.EventNID,
+) (types.EventNIDs, error) {
+	entries, err := d.EventsTable.SelectEventAuthEventNIDs(
+		ctx, events,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("d.EventsTable.SelectEventAuthEventNIDs: %w", err)
+	}
+	var lists types.EventNIDs
+	for _, nids := range entries {
+		lists = append(lists, nids...)
+	}
+	return lists[:util.SortAndUnique(lists)], nil
+}
+
 func (d *Database) SetRoomAlias(ctx context.Context, alias string, roomID string, creatorUserID string) error {
 	return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
 		return d.RoomAliasesTable.InsertRoomAlias(ctx, txn, alias, roomID, creatorUserID)

--- a/roomserver/storage/sqlite3/events_table.go
+++ b/roomserver/storage/sqlite3/events_table.go
@@ -23,7 +23,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/lib/pq"
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/roomserver/storage/shared"
@@ -597,11 +596,15 @@ func (s *eventStatements) SelectEventAuthEventNIDs(
 	result := make(map[types.EventNID][]types.EventNID)
 	for rows.Next() {
 		var eventNID types.EventNID
-		var authEventNIDs pq.Int64Array
+		var authEventNIDs string
 		if err = rows.Scan(&authEventNIDs); err != nil {
 			return nil, err
 		}
-		for _, a := range authEventNIDs {
+		var authEventNIDsArray []int64
+		if err := json.Unmarshal([]byte(authEventNIDs), &authEventNIDsArray); err != nil {
+			return nil, err
+		}
+		for _, a := range authEventNIDsArray {
 			result[eventNID] = append(result[eventNID], types.EventNID(a))
 		}
 	}

--- a/roomserver/storage/tables/interface.go
+++ b/roomserver/storage/tables/interface.go
@@ -61,6 +61,7 @@ type Events interface {
 	BulkSelectEventNID(ctx context.Context, eventIDs []string) (map[string]types.EventNID, error)
 	SelectMaxEventDepth(ctx context.Context, txn *sql.Tx, eventNIDs []types.EventNID) (int64, error)
 	SelectRoomNIDsForEventNIDs(ctx context.Context, eventNIDs []types.EventNID) (roomNIDs map[types.EventNID]types.RoomNID, err error)
+	SelectEventAuthEventNIDs(ctx context.Context, eventNIDs []types.EventNID) (map[types.EventNID][]types.EventNID, error)
 }
 
 type Rooms interface {


### PR DESCRIPTION
Beforehand, `/state_ids` was still pulling all of the state and auth events out of the database and unmarshalling them. This isn't really necessary because the `roomserver_events` table already knows both the event ID and the auth event NIDs, so we can look those up instead. This adds the necessary roomserver query shape to do just that.