### PR TITLE
Various alias fixes

### DIFF
--- a/clientapi/routing/aliases.go
+++ b/clientapi/routing/aliases.go
@@ -1,0 +1,89 @@
+// Copyright 2017 Vector Creations Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"github.com/matrix-org/dendrite/roomserver/api"
+	userapi "github.com/matrix-org/dendrite/userapi/api"
+	"github.com/matrix-org/gomatrixserverlib"
+
+	"github.com/matrix-org/util"
+)
+
+// GetAliases implements GET /_matrix/client/r0/rooms/{roomId}/aliases
+func GetAliases(
+	req *http.Request, rsAPI api.RoomserverInternalAPI, device *userapi.Device, roomID string,
+) util.JSONResponse {
+	stateTuple := gomatrixserverlib.StateKeyTuple{
+		EventType: gomatrixserverlib.MRoomHistoryVisibility,
+		StateKey:  "",
+	}
+	stateReq := &api.QueryCurrentStateRequest{
+		RoomID:      roomID,
+		StateTuples: []gomatrixserverlib.StateKeyTuple{stateTuple},
+	}
+	stateRes := &api.QueryCurrentStateResponse{}
+	if err := rsAPI.QueryCurrentState(req.Context(), stateReq, stateRes); err != nil {
+		util.GetLogger(req.Context()).WithError(err).Error("rsAPI.QueryCurrentState failed")
+		return util.ErrorResponse(fmt.Errorf("rsAPI.QueryCurrentState: %w", err))
+	}
+
+	if historyVisEvent, ok := stateRes.StateEvents[stateTuple]; ok {
+		visibility, err := historyVisEvent.HistoryVisibility()
+		if err != nil {
+			util.GetLogger(req.Context()).WithError(err).Error("historyVisEvent.HistoryVisibility failed")
+			return util.ErrorResponse(fmt.Errorf("historyVisEvent.HistoryVisibility: %w", err))
+		}
+		if visibility != "world_readable" {
+			queryReq := api.QueryMembershipForUserRequest{
+				RoomID: roomID,
+				UserID: device.UserID,
+			}
+			var queryRes api.QueryMembershipForUserResponse
+			if err := rsAPI.QueryMembershipForUser(req.Context(), &queryReq, &queryRes); err != nil {
+				util.GetLogger(req.Context()).WithError(err).Error("rsAPI.QueryMembershipsForRoom failed")
+				return jsonerror.InternalServerError()
+			}
+			if !queryRes.IsInRoom {
+				return util.JSONResponse{
+					Code: http.StatusForbidden,
+					JSON: jsonerror.Forbidden("You aren't a member of this room."),
+				}
+			}
+		}
+	}
+
+	aliasesReq := api.GetAliasesForRoomIDRequest{
+		RoomID: roomID,
+	}
+	aliasesRes := api.GetAliasesForRoomIDResponse{}
+	if err := rsAPI.GetAliasesForRoomID(req.Context(), &aliasesReq, &aliasesRes); err != nil {
+		util.GetLogger(req.Context()).WithError(err).Error("rsAPI.GetAliasesForRoomID failed")
+		return util.ErrorResponse(fmt.Errorf("rsAPI.GetAliasesForRoomID: %w", err))
+	}
+
+	return util.JSONResponse{
+		Code: 200,
+		JSON: struct {
+			Aliases []string `json:"aliases"`
+		}{
+			Aliases: aliasesRes.Aliases,
+		},
+	}
+}

--- a/clientapi/routing/aliases.go
+++ b/clientapi/routing/aliases.go
@@ -78,12 +78,17 @@ func GetAliases(
 		return util.ErrorResponse(fmt.Errorf("rsAPI.GetAliasesForRoomID: %w", err))
 	}
 
+	response := struct {
+		Aliases []string `json:"aliases"`
+	}{
+		Aliases: aliasesRes.Aliases,
+	}
+	if response.Aliases == nil {
+		response.Aliases = []string{} // pleases sytest
+	}
+
 	return util.JSONResponse{
 		Code: 200,
-		JSON: struct {
-			Aliases []string `json:"aliases"`
-		}{
-			Aliases: aliasesRes.Aliases,
-		},
+		JSON: response,
 	}
 }

--- a/clientapi/routing/aliases.go
+++ b/clientapi/routing/aliases.go
@@ -50,7 +50,7 @@ func GetAliases(
 			util.GetLogger(req.Context()).WithError(err).Error("historyVisEvent.HistoryVisibility failed")
 			return util.ErrorResponse(fmt.Errorf("historyVisEvent.HistoryVisibility: %w", err))
 		}
-		if visibility != "world_readable" {
+		if visibility != gomatrixserverlib.WorldReadable {
 			queryReq := api.QueryMembershipForUserRequest{
 				RoomID: roomID,
 				UserID: device.UserID,

--- a/clientapi/routing/aliases.go
+++ b/clientapi/routing/aliases.go
@@ -1,4 +1,4 @@
-// Copyright 2017 Vector Creations Ltd
+// Copyright 2021 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/clientapi/routing/createroom.go
+++ b/clientapi/routing/createroom.go
@@ -383,7 +383,6 @@ func createRoom(
 	//  10- m.room.topic (opt)
 	//  11- invite events (opt) - with is_direct flag if applicable TODO
 	//  12- 3pid invite events (opt) TODO
-	//  13- m.room.aliases event for HS (if alias specified) TODO
 	// This differs from Synapse slightly. Synapse would vary the ordering of 3-7
 	// depending on if those events were in "initial_state" or not. This made it
 	// harder to reason about, hence sticking to a strict static ordering.
@@ -404,7 +403,6 @@ func createRoom(
 	if aliasEvent != nil {
 		// TODO: bit of a chicken and egg problem here as the alias doesn't exist and cannot until we have made the room.
 		// This means we might fail creating the alias but say the canonical alias is something that doesn't exist.
-		// m.room.aliases is handled when we call roomserver.SetRoomAlias
 		eventsToMake = append(eventsToMake, *aliasEvent)
 	}
 

--- a/clientapi/routing/directory.go
+++ b/clientapi/routing/directory.go
@@ -293,9 +293,9 @@ func SetVisibility(
 		return jsonerror.InternalServerError()
 	}
 
-	// NOTSPEC: Check if the user's power is greater than power required to change m.room.aliases event
+	// NOTSPEC: Check if the user's power is greater than power required to change m.room.canonical_alias event
 	power, _ := gomatrixserverlib.NewPowerLevelContentFromEvent(queryEventsRes.StateEvents[0].Event)
-	if power.UserLevel(dev.UserID) < power.EventLevel(gomatrixserverlib.MRoomAliases, true) {
+	if power.UserLevel(dev.UserID) < power.EventLevel(gomatrixserverlib.MRoomCanonicalAlias, true) {
 		return util.JSONResponse{
 			Code: http.StatusForbidden,
 			JSON: jsonerror.Forbidden("userID doesn't have power level to change visibility"),

--- a/clientapi/routing/directory.go
+++ b/clientapi/routing/directory.go
@@ -165,35 +165,6 @@ func SetLocalAlias(
 		return *resErr
 	}
 
-	// Check if the user has the power to update the aliases.
-	stateTuple := gomatrixserverlib.StateKeyTuple{
-		EventType: gomatrixserverlib.MRoomPowerLevels,
-		StateKey:  "",
-	}
-	stateReq := &roomserverAPI.QueryCurrentStateRequest{
-		RoomID:      r.RoomID,
-		StateTuples: []gomatrixserverlib.StateKeyTuple{stateTuple},
-	}
-	stateRes := &roomserverAPI.QueryCurrentStateResponse{}
-	if err := rsAPI.QueryCurrentState(req.Context(), stateReq, stateRes); err != nil {
-		util.GetLogger(req.Context()).WithError(err).Error("rsAPI.QueryCurrentState failed")
-		return util.ErrorResponse(fmt.Errorf("rsAPI.QueryCurrentState: %w", err))
-	}
-	if plEvent, ok := stateRes.StateEvents[stateTuple]; ok {
-		pls, err := plEvent.PowerLevels()
-		if err != nil {
-			util.GetLogger(req.Context()).WithError(err).Error("plEvent.PowerLevels failed")
-			return util.ErrorResponse(fmt.Errorf("plEvent.PowerLevels: %w", err))
-		}
-
-		if pls.UserLevel(device.UserID) < pls.EventLevel(gomatrixserverlib.MRoomCanonicalAlias, true) {
-			return util.JSONResponse{
-				Code: http.StatusForbidden,
-				JSON: jsonerror.Forbidden("You do not have permission to set aliases."),
-			}
-		}
-	}
-
 	queryReq := roomserverAPI.SetRoomAliasRequest{
 		UserID: device.UserID,
 		RoomID: r.RoomID,

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -275,6 +275,14 @@ func Setup(
 		return OnIncomingStateRequest(req.Context(), device, rsAPI, vars["roomID"])
 	})).Methods(http.MethodGet, http.MethodOptions)
 
+	r0mux.Handle("/rooms/{roomID}/aliases", httputil.MakeAuthAPI("aliases", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+		vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
+		if err != nil {
+			return util.ErrorResponse(err)
+		}
+		return GetAliases(req, rsAPI, device, vars["roomID"])
+	})).Methods(http.MethodGet, http.MethodOptions)
+
 	r0mux.Handle("/rooms/{roomID}/state/{type:[^/]+/?}", httputil.MakeAuthAPI("room_state", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
 		vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/matrix-org/go-http-js-libp2p v0.0.0-20200518170932-783164aeeda4
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20210709140738-b0d1ba599a6d
 	github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20210721140852-67af3764c4c4
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20210721155151-4575fad563b0
 	github.com/matrix-org/naffka v0.0.0-20210623111924-14ff508b58e0
 	github.com/matrix-org/pinecone v0.0.0-20210623102758-74f885644c1b
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/matrix-org/go-http-js-libp2p v0.0.0-20200518170932-783164aeeda4
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20210709140738-b0d1ba599a6d
 	github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20210721094149-75792185bf42
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20210721140852-67af3764c4c4
 	github.com/matrix-org/naffka v0.0.0-20210623111924-14ff508b58e0
 	github.com/matrix-org/pinecone v0.0.0-20210623102758-74f885644c1b
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4

--- a/go.sum
+++ b/go.sum
@@ -1027,8 +1027,8 @@ github.com/matrix-org/go-sqlite3-js v0.0.0-20210709140738-b0d1ba599a6d/go.mod h1
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16 h1:ZtO5uywdd5dLDCud4r0r55eP4j9FuUNpl60Gmntcop4=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20210721094149-75792185bf42 h1:UsCdEX9G3svG07bBV8RKAWIyGzCgJpbX4BCP1n4ezH8=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20210721094149-75792185bf42/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20210721140852-67af3764c4c4 h1:uuw87GvlrVshfs2xZVSnuFZpKtnGmJ4pPN+4Lmi3apo=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20210721140852-67af3764c4c4/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
 github.com/matrix-org/naffka v0.0.0-20210623111924-14ff508b58e0 h1:HZCzy4oVzz55e+cOMiX/JtSF2UOY1evBl2raaE7ACcU=
 github.com/matrix-org/naffka v0.0.0-20210623111924-14ff508b58e0/go.mod h1:sjyPyRxKM5uw1nD2cJ6O2OxI6GOqyVBfNXqKjBZTBZE=
 github.com/matrix-org/pinecone v0.0.0-20210623102758-74f885644c1b h1:5X5vdWQ13xrNkJVqaJHPsrt7rKkMJH5iac0EtfOuxSg=

--- a/go.sum
+++ b/go.sum
@@ -1027,8 +1027,8 @@ github.com/matrix-org/go-sqlite3-js v0.0.0-20210709140738-b0d1ba599a6d/go.mod h1
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16 h1:ZtO5uywdd5dLDCud4r0r55eP4j9FuUNpl60Gmntcop4=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20210721140852-67af3764c4c4 h1:uuw87GvlrVshfs2xZVSnuFZpKtnGmJ4pPN+4Lmi3apo=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20210721140852-67af3764c4c4/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20210721155151-4575fad563b0 h1:W1oqIcus66YGUb2HkawPTrU3OKqT3PXhXpBKoxEwiiA=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20210721155151-4575fad563b0/go.mod h1:JsAzE1Ll3+gDWS9JSUHPJiiyAksvOOnGWF2nXdg4ZzU=
 github.com/matrix-org/naffka v0.0.0-20210623111924-14ff508b58e0 h1:HZCzy4oVzz55e+cOMiX/JtSF2UOY1evBl2raaE7ACcU=
 github.com/matrix-org/naffka v0.0.0-20210623111924-14ff508b58e0/go.mod h1:sjyPyRxKM5uw1nD2cJ6O2OxI6GOqyVBfNXqKjBZTBZE=
 github.com/matrix-org/pinecone v0.0.0-20210623102758-74f885644c1b h1:5X5vdWQ13xrNkJVqaJHPsrt7rKkMJH5iac0EtfOuxSg=

--- a/internal/eventutil/eventcontent.go
+++ b/internal/eventutil/eventcontent.go
@@ -53,7 +53,6 @@ func InitialPowerLevelsContent(roomCreator string) (c gomatrixserverlib.PowerLev
 		"m.room.history_visibility": 100,
 		"m.room.canonical_alias":    50,
 		"m.room.avatar":             50,
-		"m.room.aliases":            0, // anyone can publish aliases by default. Has to be 0 else state_default is used.
 	}
 	c.Users = map[string]int64{roomCreator: 100}
 	return c

--- a/roomserver/api/alias.go
+++ b/roomserver/api/alias.go
@@ -78,4 +78,9 @@ type RemoveRoomAliasRequest struct {
 }
 
 // RemoveRoomAliasResponse is a response to RemoveRoomAlias
-type RemoveRoomAliasResponse struct{}
+type RemoveRoomAliasResponse struct {
+	// Did the alias exist before?
+	Found bool `json:"found"`
+	// Did we remove it?
+	Removed bool `json:"removed"`
+}

--- a/roomserver/internal/alias.go
+++ b/roomserver/internal/alias.go
@@ -77,7 +77,15 @@ func (r *RoomserverInternalAPI) SetRoomAlias(
 	// At this point we've already committed the alias to the database so we
 	// shouldn't cancel this request.
 	// TODO: Ensure that we send unsent events when if server restarts.
-	return r.sendUpdatedAliasesEvent(context.TODO(), request.UserID, request.RoomID)
+	//
+	// From: https://spec.matrix.org/unstable/client-server-api/#delete_matrixclientr0directoryroomroomalias
+	// Note: Servers may choose to update the alt_aliases for the m.room.canonical_alias
+	// state event in the room when an alias is removed. Servers which choose to update
+	// the canonical alias event are recommended to, in addition to their other relevant
+	// permission checks, delete the alias and return a successful response even if the
+	// user does not have permission to update the m.room.canonical_alias event.
+	_ = r.sendUpdatedAliasesEvent(context.TODO(), request.UserID, roomID)
+	return nil
 }
 
 // GetRoomIDForAlias implements alias.RoomserverInternalAPI
@@ -172,7 +180,15 @@ func (r *RoomserverInternalAPI) RemoveRoomAlias(
 	// At this point we've already committed the alias to the database so we
 	// shouldn't cancel this request.
 	// TODO: Ensure that we send unsent events when if server restarts.
-	return r.sendUpdatedAliasesEvent(context.TODO(), request.UserID, roomID)
+	//
+	// From: https://spec.matrix.org/unstable/client-server-api/#delete_matrixclientr0directoryroomroomalias
+	// Note: Servers may choose to update the alt_aliases for the m.room.canonical_alias
+	// state event in the room when an alias is removed. Servers which choose to update
+	// the canonical alias event are recommended to, in addition to their other relevant
+	// permission checks, delete the alias and return a successful response even if the
+	// user does not have permission to update the m.room.canonical_alias event.
+	_ = r.sendUpdatedAliasesEvent(context.TODO(), request.UserID, roomID)
+	return nil
 }
 
 type roomAliasesContent struct {

--- a/roomserver/internal/alias.go
+++ b/roomserver/internal/alias.go
@@ -176,8 +176,8 @@ func (r *RoomserverInternalAPI) RemoveRoomAlias(
 }
 
 type roomAliasesContent struct {
-	Alias   string   `json:"alias"`
-	Aliases []string `json:"alt_aliases"`
+	Alias   string   `json:"alias,omitempty"`
+	Aliases []string `json:"alt_aliases,omitempty"`
 }
 
 // Build the updated m.room.aliases event to send to the room after addition or

--- a/roomserver/internal/alias.go
+++ b/roomserver/internal/alias.go
@@ -150,7 +150,7 @@ func (r *RoomserverInternalAPI) RemoveRoomAlias(
 	request *api.RemoveRoomAliasRequest,
 	response *api.RemoveRoomAliasResponse,
 ) error {
-	creatorID, err := r.DB.GetCreatorIDForAlias(ctx, request.UserID)
+	creatorID, err := r.DB.GetCreatorIDForAlias(ctx, request.Alias)
 	if err != nil {
 		return err
 	}
@@ -159,7 +159,7 @@ func (r *RoomserverInternalAPI) RemoveRoomAlias(
 		return fmt.Errorf("not allowed to delete this alias")
 	}
 
-	// Remove the dalias from the database
+	// Remove the alias from the database
 	if err := r.DB.RemoveRoomAlias(ctx, request.Alias); err != nil {
 		return err
 	}

--- a/roomserver/internal/alias.go
+++ b/roomserver/internal/alias.go
@@ -73,7 +73,7 @@ func (r *RoomserverInternalAPI) SetRoomAlias(
 		return err
 	}
 
-	// Send a m.room.aliases event with the updated list of aliases for this room
+	// Send a m.room.canonical_alias event with the updated list of aliases for this room
 	// At this point we've already committed the alias to the database so we
 	// shouldn't cancel this request.
 	// TODO: Ensure that we send unsent events when if server restarts.
@@ -176,7 +176,8 @@ func (r *RoomserverInternalAPI) RemoveRoomAlias(
 }
 
 type roomAliasesContent struct {
-	Aliases []string `json:"aliases"`
+	Alias   string   `json:"alias"`
+	Aliases []string `json:"alt_aliases"`
 }
 
 // Build the updated m.room.aliases event to send to the room after addition or
@@ -189,7 +190,7 @@ func (r *RoomserverInternalAPI) sendUpdatedAliasesEvent(
 	builder := gomatrixserverlib.EventBuilder{
 		Sender:   userID,
 		RoomID:   roomID,
-		Type:     "m.room.aliases",
+		Type:     gomatrixserverlib.MRoomCanonicalAlias,
 		StateKey: &serverName,
 	}
 
@@ -199,7 +200,9 @@ func (r *RoomserverInternalAPI) sendUpdatedAliasesEvent(
 	if err != nil {
 		return err
 	}
-	content := roomAliasesContent{Aliases: aliases}
+	content := roomAliasesContent{
+		Aliases: aliases,
+	}
 	rawContent, err := json.Marshal(content)
 	if err != nil {
 		return err

--- a/roomserver/internal/perform/perform_invite.go
+++ b/roomserver/internal/perform/perform_invite.go
@@ -223,8 +223,8 @@ func buildInviteStrippedState(
 	// https://matrix.org/docs/spec/client_server/r0.6.0#m-room-member
 	for _, t := range []string{
 		gomatrixserverlib.MRoomName, gomatrixserverlib.MRoomCanonicalAlias,
-		gomatrixserverlib.MRoomAliases, gomatrixserverlib.MRoomJoinRules,
-		"m.room.avatar", "m.room.encryption", gomatrixserverlib.MRoomCreate,
+		gomatrixserverlib.MRoomJoinRules, gomatrixserverlib.MRoomAvatar,
+		gomatrixserverlib.MRoomEncryption, gomatrixserverlib.MRoomCreate,
 	} {
 		stateWanted = append(stateWanted, gomatrixserverlib.StateKeyTuple{
 			EventType: t,

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -857,7 +857,7 @@ func (d *Database) GetStateEvent(ctx context.Context, roomID, evType, stateKey s
 	if err != nil {
 		return nil, err
 	}
-	if roomInfo == nil {
+	if roomInfo == nil || roomInfo.IsStub {
 		return nil, fmt.Errorf("room %s doesn't exist", roomID)
 	}
 	eventTypeNID, err := d.EventTypesTable.SelectEventTypeNID(ctx, nil, evType)

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -857,6 +857,9 @@ func (d *Database) GetStateEvent(ctx context.Context, roomID, evType, stateKey s
 	if err != nil {
 		return nil, err
 	}
+	if roomInfo == nil {
+		return nil, fmt.Errorf("room %s doesn't exist", roomID)
+	}
 	eventTypeNID, err := d.EventTypesTable.SelectEventTypeNID(ctx, nil, evType)
 	if err == sql.ErrNoRows {
 		// No rooms have an event of this type, otherwise we'd have an event type NID

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -537,3 +537,4 @@ Remote servers should reject attempts by non-creators to set the power levels
 Federation handles empty auth_events in state_ids sanely
 Key notary server should return an expired key if it can't find any others
 Key notary server must not overwrite a valid key with a spurious result from the origin server
+GET /rooms/:room_id/aliases lists aliases

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -538,3 +538,5 @@ Federation handles empty auth_events in state_ids sanely
 Key notary server should return an expired key if it can't find any others
 Key notary server must not overwrite a valid key with a spurious result from the origin server
 GET /rooms/:room_id/aliases lists aliases
+Only room members can list aliases of a room
+Users with sufficient power-level can delete other's aliases


### PR DESCRIPTION
This PR is a rather motley collection of fixes for aliases:

* Adds the `/room/{roomID}/aliases` endpoint
* Stops sending `m.room.aliases` events into that room, since that event no longer has any meaning in the spec
* Sends `m.room.canonical_alias` when creating the room, if an alias is specified
* No longer tries to send state events in response to changing room aliases (since we need to rethink this)
* Fixes a bunch of behaviour around the `/directory/{roomID}` endpoints for `PUT`, `DELETE` etc

Makes a couple more sytests happy and actually means that some of them that were passing before are now passing for the right reasons.