### PR TITLE
Don't set prev state when it is the same as the event it replaces

### DIFF
--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -378,7 +378,7 @@ func (s *OutputRoomEventConsumer) updateStateEvent(event *gomatrixserverlib.Head
 		return event, err
 	}
 
-	if prevEvent == nil {
+	if prevEvent == nil || prevEvent.EventID() == event.EventID() {
 		return event, nil
 	}
 


### PR DESCRIPTION
While not a complete fix for the duplicate events causing #1742, it should at least guard against us sending garbage to clients.