### PR TITLE
Key Backups (3/3) : Implement querying keys and various bugfixes

### DIFF
--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -896,7 +896,8 @@ func Setup(
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
-	// Key Backup Versions
+	// Key Backup Versions (Metadata)
+
 	r0mux.Handle("/room_keys/version/{version}",
 		httputil.MakeAuthAPI("get_backup_keys_version", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
 			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
@@ -935,7 +936,8 @@ func Setup(
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 
-	// E2E Backup Keys
+	// Inserting E2E Backup Keys
+
 	// Bulk room and session
 	r0mux.Handle("/room_keys/keys",
 		httputil.MakeAuthAPI("put_backup_keys", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
@@ -1022,6 +1024,8 @@ func Setup(
 		}),
 	).Methods(http.MethodPut)
 
+	// Querying E2E Backup Keys
+
 	r0mux.Handle("/room_keys/keys",
 		httputil.MakeAuthAPI("get_backup_keys", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
 			return GetBackupKeys(req, userAPI, device, req.URL.Query().Get("version"), "", "")
@@ -1045,6 +1049,8 @@ func Setup(
 			return GetBackupKeys(req, userAPI, device, req.URL.Query().Get("version"), vars["roomID"], vars["sessionID"])
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
+
+	// Deleting E2E Backup Keys
 
 	// Supplying a device ID is deprecated.
 	r0mux.Handle("/keys/upload/{deviceID}",

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -546,6 +546,7 @@ Responds correctly when backup is empty
 Can backup keys
 Can update keys with better versions
 Will not update keys with worse versions
+Will not back up to an old backup version
 Can create more than 10 backup versions
 Can delete backup
 Deleted & recreated backups are empty

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -540,3 +540,12 @@ Key notary server must not overwrite a valid key with a spurious result from the
 GET /rooms/:room_id/aliases lists aliases
 Only room members can list aliases of a room
 Users with sufficient power-level can delete other's aliases
+Can create backup version
+Can update backup version
+Responds correctly when backup is empty
+Can backup keys
+Can update keys with better versions
+Will not update keys with worse versions
+Can create more than 10 backup versions
+Can delete backup
+Deleted & recreated backups are empty

--- a/userapi/internal/api.go
+++ b/userapi/internal/api.go
@@ -539,8 +539,10 @@ func (a *UserInternalAPI) QueryKeyBackup(ctx context.Context, req *api.QueryKeyB
 	res.Exists = !deleted
 
 	if !req.ReturnKeys {
-		// TODO return the counts
 		res.Count, err = a.AccountDB.CountBackupKeys(ctx, version, req.UserID)
+		if err != nil {
+			res.Error = fmt.Sprintf("failed to count keys: %s", err)
+		}
 		return
 	}
 

--- a/userapi/storage/accounts/interface.go
+++ b/userapi/storage/accounts/interface.go
@@ -61,6 +61,8 @@ type Database interface {
 	DeleteKeyBackup(ctx context.Context, userID, version string) (exists bool, err error)
 	GetKeyBackup(ctx context.Context, userID, version string) (versionResult, algorithm string, authData json.RawMessage, etag string, deleted bool, err error)
 	UpsertBackupKeys(ctx context.Context, version, userID string, uploads []api.InternalKeyBackupSession) (count int64, etag string, err error)
+	GetBackupKeys(ctx context.Context, version, userID, filterRoomID, filterSessionID string) (result map[string]map[string]api.KeyBackupSession, err error)
+	CountBackupKeys(ctx context.Context, version, userID string) (count int64, err error)
 }
 
 // Err3PIDInUse is the error returned when trying to save an association involving

--- a/userapi/storage/accounts/postgres/key_backup_version_table.go
+++ b/userapi/storage/accounts/postgres/key_backup_version_table.go
@@ -67,7 +67,6 @@ type keyBackupVersionStatements struct {
 	updateKeyBackupETagStmt     *sql.Stmt
 }
 
-// nolint:unused
 func (s *keyBackupVersionStatements) prepare(db *sql.DB) (err error) {
 	_, err = db.Exec(keyBackupVersionTableSchema)
 	if err != nil {

--- a/userapi/storage/accounts/sqlite3/key_backup_version_table.go
+++ b/userapi/storage/accounts/sqlite3/key_backup_version_table.go
@@ -65,7 +65,6 @@ type keyBackupVersionStatements struct {
 	updateKeyBackupETagStmt     *sql.Stmt
 }
 
-// nolint:unused
 func (s *keyBackupVersionStatements) prepare(db *sql.DB) (err error) {
 	_, err = db.Exec(keyBackupVersionTableSchema)
 	if err != nil {

--- a/userapi/storage/accounts/sqlite3/storage.go
+++ b/userapi/storage/accounts/sqlite3/storage.go
@@ -100,13 +100,12 @@ func NewDatabase(dbProperties *config.DatabaseOptions, serverName gomatrixserver
 	if err = d.openIDTokens.prepare(db, serverName); err != nil {
 		return nil, err
 	}
-	/*
-		if err = d.keyBackupVersions.prepare(db); err != nil {
-			return nil, err
-		}
-		if err = d.keyBackups.prepare(db); err != nil {
-			return nil, err
-		} */
+	if err = d.keyBackupVersions.prepare(db); err != nil {
+		return nil, err
+	}
+	if err = d.keyBackups.prepare(db); err != nil {
+		return nil, err
+	}
 
 	return d, nil
 }
@@ -459,6 +458,37 @@ func (d *Database) GetKeyBackup(
 	return
 }
 
+func (d *Database) GetBackupKeys(
+	ctx context.Context, version, userID, filterRoomID, filterSessionID string,
+) (result map[string]map[string]api.KeyBackupSession, err error) {
+	err = d.writer.Do(d.db, nil, func(txn *sql.Tx) error {
+		if filterSessionID != "" {
+			result, err = d.keyBackups.selectKeysByRoomIDAndSessionID(ctx, txn, userID, version, filterRoomID, filterSessionID)
+			return err
+		}
+		if filterRoomID != "" {
+			result, err = d.keyBackups.selectKeysByRoomID(ctx, txn, userID, version, filterRoomID)
+			return err
+		}
+		result, err = d.keyBackups.selectKeys(ctx, txn, userID, version)
+		return err
+	})
+	return
+}
+
+func (d *Database) CountBackupKeys(
+	ctx context.Context, version, userID string,
+) (count int64, err error) {
+	err = d.writer.Do(d.db, nil, func(txn *sql.Tx) error {
+		count, err = d.keyBackups.countKeys(ctx, txn, userID, version)
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	return
+}
+
 // nolint:nakedret
 func (d *Database) UpsertBackupKeys(
 	ctx context.Context, version, userID string, uploads []api.InternalKeyBackupSession,
@@ -486,7 +516,7 @@ func (d *Database) UpsertBackupKeys(
 			if existingRoom != nil {
 				existingSession, ok := existingRoom[newKey.SessionID]
 				if ok {
-					if shouldReplaceRoomKey(existingSession, newKey.KeyBackupSession) {
+					if existingSession.ShouldReplaceRoomKey(&newKey.KeyBackupSession) {
 						err = d.keyBackups.updateBackupKey(ctx, txn, userID, version, newKey)
 						changed = true
 						if err != nil {
@@ -530,23 +560,4 @@ func (d *Database) UpsertBackupKeys(
 		return nil
 	})
 	return
-}
-
-// TODO FIXME XXX : This logic really shouldn't live in the storage layer, but I don't know where else is sensible which won't
-// create circular import loops
-func shouldReplaceRoomKey(existing, uploaded api.KeyBackupSession) bool {
-	// https://spec.matrix.org/unstable/client-server-api/#backup-algorithm-mmegolm_backupv1curve25519-aes-sha2
-	// "if the keys have different values for is_verified, then it will keep the key that has is_verified set to true"
-	if uploaded.IsVerified && !existing.IsVerified {
-		return true
-	}
-	// "if they have the same values for is_verified, then it will keep the key with a lower first_message_index"
-	if uploaded.FirstMessageIndex < existing.FirstMessageIndex {
-		return true
-	}
-	// "and finally, is is_verified and first_message_index are equal, then it will keep the key with a lower forwarded_count"
-	if uploaded.ForwardedCount < existing.ForwardedCount {
-		return true
-	}
-	return false
 }


### PR DESCRIPTION
This makes all 10 key backup sytests pass, enough to close https://github.com/matrix-org/dendrite/issues/1305

This PR hasn't yet implemented:
 - `DELETE /_matrix/client/r0/room_keys/keys/{roomId}/{sessionId}`
 - `DELETE /_matrix/client/r0/room_keys/keys/{roomId}`
 - `DELETE /_matrix/client/r0/room_keys/keys`

Sytest doesn't seem to exercise these endpoints either. 