### PR TITLE
[WIP] Implement special cases for m.room.canonical_alias

### DIFF
--- a/clientapi/jsonerror/jsonerror.go
+++ b/clientapi/jsonerror/jsonerror.go
@@ -169,3 +169,15 @@ func NotTrusted(serverName string) *MatrixError {
 		Err:     fmt.Sprintf("Untrusted server '%s'", serverName),
 	}
 }
+// BadAlias is an error which is returned when one or more aliases within a
+// m.room.canonical_alias event do not point to the room ID for which the state
+// event is to be sent to.
+func BadAlias(msg string) *MatrixError {
+    return &MatrixError{"M_BAD_ALIAS", msg}
+}
+
+// InvalidParam is an error return when an alias from a m.room.canonical_alias
+// contains a malformed alias
+func InvalidParam(msg string) *MatrixError {
+    return &MatrixError{"M_INVALID_PARAM", msg}
+}

--- a/clientapi/jsonerror/jsonerror.go
+++ b/clientapi/jsonerror/jsonerror.go
@@ -169,15 +169,16 @@ func NotTrusted(serverName string) *MatrixError {
 		Err:     fmt.Sprintf("Untrusted server '%s'", serverName),
 	}
 }
+
 // BadAlias is an error which is returned when one or more aliases within a
 // m.room.canonical_alias event do not point to the room ID for which the state
 // event is to be sent to.
 func BadAlias(msg string) *MatrixError {
-    return &MatrixError{"M_BAD_ALIAS", msg}
+	return &MatrixError{"M_BAD_ALIAS", msg}
 }
 
 // InvalidParam is an error return when an alias from a m.room.canonical_alias
 // contains a malformed alias
 func InvalidParam(msg string) *MatrixError {
-    return &MatrixError{"M_INVALID_PARAM", msg}
+	return &MatrixError{"M_INVALID_PARAM", msg}
 }

--- a/clientapi/routing/directory.go
+++ b/clientapi/routing/directory.go
@@ -15,14 +15,12 @@
 package routing
 
 import (
-	"encoding/json"
 	"fmt"
 	"net/http"
 
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	federationSenderAPI "github.com/matrix-org/dendrite/federationsender/api"
-	"github.com/matrix-org/dendrite/internal/eventutil"
 	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/dendrite/userapi/api"
@@ -223,130 +221,10 @@ func RemoveLocalAlias(
 		}
 	}
 
-	updatedCanonicalAlias := eventutil.CanonicalAlias{
-		Alias:      "",
-		AltAliases: []string{""},
-	}
-	updated, resErr := getUpdatedCanonicalAliasState(req, queryRes.RoomID, alias, rsAPI, &updatedCanonicalAlias)
-	if resErr != nil {
-		return *resErr
-	}
-	// If the alias removed is one of the alt_aliases or the canonical one,
-	// we need to also remove it from the canonical_alias event
-	if updated {
-		resErr := updateCanonicalAlias(req, device, queryRes.RoomID, cfg, rsAPI, &updatedCanonicalAlias)
-		if resErr != nil {
-			return *resErr
-		}
-	}
-
 	return util.JSONResponse{
 		Code: http.StatusOK,
 		JSON: struct{}{},
 	}
-}
-
-func getUpdatedCanonicalAliasState(
-	req *http.Request,
-	roomID string,
-	alias string,
-	rsAPI roomserverAPI.RoomserverInternalAPI,
-	updatedCanonicalAlias *eventutil.CanonicalAlias,
-) (bool, *util.JSONResponse) {
-	updated := false
-	stateTuple := gomatrixserverlib.StateKeyTuple{
-		EventType: gomatrixserverlib.MRoomCanonicalAlias,
-		StateKey:  "",
-	}
-	stateReq := roomserverAPI.QueryCurrentStateRequest{
-		RoomID:      roomID,
-		StateTuples: []gomatrixserverlib.StateKeyTuple{stateTuple},
-	}
-	stateRes := &roomserverAPI.QueryCurrentStateResponse{}
-	err := rsAPI.QueryCurrentState(req.Context(), &stateReq, stateRes)
-	if err != nil {
-		util.GetLogger(req.Context()).WithError(err).Error("Query state failed")
-		resErr := jsonerror.InternalServerError()
-		return false, &resErr
-	}
-
-	// We try to get the current canonical_alias state, and if found compare its content
-	// to the removed alias
-	if canonicalAliasEvent, ok := stateRes.StateEvents[stateTuple]; ok {
-		canonicalAliasContent := eventutil.CanonicalAlias{
-			Alias:      "",
-			AltAliases: []string{""},
-		}
-		// TODO handle differently malformed event?
-		err := json.Unmarshal(canonicalAliasEvent.Content(), &canonicalAliasContent)
-		if err != nil {
-			util.GetLogger(req.Context()).WithError(err).Error("Get canonical_alias event content failed")
-			resErr := jsonerror.InternalServerError()
-			return false, &resErr
-		}
-		if alias == canonicalAliasContent.Alias {
-			updated = true
-		} else {
-			updatedCanonicalAlias.Alias = canonicalAliasContent.Alias
-		}
-		for _, s := range canonicalAliasContent.AltAliases {
-			if alias == s {
-				updated = true
-			} else {
-				updatedCanonicalAlias.AltAliases = append(updatedCanonicalAlias.AltAliases, s)
-			}
-		}
-	}
-	return updated, nil
-}
-
-func updateCanonicalAlias(
-	req *http.Request,
-	device *api.Device,
-	roomID string,
-	cfg *config.ClientAPI,
-	rsAPI roomserverAPI.RoomserverInternalAPI,
-	updatedCanonicalAlias *eventutil.CanonicalAlias,
-) *util.JSONResponse {
-	var stateKey = ""
-	// We create a new canonical_alias event with the new alias and alt_aliase
-	// May cause some auth problems
-	builder := gomatrixserverlib.EventBuilder{
-		Sender:   device.UserID,
-		RoomID:   roomID,
-		Type:     gomatrixserverlib.MRoomCanonicalAlias,
-		StateKey: &stateKey,
-	}
-	err := builder.SetContent(updatedCanonicalAlias)
-	if err != nil {
-		util.GetLogger(req.Context()).WithError(err).Error("builder.SetContent failed")
-		resErr := jsonerror.InternalServerError()
-		return &resErr
-	}
-
-	evTime, err := httputil.ParseTSParam(req)
-	if err != nil {
-		return &util.JSONResponse{
-			Code: http.StatusBadRequest,
-			JSON: jsonerror.InvalidArgumentValue(err.Error()),
-		}
-	}
-
-	// Build the event
-	e, err := eventutil.QueryAndBuildEvent(req.Context(), &builder, cfg.Matrix, evTime, rsAPI, nil)
-	if err != nil {
-		util.GetLogger(req.Context()).WithError(err).Errorf("failed to QueryAndBuildEvent")
-		resErr := jsonerror.InternalServerError()
-		return &resErr
-	}
-	// Send the event to the room server
-	err = roomserverAPI.SendEvents(req.Context(), rsAPI, roomserverAPI.KindNew, []*gomatrixserverlib.HeaderedEvent{e}, cfg.Matrix.ServerName, nil)
-	if err != nil {
-		util.GetLogger(req.Context()).WithError(err).Errorf("failed to SendEvents")
-		resErr := jsonerror.InternalServerError()
-		return &resErr
-	}
-	return nil
 }
 
 type roomVisibility struct {

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -243,7 +243,7 @@ func Setup(
 			if err != nil {
 				return util.ErrorResponse(err)
 			}
-			return SendEvent(req, device, vars["roomID"], vars["eventType"], nil, nil, cfg, rsAPI, nil)
+			return SendEvent(req, device, vars["roomID"], vars["eventType"], nil, nil, federation, cfg, rsAPI, nil)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 	r0mux.Handle("/rooms/{roomID}/send/{eventType}/{txnID}",
@@ -254,7 +254,7 @@ func Setup(
 			}
 			txnID := vars["txnID"]
 			return SendEvent(req, device, vars["roomID"], vars["eventType"], &txnID,
-				nil, cfg, rsAPI, transactionsCache)
+				nil, federation, cfg, rsAPI, transactionsCache)
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 	r0mux.Handle("/rooms/{roomID}/event/{eventID}",
@@ -318,7 +318,7 @@ func Setup(
 			if strings.HasSuffix(eventType, "/") {
 				eventType = eventType[:len(eventType)-1]
 			}
-			return SendEvent(req, device, vars["roomID"], eventType, nil, &emptyString, cfg, rsAPI, nil)
+			return SendEvent(req, device, vars["roomID"], eventType, nil, &emptyString, federation, cfg, rsAPI, nil)
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 
@@ -329,7 +329,7 @@ func Setup(
 				return util.ErrorResponse(err)
 			}
 			stateKey := vars["stateKey"]
-			return SendEvent(req, device, vars["roomID"], vars["eventType"], nil, &stateKey, cfg, rsAPI, nil)
+			return SendEvent(req, device, vars["roomID"], vars["eventType"], nil, &stateKey, federation, cfg, rsAPI, nil)
 		}),
 	).Methods(http.MethodPut, http.MethodOptions)
 

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -373,7 +373,7 @@ func Setup(
 			if err != nil {
 				return util.ErrorResponse(err)
 			}
-			return RemoveLocalAlias(req, device, vars["roomAlias"], rsAPI)
+			return RemoveLocalAlias(req, device, vars["roomAlias"], cfg, rsAPI)
 		}),
 	).Methods(http.MethodDelete, http.MethodOptions)
 	r0mux.Handle("/directory/list/room/{roomID}",

--- a/internal/eventutil/eventcontent.go
+++ b/internal/eventutil/eventcontent.go
@@ -38,7 +38,8 @@ type HistoryVisibilityContent struct {
 
 // CanonicalAlias is the event content for https://matrix.org/docs/spec/client_server/r0.6.0#m-room-canonical-alias
 type CanonicalAlias struct {
-	Alias string `json:"alias"`
+	Alias       string      `json:"alias,omitempty"`
+    AltAliases  []string    `json:"alt_aliases,omitempty"`
 }
 
 // InitialPowerLevelsContent returns the initial values for m.room.power_levels on room creation

--- a/internal/eventutil/eventcontent.go
+++ b/internal/eventutil/eventcontent.go
@@ -38,8 +38,8 @@ type HistoryVisibilityContent struct {
 
 // CanonicalAlias is the event content for https://matrix.org/docs/spec/client_server/r0.6.0#m-room-canonical-alias
 type CanonicalAlias struct {
-	Alias       string      `json:"alias,omitempty"`
-    AltAliases  []string    `json:"alt_aliases,omitempty"`
+	Alias      string   `json:"alias,omitempty"`
+	AltAliases []string `json:"alt_aliases,omitempty"`
 }
 
 // InitialPowerLevelsContent returns the initial values for m.room.power_levels on room creation

--- a/roomserver/api/alias.go
+++ b/roomserver/api/alias.go
@@ -83,4 +83,6 @@ type RemoveRoomAliasResponse struct {
 	Found bool `json:"found"`
 	// Did we remove it?
 	Removed bool `json:"removed"`
+    // The room ID the alias refers to
+    RoomID string `json:"room_id"`
 }

--- a/roomserver/api/alias.go
+++ b/roomserver/api/alias.go
@@ -83,6 +83,6 @@ type RemoveRoomAliasResponse struct {
 	Found bool `json:"found"`
 	// Did we remove it?
 	Removed bool `json:"removed"`
-    // The room ID the alias refers to
-    RoomID string `json:"room_id"`
+	// The room ID the alias refers to
+	RoomID string `json:"room_id"`
 }

--- a/roomserver/internal/alias.go
+++ b/roomserver/internal/alias.go
@@ -154,6 +154,7 @@ func (r *RoomserverInternalAPI) RemoveRoomAlias(
 	if err != nil {
 		return fmt.Errorf("r.DB.GetRoomIDForAlias: %w", err)
 	}
+    response.RoomID = roomID
 	if roomID == "" {
 		response.Found = false
 		response.Removed = false

--- a/roomserver/internal/alias.go
+++ b/roomserver/internal/alias.go
@@ -154,7 +154,7 @@ func (r *RoomserverInternalAPI) RemoveRoomAlias(
 	if err != nil {
 		return fmt.Errorf("r.DB.GetRoomIDForAlias: %w", err)
 	}
-    response.RoomID = roomID
+	response.RoomID = roomID
 	if roomID == "" {
 		response.Found = false
 		response.Removed = false

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -540,3 +540,5 @@ Key notary server must not overwrite a valid key with a spurious result from the
 GET /rooms/:room_id/aliases lists aliases
 Only room members can list aliases of a room
 Users with sufficient power-level can delete other's aliases
+Canonical alias can be set
+Canonical alias can include alt_aliases

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -542,3 +542,4 @@ Only room members can list aliases of a room
 Users with sufficient power-level can delete other's aliases
 Canonical alias can be set
 Canonical alias can include alt_aliases
+Can delete canonical alias


### PR DESCRIPTION
WIP to implement #618

Currently doesn't pass tests for removing aliases without permission to send `m.room.canonical_alias` event, planning to investigate how event auth is handled.

Question : is there any reason to keep the `CanonicalAliasContent` at https://github.com/matrix-org/dendrite/blob/c1447a58e5de5408d80e0de84c0424342121b06c/internal/eventutil/eventcontent.go#L67 (which doesn't seem to e used anywhere) when https://github.com/matrix-org/dendrite/blob/c1447a58e5de5408d80e0de84c0424342121b06c/internal/eventutil/eventcontent.go#L40 exists ?

### Pull Request Checklist

* [x] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `Colin Weill--Duflos <lieunoir@rezel.net>`
