### PR TITLE
Read the right username field when performing account deactivation

### DIFF
--- a/clientapi/routing/deactivate.go
+++ b/clientapi/routing/deactivate.go
@@ -33,7 +33,7 @@ func Deactivate(
 		return *errRes
 	}
 
-	localpart, _, err := gomatrixserverlib.SplitID('@', login.User)
+	localpart, _, err := gomatrixserverlib.SplitID('@', login.Username())
 	if err != nil {
 		util.GetLogger(req.Context()).WithError(err).Error("gomatrixserverlib.SplitID failed")
 		return jsonerror.InternalServerError()


### PR DESCRIPTION
`Login` has 2 username fields, and we were always checking the
deprecated one. Instead, check both.

Fixes broken sytests.