### PR TITLE
Minimum version Go 1.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you have further questions, please take a look at [our FAQ](docs/FAQ.md) or j
 
 ## Requirements
 
-To build Dendrite, you will need Go 1.13 or later. 
+To build Dendrite, you will need Go 1.15 or later. 
 
 For a usable federating Dendrite deployment, you will also need:
 - A domain name (or subdomain) 

--- a/cmd/dendrite-demo-yggdrasil/README.md
+++ b/cmd/dendrite-demo-yggdrasil/README.md
@@ -1,6 +1,6 @@
 # Yggdrasil Demo
 
-This is the Dendrite Yggdrasil demo! It's easy to get started - all you need is Go 1.14 or later.
+This is the Dendrite Yggdrasil demo! It's easy to get started - all you need is Go 1.15 or later.
 
 To run the homeserver, start at the root of the Dendrite repository and run:
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -25,7 +25,7 @@ use in production environments just yet!
 
 Dendrite requires:
 
-* Go 1.14 or higher
+* Go 1.15 or higher
 * Postgres 9.6 or higher (if using Postgres databases, not needed for SQLite)
 
 If you want to run a polylith deployment, you also need:

--- a/go.mod
+++ b/go.mod
@@ -63,4 +63,4 @@ require (
 	nhooyr.io/websocket v1.8.7
 )
 
-go 1.14
+go 1.15


### PR DESCRIPTION
I am pretty sure we already require Go 1.15 because of some standard library bits, and we already run CI against Go 1.15, so this just makes that more clear.