### PR TITLE
Fix sqlite migration issues

### DIFF
--- a/roomserver/storage/sqlite3/deltas/2021041615092700_state_blocks_refactor.go
+++ b/roomserver/storage/sqlite3/deltas/2021041615092700_state_blocks_refactor.go
@@ -100,8 +100,8 @@ func UpStateBlocksRefactor(tx *sql.Tx) error {
 			// If we don't do this, we'll fail the assertions later on which try to ensure we didn't forget
 			// any snapshots.
 			_, err = tx.Exec(
-				`UPDATE roomserver_events SET state_snapshot_nid = 0 WHERE event_type_nid = $1 AND state_snapshot_nid = $2`,
-				types.MRoomCreateNID, snapshot,
+				`UPDATE roomserver_events SET state_snapshot_nid = 0 WHERE event_type_nid = $1 AND event_state_key_nid = $2 AND state_snapshot_nid = $3`,
+				types.MRoomCreateNID, types.EmptyStateKeyNID, snapshot,
 			)
 			if err != nil {
 				return fmt.Errorf("resetting create events snapshots to 0 errored: %s", err)

--- a/roomserver/storage/sqlite3/deltas/2021041615092700_state_blocks_refactor.go
+++ b/roomserver/storage/sqlite3/deltas/2021041615092700_state_blocks_refactor.go
@@ -93,6 +93,20 @@ func UpStateBlocksRefactor(tx *sql.Tx) error {
 		}
 
 		var newblocks types.StateBlockNIDs
+		if len(blocks) == 0 {
+			// some m.room.create events have a state snapshot but no state blocks at all which makes
+			// sense as there is no state before creation. The correct form should be to give the event
+			// in question a state snapshot NID of 0 to indicate 'no snapshot'.
+			// If we don't do this, we'll fail the assertions later on which try to ensure we didn't forget
+			// any snapshots.
+			_, err = tx.Exec(
+				`UPDATE roomserver_events SET state_snapshot_nid = 0 WHERE event_type_nid = $1 AND state_snapshot_nid = $2`,
+				types.MRoomCreateNID, snapshot,
+			)
+			if err != nil {
+				return fmt.Errorf("resetting create events snapshots to 0 errored: %s", err)
+			}
+		}
 		for _, block := range blocks {
 			if err = func() error {
 				blockrows, berr := tx.Query(`SELECT event_nid FROM _roomserver_state_block WHERE state_block_nid = $1`, block)

--- a/roomserver/storage/sqlite3/events_table.go
+++ b/roomserver/storage/sqlite3/events_table.go
@@ -571,6 +571,9 @@ func (s *eventStatements) SelectRoomNIDsForEventNIDs(
 }
 
 func eventNIDsAsArray(eventNIDs []types.EventNID) string {
+	if eventNIDs == nil {
+		eventNIDs = []types.EventNID{} // don't store 'null' in the DB
+	}
 	b, _ := json.Marshal(eventNIDs)
 	return string(b)
 }

--- a/roomserver/storage/sqlite3/state_block_table.go
+++ b/roomserver/storage/sqlite3/state_block_table.go
@@ -86,7 +86,7 @@ func (s *stateBlockStatements) BulkInsertStateData(
 	entries types.StateEntries,
 ) (id types.StateBlockNID, err error) {
 	entries = entries[:util.SortAndUnique(entries)]
-	var nids types.EventNIDs
+	nids := types.EventNIDs{} // zero slice to not store 'null' in the DB
 	for _, e := range entries {
 		nids = append(nids, e.EventNID)
 	}

--- a/roomserver/storage/sqlite3/state_snapshot_table.go
+++ b/roomserver/storage/sqlite3/state_snapshot_table.go
@@ -87,6 +87,9 @@ func prepareStateSnapshotTable(db *sql.DB) (tables.StateSnapshot, error) {
 func (s *stateSnapshotStatements) InsertState(
 	ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, stateBlockNIDs types.StateBlockNIDs,
 ) (stateNID types.StateSnapshotNID, err error) {
+	if stateBlockNIDs == nil {
+		stateBlockNIDs = []types.StateBlockNID{} // zero slice to not store 'null' in the DB
+	}
 	stateBlockNIDs = stateBlockNIDs[:util.SortAndUnique(stateBlockNIDs)]
 	stateBlockNIDsJSON, err := json.Marshal(stateBlockNIDs)
 	if err != nil {


### PR DESCRIPTION
- Do not store 'null' in the database for empty JSON arrays 
- sqlite migration should handle create events as having no 'before' snapshot

See commit comments for more rationale.

Partially addresses https://github.com/matrix-org/dendrite/issues/1924 (for sqlite users) thanks to @ daniele:matrix.org