### PR TITLE
Cross-signing validation for self-sigs, expose signatures over `/user/keys/query` and `/user/devices/{userId}`

### DIFF
--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -65,7 +65,7 @@ func Setup(
 	userInteractiveAuth := auth.NewUserInteractive(accountDB.GetAccountByPassword, cfg)
 
 	unstableFeatures := map[string]bool{
-		//"org.matrix.e2e_cross_signing": true,
+		"org.matrix.e2e_cross_signing": true,
 	}
 	for _, msc := range cfg.MSCs.MSCs {
 		unstableFeatures["org.matrix."+msc] = true

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -65,7 +65,7 @@ func Setup(
 	userInteractiveAuth := auth.NewUserInteractive(accountDB.GetAccountByPassword, cfg)
 
 	unstableFeatures := map[string]bool{
-		"org.matrix.e2e_cross_signing": true,
+		//"org.matrix.e2e_cross_signing": true,
 	}
 	for _, msc := range cfg.MSCs.MSCs {
 		unstableFeatures["org.matrix."+msc] = true

--- a/federationapi/routing/devices.go
+++ b/federationapi/routing/devices.go
@@ -66,8 +66,8 @@ func GetUserDevices(
 			Keys:        key,
 		}
 
-		if targetUser, ok := sigRes.Signatures[dev.UserID]; ok {
-			if targetKey, ok := targetUser[gomatrixserverlib.KeyID(dev.DeviceID)]; !ok {
+		if targetUser, ok := sigRes.Signatures[userID]; ok {
+			if targetKey, ok := targetUser[gomatrixserverlib.KeyID(dev.DeviceID)]; ok {
 				for sourceUserID, forSourceUser := range targetKey {
 					for sourceKeyID, sourceKey := range forSourceUser {
 						if _, ok := device.Keys.Signatures[sourceUserID]; !ok {

--- a/federationapi/routing/devices.go
+++ b/federationapi/routing/devices.go
@@ -66,20 +66,16 @@ func GetUserDevices(
 			Keys:        key,
 		}
 
-		targetUser, ok := sigRes.Signatures[dev.UserID]
-		if !ok {
-			continue
-		}
-		targetKey, ok := targetUser[gomatrixserverlib.KeyID(dev.DeviceID)]
-		if !ok {
-			continue
-		}
-		for sourceUserID, forSourceUser := range targetKey {
-			for sourceKeyID, sourceKey := range forSourceUser {
-				if _, ok := device.Keys.Signatures[sourceUserID]; !ok {
-					device.Keys.Signatures[sourceUserID] = map[gomatrixserverlib.KeyID]gomatrixserverlib.Base64Bytes{}
+		if targetUser, ok := sigRes.Signatures[dev.UserID]; ok {
+			if targetKey, ok := targetUser[gomatrixserverlib.KeyID(dev.DeviceID)]; !ok {
+				for sourceUserID, forSourceUser := range targetKey {
+					for sourceKeyID, sourceKey := range forSourceUser {
+						if _, ok := device.Keys.Signatures[sourceUserID]; !ok {
+							device.Keys.Signatures[sourceUserID] = map[gomatrixserverlib.KeyID]gomatrixserverlib.Base64Bytes{}
+						}
+						device.Keys.Signatures[sourceUserID][sourceKeyID] = sourceKey
+					}
 				}
-				device.Keys.Signatures[sourceUserID][sourceKeyID] = sourceKey
 			}
 		}
 

--- a/federationapi/routing/devices.go
+++ b/federationapi/routing/devices.go
@@ -20,7 +20,6 @@ import (
 	keyapi "github.com/matrix-org/dendrite/keyserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
-	"github.com/sirupsen/logrus"
 )
 
 // GetUserDevices for the given user id
@@ -45,8 +44,6 @@ func GetUserDevices(
 	for _, dev := range res.Devices {
 		sigReq.TargetIDs[userID] = append(sigReq.TargetIDs[userID], gomatrixserverlib.KeyID(dev.DeviceID))
 	}
-	logrus.Infof("Signatures request: %+v", sigReq)
-	logrus.Infof("Signatures response: %+v", sigRes)
 	keyAPI.QuerySignatures(req.Context(), sigReq, sigRes)
 
 	response := gomatrixserverlib.RespUserDevices{

--- a/federationapi/routing/devices.go
+++ b/federationapi/routing/devices.go
@@ -20,6 +20,7 @@ import (
 	keyapi "github.com/matrix-org/dendrite/keyserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
+	"github.com/sirupsen/logrus"
 )
 
 // GetUserDevices for the given user id
@@ -44,6 +45,8 @@ func GetUserDevices(
 	for _, dev := range res.Devices {
 		sigReq.TargetIDs[userID] = append(sigReq.TargetIDs[userID], gomatrixserverlib.KeyID(dev.DeviceID))
 	}
+	logrus.Infof("Signatures request: %+v", sigReq)
+	logrus.Infof("Signatures response: %+v", sigRes)
 	keyAPI.QuerySignatures(req.Context(), sigReq, sigRes)
 
 	response := gomatrixserverlib.RespUserDevices{

--- a/federationapi/routing/devices.go
+++ b/federationapi/routing/devices.go
@@ -52,6 +52,13 @@ func GetUserDevices(
 		Devices:  []gomatrixserverlib.RespUserDevice{},
 	}
 
+	if masterKey, ok := sigRes.MasterKeys[userID]; ok {
+		response.MasterKey = &masterKey
+	}
+	if selfSigningKey, ok := sigRes.SelfSigningKeys[userID]; ok {
+		response.SelfSigningKey = &selfSigningKey
+	}
+
 	for _, dev := range res.Devices {
 		var key gomatrixserverlib.RespUserDeviceKeys
 		err := json.Unmarshal(dev.DeviceKeys.KeyJSON, &key)

--- a/keyserver/api/api.go
+++ b/keyserver/api/api.go
@@ -252,7 +252,12 @@ type QuerySignaturesRequest struct {
 type QuerySignaturesResponse struct {
 	// A map of target user ID -> target key/device ID -> origin user ID -> origin key/device ID -> signatures
 	Signatures map[string]map[gomatrixserverlib.KeyID]types.CrossSigningSigMap
-	Error      *KeyError
+	// A map of target user ID -> cross-signing master key
+	MasterKeys map[string]gomatrixserverlib.CrossSigningKey
+	// A map of target user ID -> cross-signing self-signing key
+	SelfSigningKeys map[string]gomatrixserverlib.CrossSigningKey
+	// The request error, if any
+	Error *KeyError
 }
 
 type InputDeviceListUpdateRequest struct {

--- a/keyserver/api/api.go
+++ b/keyserver/api/api.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/matrix-org/dendrite/keyserver/types"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
 )
@@ -38,6 +39,7 @@ type KeyInternalAPI interface {
 	QueryKeyChanges(ctx context.Context, req *QueryKeyChangesRequest, res *QueryKeyChangesResponse)
 	QueryOneTimeKeys(ctx context.Context, req *QueryOneTimeKeysRequest, res *QueryOneTimeKeysResponse)
 	QueryDeviceMessages(ctx context.Context, req *QueryDeviceMessagesRequest, res *QueryDeviceMessagesResponse)
+	QuerySignatures(ctx context.Context, req *QuerySignaturesRequest, res *QuerySignaturesResponse)
 }
 
 // KeyError is returned if there was a problem performing/querying the server
@@ -240,6 +242,17 @@ type QueryDeviceMessagesResponse struct {
 	StreamID int
 	Devices  []DeviceMessage
 	Error    *KeyError
+}
+
+type QuerySignaturesRequest struct {
+	// A map of target user ID -> target key/device IDs to retrieve signatures for
+	TargetIDs map[string][]gomatrixserverlib.KeyID `json:"target_ids"`
+}
+
+type QuerySignaturesResponse struct {
+	// A map of target user ID -> target key/device ID -> origin user ID -> origin key/device ID -> signatures
+	Signatures map[string]map[gomatrixserverlib.KeyID]types.CrossSigningSigMap
+	Error      *KeyError
 }
 
 type InputDeviceListUpdateRequest struct {

--- a/keyserver/api/api.go
+++ b/keyserver/api/api.go
@@ -256,6 +256,8 @@ type QuerySignaturesResponse struct {
 	MasterKeys map[string]gomatrixserverlib.CrossSigningKey
 	// A map of target user ID -> cross-signing self-signing key
 	SelfSigningKeys map[string]gomatrixserverlib.CrossSigningKey
+	// A map of target user ID -> cross-signing user-signing key
+	UserSigningKeys map[string]gomatrixserverlib.CrossSigningKey
 	// The request error, if any
 	Error *KeyError
 }

--- a/keyserver/internal/cross_signing.go
+++ b/keyserver/internal/cross_signing.go
@@ -473,7 +473,7 @@ func (a *KeyInternalAPI) QuerySignatures(ctx context.Context, req *api.QuerySign
 			}
 
 			for sourceUserID, forSourceUser := range keyMap {
-				for targetKeyID, targetSig := range forSourceUser {
+				for sourceKeyID, sourceSig := range forSourceUser {
 					if res.Signatures == nil {
 						res.Signatures = map[string]map[gomatrixserverlib.KeyID]types.CrossSigningSigMap{}
 					}
@@ -486,7 +486,7 @@ func (a *KeyInternalAPI) QuerySignatures(ctx context.Context, req *api.QuerySign
 					if _, ok := res.Signatures[targetUserID][targetKeyID][sourceUserID]; !ok {
 						res.Signatures[targetUserID][targetKeyID][sourceUserID] = map[gomatrixserverlib.KeyID]gomatrixserverlib.Base64Bytes{}
 					}
-					res.Signatures[targetUserID][targetKeyID][sourceUserID][targetKeyID] = targetSig
+					res.Signatures[targetUserID][targetKeyID][sourceUserID][sourceKeyID] = sourceSig
 				}
 			}
 		}

--- a/keyserver/internal/cross_signing.go
+++ b/keyserver/internal/cross_signing.go
@@ -348,7 +348,7 @@ func (a *KeyInternalAPI) processSelfSignatures(
 					for originKeyID, originSig := range forOriginUserID {
 						originSelfSigningKeys, ok := queryRes.SelfSigningKeys[originUserID]
 						if !ok {
-							return fmt.Errorf("missing master key for user %q", originUserID)
+							return fmt.Errorf("missing self-signing key for user %q", originUserID)
 						}
 
 						var originSelfSigningKeyID gomatrixserverlib.KeyID

--- a/keyserver/internal/cross_signing.go
+++ b/keyserver/internal/cross_signing.go
@@ -472,8 +472,14 @@ func (a *KeyInternalAPI) QuerySignatures(ctx context.Context, req *api.QuerySign
 			for targetPurpose, targetKey := range keyMap {
 				switch targetPurpose {
 				case gomatrixserverlib.CrossSigningKeyPurposeMaster:
+					if res.MasterKeys == nil {
+						res.MasterKeys = map[string]gomatrixserverlib.CrossSigningKey{}
+					}
 					res.MasterKeys[targetUserID] = targetKey
 				case gomatrixserverlib.CrossSigningKeyPurposeSelfSigning:
+					if res.SelfSigningKeys == nil {
+						res.SelfSigningKeys = map[string]gomatrixserverlib.CrossSigningKey{}
+					}
 					res.SelfSigningKeys[targetUserID] = targetKey
 				}
 			}

--- a/keyserver/internal/cross_signing.go
+++ b/keyserver/internal/cross_signing.go
@@ -473,6 +473,9 @@ func (a *KeyInternalAPI) QuerySignatures(ctx context.Context, req *api.QuerySign
 			}
 
 			for sourceUserID, forSourceUser := range keyMap {
+				if res.Signatures == nil {
+					res.Signatures = map[string]map[gomatrixserverlib.KeyID]types.CrossSigningSigMap{}
+				}
 				if _, ok := res.Signatures[targetUserID]; !ok {
 					res.Signatures[targetUserID] = map[gomatrixserverlib.KeyID]types.CrossSigningSigMap{}
 				}

--- a/keyserver/internal/cross_signing.go
+++ b/keyserver/internal/cross_signing.go
@@ -17,6 +17,7 @@ package internal
 import (
 	"context"
 	"crypto/ed25519"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -466,6 +467,9 @@ func (a *KeyInternalAPI) QuerySignatures(ctx context.Context, req *api.QuerySign
 		for _, targetKeyID := range forTargetUser {
 			keyMap, err := a.DB.CrossSigningSigsForTarget(ctx, targetUserID, targetKeyID)
 			if err != nil {
+				if err == sql.ErrNoRows {
+					continue
+				}
 				res.Error = &api.KeyError{
 					Err: fmt.Sprintf("a.DB.CrossSigningSigsForTarget: %s", err),
 				}

--- a/keyserver/internal/cross_signing.go
+++ b/keyserver/internal/cross_signing.go
@@ -473,19 +473,19 @@ func (a *KeyInternalAPI) QuerySignatures(ctx context.Context, req *api.QuerySign
 			}
 
 			for sourceUserID, forSourceUser := range keyMap {
-				if res.Signatures == nil {
-					res.Signatures = map[string]map[gomatrixserverlib.KeyID]types.CrossSigningSigMap{}
-				}
-				if _, ok := res.Signatures[targetUserID]; !ok {
-					res.Signatures[targetUserID] = map[gomatrixserverlib.KeyID]types.CrossSigningSigMap{}
-				}
-				if _, ok := res.Signatures[targetUserID][targetKeyID]; !ok {
-					res.Signatures[targetUserID][targetKeyID] = types.CrossSigningSigMap{}
-				}
-				if _, ok := res.Signatures[targetUserID][targetKeyID][sourceUserID]; !ok {
-					res.Signatures[targetUserID][targetKeyID][sourceUserID] = map[gomatrixserverlib.KeyID]gomatrixserverlib.Base64Bytes{}
-				}
 				for targetKeyID, targetSig := range forSourceUser {
+					if res.Signatures == nil {
+						res.Signatures = map[string]map[gomatrixserverlib.KeyID]types.CrossSigningSigMap{}
+					}
+					if _, ok := res.Signatures[targetUserID]; !ok {
+						res.Signatures[targetUserID] = map[gomatrixserverlib.KeyID]types.CrossSigningSigMap{}
+					}
+					if _, ok := res.Signatures[targetUserID][targetKeyID]; !ok {
+						res.Signatures[targetUserID][targetKeyID] = types.CrossSigningSigMap{}
+					}
+					if _, ok := res.Signatures[targetUserID][targetKeyID][sourceUserID]; !ok {
+						res.Signatures[targetUserID][targetKeyID][sourceUserID] = map[gomatrixserverlib.KeyID]gomatrixserverlib.Base64Bytes{}
+					}
 					res.Signatures[targetUserID][targetKeyID][sourceUserID][targetKeyID] = targetSig
 				}
 			}

--- a/keyserver/internal/cross_signing.go
+++ b/keyserver/internal/cross_signing.go
@@ -346,21 +346,21 @@ func (a *KeyInternalAPI) processSelfSignatures(
 
 				for originUserID, forOriginUserID := range sig.Signatures {
 					for originKeyID, originSig := range forOriginUserID {
-						originMasterKeys, ok := queryRes.MasterKeys[originUserID]
+						originSelfSigningKeys, ok := queryRes.SelfSigningKeys[originUserID]
 						if !ok {
 							return fmt.Errorf("missing master key for user %q", originUserID)
 						}
 
-						var originMasterKeyID gomatrixserverlib.KeyID
-						var originMasterKey gomatrixserverlib.Base64Bytes
-						for keyID, key := range originMasterKeys.Keys {
-							originMasterKeyID, originMasterKey = keyID, key
+						var originSelfSigningKeyID gomatrixserverlib.KeyID
+						var originSelfSigningKey gomatrixserverlib.Base64Bytes
+						for keyID, key := range originSelfSigningKeys.Keys {
+							originSelfSigningKeyID, originSelfSigningKey = keyID, key
 							break
 						}
 
-						originMasterKeyPublic := ed25519.PublicKey(originMasterKey)
+						originSelfSigningKeyPublic := ed25519.PublicKey(originSelfSigningKey)
 
-						if err := gomatrixserverlib.VerifyJSON(originUserID, originMasterKeyID, originMasterKeyPublic, j); err != nil {
+						if err := gomatrixserverlib.VerifyJSON(originUserID, originSelfSigningKeyID, originSelfSigningKeyPublic, j); err != nil {
 							return fmt.Errorf("gomatrixserverlib.VerifyJSON: %w", err)
 						}
 

--- a/keyserver/internal/cross_signing.go
+++ b/keyserver/internal/cross_signing.go
@@ -230,7 +230,6 @@ func (a *KeyInternalAPI) PerformUploadDeviceKeys(ctx context.Context, req *api.P
 				continue
 			}
 			for sigKeyID, sigBytes := range forSigUserID {
-				// origin origin target target
 				if err := a.DB.StoreCrossSigningSigsForTarget(ctx, sigUserID, sigKeyID, req.UserID, targetKeyID, sigBytes); err != nil {
 					res.Error = &api.KeyError{
 						Err: fmt.Sprintf("a.DB.StoreCrossSigningSigsForTarget: %s", err),

--- a/keyserver/internal/cross_signing.go
+++ b/keyserver/internal/cross_signing.go
@@ -177,21 +177,85 @@ func (a *KeyInternalAPI) PerformUploadDeviceKeys(ctx context.Context, req *api.P
 	}
 	for purpose, key := range toVerify {
 		// Collect together the key IDs we need to verify with. This will include
-		// all of the key IDs specified in the signatures. We don't do this for
-		// the master key because we have no means to verify the signatures - we
-		// instead just need to store them.
-		if purpose != gomatrixserverlib.CrossSigningKeyPurposeMaster {
-			// Marshal the specific key back into JSON so that we can verify the
-			// signature of it.
-			keyJSON, err := json.Marshal(key)
-			if err != nil {
-				res.Error = &api.KeyError{
-					Err: fmt.Sprintf("The JSON of the key section is invalid: %s", err.Error()),
+		// all of the key IDs specified in the signatures.
+		keyJSON, err := json.Marshal(key)
+		if err != nil {
+			res.Error = &api.KeyError{
+				Err: fmt.Sprintf("The JSON of the key section is invalid: %s", err.Error()),
+			}
+			return
+		}
+
+		switch purpose {
+		case gomatrixserverlib.CrossSigningKeyPurposeMaster:
+			// The master key should be signed by the device key that uploaded it.
+			// Does the device key exist?
+			var signaturesFound []string
+			for userID, forUser := range req.MasterKey.Signatures {
+				if userID != req.UserID {
+					// Ignore signatures that didn't come from this user. We only
+					// care if the user signed their own master key.
+					continue
 				}
-				return
+				for keyID := range forUser {
+					signaturesFound = append(signaturesFound, string(keyID))
+				}
 			}
 
-			// Now check if the subkey is signed by the master key.
+			// If there is a signature from another of the user's key, let's find those keys.
+			if len(signaturesFound) > 0 {
+				localKeys, err := a.DB.DeviceKeysForUser(ctx, req.UserID, signaturesFound)
+				if err != nil {
+					res.Error = &api.KeyError{
+						Err: fmt.Sprintf("Failed to retrieve user device keys: %s", err.Error()),
+					}
+					return
+				}
+
+				// Look through the keys we were given and unmarshal them.
+				allDeviceKeys := map[string]map[gomatrixserverlib.KeyID]gomatrixserverlib.Base64Bytes{}
+				for _, localKey := range localKeys {
+					var deviceKeys gomatrixserverlib.DeviceKeys
+					if err := json.Unmarshal(localKey.KeyJSON, &deviceKeys); err != nil {
+						res.Error = &api.KeyError{
+							Err: fmt.Sprintf("Failed to unmarshal user device keys: %s", err.Error()),
+						}
+						return
+					}
+					allDeviceKeys[localKey.UserID] = deviceKeys.Keys
+				}
+
+				// For each signature we have, see if we can verify the signature.
+				for userID, forUser := range req.MasterKey.Signatures {
+					userKeys, ok := allDeviceKeys[userID]
+					if !ok {
+						res.Error = &api.KeyError{
+							Err: fmt.Sprintf("No keys were found for user %q", userID),
+						}
+						return
+					}
+					for keyID := range forUser {
+						key, ok := userKeys[keyID]
+						if !ok {
+							res.Error = &api.KeyError{
+								Err: fmt.Sprintf("No keys were found for user %q with key ID %q", userID, keyID),
+							}
+							return
+						}
+
+						if err := gomatrixserverlib.VerifyJSON(userID, keyID, ed25519.PublicKey(key), keyJSON); err != nil {
+							res.Error = &api.KeyError{
+								Err:                fmt.Sprintf("The master key failed signature verification: %s", err.Error()),
+								IsInvalidSignature: true,
+							}
+							return
+						}
+					}
+				}
+			}
+
+		default:
+			// Sub-keys should be signed by the master key.
 			if err := gomatrixserverlib.VerifyJSON(req.UserID, masterKeyID, ed25519.PublicKey(masterKey), keyJSON); err != nil {
 				res.Error = &api.KeyError{
 					Err:                fmt.Sprintf("The %q sub-key failed master key signature verification: %s", purpose, err.Error()),

--- a/keyserver/inthttp/client.go
+++ b/keyserver/inthttp/client.go
@@ -36,6 +36,7 @@ const (
 	QueryKeyChangesPath               = "/keyserver/queryKeyChanges"
 	QueryOneTimeKeysPath              = "/keyserver/queryOneTimeKeys"
 	QueryDeviceMessagesPath           = "/keyserver/queryDeviceMessages"
+	QuerySignaturesPath               = "/keyserver/querySignatures"
 )
 
 // NewKeyServerClient creates a KeyInternalAPI implemented by talking to a HTTP POST API.
@@ -204,6 +205,23 @@ func (h *httpKeyInternalAPI) PerformUploadDeviceSignatures(
 	defer span.Finish()
 
 	apiURL := h.apiURL + PerformUploadDeviceSignaturesPath
+	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+	if err != nil {
+		response.Error = &api.KeyError{
+			Err: err.Error(),
+		}
+	}
+}
+
+func (h *httpKeyInternalAPI) QuerySignatures(
+	ctx context.Context,
+	request *api.QuerySignaturesRequest,
+	response *api.QuerySignaturesResponse,
+) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "QuerySignatures")
+	defer span.Finish()
+
+	apiURL := h.apiURL + QuerySignaturesPath
 	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
 	if err != nil {
 		response.Error = &api.KeyError{

--- a/keyserver/inthttp/server.go
+++ b/keyserver/inthttp/server.go
@@ -124,4 +124,15 @@ func AddRoutes(internalAPIMux *mux.Router, s api.KeyInternalAPI) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
+	internalAPIMux.Handle(QuerySignaturesPath,
+		httputil.MakeInternalAPI("querySignatures", func(req *http.Request) util.JSONResponse {
+			request := api.QuerySignaturesRequest{}
+			response := api.QuerySignaturesResponse{}
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.MessageResponse(http.StatusBadRequest, err.Error())
+			}
+			s.QuerySignatures(req.Context(), &request, &response)
+			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
+		}),
+	)
 }

--- a/keyserver/storage/interface.go
+++ b/keyserver/storage/interface.go
@@ -78,7 +78,8 @@ type Database interface {
 	// MarkDeviceListStale sets the stale bit for this user to isStale.
 	MarkDeviceListStale(ctx context.Context, userID string, isStale bool) error
 
-	CrossSigningKeysForUser(ctx context.Context, userID string) (types.CrossSigningKeyMap, error)
+	CrossSigningKeysForUser(ctx context.Context, userID string) (map[gomatrixserverlib.CrossSigningKeyPurpose]gomatrixserverlib.CrossSigningKey, error)
+	CrossSigningKeysDataForUser(ctx context.Context, userID string) (types.CrossSigningKeyMap, error)
 	CrossSigningSigsForTarget(ctx context.Context, targetUserID string, targetKeyID gomatrixserverlib.KeyID) (types.CrossSigningSigMap, error)
 
 	StoreCrossSigningKeysForUser(ctx context.Context, userID string, keyMap types.CrossSigningKeyMap) error

--- a/syncapi/internal/keychange_test.go
+++ b/syncapi/internal/keychange_test.go
@@ -50,6 +50,8 @@ func (k *mockKeyAPI) QueryDeviceMessages(ctx context.Context, req *keyapi.QueryD
 func (k *mockKeyAPI) InputDeviceListUpdate(ctx context.Context, req *keyapi.InputDeviceListUpdateRequest, res *keyapi.InputDeviceListUpdateResponse) {
 
 }
+func (k *mockKeyAPI) QuerySignatures(ctx context.Context, req *keyapi.QuerySignaturesRequest, res *keyapi.QuerySignaturesResponse) {
+}
 
 type mockRoomserverAPI struct {
 	api.RoomserverInternalAPITrace


### PR DESCRIPTION
This PR adds some validation to signature upload (master keys should be signed with a valid device, devices should be signed by a valid master key). It also exposes signatures via `/user/keys/query` and `/user/devices/{userId}` over federation.