### PR TITLE
Add Password Complexity Configuration

### DIFF
--- a/build/docker/config/dendrite-config.yaml
+++ b/build/docker/config/dendrite-config.yaml
@@ -157,6 +157,15 @@ client_api:
     threshold: 5
     cooloff_ms: 500
 
+  # Settings for requiring complexity out of passwords.
+  password_requirements:
+    min_password_length: 8 # synapse default
+    max_password_length: 512 # synapse default
+    # minimum number of symbols (non a-z, A-Z to have)
+    min_number_symbols: 0
+    # should passwords have uppercase and lowercase characters?
+    require_mixed_case: false
+
 # Configuration for the EDU server.
 edu_server:
   internal_api:

--- a/clientapi/routing/password.go
+++ b/clientapi/routing/password.go
@@ -78,7 +78,7 @@ func Password(
 	AddCompletedSessionStage(sessionID, authtypes.LoginTypePassword)
 
 	// Check the new password strength.
-	if resErr = validatePassword(r.NewPassword); resErr != nil {
+	if resErr = validatePassword(r.NewPassword, cfg.PasswordRequirements); resErr != nil {
 		return *resErr
 	}
 

--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -232,7 +232,7 @@ func validatePassword(password string, cfg config.PasswordRequirements) *util.JS
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.WeakPassword(fmt.Sprintf("'password' >%d characters", cfg.MaxPasswordLength)),
 		}
-	} else if len(password) >= 0 && len(password) < cfg.MinPasswordLength {
+	} else if len(password) > 0 && len(password) < cfg.MinPasswordLength {
 		return &util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.WeakPassword(fmt.Sprintf("password too weak: min %d chars", cfg.MinPasswordLength)),
@@ -541,9 +541,9 @@ func Register(
 		if resErr = validateUsername(r.Username); resErr != nil {
 			return *resErr
 		}
-	}
-	if resErr = validatePassword(r.Password, cfg.PasswordRequirements); resErr != nil {
-		return *resErr
+		if resErr = validatePassword(r.Password, cfg.PasswordRequirements); resErr != nil {
+			return *resErr
+		}
 	}
 
 	logger := util.GetLogger(req.Context())

--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -232,7 +232,7 @@ func validatePassword(password string, cfg config.PasswordRequirements) *util.JS
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.WeakPassword(fmt.Sprintf("'password' >%d characters", cfg.MaxPasswordLength)),
 		}
-	} else if len(password) > 0 && len(password) < cfg.MinPasswordLength {
+	} else if len(password) < cfg.MinPasswordLength {
 		return &util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.WeakPassword(fmt.Sprintf("password too weak: min %d chars", cfg.MinPasswordLength)),

--- a/clientapi/routing/register_test.go
+++ b/clientapi/routing/register_test.go
@@ -237,7 +237,10 @@ func TestValidatePassword(t *testing.T) {
 			&util.JSONResponse{
 				Code: http.StatusBadRequest,
 				JSON: jsonerror.WeakPassword(fmt.Sprintf("password too weak: min %d chars", defaults.MinPasswordLength)),
-			}}, {"default reject too long",
+			},
+		},
+		{
+			"default reject too long",
 			*defaults,
 			// len 600
 			"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -247,7 +250,19 @@ func TestValidatePassword(t *testing.T) {
 			},
 		},
 		{
-			"set min too short",
+			"default allow long enough",
+			*defaults,
+			"thisisalongenoughpassword",
+			nil,
+		},
+		{
+			"default allow with symbols",
+			*defaults,
+			"ih@ve$ome$ymbol$_here",
+			nil,
+		},
+		{
+			"set min reject too short",
 			*custom,
 			"abcd",
 			&util.JSONResponse{
@@ -256,7 +271,7 @@ func TestValidatePassword(t *testing.T) {
 			},
 		},
 		{
-			"set max too long",
+			"set max reject too long",
 			*custom,
 			// len 33
 			"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
@@ -275,7 +290,7 @@ func TestValidatePassword(t *testing.T) {
 			},
 		},
 		{
-			"require mixed case but none",
+			"require mixed case but none given",
 			*custom,
 			"haha_all_lowercase_cant_catch_me",
 			&util.JSONResponse{
@@ -284,7 +299,7 @@ func TestValidatePassword(t *testing.T) {
 			},
 		},
 		{
-			"custom settings but valid",
+			"custom settings allow",
 			*custom,
 			"$0me_$up3r_$trong_P@ass",
 			nil,

--- a/clientapi/routing/register_test.go
+++ b/clientapi/routing/register_test.go
@@ -305,13 +305,6 @@ func TestValidatePassword(t *testing.T) {
 				t.Errorf("expected password to fail, but was validated")
 			} else if test.expected != nil && test.expected.Code != response.Code {
 				t.Errorf("expected error code %d, got %d", test.expected.Code, response.Code)
-				// } else if test.expected != nil && response != nil {
-				// 	matrixError := response.JSON.(*jsonerror.MatrixError)
-				// 	expectedError := test.expected.JSON.(*jsonerror.MatrixError)
-
-				// 	if expectedError.Err != matrixError.Err {
-				// 		t.Errorf("expected error: %s, got error: %s", expectedError.Err, matrixError.Err)
-				// 	}
 			} else if test.expected != nil && test.expected.Code == response.Code {
 				t.Logf("expected error code %d matches %d", test.expected.Code, response.Code)
 			} else if test.expected == nil && response == nil {

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -107,7 +107,7 @@ func Setup(
 					}
 				}
 				if req.Method == http.MethodPost {
-					return handleSharedSecretRegistration(userAPI, sr, req)
+					return handleSharedSecretRegistration(userAPI, sr, cfg.PasswordRequirements, req)
 				}
 				return util.JSONResponse{
 					Code: http.StatusMethodNotAllowed,

--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -174,6 +174,15 @@ client_api:
     threshold: 5
     cooloff_ms: 500
 
+  # Settings for requiring complexity out of passwords.
+  password_requirements:
+    min_password_length: 8 # synapse default
+    max_password_length: 512 # synapse default
+    # minimum number of symbols (non a-z, A-Z to have)
+    min_number_symbols: 0
+    # should passwords have uppercase and lowercase characters?
+    require_mixed_case: false
+
 # Configuration for the EDU server.
 edu_server:
   internal_api:

--- a/setup/config/config_clientapi_test.go
+++ b/setup/config/config_clientapi_test.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestPasswordRequirementsDefaults(t *testing.T) {
+	requirements := &PasswordRequirements{}
+	requirements.Defaults()
+
+	if requirements.MinPasswordLength <= 0 {
+		t.Errorf("default minimum password length should be greater than 0, got %d", requirements.MinPasswordLength)
+	}
+
+	if requirements.MinPasswordLength > requirements.MaxPasswordLength {
+		t.Errorf(
+			"default minimum password length should not be greater than maxmium password length. currently: %d > %d",
+			requirements.MinPasswordLength,
+			requirements.MaxPasswordLength,
+		)
+	}
+}

--- a/setup/config/config_test.go
+++ b/setup/config/config_test.go
@@ -86,6 +86,11 @@ client_api:
     turn_shared_secret: ""
     turn_username: ""
     turn_password: ""
+  password_requirements:
+    min_password_length: 6
+    max_password_length: 64
+    required_number_symbols: 2
+    require_mixed_case: true
 current_state_server:
   internal_api:
     listen: http://localhost:7782


### PR DESCRIPTION
A potential solution to #1963.

This commit does the following:

1. Moves the values for minimum and maximum password length into the
ClientAPI configuration struct.
2. Introduces a new struct representing the password complexity
requirements defined in dendrite-config.yml, with four options. Defaults
are compatible with what users probably expect out of synapse.
  * Minimum length, default of 8
  * Maximum length, default of 512
  * Minimum number of symbols, default of 0
  * Requiring mixed case toggle, default of false
3. Adds tests for the logic of validating passwords.

Signed-off-by: Devon Mizelle <dev@devon.so>

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)
