### PR TITLE
Delete device keys/signatures from key server when deleting devices

### DIFF
--- a/keyserver/api/api.go
+++ b/keyserver/api/api.go
@@ -34,6 +34,7 @@ type KeyInternalAPI interface {
 	PerformUploadKeys(ctx context.Context, req *PerformUploadKeysRequest, res *PerformUploadKeysResponse)
 	// PerformClaimKeys claims one-time keys for use in pre-key messages
 	PerformClaimKeys(ctx context.Context, req *PerformClaimKeysRequest, res *PerformClaimKeysResponse)
+	PerformDeleteKeys(ctx context.Context, req *PerformDeleteKeysRequest, res *PerformDeleteKeysResponse)
 	PerformUploadDeviceKeys(ctx context.Context, req *PerformUploadDeviceKeysRequest, res *PerformUploadDeviceKeysResponse)
 	PerformUploadDeviceSignatures(ctx context.Context, req *PerformUploadDeviceSignaturesRequest, res *PerformUploadDeviceSignaturesResponse)
 	QueryKeys(ctx context.Context, req *QueryKeysRequest, res *QueryKeysResponse)
@@ -143,6 +144,18 @@ type PerformUploadKeysResponse struct {
 	// A map of user_id -> device_id -> Error for tracking failures.
 	KeyErrors        map[string]map[string]*KeyError
 	OneTimeKeyCounts []OneTimeKeysCount
+}
+
+// PerformDeleteKeysRequest asks the keyserver to forget about certain
+// keys, and signatures related to those keys.
+type PerformDeleteKeysRequest struct {
+	UserID string
+	KeyIDs []gomatrixserverlib.KeyID
+}
+
+// PerformDeleteKeysResponse is the response to PerformDeleteKeysRequest.
+type PerformDeleteKeysResponse struct {
+	Error *KeyError
 }
 
 // KeyError sets a key error field on KeyErrors

--- a/keyserver/internal/internal.go
+++ b/keyserver/internal/internal.go
@@ -183,11 +183,9 @@ func (a *KeyInternalAPI) claimRemoteKeys(
 }
 
 func (a *KeyInternalAPI) PerformDeleteKeys(ctx context.Context, req *api.PerformDeleteKeysRequest, res *api.PerformDeleteKeysResponse) {
-	for _, keyID := range req.KeyIDs {
-		if err := a.DB.DeleteDeviceKeys(ctx, req.UserID, keyID); err != nil {
-			res.Error = &api.KeyError{
-				Err: fmt.Sprintf("Failed to delete device keys: %s", err),
-			}
+	if err := a.DB.DeleteDeviceKeys(ctx, req.UserID, req.KeyIDs); err != nil {
+		res.Error = &api.KeyError{
+			Err: fmt.Sprintf("Failed to delete device keys: %s", err),
 		}
 	}
 }

--- a/keyserver/internal/internal.go
+++ b/keyserver/internal/internal.go
@@ -182,6 +182,16 @@ func (a *KeyInternalAPI) claimRemoteKeys(
 	util.GetLogger(ctx).WithField("num_keys", keysClaimed).Info("Claimed remote keys")
 }
 
+func (a *KeyInternalAPI) PerformDeleteKeys(ctx context.Context, req *api.PerformDeleteKeysRequest, res *api.PerformDeleteKeysResponse) {
+	for _, keyID := range req.KeyIDs {
+		if err := a.DB.DeleteDeviceKeys(ctx, req.UserID, keyID); err != nil {
+			res.Error = &api.KeyError{
+				Err: fmt.Sprintf("Failed to delete device keys: %s", err),
+			}
+		}
+	}
+}
+
 func (a *KeyInternalAPI) QueryOneTimeKeys(ctx context.Context, req *api.QueryOneTimeKeysRequest, res *api.QueryOneTimeKeysResponse) {
 	count, err := a.DB.OneTimeKeysCount(ctx, req.UserID, req.DeviceID)
 	if err != nil {

--- a/keyserver/inthttp/client.go
+++ b/keyserver/inthttp/client.go
@@ -30,6 +30,7 @@ const (
 	InputDeviceListUpdatePath         = "/keyserver/inputDeviceListUpdate"
 	PerformUploadKeysPath             = "/keyserver/performUploadKeys"
 	PerformClaimKeysPath              = "/keyserver/performClaimKeys"
+	PerformDeleteKeysPath             = "/keyserver/performDeleteKeys"
 	PerformUploadDeviceKeysPath       = "/keyserver/performUploadDeviceKeys"
 	PerformUploadDeviceSignaturesPath = "/keyserver/performUploadDeviceSignatures"
 	QueryKeysPath                     = "/keyserver/queryKeys"
@@ -81,6 +82,23 @@ func (h *httpKeyInternalAPI) PerformClaimKeys(
 	ctx context.Context,
 	request *api.PerformClaimKeysRequest,
 	response *api.PerformClaimKeysResponse,
+) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "PerformClaimKeys")
+	defer span.Finish()
+
+	apiURL := h.apiURL + PerformClaimKeysPath
+	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, request, response)
+	if err != nil {
+		response.Error = &api.KeyError{
+			Err: err.Error(),
+		}
+	}
+}
+
+func (h *httpKeyInternalAPI) PerformDeleteKeys(
+	ctx context.Context,
+	request *api.PerformDeleteKeysRequest,
+	response *api.PerformDeleteKeysResponse,
 ) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "PerformClaimKeys")
 	defer span.Finish()

--- a/keyserver/inthttp/server.go
+++ b/keyserver/inthttp/server.go
@@ -47,6 +47,17 @@ func AddRoutes(internalAPIMux *mux.Router, s api.KeyInternalAPI) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
+	internalAPIMux.Handle(PerformDeleteKeysPath,
+		httputil.MakeInternalAPI("performDeleteKeys", func(req *http.Request) util.JSONResponse {
+			request := api.PerformDeleteKeysRequest{}
+			response := api.PerformDeleteKeysResponse{}
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.MessageResponse(http.StatusBadRequest, err.Error())
+			}
+			s.PerformDeleteKeys(req.Context(), &request, &response)
+			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
+		}),
+	)
 	internalAPIMux.Handle(PerformUploadKeysPath,
 		httputil.MakeInternalAPI("performUploadKeys", func(req *http.Request) util.JSONResponse {
 			request := api.PerformUploadKeysRequest{}

--- a/keyserver/storage/interface.go
+++ b/keyserver/storage/interface.go
@@ -58,6 +58,10 @@ type Database interface {
 	// If there are some missing keys, they are omitted from the returned slice. There is no ordering on the returned slice.
 	DeviceKeysForUser(ctx context.Context, userID string, deviceIDs []string) ([]api.DeviceMessage, error)
 
+	// DeleteDeviceKeys removes the device keys for a given user/device, and any accompanying
+	// cross-signing signatures relating to that device.
+	DeleteDeviceKeys(ctx context.Context, userID string, deviceID gomatrixserverlib.KeyID) error
+
 	// ClaimKeys based on the 3-uple of user_id, device_id and algorithm name. Returns the keys claimed. Returns no error if a key
 	// cannot be claimed or if none exist for this (user, device, algorithm), instead it is omitted from the returned slice.
 	ClaimKeys(ctx context.Context, userToDeviceToAlgorithm map[string]map[string]string) ([]api.OneTimeKeys, error)

--- a/keyserver/storage/interface.go
+++ b/keyserver/storage/interface.go
@@ -60,7 +60,7 @@ type Database interface {
 
 	// DeleteDeviceKeys removes the device keys for a given user/device, and any accompanying
 	// cross-signing signatures relating to that device.
-	DeleteDeviceKeys(ctx context.Context, userID string, deviceID gomatrixserverlib.KeyID) error
+	DeleteDeviceKeys(ctx context.Context, userID string, deviceIDs []gomatrixserverlib.KeyID) error
 
 	// ClaimKeys based on the 3-uple of user_id, device_id and algorithm name. Returns the keys claimed. Returns no error if a key
 	// cannot be claimed or if none exist for this (user, device, algorithm), instead it is omitted from the returned slice.

--- a/keyserver/storage/shared/storage.go
+++ b/keyserver/storage/shared/storage.go
@@ -160,13 +160,15 @@ func (d *Database) MarkDeviceListStale(ctx context.Context, userID string, isSta
 
 // DeleteDeviceKeys removes the device keys for a given user/device, and any accompanying
 // cross-signing signatures relating to that device.
-func (d *Database) DeleteDeviceKeys(ctx context.Context, userID string, deviceID gomatrixserverlib.KeyID) error {
+func (d *Database) DeleteDeviceKeys(ctx context.Context, userID string, deviceIDs []gomatrixserverlib.KeyID) error {
 	return d.Writer.Do(nil, nil, func(txn *sql.Tx) error {
-		if err := d.CrossSigningSigsTable.DeleteCrossSigningSigsForTarget(ctx, txn, userID, deviceID); err != nil {
-			return fmt.Errorf("d.CrossSigningSigsTable.DeleteCrossSigningSigsForTarget: %w", err)
-		}
-		if err := d.DeviceKeysTable.DeleteDeviceKeys(ctx, txn, userID, string(deviceID)); err != nil {
-			return fmt.Errorf("d.DeviceKeysTable.DeleteDeviceKeys: %w", err)
+		for _, deviceID := range deviceIDs {
+			if err := d.CrossSigningSigsTable.DeleteCrossSigningSigsForTarget(ctx, txn, userID, deviceID); err != nil {
+				return fmt.Errorf("d.CrossSigningSigsTable.DeleteCrossSigningSigsForTarget: %w", err)
+			}
+			if err := d.DeviceKeysTable.DeleteDeviceKeys(ctx, txn, userID, string(deviceID)); err != nil {
+				return fmt.Errorf("d.DeviceKeysTable.DeleteDeviceKeys: %w", err)
+			}
 		}
 		return nil
 	})

--- a/keyserver/storage/shared/storage.go
+++ b/keyserver/storage/shared/storage.go
@@ -158,6 +158,20 @@ func (d *Database) MarkDeviceListStale(ctx context.Context, userID string, isSta
 	})
 }
 
+// DeleteDeviceKeys removes the device keys for a given user/device, and any accompanying
+// cross-signing signatures relating to that device.
+func (d *Database) DeleteDeviceKeys(ctx context.Context, userID string, deviceID gomatrixserverlib.KeyID) error {
+	return d.Writer.Do(nil, nil, func(txn *sql.Tx) error {
+		if err := d.CrossSigningSigsTable.DeleteCrossSigningSigsForTarget(ctx, txn, userID, deviceID); err != nil {
+			return fmt.Errorf("d.CrossSigningSigsTable.DeleteCrossSigningSigsForTarget: %w", err)
+		}
+		if err := d.DeviceKeysTable.DeleteDeviceKeys(ctx, txn, userID, string(deviceID)); err != nil {
+			return fmt.Errorf("d.DeviceKeysTable.DeleteDeviceKeys: %w", err)
+		}
+		return nil
+	})
+}
+
 // CrossSigningKeysForUser returns the latest known cross-signing keys for a user, if any.
 func (d *Database) CrossSigningKeysForUser(ctx context.Context, userID string) (map[gomatrixserverlib.CrossSigningKeyPurpose]gomatrixserverlib.CrossSigningKey, error) {
 	keyMap, err := d.CrossSigningKeysTable.SelectCrossSigningKeysForUser(ctx, nil, userID)

--- a/keyserver/storage/shared/storage.go
+++ b/keyserver/storage/shared/storage.go
@@ -163,10 +163,10 @@ func (d *Database) MarkDeviceListStale(ctx context.Context, userID string, isSta
 func (d *Database) DeleteDeviceKeys(ctx context.Context, userID string, deviceIDs []gomatrixserverlib.KeyID) error {
 	return d.Writer.Do(nil, nil, func(txn *sql.Tx) error {
 		for _, deviceID := range deviceIDs {
-			if err := d.CrossSigningSigsTable.DeleteCrossSigningSigsForTarget(ctx, txn, userID, deviceID); err != nil {
+			if err := d.CrossSigningSigsTable.DeleteCrossSigningSigsForTarget(ctx, txn, userID, deviceID); err != nil && err != sql.ErrNoRows {
 				return fmt.Errorf("d.CrossSigningSigsTable.DeleteCrossSigningSigsForTarget: %w", err)
 			}
-			if err := d.DeviceKeysTable.DeleteDeviceKeys(ctx, txn, userID, string(deviceID)); err != nil {
+			if err := d.DeviceKeysTable.DeleteDeviceKeys(ctx, txn, userID, string(deviceID)); err != nil && err != sql.ErrNoRows {
 				return fmt.Errorf("d.DeviceKeysTable.DeleteDeviceKeys: %w", err)
 			}
 		}

--- a/keyserver/storage/tables/interface.go
+++ b/keyserver/storage/tables/interface.go
@@ -39,6 +39,7 @@ type DeviceKeys interface {
 	SelectMaxStreamIDForUser(ctx context.Context, txn *sql.Tx, userID string) (streamID int32, err error)
 	CountStreamIDsForUser(ctx context.Context, userID string, streamIDs []int64) (int, error)
 	SelectBatchDeviceKeys(ctx context.Context, userID string, deviceIDs []string) ([]api.DeviceMessage, error)
+	DeleteDeviceKeys(ctx context.Context, txn *sql.Tx, userID, deviceID string) error
 	DeleteAllDeviceKeys(ctx context.Context, txn *sql.Tx, userID string) error
 }
 
@@ -62,4 +63,5 @@ type CrossSigningKeys interface {
 type CrossSigningSigs interface {
 	SelectCrossSigningSigsForTarget(ctx context.Context, txn *sql.Tx, targetUserID string, targetKeyID gomatrixserverlib.KeyID) (r types.CrossSigningSigMap, err error)
 	UpsertCrossSigningSigsForTarget(ctx context.Context, txn *sql.Tx, originUserID string, originKeyID gomatrixserverlib.KeyID, targetUserID string, targetKeyID gomatrixserverlib.KeyID, signature gomatrixserverlib.Base64Bytes) error
+	DeleteCrossSigningSigsForTarget(ctx context.Context, txn *sql.Tx, targetUserID string, targetKeyID gomatrixserverlib.KeyID) error
 }

--- a/syncapi/internal/keychange_test.go
+++ b/syncapi/internal/keychange_test.go
@@ -33,6 +33,8 @@ func (k *mockKeyAPI) SetUserAPI(i userapi.UserInternalAPI) {}
 // PerformClaimKeys claims one-time keys for use in pre-key messages
 func (k *mockKeyAPI) PerformClaimKeys(ctx context.Context, req *keyapi.PerformClaimKeysRequest, res *keyapi.PerformClaimKeysResponse) {
 }
+func (k *mockKeyAPI) PerformDeleteKeys(ctx context.Context, req *keyapi.PerformDeleteKeysRequest, res *keyapi.PerformDeleteKeysResponse) {
+}
 func (k *mockKeyAPI) PerformUploadDeviceKeys(ctx context.Context, req *keyapi.PerformUploadDeviceKeysRequest, res *keyapi.PerformUploadDeviceKeysResponse) {
 }
 func (k *mockKeyAPI) PerformUploadDeviceSignatures(ctx context.Context, req *keyapi.PerformUploadDeviceSignaturesRequest, res *keyapi.PerformUploadDeviceSignaturesResponse) {


### PR DESCRIPTION
This stops us from getting ghost keys/signatures in the key server after the user has deleted their device from the Security tab in Element Web.