### PR TITLE
Add POST routing handler to `/publicRooms`

### DIFF
--- a/federationapi/routing/routing.go
+++ b/federationapi/routing/routing.go
@@ -449,7 +449,7 @@ func Setup(
 		httputil.MakeExternalAPI("federation_public_rooms", func(req *http.Request) util.JSONResponse {
 			return GetPostPublicRooms(req, rsAPI)
 		}),
-	).Methods(http.MethodGet)
+	).Methods(http.MethodGet, http.MethodPost)
 
 	v1fedmux.Handle("/user/keys/claim", httputil.MakeFedAPI(
 		"federation_keys_claim", cfg.Matrix.ServerName, keys, wakeup,


### PR DESCRIPTION
publicRooms should accept POST as well as GET, but apparently the routing was wrong.