### PR TITLE
Don't return nonsense canonical room aliases in public rooms

### DIFF
--- a/federationapi/routing/publicrooms.go
+++ b/federationapi/routing/publicrooms.go
@@ -156,7 +156,9 @@ func fillInRooms(ctx context.Context, roomIDs []string, rsAPI roomserverAPI.Room
 			case topicTuple:
 				pub.Topic = contentVal
 			case canonicalTuple:
-				pub.CanonicalAlias = contentVal
+				if _, _, err := gomatrixserverlib.SplitID('#', contentVal); err == nil {
+					pub.CanonicalAlias = contentVal
+				}
 			case visibilityTuple:
 				pub.WorldReadable = contentVal == "world_readable"
 			// need both of these to determine whether guests can join

--- a/roomserver/api/wrapper.go
+++ b/roomserver/api/wrapper.go
@@ -215,7 +215,9 @@ func PopulatePublicRooms(ctx context.Context, roomIDs []string, rsAPI Roomserver
 			case topicTuple:
 				pub.Topic = contentVal
 			case canonicalTuple:
-				pub.CanonicalAlias = contentVal
+				if _, _, err := gomatrixserverlib.SplitID('#', contentVal); err == nil {
+					pub.CanonicalAlias = contentVal
+				}
 			case visibilityTuple:
 				pub.WorldReadable = contentVal == "world_readable"
 			// need both of these to determine whether guests can join


### PR DESCRIPTION
We should also validate these at the point of upload probably, for a future PR.