### PR TITLE
0️⃣ Media API: Fix maxFileSizeBytes=0 handling

### DIFF
--- a/mediaapi/routing/download.go
+++ b/mediaapi/routing/download.go
@@ -737,7 +737,7 @@ func (r *downloadRequest) fetchRemoteFile(
 		return "", false, parseErr
 	}
 
-	if contentLength > int64(maxFileSizeBytes) {
+	if maxFileSizeBytes > 0 && contentLength > int64(maxFileSizeBytes) {
 		// TODO: Bubble up this as a 413
 		return "", false, fmt.Errorf("remote file is too large (%v > %v bytes)", contentLength, maxFileSizeBytes)
 	}


### PR DESCRIPTION
Fixes error `Failed to download: r.fetchRemoteFileAndStoreMetadata: remote file is too large (6670 > 0 bytes)` when `media_api.max_file_size_bytes = 0`.

### Pull Request Checklist

* [x] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `database64128 <free122448@hotmail.com>`