### PR TITLE
Ratelimit requests to /media/r0/download|upload

### DIFF
--- a/cmd/dendrite-polylith-multi/personalities/mediaapi.go
+++ b/cmd/dendrite-polylith-multi/personalities/mediaapi.go
@@ -24,7 +24,7 @@ func MediaAPI(base *setup.BaseDendrite, cfg *config.Dendrite) {
 	userAPI := base.UserAPIClient()
 	client := base.CreateClient()
 
-	mediaapi.AddPublicRoutes(base.PublicMediaAPIMux, &base.Cfg.MediaAPI, userAPI, client)
+	mediaapi.AddPublicRoutes(base.PublicMediaAPIMux, &base.Cfg.MediaAPI, &base.Cfg.ClientAPI.RateLimiting, userAPI, client)
 
 	base.SetupAndServeHTTP(
 		base.Cfg.MediaAPI.InternalAPI.Listen,

--- a/mediaapi/mediaapi.go
+++ b/mediaapi/mediaapi.go
@@ -26,7 +26,9 @@ import (
 
 // AddPublicRoutes sets up and registers HTTP handlers for the MediaAPI component.
 func AddPublicRoutes(
-	router *mux.Router, cfg *config.MediaAPI,
+	router *mux.Router,
+	cfg *config.MediaAPI,
+	rateLimit *config.RateLimiting,
 	userAPI userapi.UserInternalAPI,
 	client *gomatrixserverlib.Client,
 ) {
@@ -36,6 +38,6 @@ func AddPublicRoutes(
 	}
 
 	routing.Setup(
-		router, cfg, mediaDB, userAPI, client,
+		router, cfg, rateLimit, mediaDB, userAPI, client,
 	)
 }

--- a/mediaapi/routing/routing.go
+++ b/mediaapi/routing/routing.go
@@ -125,11 +125,11 @@ func makeDownloadAPI(
 
 		// Ratelimit requests
 		if r := rateLimits.Limit(req); r != nil {
-			rw := json.NewEncoder(w)
-			w.WriteHeader(http.StatusTooManyRequests)
-			if err := rw.Encode(r); err != nil {
+			if err := json.NewEncoder(w).Encode(r); err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
+				return
 			}
+			w.WriteHeader(http.StatusTooManyRequests)
 			return
 		}
 

--- a/setup/monolith.go
+++ b/setup/monolith.go
@@ -70,7 +70,7 @@ func (m *Monolith) AddAllPublicRoutes(process *process.ProcessContext, csMux, ss
 		m.KeyRing, m.RoomserverAPI, m.FederationSenderAPI,
 		m.EDUInternalAPI, m.KeyAPI, &m.Config.MSCs, nil,
 	)
-	mediaapi.AddPublicRoutes(mediaMux, &m.Config.MediaAPI, m.UserAPI, m.Client)
+	mediaapi.AddPublicRoutes(mediaMux, &m.Config.MediaAPI, &m.Config.ClientAPI.RateLimiting, m.UserAPI, m.Client)
 	syncapi.AddPublicRoutes(
 		process, csMux, m.UserAPI, m.RoomserverAPI,
 		m.KeyAPI, m.FedClient, &m.Config.SyncAPI,

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -556,3 +556,5 @@ Fails to upload self-signing key without master key
 can fetch self-signing keys over federation
 Changing master key notifies local users
 Changing user-signing key notifies local users
+Inbound federation correctly handles soft failed events as extremities
+Can read configuration endpoint


### PR DESCRIPTION
Moves `rate_limiting.go` to internal/httputil, so it can be used in other components.

Also adds `/r0/config`, which fixes an error message when starting e.g. mautrix-telegram.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)
