### PR TITLE
Run gofmt on dendrite - apply go 1.17 preferred build tags

### DIFF
--- a/appservice/storage/storage.go
+++ b/appservice/storage/storage.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !wasm
 // +build !wasm
 
 package storage

--- a/build/gobind-pinecone/platform_ios.go
+++ b/build/gobind-pinecone/platform_ios.go
@@ -1,3 +1,4 @@
+//go:build ios
 // +build ios
 
 package gobind

--- a/build/gobind-pinecone/platform_other.go
+++ b/build/gobind-pinecone/platform_other.go
@@ -1,3 +1,4 @@
+//go:build !ios
 // +build !ios
 
 package gobind

--- a/build/gobind-yggdrasil/platform_ios.go
+++ b/build/gobind-yggdrasil/platform_ios.go
@@ -1,3 +1,4 @@
+//go:build ios
 // +build ios
 
 package gobind

--- a/build/gobind-yggdrasil/platform_other.go
+++ b/build/gobind-yggdrasil/platform_other.go
@@ -1,3 +1,4 @@
+//go:build !ios
 // +build !ios
 
 package gobind

--- a/cmd/dendrite-demo-pinecone/embed/embed_elementweb.go
+++ b/cmd/dendrite-demo-pinecone/embed/embed_elementweb.go
@@ -1,3 +1,4 @@
+//go:build elementweb
 // +build elementweb
 
 package embed

--- a/cmd/dendrite-demo-pinecone/embed/embed_other.go
+++ b/cmd/dendrite-demo-pinecone/embed/embed_other.go
@@ -1,3 +1,4 @@
+//go:build !elementweb
 // +build !elementweb
 
 package embed

--- a/cmd/dendrite-demo-yggdrasil/embed/embed_elementweb.go
+++ b/cmd/dendrite-demo-yggdrasil/embed/embed_elementweb.go
@@ -1,3 +1,4 @@
+//go:build elementweb
 // +build elementweb
 
 package embed

--- a/cmd/dendrite-demo-yggdrasil/embed/embed_other.go
+++ b/cmd/dendrite-demo-yggdrasil/embed/embed_other.go
@@ -1,3 +1,4 @@
+//go:build !elementweb
 // +build !elementweb
 
 package embed

--- a/cmd/dendritejs-pinecone/jsServer.go
+++ b/cmd/dendritejs-pinecone/jsServer.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build wasm
 // +build wasm
 
 package main

--- a/cmd/dendritejs-pinecone/main_noop.go
+++ b/cmd/dendritejs-pinecone/main_noop.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !wasm
 // +build !wasm
 
 package main

--- a/cmd/dendritejs-pinecone/main_test.go
+++ b/cmd/dendritejs-pinecone/main_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build wasm
 // +build wasm
 
 package main

--- a/cmd/dendritejs/jsServer.go
+++ b/cmd/dendritejs/jsServer.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build wasm
 // +build wasm
 
 package main

--- a/cmd/dendritejs/keyfetcher.go
+++ b/cmd/dendritejs/keyfetcher.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build wasm
 // +build wasm
 
 package main

--- a/cmd/dendritejs/main.go
+++ b/cmd/dendritejs/main.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build wasm
 // +build wasm
 
 package main

--- a/cmd/dendritejs/main_noop.go
+++ b/cmd/dendritejs/main_noop.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !wasm
 // +build !wasm
 
 package main

--- a/cmd/dendritejs/publicrooms.go
+++ b/cmd/dendritejs/publicrooms.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build wasm
 // +build wasm
 
 package main

--- a/federationsender/storage/storage.go
+++ b/federationsender/storage/storage.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !wasm
 // +build !wasm
 
 package storage

--- a/internal/sqlutil/postgres.go
+++ b/internal/sqlutil/postgres.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !wasm
 // +build !wasm
 
 package sqlutil

--- a/internal/sqlutil/postgres_wasm.go
+++ b/internal/sqlutil/postgres_wasm.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build wasm
 // +build wasm
 
 package sqlutil

--- a/internal/sqlutil/trace_driver.go
+++ b/internal/sqlutil/trace_driver.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !wasm
 // +build !wasm
 
 package sqlutil

--- a/internal/sqlutil/trace_driver_wasm.go
+++ b/internal/sqlutil/trace_driver_wasm.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build wasm
 // +build wasm
 
 package sqlutil

--- a/keyserver/storage/storage.go
+++ b/keyserver/storage/storage.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !wasm
 // +build !wasm
 
 package storage

--- a/mediaapi/storage/storage.go
+++ b/mediaapi/storage/storage.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !wasm
 // +build !wasm
 
 package storage

--- a/mediaapi/thumbnailer/thumbnailer_bimg.go
+++ b/mediaapi/thumbnailer/thumbnailer_bimg.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build bimg
 // +build bimg
 
 package thumbnailer

--- a/mediaapi/thumbnailer/thumbnailer_nfnt.go
+++ b/mediaapi/thumbnailer/thumbnailer_nfnt.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !bimg
 // +build !bimg
 
 package thumbnailer

--- a/roomserver/storage/storage.go
+++ b/roomserver/storage/storage.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !wasm
 // +build !wasm
 
 package storage

--- a/signingkeyserver/storage/keydb.go
+++ b/signingkeyserver/storage/keydb.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !wasm
 // +build !wasm
 
 package storage

--- a/signingkeyserver/storage/keydb_wasm.go
+++ b/signingkeyserver/storage/keydb_wasm.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build wasm
 // +build wasm
 
 package storage

--- a/syncapi/storage/storage.go
+++ b/syncapi/storage/storage.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !wasm
 // +build !wasm
 
 package storage

--- a/userapi/storage/accounts/sqlite3/constraint_wasm.go
+++ b/userapi/storage/accounts/sqlite3/constraint_wasm.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build wasm
 // +build wasm
 
 package sqlite3

--- a/userapi/storage/accounts/storage.go
+++ b/userapi/storage/accounts/storage.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !wasm
 // +build !wasm
 
 package accounts

--- a/userapi/storage/devices/storage.go
+++ b/userapi/storage/devices/storage.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !wasm
 // +build !wasm
 
 package devices


### PR DESCRIPTION
Go 1.17 introduces new way to add build tags - see [release notes](https://golang.org/doc/go1.17#go-command), section `//go:build lines`. Running `gofmt -w .` in Dendrite directory yields changes in this PR. Apparently, `golangci-lint run` fails  because of that with output below (assuming go 1.17). I didn't find an option to configure it and make it non fatal. This failing logs are annoying when linting locally. We also should catch up witch language changes.


```
syncapi/storage/storage.go:14: File is not `goimports`-ed (goimports)

roomserver/storage/storage.go:14: File is not `goimports`-ed (goimports)

internal/sqlutil/postgres.go:14: File is not `goimports`-ed (goimports)

internal/sqlutil/trace_driver.go:14: File is not `goimports`-ed (goimports)

federationsender/storage/storage.go:14: File is not `goimports`-ed (goimports)

mediaapi/storage/storage.go:14: File is not `goimports`-ed (goimports)

cmd/dendritejs/main_noop.go:14: File is not `goimports`-ed (goimports)

appservice/storage/storage.go:14: File is not `goimports`-ed (goimports)

userapi/storage/accounts/storage.go:14: File is not `goimports`-ed (goimports)

userapi/storage/devices/storage.go:14: File is not `goimports`-ed (goimports)

signingkeyserver/storage/keydb.go:14: File is not `goimports`-ed (goimports)

mediaapi/thumbnailer/thumbnailer_nfnt.go:14: File is not `goimports`-ed (goimports)

cmd/dendrite-demo-pinecone/embed/embed_other.go:1: File is not `goimports`-ed (goimports)
// +build !elementweb
cmd/dendrite-demo-yggdrasil/embed/embed_other.go:1: File is not `goimports`-ed (goimports)
// +build !elementweb
cmd/dendritejs-pinecone/main_noop.go:14: File is not `goimports`-ed (goimports)

keyserver/storage/storage.go:14: File is not `goimports`-ed (goimports)
```

### Pull Request Checklist

* [x] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `Piotr Kozimor <p1996k@gmail.com>`
