### PR TITLE
Add 'Federation publicRoom Name/topic keys are correct' to the sytest whitelist

### DIFF
--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -565,3 +565,4 @@ User can invite remote user to room with version 7
 Remote user can backfill in a room with version 7
 Can reject invites over federation for rooms with version 7
 Can receive redactions from regular users over federation in room version 7
+Federation publicRoom Name/topic keys are correct


### PR DESCRIPTION
Sytest had two tests with the name `Name/topic keys are correct`. https://github.com/matrix-org/sytest/pull/1098 edited one so that the names were unique.

It seems that this test name was in the dendrite Sytest whitelist. This PR adds the additional, new name to the whitelist as well. Time to see if CI passes!

Also: are the entries in the whitelist supposed to be in a certain order?