### PR TITLE
Fix panic in `AddState`

### DIFF
--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -165,13 +165,20 @@ func (d *Database) AddState(
 		if berr != nil {
 			return 0, fmt.Errorf("d.StateBlockTable.BulkSelectStateBlockEntries: %w", berr)
 		}
+		var found bool
 		for i := len(state) - 1; i >= 0; i-- {
+			found = false
 			for _, events := range blocks {
 				for _, event := range events {
 					if state[i].EventNID == event {
-						state = append(state[:i], state[i+1:]...)
+						found = true
+						break
 					}
 				}
+			}
+			if found {
+				state = append(state[:i], state[i+1:]...)
+				i--
 			}
 		}
 	}


### PR DESCRIPTION
This should fix #2028 by ensuring that we don't panic by re-slicing `state` more times than we should in a given iteration.

Closes #2000, #2001. 