### PR TITLE
Only return non-stub rooms from `GetKnownRooms`

### DIFF
--- a/roomserver/storage/postgres/rooms_table.go
+++ b/roomserver/storage/postgres/rooms_table.go
@@ -74,7 +74,7 @@ const selectRoomInfoSQL = "" +
 	"SELECT room_version, room_nid, state_snapshot_nid, latest_event_nids FROM roomserver_rooms WHERE room_id = $1"
 
 const selectRoomIDsSQL = "" +
-	"SELECT room_id FROM roomserver_rooms"
+	"SELECT room_id FROM roomserver_rooms WHERE array_length(latest_event_nids, 1) > 0"
 
 const bulkSelectRoomIDsSQL = "" +
 	"SELECT room_id FROM roomserver_rooms WHERE room_nid = ANY($1)"

--- a/roomserver/storage/sqlite3/rooms_table.go
+++ b/roomserver/storage/sqlite3/rooms_table.go
@@ -65,7 +65,7 @@ const selectRoomInfoSQL = "" +
 	"SELECT room_version, room_nid, state_snapshot_nid, latest_event_nids FROM roomserver_rooms WHERE room_id = $1"
 
 const selectRoomIDsSQL = "" +
-	"SELECT room_id, latest_event_nids FROM roomserver_rooms WHERE latest_event_nids != '[]'"
+	"SELECT room_id FROM roomserver_rooms WHERE latest_event_nids != '[]'"
 
 const bulkSelectRoomIDsSQL = "" +
 	"SELECT room_id FROM roomserver_rooms WHERE room_nid IN ($1)"

--- a/roomserver/storage/sqlite3/rooms_table.go
+++ b/roomserver/storage/sqlite3/rooms_table.go
@@ -65,7 +65,7 @@ const selectRoomInfoSQL = "" +
 	"SELECT room_version, room_nid, state_snapshot_nid, latest_event_nids FROM roomserver_rooms WHERE room_id = $1"
 
 const selectRoomIDsSQL = "" +
-	"SELECT room_id FROM roomserver_rooms"
+	"SELECT room_id, latest_event_nids FROM roomserver_rooms WHERE latest_event_nids != '[]'"
 
 const bulkSelectRoomIDsSQL = "" +
 	"SELECT room_id FROM roomserver_rooms WHERE room_nid IN ($1)"


### PR DESCRIPTION
This should stop a bunch of errors at startup with invalid server ACLs. There isn't really any use in returning stub rooms in any case.