### PR TITLE
Don't let things added to the media_store/ directory find their way into the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ cmd/dendrite-demo-yggdrasil/embed/fs*.go
 
 # Test dependencies
 test/wasm/node_modules
+
+media_store/
+


### PR DESCRIPTION
```sh
root@somesite:/home/dendrite/dendrite# git status
On branch master
Your branch is up to date with 'origin/master'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	media_store/

nothing added to commit but untracked files present (use "git add" to track)
```

I shouldn't see this. It's the default media store directory and if I don't edit anything but run the server and upload an avatar, I see this. Could lead to a lot of accidental commits to that.

### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [x] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `Bob Arctor <neetzsche@tutanota.com>`
