### PR TITLE
Don't populate config defaults where it doesn't make sense

### DIFF
--- a/build/gobind-pinecone/monolith.go
+++ b/build/gobind-pinecone/monolith.go
@@ -260,7 +260,7 @@ func (m *DendriteMonolith) Start() {
 
 	prefix := hex.EncodeToString(pk)
 	cfg := &config.Dendrite{}
-	cfg.Defaults()
+	cfg.Defaults(true)
 	cfg.Global.ServerName = gomatrixserverlib.ServerName(hex.EncodeToString(pk))
 	cfg.Global.PrivateKey = sk
 	cfg.Global.KeyID = gomatrixserverlib.KeyID(signing.KeyID)

--- a/build/gobind-yggdrasil/monolith.go
+++ b/build/gobind-yggdrasil/monolith.go
@@ -82,7 +82,7 @@ func (m *DendriteMonolith) Start() {
 	m.YggdrasilNode = ygg
 
 	cfg := &config.Dendrite{}
-	cfg.Defaults()
+	cfg.Defaults(true)
 	cfg.Global.ServerName = gomatrixserverlib.ServerName(ygg.DerivedServerName())
 	cfg.Global.PrivateKey = ygg.PrivateKey()
 	cfg.Global.KeyID = gomatrixserverlib.KeyID(signing.KeyID)

--- a/clientapi/routing/register_test.go
+++ b/clientapi/routing/register_test.go
@@ -180,7 +180,7 @@ func TestValidationOfApplicationServices(t *testing.T) {
 
 	// Set up a config
 	fakeConfig := &config.Dendrite{}
-	fakeConfig.Defaults()
+	fakeConfig.Defaults(true)
 	fakeConfig.Global.ServerName = "localhost"
 	fakeConfig.ClientAPI.Derived.ApplicationServices = []config.ApplicationService{fakeApplicationService}
 

--- a/cmd/dendrite-demo-libp2p/main.go
+++ b/cmd/dendrite-demo-libp2p/main.go
@@ -119,7 +119,7 @@ func main() {
 	}
 
 	cfg := config.Dendrite{}
-	cfg.Defaults()
+	cfg.Defaults(true)
 	cfg.Global.ServerName = "p2p"
 	cfg.Global.PrivateKey = privKey
 	cfg.Global.KeyID = gomatrixserverlib.KeyID(fmt.Sprintf("ed25519:%s", *instanceName))

--- a/cmd/dendrite-demo-pinecone/main.go
+++ b/cmd/dendrite-demo-pinecone/main.go
@@ -142,7 +142,7 @@ func main() {
 	}
 
 	cfg := &config.Dendrite{}
-	cfg.Defaults()
+	cfg.Defaults(true)
 	cfg.Global.ServerName = gomatrixserverlib.ServerName(hex.EncodeToString(pk))
 	cfg.Global.PrivateKey = sk
 	cfg.Global.KeyID = gomatrixserverlib.KeyID(signing.KeyID)

--- a/cmd/dendrite-demo-yggdrasil/main.go
+++ b/cmd/dendrite-demo-yggdrasil/main.go
@@ -73,7 +73,7 @@ func main() {
 	*/
 
 	cfg := &config.Dendrite{}
-	cfg.Defaults()
+	cfg.Defaults(true)
 	cfg.Global.ServerName = gomatrixserverlib.ServerName(ygg.DerivedServerName())
 	cfg.Global.PrivateKey = ygg.PrivateKey()
 	cfg.Global.KeyID = gomatrixserverlib.KeyID(signing.KeyID)

--- a/cmd/dendritejs-pinecone/main.go
+++ b/cmd/dendritejs-pinecone/main.go
@@ -161,7 +161,7 @@ func startup() {
 	pSessions := pineconeSessions.NewSessions(logger, pRouter)
 
 	cfg := &config.Dendrite{}
-	cfg.Defaults()
+	cfg.Defaults(true)
 	cfg.UserAPI.AccountDatabase.ConnectionString = "file:/idb/dendritejs_account.db"
 	cfg.AppServiceAPI.Database.ConnectionString = "file:/idb/dendritejs_appservice.db"
 	cfg.UserAPI.DeviceDatabase.ConnectionString = "file:/idb/dendritejs_device.db"

--- a/cmd/dendritejs/main.go
+++ b/cmd/dendritejs/main.go
@@ -164,7 +164,7 @@ func createP2PNode(privKey ed25519.PrivateKey) (serverName string, node *go_http
 
 func main() {
 	cfg := &config.Dendrite{}
-	cfg.Defaults()
+	cfg.Defaults(true)
 	cfg.UserAPI.AccountDatabase.ConnectionString = "file:/idb/dendritejs_account.db"
 	cfg.AppServiceAPI.Database.ConnectionString = "file:/idb/dendritejs_appservice.db"
 	cfg.UserAPI.DeviceDatabase.ConnectionString = "file:/idb/dendritejs_device.db"

--- a/cmd/generate-config/main.go
+++ b/cmd/generate-config/main.go
@@ -17,7 +17,7 @@ func main() {
 	flag.Parse()
 
 	cfg := &config.Dendrite{}
-	cfg.Defaults()
+	cfg.Defaults(true)
 	if *serverName != "" {
 		cfg.Global.ServerName = gomatrixserverlib.ServerName(*serverName)
 	}

--- a/federationapi/federationapi_keys_test.go
+++ b/federationapi/federationapi_keys_test.go
@@ -71,7 +71,7 @@ func TestMain(m *testing.M) {
 		// Draw up just enough Dendrite config for the server key
 		// API to work.
 		cfg := &config.Dendrite{}
-		cfg.Defaults()
+		cfg.Defaults(true)
 		cfg.Global.ServerName = gomatrixserverlib.ServerName(s.name)
 		cfg.Global.PrivateKey = testPriv
 		cfg.Global.Kafka.UseNaffka = true

--- a/federationapi/federationapi_test.go
+++ b/federationapi/federationapi_test.go
@@ -19,7 +19,7 @@ import (
 func TestRoomsV3URLEscapeDoNot404(t *testing.T) {
 	_, privKey, _ := ed25519.GenerateKey(nil)
 	cfg := &config.Dendrite{}
-	cfg.Defaults()
+	cfg.Defaults(true)
 	cfg.Global.KeyID = gomatrixserverlib.KeyID("ed25519:auto")
 	cfg.Global.ServerName = gomatrixserverlib.ServerName("localhost")
 	cfg.Global.PrivateKey = privKey

--- a/internal/test/config.go
+++ b/internal/test/config.go
@@ -50,7 +50,7 @@ const (
 // Generates new matrix and TLS keys for the server.
 func MakeConfig(configDir, kafkaURI, database, host string, startPort int) (*config.Dendrite, int, error) {
 	var cfg config.Dendrite
-	cfg.Defaults()
+	cfg.Defaults(true)
 
 	port := startPort
 	assignAddress := func() config.HTTPAddress {

--- a/roomserver/roomserver_test.go
+++ b/roomserver/roomserver_test.go
@@ -158,7 +158,7 @@ func mustLoadRawEvents(t *testing.T, ver gomatrixserverlib.RoomVersion, events [
 func mustCreateRoomserverAPI(t *testing.T) (api.RoomserverInternalAPI, *dummyProducer) {
 	t.Helper()
 	cfg := &config.Dendrite{}
-	cfg.Defaults()
+	cfg.Defaults(true)
 	cfg.Global.ServerName = testOrigin
 	cfg.Global.Kafka.UseNaffka = true
 	cfg.RoomServer.Database = config.DatabaseOptions{

--- a/setup/config/config.go
+++ b/setup/config/config.go
@@ -210,7 +210,7 @@ func loadConfig(
 	monolithic bool,
 ) (*Dendrite, error) {
 	var c Dendrite
-	c.Defaults()
+	c.Defaults(false)
 
 	var err error
 	if err = yaml.Unmarshal(configData, &c); err != nil {
@@ -291,20 +291,20 @@ func (config *Dendrite) Derive() error {
 }
 
 // SetDefaults sets default config values if they are not explicitly set.
-func (c *Dendrite) Defaults() {
+func (c *Dendrite) Defaults(generate bool) {
 	c.Version = 1
 
-	c.Global.Defaults()
-	c.ClientAPI.Defaults()
-	c.EDUServer.Defaults()
-	c.FederationAPI.Defaults()
-	c.KeyServer.Defaults()
-	c.MediaAPI.Defaults()
-	c.RoomServer.Defaults()
-	c.SyncAPI.Defaults()
-	c.UserAPI.Defaults()
-	c.AppServiceAPI.Defaults()
-	c.MSCs.Defaults()
+	c.Global.Defaults(generate)
+	c.ClientAPI.Defaults(generate)
+	c.EDUServer.Defaults(generate)
+	c.FederationAPI.Defaults(generate)
+	c.KeyServer.Defaults(generate)
+	c.MediaAPI.Defaults(generate)
+	c.RoomServer.Defaults(generate)
+	c.SyncAPI.Defaults(generate)
+	c.UserAPI.Defaults(generate)
+	c.AppServiceAPI.Defaults(generate)
+	c.MSCs.Defaults(generate)
 
 	c.Wiring()
 }

--- a/setup/config/config_appservice.go
+++ b/setup/config/config_appservice.go
@@ -40,11 +40,13 @@ type AppServiceAPI struct {
 	ConfigFiles []string `yaml:"config_files"`
 }
 
-func (c *AppServiceAPI) Defaults() {
+func (c *AppServiceAPI) Defaults(generate bool) {
 	c.InternalAPI.Listen = "http://localhost:7777"
 	c.InternalAPI.Connect = "http://localhost:7777"
 	c.Database.Defaults(5)
-	c.Database.ConnectionString = "file:appservice.db"
+	if generate {
+		c.Database.ConnectionString = "file:appservice.db"
+	}
 }
 
 func (c *AppServiceAPI) Verify(configErrs *ConfigErrors, isMonolith bool) {

--- a/setup/config/config_clientapi.go
+++ b/setup/config/config_clientapi.go
@@ -41,7 +41,7 @@ type ClientAPI struct {
 	MSCs *MSCs `yaml:"mscs"`
 }
 
-func (c *ClientAPI) Defaults() {
+func (c *ClientAPI) Defaults(generate bool) {
 	c.InternalAPI.Listen = "http://localhost:7771"
 	c.InternalAPI.Connect = "http://localhost:7771"
 	c.ExternalAPI.Listen = "http://[::]:8071"

--- a/setup/config/config_eduserver.go
+++ b/setup/config/config_eduserver.go
@@ -6,7 +6,7 @@ type EDUServer struct {
 	InternalAPI InternalAPIOptions `yaml:"internal_api"`
 }
 
-func (c *EDUServer) Defaults() {
+func (c *EDUServer) Defaults(generate bool) {
 	c.InternalAPI.Listen = "http://localhost:7778"
 	c.InternalAPI.Connect = "http://localhost:7778"
 }

--- a/setup/config/config_federationapi.go
+++ b/setup/config/config_federationapi.go
@@ -39,12 +39,14 @@ type FederationAPI struct {
 	PreferDirectFetch bool `yaml:"prefer_direct_fetch"`
 }
 
-func (c *FederationAPI) Defaults() {
+func (c *FederationAPI) Defaults(generate bool) {
 	c.InternalAPI.Listen = "http://localhost:7772"
 	c.InternalAPI.Connect = "http://localhost:7772"
 	c.ExternalAPI.Listen = "http://[::]:8072"
 	c.Database.Defaults(10)
-	c.Database.ConnectionString = "file:federationapi.db"
+	if generate {
+		c.Database.ConnectionString = "file:federationapi.db"
+	}
 
 	c.FederationMaxRetries = 16
 	c.DisableTLSValidation = false

--- a/setup/config/config_global.go
+++ b/setup/config/config_global.go
@@ -59,15 +59,17 @@ type Global struct {
 	DNSCache DNSCacheOptions `yaml:"dns_cache"`
 }
 
-func (c *Global) Defaults() {
-	c.ServerName = "localhost"
-	c.PrivateKeyPath = "matrix_key.pem"
-	_, c.PrivateKey, _ = ed25519.GenerateKey(rand.New(rand.NewSource(0)))
-	c.KeyID = "ed25519:auto"
+func (c *Global) Defaults(generate bool) {
+	if generate {
+		c.ServerName = "localhost"
+		c.PrivateKeyPath = "matrix_key.pem"
+		_, c.PrivateKey, _ = ed25519.GenerateKey(rand.New(rand.NewSource(0)))
+		c.KeyID = "ed25519:auto"
+	}
 	c.KeyValidityPeriod = time.Hour * 24 * 7
 
-	c.Kafka.Defaults()
-	c.Metrics.Defaults()
+	c.Kafka.Defaults(generate)
+	c.Metrics.Defaults(generate)
 	c.DNSCache.Defaults()
 	c.Sentry.Defaults()
 }
@@ -110,10 +112,12 @@ type Metrics struct {
 	} `yaml:"basic_auth"`
 }
 
-func (c *Metrics) Defaults() {
+func (c *Metrics) Defaults(generate bool) {
 	c.Enabled = false
-	c.BasicAuth.Username = "metrics"
-	c.BasicAuth.Password = "metrics"
+	if generate {
+		c.BasicAuth.Username = "metrics"
+		c.BasicAuth.Password = "metrics"
+	}
 }
 
 func (c *Metrics) Verify(configErrs *ConfigErrors, isMonolith bool) {

--- a/setup/config/config_kafka.go
+++ b/setup/config/config_kafka.go
@@ -34,11 +34,13 @@ func (k *Kafka) TopicFor(name string) string {
 	return fmt.Sprintf("%s%s", k.TopicPrefix, name)
 }
 
-func (c *Kafka) Defaults() {
+func (c *Kafka) Defaults(generate bool) {
 	c.UseNaffka = true
 	c.Database.Defaults(10)
-	c.Addresses = []string{"localhost:2181"}
-	c.Database.ConnectionString = DataSource("file:naffka.db")
+	if generate {
+		c.Addresses = []string{"localhost:2181"}
+		c.Database.ConnectionString = DataSource("file:naffka.db")
+	}
 	c.TopicPrefix = "Dendrite"
 
 	maxBytes := 1024 * 1024 * 8 // about 8MB

--- a/setup/config/config_keyserver.go
+++ b/setup/config/config_keyserver.go
@@ -8,11 +8,13 @@ type KeyServer struct {
 	Database DatabaseOptions `yaml:"database"`
 }
 
-func (c *KeyServer) Defaults() {
+func (c *KeyServer) Defaults(generate bool) {
 	c.InternalAPI.Listen = "http://localhost:7779"
 	c.InternalAPI.Connect = "http://localhost:7779"
 	c.Database.Defaults(10)
-	c.Database.ConnectionString = "file:keyserver.db"
+	if generate {
+		c.Database.ConnectionString = "file:keyserver.db"
+	}
 }
 
 func (c *KeyServer) Verify(configErrs *ConfigErrors, isMonolith bool) {

--- a/setup/config/config_mediaapi.go
+++ b/setup/config/config_mediaapi.go
@@ -38,16 +38,18 @@ type MediaAPI struct {
 // DefaultMaxFileSizeBytes defines the default file size allowed in transfers
 var DefaultMaxFileSizeBytes = FileSizeBytes(10485760)
 
-func (c *MediaAPI) Defaults() {
+func (c *MediaAPI) Defaults(generate bool) {
 	c.InternalAPI.Listen = "http://localhost:7774"
 	c.InternalAPI.Connect = "http://localhost:7774"
 	c.ExternalAPI.Listen = "http://[::]:8074"
 	c.Database.Defaults(5)
-	c.Database.ConnectionString = "file:mediaapi.db"
+	if generate {
+		c.Database.ConnectionString = "file:mediaapi.db"
+		c.BasePath = "./media_store"
+	}
 
 	c.MaxFileSizeBytes = &DefaultMaxFileSizeBytes
 	c.MaxThumbnailGenerators = 10
-	c.BasePath = "./media_store"
 }
 
 func (c *MediaAPI) Verify(configErrs *ConfigErrors, isMonolith bool) {

--- a/setup/config/config_mscs.go
+++ b/setup/config/config_mscs.go
@@ -13,9 +13,11 @@ type MSCs struct {
 	Database DatabaseOptions `yaml:"database"`
 }
 
-func (c *MSCs) Defaults() {
+func (c *MSCs) Defaults(generate bool) {
 	c.Database.Defaults(5)
-	c.Database.ConnectionString = "file:mscs.db"
+	if generate {
+		c.Database.ConnectionString = "file:mscs.db"
+	}
 }
 
 // Enabled returns true if the given msc is enabled. Should in the form 'msc12345'.

--- a/setup/config/config_roomserver.go
+++ b/setup/config/config_roomserver.go
@@ -8,11 +8,13 @@ type RoomServer struct {
 	Database DatabaseOptions `yaml:"database"`
 }
 
-func (c *RoomServer) Defaults() {
+func (c *RoomServer) Defaults(generate bool) {
 	c.InternalAPI.Listen = "http://localhost:7770"
 	c.InternalAPI.Connect = "http://localhost:7770"
 	c.Database.Defaults(10)
-	c.Database.ConnectionString = "file:roomserver.db"
+	if generate {
+		c.Database.ConnectionString = "file:roomserver.db"
+	}
 }
 
 func (c *RoomServer) Verify(configErrs *ConfigErrors, isMonolith bool) {

--- a/setup/config/config_syncapi.go
+++ b/setup/config/config_syncapi.go
@@ -11,12 +11,14 @@ type SyncAPI struct {
 	RealIPHeader string `yaml:"real_ip_header"`
 }
 
-func (c *SyncAPI) Defaults() {
+func (c *SyncAPI) Defaults(generate bool) {
 	c.InternalAPI.Listen = "http://localhost:7773"
 	c.InternalAPI.Connect = "http://localhost:7773"
 	c.ExternalAPI.Listen = "http://localhost:8073"
 	c.Database.Defaults(10)
-	c.Database.ConnectionString = "file:syncapi.db"
+	if generate {
+		c.Database.ConnectionString = "file:syncapi.db"
+	}
 }
 
 func (c *SyncAPI) Verify(configErrs *ConfigErrors, isMonolith bool) {

--- a/setup/config/config_userapi.go
+++ b/setup/config/config_userapi.go
@@ -23,13 +23,15 @@ type UserAPI struct {
 
 const DefaultOpenIDTokenLifetimeMS = 3600000 // 60 minutes
 
-func (c *UserAPI) Defaults() {
+func (c *UserAPI) Defaults(generate bool) {
 	c.InternalAPI.Listen = "http://localhost:7781"
 	c.InternalAPI.Connect = "http://localhost:7781"
 	c.AccountDatabase.Defaults(10)
 	c.DeviceDatabase.Defaults(10)
-	c.AccountDatabase.ConnectionString = "file:userapi_accounts.db"
-	c.DeviceDatabase.ConnectionString = "file:userapi_devices.db"
+	if generate {
+		c.AccountDatabase.ConnectionString = "file:userapi_accounts.db"
+		c.DeviceDatabase.ConnectionString = "file:userapi_devices.db"
+	}
 	c.BCryptCost = bcrypt.DefaultCost
 	c.OpenIDTokenLifetimeMS = DefaultOpenIDTokenLifetimeMS
 }

--- a/setup/mscs/msc2836/msc2836_test.go
+++ b/setup/mscs/msc2836/msc2836_test.go
@@ -545,7 +545,7 @@ func (r *testRoomserverAPI) QueryMembershipForUser(ctx context.Context, req *roo
 func injectEvents(t *testing.T, userAPI userapi.UserInternalAPI, rsAPI roomserver.RoomserverInternalAPI, events []*gomatrixserverlib.HeaderedEvent) *mux.Router {
 	t.Helper()
 	cfg := &config.Dendrite{}
-	cfg.Defaults()
+	cfg.Defaults(true)
 	cfg.Global.ServerName = "localhost"
 	cfg.MSCs.Database.ConnectionString = "file:msc2836_test.db"
 	cfg.MSCs.MSCs = []string{"msc2836"}

--- a/setup/mscs/msc2946/msc2946_test.go
+++ b/setup/mscs/msc2946/msc2946_test.go
@@ -411,7 +411,7 @@ func (r *testRoomserverAPI) QueryCurrentState(ctx context.Context, req *roomserv
 func injectEvents(t *testing.T, userAPI userapi.UserInternalAPI, rsAPI roomserver.RoomserverInternalAPI, events []*gomatrixserverlib.HeaderedEvent) *mux.Router {
 	t.Helper()
 	cfg := &config.Dendrite{}
-	cfg.Defaults()
+	cfg.Defaults(true)
 	cfg.Global.ServerName = "localhost"
 	cfg.MSCs.Database.ConnectionString = "file:msc2946_test.db"
 	cfg.MSCs.MSCs = []string{"msc2946"}


### PR DESCRIPTION
The various `Defaults()` functions are designed to populate sane defaults before we unmarshal the config, so that any obviously missing but useful fields are populated. We also use this for `cmd/generate-config` and for the various P2P demos, which mostly want to run with defaults.

The problem is that we can accidentally populate defaults that aren't that sane for regular monolith/polylith installs. For example, the federation refactoring in matrix-org/dendrite#2055 would not complain about the missing `database` section from the `federation_api` config section because it was being defaulted.

This adds a "generate" flag to the various `Defaults()` functions for specifying if we want a *full* configuration generating, or whether to omit things that we obviously want to fail if they are missing. We definitely don't want to populate things like database connection strings if they are missing as we would rather panic and signal to the user that there's a problem in the config instead.