### PR TITLE
Updating example to Postgres v14

### DIFF
--- a/build/docker/docker-compose.deps.yml
+++ b/build/docker/docker-compose.deps.yml
@@ -3,7 +3,7 @@ services:
   # PostgreSQL is needed for both polylith and monolith modes.
   postgres:
     hostname: postgres
-    image: postgres:11
+    image: postgres:14
     restart: always
     volumes:
       - ./postgres/create_db.sh:/docker-entrypoint-initdb.d/20-create_db.sh


### PR DESCRIPTION
See issue #2052 - this PR updates the example docker-compose file to use the latest Postgres major version, to ensure new users aren't accidentally deploying an outdated version of Postgres.

### Pull Request Checklist
<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [n/a] I have added any new tests that need to pass to `sytest-whitelist` as specified in [docs/sytest.md](https://github.com/matrix-org/dendrite/blob/master/docs/sytest.md)
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `Ben Yanke <ben@benyanke.com>`
