### PR TITLE
Return event NID from `StoreEvent`, match PSQL vs SQLite behaviour, tweak backfill persistence

### DIFF
--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -122,7 +122,7 @@ func (r *Inputer) processRoomEvent(
 	}
 
 	// Store the event.
-	_, stateAtEvent, redactionEvent, redactedEventID, err := r.DB.StoreEvent(ctx, event, authEventNIDs, isRejected)
+	_, _, stateAtEvent, redactionEvent, redactedEventID, err := r.DB.StoreEvent(ctx, event, authEventNIDs, isRejected)
 	if err != nil {
 		return "", fmt.Errorf("r.DB.StoreEvent: %w", err)
 	}

--- a/roomserver/storage/interface.go
+++ b/roomserver/storage/interface.go
@@ -70,7 +70,7 @@ type Database interface {
 	StoreEvent(
 		ctx context.Context, event *gomatrixserverlib.Event, authEventNIDs []types.EventNID,
 		isRejected bool,
-	) (types.RoomNID, types.StateAtEvent, *gomatrixserverlib.Event, string, error)
+	) (types.EventNID, types.RoomNID, types.StateAtEvent, *gomatrixserverlib.Event, string, error)
 	// Look up the state entries for a list of string event IDs
 	// Returns an error if the there is an error talking to the database
 	// Returns a types.MissingEventError if the event IDs aren't in the database.


### PR DESCRIPTION
Now that we can use `RETURNING` in SQLite, we should match the behaviour across both storage backends. It also returns the event NID from the `StoreEvent` function, which will be useful in another PR I am working on.