### PR TITLE
Fix #2084 - incorrect /event_auth response

### DIFF
--- a/roomserver/api/query.go
+++ b/roomserver/api/query.go
@@ -226,7 +226,7 @@ type QueryStateAndAuthChainRequest struct {
 	PrevEventIDs []string `json:"prev_event_ids"`
 	// The list of auth events for the event. Used to calculate the auth chain
 	AuthEventIDs []string `json:"auth_event_ids"`
-	// If true, the auth chain events for the authh event IDs given will be fetched only. Prev event IDs are ignored.
+	// If true, the auth chain events for the auth event IDs given will be fetched only. Prev event IDs are ignored.
 	// If false, state and auth chain events for the prev event IDs and entire current state will be included.
 	// TODO: not a great API shape. It serves 2 main uses: false=>response for send_join, true=>response for /event_auth
 	OnlyFetchAuthChain bool `json:"only_fetch_auth_chain"`

--- a/roomserver/api/query.go
+++ b/roomserver/api/query.go
@@ -226,6 +226,10 @@ type QueryStateAndAuthChainRequest struct {
 	PrevEventIDs []string `json:"prev_event_ids"`
 	// The list of auth events for the event. Used to calculate the auth chain
 	AuthEventIDs []string `json:"auth_event_ids"`
+	// If true, the auth chain events for the authh event IDs given will be fetched only. Prev event IDs are ignored.
+	// If false, state and auth chain events for the prev event IDs and entire current state will be included.
+	// TODO: not a great API shape. It serves 2 main uses: false=>response for send_join, true=>response for /event_auth
+	OnlyFetchAuthChain bool `json:"only_fetch_auth_chain"`
 	// Should state resolution be ran on the result events?
 	// TODO: check call sites and remove if we always want to do state res
 	ResolveState bool `json:"resolve_state"`

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -457,6 +457,19 @@ func (r *Queryer) QueryStateAndAuthChain(
 	response.RoomExists = true
 	response.RoomVersion = info.RoomVersion
 
+	// handle this entirely separately to the other case so we don't have to pull out
+	// the entire current state of the room
+	// TODO: this probably means it should be a different query operation...
+	if request.OnlyFetchAuthChain {
+		authEvents, err := GetAuthChain(ctx, r.DB.EventsFromIDs, request.AuthEventIDs)
+		if err != nil {
+			return err
+		}
+		for _, event := range authEvents {
+			response.AuthChainEvents = append(response.AuthChainEvents, event.Headered(info.RoomVersion))
+		}
+	}
+
 	var stateEvents []*gomatrixserverlib.Event
 	stateEvents, err = r.loadStateAtEventIDs(ctx, *info, request.PrevEventIDs)
 	if err != nil {

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -468,6 +468,7 @@ func (r *Queryer) QueryStateAndAuthChain(
 		for _, event := range authEvents {
 			response.AuthChainEvents = append(response.AuthChainEvents, event.Headered(info.RoomVersion))
 		}
+		return nil
 	}
 
 	var stateEvents []*gomatrixserverlib.Event

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -461,7 +461,8 @@ func (r *Queryer) QueryStateAndAuthChain(
 	// the entire current state of the room
 	// TODO: this probably means it should be a different query operation...
 	if request.OnlyFetchAuthChain {
-		authEvents, err := GetAuthChain(ctx, r.DB.EventsFromIDs, request.AuthEventIDs)
+		var authEvents []*gomatrixserverlib.Event
+		authEvents, err = GetAuthChain(ctx, r.DB.EventsFromIDs, request.AuthEventIDs)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
We now very strictly only return the auth chain for the event given. I've also made it so that we don't load the entire current state (!!!!) for this operation. This will save on allocations / memory spikes when other servers call `/event_auth` on Dendrite, which it sounds like it could be reasonably frequently in busy IRC rooms where auth events are constantly changing. According to vdh:

> Synapse does it whenever it receives an event where we don't already have all the auth_events

So this will be done less frequently than `/get_missing_events` but still frequently in high event loss rooms (this may be particularly important for P2P rooms).