### PR TITLE
Send created room events as new events

### DIFF
--- a/roomserver/storage/postgres/events_table.go
+++ b/roomserver/storage/postgres/events_table.go
@@ -311,7 +311,7 @@ func (s *eventStatements) BulkSelectStateAtEventByID(
 		); err != nil {
 			return nil, err
 		}
-		if result.BeforeStateSnapshotNID == 0 {
+		if result.BeforeStateSnapshotNID == 0 && result.EventTypeNID != types.MRoomCreateNID {
 			return nil, types.MissingEventError(
 				fmt.Sprintf("storage: missing state for event NID %d", result.EventNID),
 			)

--- a/roomserver/storage/sqlite3/events_table.go
+++ b/roomserver/storage/sqlite3/events_table.go
@@ -322,7 +322,7 @@ func (s *eventStatements) BulkSelectStateAtEventByID(
 		); err != nil {
 			return nil, err
 		}
-		if result.BeforeStateSnapshotNID == 0 {
+		if result.BeforeStateSnapshotNID == 0 && result.EventTypeNID != types.MRoomCreateNID {
 			return nil, types.MissingEventError(
 				fmt.Sprintf("storage: missing state for event NID %d", result.EventNID),
 			)


### PR DESCRIPTION
... rather than outliers, so the state is rolled forward correctly.

Also don't complain if create events don't have a state snapshot NID of 0, because that's an acceptable case.