### PR TITLE
Increase NATS maximum message size to 16MB

### DIFF
--- a/setup/jetstream/nats.go
+++ b/setup/jetstream/nats.go
@@ -33,6 +33,7 @@ func Prepare(cfg *config.JetStream) (nats.JetStreamContext, sarama.Consumer, sar
 			StoreDir:         string(cfg.StoragePath),
 			NoSystemAccount:  true,
 			AllowNewAccounts: false,
+			MaxPayload:       16 * 1024 * 1024,
 		})
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Currently joining rooms with huge auth chains or state can cause us to hit this limit on the output events. This is by no means a permanent fix — we need to refactor how state is communicated via the roomserver output events — but this should alleviate the symptoms a bit in the meantime. 