### PR TITLE
Try federation when backfill fails to find events in the database

### DIFF
--- a/roomserver/internal/perform/perform_backfill.go
+++ b/roomserver/internal/perform/perform_backfill.go
@@ -79,21 +79,24 @@ func (r *Backfiller) PerformBackfill(
 	// Scan the event tree for events to send back.
 	resultNIDs, err := helpers.ScanEventTree(ctx, r.DB, info, front, visited, request.Limit, request.ServerName)
 	if err != nil {
-		return err
+		return r.backfillViaFederation(ctx, request, response)
 	}
 
 	// Retrieve events from the list that was filled previously.
 	var loadedEvents []*gomatrixserverlib.Event
 	loadedEvents, err = helpers.LoadEvents(ctx, r.DB, resultNIDs)
 	if err != nil {
-		return err
+		return r.backfillViaFederation(ctx, request, response)
 	}
 
 	for _, event := range loadedEvents {
 		response.Events = append(response.Events, event.Headered(info.RoomVersion))
 	}
 
-	return err
+	if err != nil {
+		return r.backfillViaFederation(ctx, request, response)
+	}
+	return nil
 }
 
 func (r *Backfiller) backfillViaFederation(ctx context.Context, req *api.PerformBackfillRequest, res *api.PerformBackfillResponse) error {


### PR DESCRIPTION
If backfilling fails to find events in the database for some reason, give federation one more try.