### PR TITLE
Call hooks for outliers

### DIFF
--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -25,7 +25,6 @@ import (
 	"github.com/Arceliar/phony"
 	"github.com/getsentry/sentry-go"
 	fedapi "github.com/matrix-org/dendrite/federationapi/api"
-	"github.com/matrix-org/dendrite/internal/hooks"
 	"github.com/matrix-org/dendrite/roomserver/acls"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/roomserver/internal/query"
@@ -105,8 +104,6 @@ func (r *Inputer) Start() error {
 					if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
 						sentry.CaptureException(err)
 					}
-				} else {
-					go hooks.Run(hooks.KindNewEventPersisted, inputRoomEvent.Event)
 				}
 				_ = msg.Ack()
 			})
@@ -176,8 +173,6 @@ func (r *Inputer) InputRoomEvents(
 					if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
 						sentry.CaptureException(err)
 					}
-				} else {
-					go hooks.Run(hooks.KindNewEventPersisted, inputRoomEvent.Event)
 				}
 				select {
 				case <-ctx.Done():

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -250,6 +250,7 @@ func (r *Inputer) processRoomEvent(
 	// notify anyone about it.
 	if input.Kind == api.KindOutlier {
 		logger.Debug("Stored outlier")
+		hooks.Run(hooks.KindNewEventPersisted, headered)
 		return nil
 	}
 

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -25,6 +25,7 @@ import (
 	fedapi "github.com/matrix-org/dendrite/federationapi/api"
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/eventutil"
+	"github.com/matrix-org/dendrite/internal/hooks"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/roomserver/internal/helpers"
 	"github.com/matrix-org/dendrite/roomserver/state"
@@ -321,7 +322,9 @@ func (r *Inputer) processRoomEvent(
 		}
 	}
 
-	// Update the extremities of the event graph for the room
+	// Everything was OK — the latest events updater didn't error and
+	// we've sent output events. Finally, generate a hook call.
+	hooks.Run(hooks.KindNewEventPersisted, event)
 	return nil
 }
 

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -324,7 +324,7 @@ func (r *Inputer) processRoomEvent(
 
 	// Everything was OK — the latest events updater didn't error and
 	// we've sent output events. Finally, generate a hook call.
-	hooks.Run(hooks.KindNewEventPersisted, event)
+	hooks.Run(hooks.KindNewEventPersisted, headered)
 	return nil
 }
 


### PR DESCRIPTION
We undid that in #2118, so now we'll ignore duplicate events but we will notify for outliers.