### PR TITLE
Require Go 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you have further questions, please take a look at [our FAQ](docs/FAQ.md) or j
 
 ## Requirements
 
-To build Dendrite, you will need Go 1.15 or later. 
+To build Dendrite, you will need Go 1.16 or later. 
 
 For a usable federating Dendrite deployment, you will also need:
 - A domain name (or subdomain) 

--- a/cmd/dendrite-demo-yggdrasil/README.md
+++ b/cmd/dendrite-demo-yggdrasil/README.md
@@ -1,6 +1,6 @@
 # Yggdrasil Demo
 
-This is the Dendrite Yggdrasil demo! It's easy to get started - all you need is Go 1.15 or later.
+This is the Dendrite Yggdrasil demo! It's easy to get started - all you need is Go 1.16 or later.
 
 To run the homeserver, start at the root of the Dendrite repository and run:
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -27,7 +27,7 @@ use in production environments just yet!
 
 Dendrite requires:
 
-* Go 1.15 or higher
+* Go 1.16 or higher
 * PostgreSQL 12 or higher (if using PostgreSQL databases, not needed for SQLite)
 
 If you want to run a polylith deployment, you also need:

--- a/go.mod
+++ b/go.mod
@@ -72,4 +72,4 @@ require (
 	nhooyr.io/websocket v1.8.7
 )
 
-go 1.15
+go 1.16


### PR DESCRIPTION
This bumps the minimum version to Go 1.16.