### PR TITLE
Allow uppercase username on login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@
 /vendor/bin
 /docker/build
 /logs
+/jetstream
 
 # Architecture specific extensions/prefixes
 *.[568vq]


### PR DESCRIPTION
FIX for #2073 

Support uppercase usernames from older dendrite versions. If dendrite is not finding the users localpart with lowercase it tries the login with the original localpart again.

This is my first Pull Requests on this project and on Github in general. Please give me feedback if anything is missing or not described clearly.

### Pull Request Checklist

<!-- Please read docs/CONTRIBUTING.md before submitting your pull request -->

* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/master/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `Julian Hörnschemeyer <julian.hoernschemeyer@mailbox.org>`
