### PR TITLE
Roomserver fixes

### DIFF
--- a/federationapi/internal/perform.go
+++ b/federationapi/internal/perform.go
@@ -251,7 +251,7 @@ func (r *FederationInternalAPI) performJoinUsingServer(
 			event.Headered(respMakeJoin.RoomVersion),
 			serverName,
 			nil,
-			true,
+			false,
 		); err != nil {
 			logrus.WithFields(logrus.Fields{
 				"room_id": roomID,

--- a/federationapi/internal/perform.go
+++ b/federationapi/internal/perform.go
@@ -251,7 +251,7 @@ func (r *FederationInternalAPI) performJoinUsingServer(
 			event.Headered(respMakeJoin.RoomVersion),
 			serverName,
 			nil,
-			false,
+			true,
 		); err != nil {
 			logrus.WithFields(logrus.Fields{
 				"room_id": roomID,

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -159,6 +159,7 @@ func (r *Inputer) processRoomEvent(
 		}
 		for server := range servers {
 			serverRes.ServerNames = append(serverRes.ServerNames, server)
+			delete(servers, server)
 		}
 	}
 

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -472,7 +472,7 @@ func (r *Inputer) calculateAndSetState(
 	var err error
 	roomState := state.NewStateResolution(r.DB, roomInfo)
 
-	if input.HasState && !isRejected {
+	if input.HasState {
 		// Check here if we think we're in the room already.
 		stateAtEvent.Overwrite = true
 		var joinEventNIDs []types.EventNID

--- a/roomserver/internal/input/input_missing.go
+++ b/roomserver/internal/input/input_missing.go
@@ -25,7 +25,7 @@ type missingStateReq struct {
 	keys            gomatrixserverlib.JSONVerifier
 	federation      fedapi.FederationInternalAPI
 	roomsMu         *internal.MutexByRoom
-	servers         map[gomatrixserverlib.ServerName]struct{}
+	servers         []gomatrixserverlib.ServerName
 	hadEvents       map[string]bool
 	hadEventsMutex  sync.Mutex
 	haveEvents      map[string]*gomatrixserverlib.HeaderedEvent
@@ -417,7 +417,7 @@ func (t *missingStateReq) getMissingEvents(ctx context.Context, e *gomatrixserve
 	}
 
 	var missingResp *gomatrixserverlib.RespMissingEvents
-	for server := range t.servers {
+	for _, server := range t.servers {
 		var m gomatrixserverlib.RespMissingEvents
 		if m, err = t.federation.LookupMissingEvents(ctx, server, e.RoomID(), gomatrixserverlib.MissingEvents{
 			Limit: 20,
@@ -700,7 +700,7 @@ func (t *missingStateReq) lookupEvent(ctx context.Context, roomVersion gomatrixs
 	}
 	var event *gomatrixserverlib.Event
 	found := false
-	for serverName := range t.servers {
+	for _, serverName := range t.servers {
 		reqctx, cancel := context.WithTimeout(ctx, time.Second*30)
 		defer cancel()
 		txn, err := t.federation.GetEvent(reqctx, serverName, missingEventID)

--- a/roomserver/internal/perform/perform_join.go
+++ b/roomserver/internal/perform/perform_join.go
@@ -51,7 +51,7 @@ func (r *Joiner) PerformJoin(
 	req *rsAPI.PerformJoinRequest,
 	res *rsAPI.PerformJoinResponse,
 ) {
-	roomID, joinedVia, err := r.performJoin(ctx, req)
+	roomID, joinedVia, err := r.performJoin(context.Background(), req)
 	if err != nil {
 		logrus.WithContext(ctx).WithFields(logrus.Fields{
 			"room_id": req.RoomIDOrAlias,

--- a/roomserver/internal/perform/perform_leave.go
+++ b/roomserver/internal/perform/perform_leave.go
@@ -52,7 +52,7 @@ func (r *Leaver) PerformLeave(
 		return nil, fmt.Errorf("user %q does not belong to this homeserver", req.UserID)
 	}
 	if strings.HasPrefix(req.RoomID, "!") {
-		output, err := r.performLeaveRoomByID(ctx, req, res)
+		output, err := r.performLeaveRoomByID(context.Background(), req, res)
 		if err != nil {
 			logrus.WithContext(ctx).WithFields(logrus.Fields{
 				"room_id": req.RoomID,


### PR DESCRIPTION
This PR includes a few very small fixes:

* Joins and leaves now use a background context, since they can take longer than the client is willing to wait
* Resident servers are now calculated without duplicates, with the input and event origins up front and with the rest of the ordering randomised for safety
* Rejected events with `HasState` are now persisted with state properly