### PR TITLE
Use background contexts during federated join for clarity

### DIFF
--- a/federationapi/internal/perform.go
+++ b/federationapi/internal/perform.go
@@ -253,7 +253,6 @@ func (r *FederationInternalAPI) performJoinUsingServer(
 		}
 	}()
 
-	<-ctx.Done()
 	return nil
 }
 


### PR DESCRIPTION
I think the `cancel()` sometimes happens prematurely and since it's all just a background context anyway, we'd might as well just be explicit about it.