### PR TITLE
Full roomserver input transactional isolation

### DIFF
--- a/internal/sqlutil/sql.go
+++ b/internal/sqlutil/sql.go
@@ -40,6 +40,11 @@ type Transaction interface {
 // You MUST check the error returned from this function to be sure that the transaction
 // was applied correctly. For example, 'database is locked' errors in sqlite will happen here.
 func EndTransaction(txn Transaction, succeeded *bool) error {
+	if txn == nil {
+		// Sometimes in SQLite mode we have nil transactions. If that's the case
+		// then we are working outside of a transaction and should do nothing here.
+		return nil
+	}
 	if *succeeded {
 		return txn.Commit()
 	} else {

--- a/internal/sqlutil/sql.go
+++ b/internal/sqlutil/sql.go
@@ -40,11 +40,6 @@ type Transaction interface {
 // You MUST check the error returned from this function to be sure that the transaction
 // was applied correctly. For example, 'database is locked' errors in sqlite will happen here.
 func EndTransaction(txn Transaction, succeeded *bool) error {
-	if txn == nil {
-		// Sometimes in SQLite mode we have nil transactions. If that's the case
-		// then we are working outside of a transaction and should do nothing here.
-		return nil
-	}
 	if *succeeded {
 		return txn.Commit()
 	} else {

--- a/roomserver/internal/helpers/auth.go
+++ b/roomserver/internal/helpers/auth.go
@@ -24,7 +24,7 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
-type checkForSoftFailStorage interface {
+type checkForAuthAndSoftFailStorage interface {
 	state.StateResolutionStorage
 	StateEntriesForEventIDs(ctx context.Context, eventIDs []string) ([]types.StateEntry, error)
 	RoomInfo(ctx context.Context, roomID string) (*types.RoomInfo, error)
@@ -35,7 +35,7 @@ type checkForSoftFailStorage interface {
 // the soft-fail bool.
 func CheckForSoftFail(
 	ctx context.Context,
-	db checkForSoftFailStorage,
+	db checkForAuthAndSoftFailStorage,
 	event *gomatrixserverlib.HeaderedEvent,
 	stateEventIDs []string,
 ) (bool, error) {
@@ -97,7 +97,7 @@ func CheckForSoftFail(
 // Returns the numeric IDs for the auth events.
 func CheckAuthEvents(
 	ctx context.Context,
-	db checkForSoftFailStorage,
+	db checkForAuthAndSoftFailStorage,
 	event *gomatrixserverlib.HeaderedEvent,
 	authEventIDs []string,
 ) ([]types.EventNID, error) {

--- a/roomserver/internal/helpers/auth.go
+++ b/roomserver/internal/helpers/auth.go
@@ -20,17 +20,22 @@ import (
 	"sort"
 
 	"github.com/matrix-org/dendrite/roomserver/state"
-	"github.com/matrix-org/dendrite/roomserver/storage"
 	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib"
 )
+
+type checkForSoftFailStorage interface {
+	state.StateResolutionStorage
+	StateEntriesForEventIDs(ctx context.Context, eventIDs []string) ([]types.StateEntry, error)
+	RoomInfo(ctx context.Context, roomID string) (*types.RoomInfo, error)
+}
 
 // CheckForSoftFail returns true if the event should be soft-failed
 // and false otherwise. The return error value should be checked before
 // the soft-fail bool.
 func CheckForSoftFail(
 	ctx context.Context,
-	db storage.Database,
+	db checkForSoftFailStorage,
 	event *gomatrixserverlib.HeaderedEvent,
 	stateEventIDs []string,
 ) (bool, error) {
@@ -92,7 +97,7 @@ func CheckForSoftFail(
 // Returns the numeric IDs for the auth events.
 func CheckAuthEvents(
 	ctx context.Context,
-	db storage.Database,
+	db checkForSoftFailStorage,
 	event *gomatrixserverlib.HeaderedEvent,
 	authEventIDs []string,
 ) ([]types.EventNID, error) {
@@ -193,7 +198,7 @@ func (ae *authEvents) lookupEvent(typeNID types.EventTypeNID, stateKey string) *
 // loadAuthEvents loads the events needed for authentication from the supplied room state.
 func loadAuthEvents(
 	ctx context.Context,
-	db storage.Database,
+	db state.StateResolutionStorage,
 	needed gomatrixserverlib.StateNeeded,
 	state []types.StateEntry,
 ) (result authEvents, err error) {

--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -157,18 +157,15 @@ func (r *Inputer) processRoomEventUsingUpdater(
 	}
 	commit, err := r.processRoomEvent(ctx, updater, inputRoomEvent)
 	if commit {
-		if err = updater.Commit(); err != nil {
-			return false, fmt.Errorf("updater.Commit: %w", err)
+		if cerr := updater.Commit(); err != nil {
+			return true, fmt.Errorf("updater.Commit: %w", cerr)
 		}
 	} else {
 		if rerr := updater.Rollback(); rerr != nil {
-			return true, fmt.Errorf("updater.Rollback: %w", err)
+			return true, fmt.Errorf("updater.Rollback: %w", rerr)
 		}
 	}
-	if err != nil {
-		return true, err
-	}
-	return false, nil
+	return false, err
 }
 
 // InputRoomEvents implements api.RoomserverInternalAPI

--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -113,10 +113,10 @@ func (r *Inputer) Start() error {
 						"type":     inputRoomEvent.Event.Type(),
 					}).Warn("Roomserver failed to process async event")
 				}
-				if !retry {
-					_ = msg.Ack()
-				} else {
+				if retry {
 					_ = msg.Nak()
+				} else {
+					_ = msg.Ack()
 				}
 			})
 		},

--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -157,7 +157,7 @@ func (r *Inputer) processRoomEventUsingUpdater(
 	}
 	commit, err := r.processRoomEvent(ctx, updater, inputRoomEvent)
 	if commit {
-		if cerr := updater.Commit(); err != nil {
+		if cerr := updater.Commit(); cerr != nil {
 			return true, fmt.Errorf("updater.Commit: %w", cerr)
 		}
 	} else {

--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -151,7 +151,7 @@ func (r *Inputer) processRoomEventUsingUpdater(
 	if err != nil {
 		return false, fmt.Errorf("r.DB.RoomInfo: %w", err)
 	}
-	updater, err := r.DB.GetRoomUpdater(ctx, *roomInfo)
+	updater, err := r.DB.GetRoomUpdater(ctx, roomInfo)
 	if err != nil {
 		return true, fmt.Errorf("r.DB.GetRoomUpdater: %w", err)
 	}

--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -26,7 +26,6 @@ import (
 	"github.com/Arceliar/phony"
 	"github.com/getsentry/sentry-go"
 	fedapi "github.com/matrix-org/dendrite/federationapi/api"
-	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/roomserver/acls"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/roomserver/internal/query"
@@ -103,7 +102,8 @@ func (r *Inputer) Start() error {
 				_ = msg.InProgress() // resets the acknowledgement wait timer
 				defer eventsInProgress.Delete(index)
 				defer roomserverInputBackpressure.With(prometheus.Labels{"room_id": roomID}).Dec()
-				if err := r.processRoomEventUsingUpdater(context.Background(), roomID, &inputRoomEvent); err != nil {
+				retry, err := r.processRoomEventUsingUpdater(context.Background(), roomID, &inputRoomEvent)
+				if err != nil {
 					if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
 						sentry.CaptureException(err)
 					}
@@ -113,7 +113,11 @@ func (r *Inputer) Start() error {
 						"type":     inputRoomEvent.Event.Type(),
 					}).Warn("Roomserver failed to process async event")
 				}
-				_ = msg.Ack()
+				if !retry {
+					_ = msg.Ack()
+				} else {
+					_ = msg.Nak()
+				}
 			})
 		},
 		// NATS wants to acknowledge automatically by default when the message is
@@ -133,26 +137,34 @@ func (r *Inputer) Start() error {
 	return err
 }
 
+// processRoomEventUsingUpdater opens up a room updater and tries to
+// process the event. It returns two values: the bool signifying whether
+// we should retry later if possible (i.e. using NATS, because we couldn't
+// commit the transaction) and an error signifying anything else that may
+// have gone wrong.
 func (r *Inputer) processRoomEventUsingUpdater(
 	ctx context.Context,
 	roomID string,
 	inputRoomEvent *api.InputRoomEvent,
-) error {
+) (bool, error) {
 	roomInfo, err := r.DB.RoomInfo(ctx, roomID)
 	if err != nil {
-		return fmt.Errorf("r.DB.RoomInfo: %w", err)
+		return false, fmt.Errorf("r.DB.RoomInfo: %w", err)
 	}
 	updater, err := r.DB.GetRoomUpdater(ctx, *roomInfo)
 	if err != nil {
-		return fmt.Errorf("r.DB.GetRoomUpdater: %w", err)
+		return true, fmt.Errorf("r.DB.GetRoomUpdater: %w", err)
 	}
-	succeeded := false
-	defer sqlutil.EndTransactionWithCheck(updater, &succeeded, &err)
 	if err = r.processRoomEvent(ctx, updater, inputRoomEvent); err != nil {
-		return fmt.Errorf("r.processRoomEvent: %w", err)
+		if rerr := updater.Rollback(); rerr != nil {
+			return false, fmt.Errorf("r.processRoomEvent: %w (with additional error rolling back transaction: %s)", err, rerr)
+		}
+		return false, fmt.Errorf("r.processRoomEvent: %w", err)
 	}
-	succeeded = true
-	return nil
+	if err = updater.Commit(); err != nil {
+		return true, fmt.Errorf("updater.Commit: %w", err)
+	}
+	return false, nil
 }
 
 // InputRoomEvents implements api.RoomserverInternalAPI
@@ -202,7 +214,7 @@ func (r *Inputer) InputRoomEvents(
 			worker.Act(nil, func() {
 				defer eventsInProgress.Delete(index)
 				defer roomserverInputBackpressure.With(prometheus.Labels{"room_id": roomID}).Dec()
-				err := r.processRoomEventUsingUpdater(ctx, roomID, &inputRoomEvent)
+				_, err := r.processRoomEventUsingUpdater(ctx, roomID, &inputRoomEvent)
 				if err != nil {
 					if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
 						sentry.CaptureException(err)

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -204,7 +204,7 @@ func (r *Inputer) processRoomEvent(
 	if input.Kind == api.KindNew {
 		// Check that the event passes authentication checks based on the
 		// current room state.
-		softfail, err = helpers.CheckForSoftFail(ctx, r.DB, headered, input.StateEventIDs)
+		softfail, err = helpers.CheckForSoftFail(ctx, updater, headered, input.StateEventIDs)
 		if err != nil {
 			logger.WithError(err).Warn("Error authing soft-failed event")
 		}

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -296,7 +296,7 @@ func (r *Inputer) processRoomEvent(
 			"soft_fail":    softfail,
 			"missing_prev": missingPrev,
 		}).Warn("Stored rejected event")
-		return rejectionErr
+		return nil
 	}
 
 	switch input.Kind {

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -483,7 +483,7 @@ func (r *Inputer) calculateAndSetState(
 	isRejected bool,
 ) error {
 	var err error
-	roomState := state.NewStateResolution(r.DB, roomInfo)
+	roomState := state.NewStateResolution(updater, roomInfo)
 
 	if input.HasState {
 		// Check here if we think we're in the room already.

--- a/roomserver/internal/input/input_latest_events.go
+++ b/roomserver/internal/input/input_latest_events.go
@@ -405,7 +405,7 @@ func (u *latestEventsUpdater) extraEventsForIDs(roomVersion gomatrixserverlib.Ro
 	if len(extraEventIDs) == 0 {
 		return nil, nil
 	}
-	extraEvents, err := u.api.DB.EventsFromIDs(u.ctx, extraEventIDs)
+	extraEvents, err := u.updater.EventsFromIDs(u.ctx, extraEventIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -428,7 +428,7 @@ func (u *latestEventsUpdater) stateEventMap() (map[types.EventNID]string, error)
 		stateEventNIDs = append(stateEventNIDs, entry.EventNID)
 	}
 	stateEventNIDs = stateEventNIDs[:util.SortAndUnique(eventNIDSorter(stateEventNIDs))]
-	return u.api.DB.EventIDs(u.ctx, stateEventNIDs)
+	return u.updater.EventIDs(u.ctx, stateEventNIDs)
 }
 
 type eventNIDSorter []types.EventNID

--- a/roomserver/internal/input/input_latest_events.go
+++ b/roomserver/internal/input/input_latest_events.go
@@ -191,7 +191,7 @@ func (u *latestEventsUpdater) doUpdateLatestEvents() error {
 
 func (u *latestEventsUpdater) latestState() error {
 	var err error
-	roomState := state.NewStateResolution(u.api.DB, u.roomInfo)
+	roomState := state.NewStateResolution(u.updater, u.roomInfo)
 
 	// Work out if the state at the extremities has actually changed
 	// or not. If they haven't then we won't bother doing all of the

--- a/roomserver/internal/input/input_membership.go
+++ b/roomserver/internal/input/input_membership.go
@@ -31,7 +31,7 @@ import (
 // consumers about the invites added or retired by the change in current state.
 func (r *Inputer) updateMemberships(
 	ctx context.Context,
-	updater *shared.LatestEventsUpdater,
+	updater *shared.RoomUpdater,
 	removed, added []types.StateEntry,
 ) ([]api.OutputEvent, error) {
 	changes := membershipChanges(removed, added)
@@ -79,7 +79,7 @@ func (r *Inputer) updateMemberships(
 }
 
 func (r *Inputer) updateMembership(
-	updater *shared.LatestEventsUpdater,
+	updater *shared.RoomUpdater,
 	targetUserNID types.EventStateKeyNID,
 	remove, add *gomatrixserverlib.Event,
 	updates []api.OutputEvent,

--- a/roomserver/internal/input/input_missing.go
+++ b/roomserver/internal/input/input_missing.go
@@ -666,7 +666,7 @@ func (t *missingStateReq) createRespStateFromStateIDs(stateIDs gomatrixserverlib
 	for i := range stateIDs.StateEventIDs {
 		ev, ok := t.haveEvents[stateIDs.StateEventIDs[i]]
 		if !ok {
-			logrus.Warnf("Missing state event in createRespStateFromStateIDs: %s", stateIDs.StateEventIDs[i])
+			logrus.Tracef("Missing state event in createRespStateFromStateIDs: %s", stateIDs.StateEventIDs[i])
 			continue
 		}
 		respState.StateEvents = append(respState.StateEvents, ev.Unwrap())
@@ -674,7 +674,7 @@ func (t *missingStateReq) createRespStateFromStateIDs(stateIDs gomatrixserverlib
 	for i := range stateIDs.AuthEventIDs {
 		ev, ok := t.haveEvents[stateIDs.AuthEventIDs[i]]
 		if !ok {
-			logrus.Warnf("Missing auth event in createRespStateFromStateIDs: %s", stateIDs.AuthEventIDs[i])
+			logrus.Tracef("Missing auth event in createRespStateFromStateIDs: %s", stateIDs.AuthEventIDs[i])
 			continue
 		}
 		respState.AuthEvents = append(respState.AuthEvents, ev.Unwrap())
@@ -718,7 +718,7 @@ func (t *missingStateReq) lookupEvent(ctx context.Context, roomVersion gomatrixs
 		}
 		event, err = gomatrixserverlib.NewEventFromUntrustedJSON(txn.PDUs[0], roomVersion)
 		if err != nil {
-			util.GetLogger(ctx).WithError(err).WithField("event_id", missingEventID).Warnf("Transaction: Failed to parse event JSON of event")
+			util.GetLogger(ctx).WithError(err).WithField("event_id", missingEventID).Warnf("Failed to parse event JSON of event returned from /event")
 			continue
 		}
 		found = true
@@ -729,7 +729,7 @@ func (t *missingStateReq) lookupEvent(ctx context.Context, roomVersion gomatrixs
 		return nil, fmt.Errorf("wasn't able to find event via %d server(s)", len(t.servers))
 	}
 	if err := event.VerifyEventSignatures(ctx, t.keys); err != nil {
-		util.GetLogger(ctx).WithError(err).Warnf("Transaction: Couldn't validate signature of event %q", event.EventID())
+		util.GetLogger(ctx).WithError(err).Warnf("Couldn't validate signature of event %q from /event", event.EventID())
 		return nil, verifySigError{event.EventID(), err}
 	}
 	return t.cacheAndReturn(event.Headered(roomVersion)), nil

--- a/roomserver/internal/input/input_missing.go
+++ b/roomserver/internal/input/input_missing.go
@@ -11,15 +11,16 @@ import (
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/roomserver/internal/query"
-	"github.com/matrix-org/dendrite/roomserver/storage"
+	"github.com/matrix-org/dendrite/roomserver/storage/shared"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 	"github.com/sirupsen/logrus"
 )
 
 type missingStateReq struct {
-	origin          gomatrixserverlib.ServerName
-	db              storage.Database
+	origin gomatrixserverlib.ServerName
+	//db              storage.Database
+	db              *shared.RoomUpdater
 	inputer         *Inputer
 	queryer         *query.Queryer
 	keys            gomatrixserverlib.JSONVerifier
@@ -78,7 +79,7 @@ func (t *missingStateReq) processEventWithMissingState(
 		// we can just inject all the newEvents as new as we may have only missed 1 or 2 events and have filled
 		// in the gap in the DAG
 		for _, newEvent := range newEvents {
-			err = t.inputer.processRoomEvent(ctx, &api.InputRoomEvent{
+			err = t.inputer.processRoomEvent(ctx, t.db, &api.InputRoomEvent{
 				Kind:         api.KindNew,
 				Event:        newEvent.Headered(roomVersion),
 				Origin:       t.origin,
@@ -187,7 +188,7 @@ func (t *missingStateReq) processEventWithMissingState(
 	}
 	// TODO: we could do this concurrently?
 	for _, ire := range outlierRoomEvents {
-		if err = t.inputer.processRoomEvent(ctx, &ire); err != nil {
+		if err = t.inputer.processRoomEvent(ctx, t.db, &ire); err != nil {
 			return fmt.Errorf("t.inputer.processRoomEvent[outlier]: %w", err)
 		}
 	}
@@ -200,7 +201,7 @@ func (t *missingStateReq) processEventWithMissingState(
 		stateIDs = append(stateIDs, event.EventID())
 	}
 
-	err = t.inputer.processRoomEvent(ctx, &api.InputRoomEvent{
+	err = t.inputer.processRoomEvent(ctx, t.db, &api.InputRoomEvent{
 		Kind:          api.KindOld,
 		Event:         backwardsExtremity.Headered(roomVersion),
 		Origin:        t.origin,
@@ -217,7 +218,7 @@ func (t *missingStateReq) processEventWithMissingState(
 	// they will automatically fast-forward based on the room state at the
 	// extremity in the last step.
 	for _, newEvent := range newEvents {
-		err = t.inputer.processRoomEvent(ctx, &api.InputRoomEvent{
+		err = t.inputer.processRoomEvent(ctx, t.db, &api.InputRoomEvent{
 			Kind:         api.KindOld,
 			Event:        newEvent.Headered(roomVersion),
 			Origin:       t.origin,

--- a/roomserver/internal/input/input_missing.go
+++ b/roomserver/internal/input/input_missing.go
@@ -79,7 +79,7 @@ func (t *missingStateReq) processEventWithMissingState(
 		// we can just inject all the newEvents as new as we may have only missed 1 or 2 events and have filled
 		// in the gap in the DAG
 		for _, newEvent := range newEvents {
-			err = t.inputer.processRoomEvent(ctx, t.db, &api.InputRoomEvent{
+			_, err = t.inputer.processRoomEvent(ctx, t.db, &api.InputRoomEvent{
 				Kind:         api.KindNew,
 				Event:        newEvent.Headered(roomVersion),
 				Origin:       t.origin,
@@ -188,7 +188,7 @@ func (t *missingStateReq) processEventWithMissingState(
 	}
 	// TODO: we could do this concurrently?
 	for _, ire := range outlierRoomEvents {
-		if err = t.inputer.processRoomEvent(ctx, t.db, &ire); err != nil {
+		if _, err = t.inputer.processRoomEvent(ctx, t.db, &ire); err != nil {
 			return fmt.Errorf("t.inputer.processRoomEvent[outlier]: %w", err)
 		}
 	}
@@ -201,7 +201,7 @@ func (t *missingStateReq) processEventWithMissingState(
 		stateIDs = append(stateIDs, event.EventID())
 	}
 
-	err = t.inputer.processRoomEvent(ctx, t.db, &api.InputRoomEvent{
+	_, err = t.inputer.processRoomEvent(ctx, t.db, &api.InputRoomEvent{
 		Kind:          api.KindOld,
 		Event:         backwardsExtremity.Headered(roomVersion),
 		Origin:        t.origin,
@@ -218,7 +218,7 @@ func (t *missingStateReq) processEventWithMissingState(
 	// they will automatically fast-forward based on the room state at the
 	// extremity in the last step.
 	for _, newEvent := range newEvents {
-		err = t.inputer.processRoomEvent(ctx, t.db, &api.InputRoomEvent{
+		_, err = t.inputer.processRoomEvent(ctx, t.db, &api.InputRoomEvent{
 			Kind:         api.KindOld,
 			Event:        newEvent.Headered(roomVersion),
 			Origin:       t.origin,

--- a/roomserver/internal/input/input_missing.go
+++ b/roomserver/internal/input/input_missing.go
@@ -18,8 +18,7 @@ import (
 )
 
 type missingStateReq struct {
-	origin gomatrixserverlib.ServerName
-	//db              storage.Database
+	origin          gomatrixserverlib.ServerName
 	db              *shared.RoomUpdater
 	inputer         *Inputer
 	queryer         *query.Queryer

--- a/roomserver/internal/perform/perform_join.go
+++ b/roomserver/internal/perform/perform_join.go
@@ -51,13 +51,15 @@ func (r *Joiner) PerformJoin(
 	req *rsAPI.PerformJoinRequest,
 	res *rsAPI.PerformJoinResponse,
 ) {
+	logger := logrus.WithContext(ctx).WithFields(logrus.Fields{
+		"room_id": req.RoomIDOrAlias,
+		"user_id": req.UserID,
+		"servers": req.ServerNames,
+	})
+	logger.Info("User requested to room join")
 	roomID, joinedVia, err := r.performJoin(context.Background(), req)
 	if err != nil {
-		logrus.WithContext(ctx).WithFields(logrus.Fields{
-			"room_id": req.RoomIDOrAlias,
-			"user_id": req.UserID,
-			"servers": req.ServerNames,
-		}).WithError(err).Error("Failed to join room")
+		logger.WithError(err).Error("Failed to join room")
 		sentry.CaptureException(err)
 		perr, ok := err.(*rsAPI.PerformError)
 		if ok {
@@ -67,7 +69,9 @@ func (r *Joiner) PerformJoin(
 				Msg: err.Error(),
 			}
 		}
+		return
 	}
+	logger.Info("User joined room successfully")
 	res.RoomID = roomID
 	res.JoinedVia = joinedVia
 }

--- a/roomserver/internal/perform/perform_leave.go
+++ b/roomserver/internal/perform/perform_leave.go
@@ -51,13 +51,17 @@ func (r *Leaver) PerformLeave(
 	if domain != r.Cfg.Matrix.ServerName {
 		return nil, fmt.Errorf("user %q does not belong to this homeserver", req.UserID)
 	}
+	logger := logrus.WithContext(ctx).WithFields(logrus.Fields{
+		"room_id": req.RoomID,
+		"user_id": req.UserID,
+	})
+	logger.Info("User requested to leave join")
 	if strings.HasPrefix(req.RoomID, "!") {
 		output, err := r.performLeaveRoomByID(context.Background(), req, res)
 		if err != nil {
-			logrus.WithContext(ctx).WithFields(logrus.Fields{
-				"room_id": req.RoomID,
-				"user_id": req.UserID,
-			}).WithError(err).Error("Failed to leave room")
+			logger.WithError(err).Error("Failed to leave room")
+		} else {
+			logger.Info("User left room successfully")
 		}
 		return output, err
 	}

--- a/roomserver/storage/interface.go
+++ b/roomserver/storage/interface.go
@@ -24,8 +24,8 @@ import (
 )
 
 type Database interface {
-	// Do we support processing input events for more than one room at a time?
-	SupportsConcurrentRoomInputs() bool
+	// Do we support transactional isolation on this database engine?
+	SupportsTransactionalIsolation() bool
 	// RoomInfo returns room information for the given room ID, or nil if there is no room.
 	RoomInfo(ctx context.Context, roomID string) (*types.RoomInfo, error)
 	// Store the room state at an event in the database

--- a/roomserver/storage/interface.go
+++ b/roomserver/storage/interface.go
@@ -24,8 +24,8 @@ import (
 )
 
 type Database interface {
-	// Do we support transactional isolation on this database engine?
-	SupportsTransactionalIsolation() bool
+	// Do we support processing input events for more than one room at a time?
+	SupportsConcurrentRoomInputs() bool
 	// RoomInfo returns room information for the given room ID, or nil if there is no room.
 	RoomInfo(ctx context.Context, roomID string) (*types.RoomInfo, error)
 	// Store the room state at an event in the database

--- a/roomserver/storage/interface.go
+++ b/roomserver/storage/interface.go
@@ -89,7 +89,7 @@ type Database interface {
 	// Opens and returns a room updater, which locks the room and opens a transaction.
 	// The GetRoomUpdater must have Commit or Rollback called on it if this doesn't return an error.
 	// If this returns an error then no further action is required.
-	GetRoomUpdater(ctx context.Context, roomInfo types.RoomInfo) (*shared.RoomUpdater, error)
+	GetRoomUpdater(ctx context.Context, roomInfo *types.RoomInfo) (*shared.RoomUpdater, error)
 	// Look up event references for the latest events in the room and the current state snapshot.
 	// Returns the latest events, the current state and the maximum depth of the latest events plus 1.
 	// Returns an error if there was a problem talking to the database.

--- a/roomserver/storage/interface.go
+++ b/roomserver/storage/interface.go
@@ -86,11 +86,10 @@ type Database interface {
 	// Lookup the event IDs for a batch of event numeric IDs.
 	// Returns an error if the retrieval went wrong.
 	EventIDs(ctx context.Context, eventNIDs []types.EventNID) (map[types.EventNID]string, error)
-	// Look up the latest events in a room in preparation for an update.
-	// The RoomRecentEventsUpdater must have Commit or Rollback called on it if this doesn't return an error.
-	// Returns the latest events in the room and the last eventID sent to the log along with an updater.
+	// Opens and returns a room updater, which locks the room and opens a transaction.
+	// The GetRoomUpdater must have Commit or Rollback called on it if this doesn't return an error.
 	// If this returns an error then no further action is required.
-	GetLatestEventsForUpdate(ctx context.Context, roomInfo types.RoomInfo) (*shared.LatestEventsUpdater, error)
+	GetRoomUpdater(ctx context.Context, roomInfo types.RoomInfo) (*shared.RoomUpdater, error)
 	// Look up event references for the latest events in the room and the current state snapshot.
 	// Returns the latest events, the current state and the maximum depth of the latest events plus 1.
 	// Returns an error if there was a problem talking to the database.

--- a/roomserver/storage/postgres/event_json_table.go
+++ b/roomserver/storage/postgres/event_json_table.go
@@ -81,9 +81,10 @@ func (s *eventJSONStatements) InsertEventJSON(
 }
 
 func (s *eventJSONStatements) BulkSelectEventJSON(
-	ctx context.Context, eventNIDs []types.EventNID,
+	ctx context.Context, txn *sql.Tx, eventNIDs []types.EventNID,
 ) ([]tables.EventJSONPair, error) {
-	rows, err := s.bulkSelectEventJSONStmt.QueryContext(ctx, eventNIDsAsArray(eventNIDs))
+	stmt := sqlutil.TxStmt(txn, s.bulkSelectEventJSONStmt)
+	rows, err := stmt.QueryContext(ctx, eventNIDsAsArray(eventNIDs))
 	if err != nil {
 		return nil, err
 	}

--- a/roomserver/storage/postgres/event_state_keys_table.go
+++ b/roomserver/storage/postgres/event_state_keys_table.go
@@ -111,9 +111,10 @@ func (s *eventStateKeyStatements) SelectEventStateKeyNID(
 }
 
 func (s *eventStateKeyStatements) BulkSelectEventStateKeyNID(
-	ctx context.Context, eventStateKeys []string,
+	ctx context.Context, txn *sql.Tx, eventStateKeys []string,
 ) (map[string]types.EventStateKeyNID, error) {
-	rows, err := s.bulkSelectEventStateKeyNIDStmt.QueryContext(
+	stmt := sqlutil.TxStmt(txn, s.bulkSelectEventStateKeyNIDStmt)
+	rows, err := stmt.QueryContext(
 		ctx, pq.StringArray(eventStateKeys),
 	)
 	if err != nil {
@@ -134,13 +135,14 @@ func (s *eventStateKeyStatements) BulkSelectEventStateKeyNID(
 }
 
 func (s *eventStateKeyStatements) BulkSelectEventStateKey(
-	ctx context.Context, eventStateKeyNIDs []types.EventStateKeyNID,
+	ctx context.Context, txn *sql.Tx, eventStateKeyNIDs []types.EventStateKeyNID,
 ) (map[types.EventStateKeyNID]string, error) {
 	nIDs := make(pq.Int64Array, len(eventStateKeyNIDs))
 	for i := range eventStateKeyNIDs {
 		nIDs[i] = int64(eventStateKeyNIDs[i])
 	}
-	rows, err := s.bulkSelectEventStateKeyStmt.QueryContext(ctx, nIDs)
+	stmt := sqlutil.TxStmt(txn, s.bulkSelectEventStateKeyStmt)
+	rows, err := stmt.QueryContext(ctx, nIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/roomserver/storage/postgres/event_types_table.go
+++ b/roomserver/storage/postgres/event_types_table.go
@@ -133,9 +133,10 @@ func (s *eventTypeStatements) SelectEventTypeNID(
 }
 
 func (s *eventTypeStatements) BulkSelectEventTypeNID(
-	ctx context.Context, eventTypes []string,
+	ctx context.Context, txn *sql.Tx, eventTypes []string,
 ) (map[string]types.EventTypeNID, error) {
-	rows, err := s.bulkSelectEventTypeNIDStmt.QueryContext(ctx, pq.StringArray(eventTypes))
+	stmt := sqlutil.TxStmt(txn, s.bulkSelectEventTypeNIDStmt)
+	rows, err := stmt.QueryContext(ctx, pq.StringArray(eventTypes))
 	if err != nil {
 		return nil, err
 	}

--- a/roomserver/storage/postgres/events_table.go
+++ b/roomserver/storage/postgres/events_table.go
@@ -212,9 +212,10 @@ func (s *eventStatements) SelectEvent(
 // bulkSelectStateEventByID lookups a list of state events by event ID.
 // If any of the requested events are missing from the database it returns a types.MissingEventError
 func (s *eventStatements) BulkSelectStateEventByID(
-	ctx context.Context, eventIDs []string,
+	ctx context.Context, txn *sql.Tx, eventIDs []string,
 ) ([]types.StateEntry, error) {
-	rows, err := s.bulkSelectStateEventByIDStmt.QueryContext(ctx, pq.StringArray(eventIDs))
+	stmt := sqlutil.TxStmt(txn, s.bulkSelectStateEventByIDStmt)
+	rows, err := stmt.QueryContext(ctx, pq.StringArray(eventIDs))
 	if err != nil {
 		return nil, err
 	}
@@ -254,13 +255,14 @@ func (s *eventStatements) BulkSelectStateEventByID(
 // bulkSelectStateEventByNID lookups a list of state events by event NID.
 // If any of the requested events are missing from the database it returns a types.MissingEventError
 func (s *eventStatements) BulkSelectStateEventByNID(
-	ctx context.Context, eventNIDs []types.EventNID,
+	ctx context.Context, txn *sql.Tx, eventNIDs []types.EventNID,
 	stateKeyTuples []types.StateKeyTuple,
 ) ([]types.StateEntry, error) {
 	tuples := stateKeyTupleSorter(stateKeyTuples)
 	sort.Sort(tuples)
 	eventTypeNIDArray, eventStateKeyNIDArray := tuples.typesAndStateKeysAsArrays()
-	rows, err := s.bulkSelectStateEventByNIDStmt.QueryContext(ctx, eventNIDsAsArray(eventNIDs), eventTypeNIDArray, eventStateKeyNIDArray)
+	stmt := sqlutil.TxStmt(txn, s.bulkSelectStateEventByNIDStmt)
+	rows, err := stmt.QueryContext(ctx, eventNIDsAsArray(eventNIDs), eventTypeNIDArray, eventStateKeyNIDArray)
 	if err != nil {
 		return nil, err
 	}
@@ -291,9 +293,10 @@ func (s *eventStatements) BulkSelectStateEventByNID(
 // If any of the requested events are missing from the database it returns a types.MissingEventError.
 // If we do not have the state for any of the requested events it returns a types.MissingEventError.
 func (s *eventStatements) BulkSelectStateAtEventByID(
-	ctx context.Context, eventIDs []string,
+	ctx context.Context, txn *sql.Tx, eventIDs []string,
 ) ([]types.StateAtEvent, error) {
-	rows, err := s.bulkSelectStateAtEventByIDStmt.QueryContext(ctx, pq.StringArray(eventIDs))
+	stmt := sqlutil.TxStmt(txn, s.bulkSelectStateAtEventByIDStmt)
+	rows, err := stmt.QueryContext(ctx, pq.StringArray(eventIDs))
 	if err != nil {
 		return nil, err
 	}
@@ -428,8 +431,9 @@ func (s *eventStatements) BulkSelectEventReference(
 }
 
 // bulkSelectEventID returns a map from numeric event ID to string event ID.
-func (s *eventStatements) BulkSelectEventID(ctx context.Context, eventNIDs []types.EventNID) (map[types.EventNID]string, error) {
-	rows, err := s.bulkSelectEventIDStmt.QueryContext(ctx, eventNIDsAsArray(eventNIDs))
+func (s *eventStatements) BulkSelectEventID(ctx context.Context, txn *sql.Tx, eventNIDs []types.EventNID) (map[types.EventNID]string, error) {
+	stmt := sqlutil.TxStmt(txn, s.bulkSelectEventIDStmt)
+	rows, err := stmt.QueryContext(ctx, eventNIDsAsArray(eventNIDs))
 	if err != nil {
 		return nil, err
 	}
@@ -455,8 +459,9 @@ func (s *eventStatements) BulkSelectEventID(ctx context.Context, eventNIDs []typ
 
 // bulkSelectEventNIDs returns a map from string event ID to numeric event ID.
 // If an event ID is not in the database then it is omitted from the map.
-func (s *eventStatements) BulkSelectEventNID(ctx context.Context, eventIDs []string) (map[string]types.EventNID, error) {
-	rows, err := s.bulkSelectEventNIDStmt.QueryContext(ctx, pq.StringArray(eventIDs))
+func (s *eventStatements) BulkSelectEventNID(ctx context.Context, txn *sql.Tx, eventIDs []string) (map[string]types.EventNID, error) {
+	stmt := sqlutil.TxStmt(txn, s.bulkSelectEventNIDStmt)
+	rows, err := stmt.QueryContext(ctx, pq.StringArray(eventIDs))
 	if err != nil {
 		return nil, err
 	}
@@ -484,9 +489,10 @@ func (s *eventStatements) SelectMaxEventDepth(ctx context.Context, txn *sql.Tx, 
 }
 
 func (s *eventStatements) SelectRoomNIDsForEventNIDs(
-	ctx context.Context, eventNIDs []types.EventNID,
+	ctx context.Context, txn *sql.Tx, eventNIDs []types.EventNID,
 ) (map[types.EventNID]types.RoomNID, error) {
-	rows, err := s.selectRoomNIDsForEventNIDsStmt.QueryContext(ctx, eventNIDsAsArray(eventNIDs))
+	stmt := sqlutil.TxStmt(txn, s.selectRoomNIDsForEventNIDsStmt)
+	rows, err := stmt.QueryContext(ctx, eventNIDsAsArray(eventNIDs))
 	if err != nil {
 		return nil, err
 	}

--- a/roomserver/storage/postgres/invite_table.go
+++ b/roomserver/storage/postgres/invite_table.go
@@ -97,8 +97,8 @@ func prepareInvitesTable(db *sql.DB) (tables.Invites, error) {
 }
 
 func (s *inviteStatements) InsertInviteEvent(
-	ctx context.Context,
-	txn *sql.Tx, inviteEventID string, roomNID types.RoomNID,
+	ctx context.Context, txn *sql.Tx,
+	inviteEventID string, roomNID types.RoomNID,
 	targetUserNID, senderUserNID types.EventStateKeyNID,
 	inviteEventJSON []byte,
 ) (bool, error) {
@@ -116,8 +116,8 @@ func (s *inviteStatements) InsertInviteEvent(
 }
 
 func (s *inviteStatements) UpdateInviteRetired(
-	ctx context.Context,
-	txn *sql.Tx, roomNID types.RoomNID, targetUserNID types.EventStateKeyNID,
+	ctx context.Context, txn *sql.Tx,
+	roomNID types.RoomNID, targetUserNID types.EventStateKeyNID,
 ) ([]string, error) {
 	stmt := sqlutil.TxStmt(txn, s.updateInviteRetiredStmt)
 	rows, err := stmt.QueryContext(ctx, roomNID, targetUserNID)
@@ -139,10 +139,11 @@ func (s *inviteStatements) UpdateInviteRetired(
 
 // SelectInviteActiveForUserInRoom returns a list of sender state key NIDs
 func (s *inviteStatements) SelectInviteActiveForUserInRoom(
-	ctx context.Context,
+	ctx context.Context, txn *sql.Tx,
 	targetUserNID types.EventStateKeyNID, roomNID types.RoomNID,
 ) ([]types.EventStateKeyNID, []string, error) {
-	rows, err := s.selectInviteActiveForUserInRoomStmt.QueryContext(
+	stmt := sqlutil.TxStmt(txn, s.selectInviteActiveForUserInRoomStmt)
+	rows, err := stmt.QueryContext(
 		ctx, targetUserNID, roomNID,
 	)
 	if err != nil {

--- a/roomserver/storage/postgres/published_table.go
+++ b/roomserver/storage/postgres/published_table.go
@@ -73,9 +73,10 @@ func (s *publishedStatements) UpsertRoomPublished(
 }
 
 func (s *publishedStatements) SelectPublishedFromRoomID(
-	ctx context.Context, roomID string,
+	ctx context.Context, txn *sql.Tx, roomID string,
 ) (published bool, err error) {
-	err = s.selectPublishedStmt.QueryRowContext(ctx, roomID).Scan(&published)
+	stmt := sqlutil.TxStmt(txn, s.selectPublishedStmt)
+	err = stmt.QueryRowContext(ctx, roomID).Scan(&published)
 	if err == sql.ErrNoRows {
 		return false, nil
 	}
@@ -83,9 +84,10 @@ func (s *publishedStatements) SelectPublishedFromRoomID(
 }
 
 func (s *publishedStatements) SelectAllPublishedRooms(
-	ctx context.Context, published bool,
+	ctx context.Context, txn *sql.Tx, published bool,
 ) ([]string, error) {
-	rows, err := s.selectAllPublishedStmt.QueryContext(ctx, published)
+	stmt := sqlutil.TxStmt(txn, s.selectAllPublishedStmt)
+	rows, err := stmt.QueryContext(ctx, published)
 	if err != nil {
 		return nil, err
 	}

--- a/roomserver/storage/postgres/room_aliases_table.go
+++ b/roomserver/storage/postgres/room_aliases_table.go
@@ -87,9 +87,10 @@ func (s *roomAliasesStatements) InsertRoomAlias(
 }
 
 func (s *roomAliasesStatements) SelectRoomIDFromAlias(
-	ctx context.Context, alias string,
+	ctx context.Context, txn *sql.Tx, alias string,
 ) (roomID string, err error) {
-	err = s.selectRoomIDFromAliasStmt.QueryRowContext(ctx, alias).Scan(&roomID)
+	stmt := sqlutil.TxStmt(txn, s.selectRoomIDFromAliasStmt)
+	err = stmt.QueryRowContext(ctx, alias).Scan(&roomID)
 	if err == sql.ErrNoRows {
 		return "", nil
 	}
@@ -97,9 +98,10 @@ func (s *roomAliasesStatements) SelectRoomIDFromAlias(
 }
 
 func (s *roomAliasesStatements) SelectAliasesFromRoomID(
-	ctx context.Context, roomID string,
+	ctx context.Context, txn *sql.Tx, roomID string,
 ) ([]string, error) {
-	rows, err := s.selectAliasesFromRoomIDStmt.QueryContext(ctx, roomID)
+	stmt := sqlutil.TxStmt(txn, s.selectAliasesFromRoomIDStmt)
+	rows, err := stmt.QueryContext(ctx, roomID)
 	if err != nil {
 		return nil, err
 	}
@@ -118,9 +120,10 @@ func (s *roomAliasesStatements) SelectAliasesFromRoomID(
 }
 
 func (s *roomAliasesStatements) SelectCreatorIDFromAlias(
-	ctx context.Context, alias string,
+	ctx context.Context, txn *sql.Tx, alias string,
 ) (creatorID string, err error) {
-	err = s.selectCreatorIDFromAliasStmt.QueryRowContext(ctx, alias).Scan(&creatorID)
+	stmt := sqlutil.TxStmt(txn, s.selectCreatorIDFromAliasStmt)
+	err = stmt.QueryRowContext(ctx, alias).Scan(&creatorID)
 	if err == sql.ErrNoRows {
 		return "", nil
 	}

--- a/roomserver/storage/postgres/state_snapshot_table.go
+++ b/roomserver/storage/postgres/state_snapshot_table.go
@@ -105,13 +105,14 @@ func (s *stateSnapshotStatements) InsertState(
 }
 
 func (s *stateSnapshotStatements) BulkSelectStateBlockNIDs(
-	ctx context.Context, stateNIDs []types.StateSnapshotNID,
+	ctx context.Context, txn *sql.Tx, stateNIDs []types.StateSnapshotNID,
 ) ([]types.StateBlockNIDList, error) {
 	nids := make([]int64, len(stateNIDs))
 	for i := range stateNIDs {
 		nids[i] = int64(stateNIDs[i])
 	}
-	rows, err := s.bulkSelectStateBlockNIDsStmt.QueryContext(ctx, pq.Int64Array(nids))
+	stmt := sqlutil.TxStmt(txn, s.bulkSelectStateBlockNIDsStmt)
+	rows, err := stmt.QueryContext(ctx, pq.Int64Array(nids))
 	if err != nil {
 		return nil, err
 	}

--- a/roomserver/storage/shared/room_updater.go
+++ b/roomserver/storage/shared/room_updater.go
@@ -25,16 +25,7 @@ func rollback(txn *sql.Tx) {
 	txn.Rollback() // nolint: errcheck
 }
 
-func NewRoomUpdater(ctx context.Context, d *Database, roomInfo *types.RoomInfo) (*RoomUpdater, error) {
-	var txn *sql.Tx
-	if d.SupportsTransactionalIsolation() {
-		var err error
-		txn, err = d.DB.Begin()
-		if err != nil {
-			return nil, err
-		}
-	}
-
+func NewRoomUpdater(ctx context.Context, d *Database, txn *sql.Tx, roomInfo *types.RoomInfo) (*RoomUpdater, error) {
 	// If the roomInfo is nil then that means that the room doesn't exist
 	// yet, so we can't do `SelectLatestEventsNIDsForUpdate` because that
 	// would involve locking a row on the table that doesn't exist. Instead

--- a/roomserver/storage/shared/room_updater.go
+++ b/roomserver/storage/shared/room_updater.go
@@ -181,6 +181,12 @@ func (u *RoomUpdater) RoomInfo(ctx context.Context, roomID string) (*types.RoomI
 	return u.d.roomInfo(ctx, u.txn, roomID)
 }
 
+func (u *RoomUpdater) EventIDs(
+	ctx context.Context, eventNIDs []types.EventNID,
+) (map[types.EventNID]string, error) {
+	return u.d.EventsTable.BulkSelectEventID(ctx, u.txn, eventNIDs)
+}
+
 func (u *RoomUpdater) StateAtEventIDs(
 	ctx context.Context, eventIDs []string,
 ) ([]types.StateAtEvent, error) {

--- a/roomserver/storage/shared/room_updater.go
+++ b/roomserver/storage/shared/room_updater.go
@@ -9,7 +9,7 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
-type LatestEventsUpdater struct {
+type RoomUpdater struct {
 	transaction
 	d                       *Database
 	roomInfo                types.RoomInfo
@@ -25,7 +25,7 @@ func rollback(txn *sql.Tx) {
 	txn.Rollback() // nolint: errcheck
 }
 
-func NewLatestEventsUpdater(ctx context.Context, d *Database, txn *sql.Tx, roomInfo types.RoomInfo) (*LatestEventsUpdater, error) {
+func NewRoomUpdater(ctx context.Context, d *Database, txn *sql.Tx, roomInfo types.RoomInfo) (*RoomUpdater, error) {
 	eventNIDs, lastEventNIDSent, currentStateSnapshotNID, err :=
 		d.RoomsTable.SelectLatestEventsNIDsForUpdate(ctx, txn, roomInfo.RoomNID)
 	if err != nil {
@@ -45,33 +45,33 @@ func NewLatestEventsUpdater(ctx context.Context, d *Database, txn *sql.Tx, roomI
 			return nil, err
 		}
 	}
-	return &LatestEventsUpdater{
+	return &RoomUpdater{
 		transaction{ctx, txn}, d, roomInfo, stateAndRefs, lastEventIDSent, currentStateSnapshotNID,
 	}, nil
 }
 
 // RoomVersion implements types.RoomRecentEventsUpdater
-func (u *LatestEventsUpdater) RoomVersion() (version gomatrixserverlib.RoomVersion) {
+func (u *RoomUpdater) RoomVersion() (version gomatrixserverlib.RoomVersion) {
 	return u.roomInfo.RoomVersion
 }
 
 // LatestEvents implements types.RoomRecentEventsUpdater
-func (u *LatestEventsUpdater) LatestEvents() []types.StateAtEventAndReference {
+func (u *RoomUpdater) LatestEvents() []types.StateAtEventAndReference {
 	return u.latestEvents
 }
 
 // LastEventIDSent implements types.RoomRecentEventsUpdater
-func (u *LatestEventsUpdater) LastEventIDSent() string {
+func (u *RoomUpdater) LastEventIDSent() string {
 	return u.lastEventIDSent
 }
 
 // CurrentStateSnapshotNID implements types.RoomRecentEventsUpdater
-func (u *LatestEventsUpdater) CurrentStateSnapshotNID() types.StateSnapshotNID {
+func (u *RoomUpdater) CurrentStateSnapshotNID() types.StateSnapshotNID {
 	return u.currentStateSnapshotNID
 }
 
 // StorePreviousEvents implements types.RoomRecentEventsUpdater - This must be called from a Writer
-func (u *LatestEventsUpdater) StorePreviousEvents(eventNID types.EventNID, previousEventReferences []gomatrixserverlib.EventReference) error {
+func (u *RoomUpdater) StorePreviousEvents(eventNID types.EventNID, previousEventReferences []gomatrixserverlib.EventReference) error {
 	for _, ref := range previousEventReferences {
 		if err := u.d.PrevEventsTable.InsertPreviousEvent(u.ctx, u.txn, ref.EventID, ref.EventSHA256, eventNID); err != nil {
 			return fmt.Errorf("u.d.PrevEventsTable.InsertPreviousEvent: %w", err)
@@ -80,8 +80,58 @@ func (u *LatestEventsUpdater) StorePreviousEvents(eventNID types.EventNID, previ
 	return nil
 }
 
+func (u *RoomUpdater) StoreEvent(
+	ctx context.Context, event *gomatrixserverlib.Event,
+	authEventNIDs []types.EventNID, isRejected bool,
+) (types.EventNID, types.RoomNID, types.StateAtEvent, *gomatrixserverlib.Event, string, error) {
+	return u.d.storeEvent(ctx, u.txn, event, authEventNIDs, isRejected)
+}
+
+func (u *RoomUpdater) AddState(
+	ctx context.Context,
+	roomNID types.RoomNID,
+	stateBlockNIDs []types.StateBlockNID,
+	state []types.StateEntry,
+) (stateNID types.StateSnapshotNID, err error) {
+	return u.d.addState(ctx, u.txn, roomNID, stateBlockNIDs, state)
+}
+
+func (u *RoomUpdater) SetState(
+	ctx context.Context, eventNID types.EventNID, stateNID types.StateSnapshotNID,
+) error {
+	return u.d.Writer.Do(u.d.DB, u.txn, func(txn *sql.Tx) error {
+		return u.d.EventsTable.UpdateEventState(ctx, txn, eventNID, stateNID)
+	})
+}
+
+func (u *RoomUpdater) RoomInfo(ctx context.Context, roomID string) (*types.RoomInfo, error) {
+	return u.d.roomInfo(ctx, u.txn, roomID)
+}
+
+func (u *RoomUpdater) StateAtEventIDs(
+	ctx context.Context, eventIDs []string,
+) ([]types.StateAtEvent, error) {
+	return u.d.EventsTable.BulkSelectStateAtEventByID(ctx, u.txn, eventIDs)
+}
+
+func (u *RoomUpdater) StateEntriesForEventIDs(
+	ctx context.Context, eventIDs []string,
+) ([]types.StateEntry, error) {
+	return u.d.EventsTable.BulkSelectStateEventByID(ctx, u.txn, eventIDs)
+}
+
+func (u *RoomUpdater) EventsFromIDs(ctx context.Context, eventIDs []string) ([]types.Event, error) {
+	return u.d.eventsFromIDs(ctx, u.txn, eventIDs)
+}
+
+func (u *RoomUpdater) GetMembershipEventNIDsForRoom(
+	ctx context.Context, roomNID types.RoomNID, joinOnly bool, localOnly bool,
+) ([]types.EventNID, error) {
+	return u.d.getMembershipEventNIDsForRoom(ctx, u.txn, roomNID, joinOnly, localOnly)
+}
+
 // IsReferenced implements types.RoomRecentEventsUpdater
-func (u *LatestEventsUpdater) IsReferenced(eventReference gomatrixserverlib.EventReference) (bool, error) {
+func (u *RoomUpdater) IsReferenced(eventReference gomatrixserverlib.EventReference) (bool, error) {
 	err := u.d.PrevEventsTable.SelectPreviousEventExists(u.ctx, u.txn, eventReference.EventID, eventReference.EventSHA256)
 	if err == nil {
 		return true, nil
@@ -93,7 +143,7 @@ func (u *LatestEventsUpdater) IsReferenced(eventReference gomatrixserverlib.Even
 }
 
 // SetLatestEvents implements types.RoomRecentEventsUpdater
-func (u *LatestEventsUpdater) SetLatestEvents(
+func (u *RoomUpdater) SetLatestEvents(
 	roomNID types.RoomNID, latest []types.StateAtEventAndReference, lastEventNIDSent types.EventNID,
 	currentStateSnapshotNID types.StateSnapshotNID,
 ) error {
@@ -117,17 +167,17 @@ func (u *LatestEventsUpdater) SetLatestEvents(
 }
 
 // HasEventBeenSent implements types.RoomRecentEventsUpdater
-func (u *LatestEventsUpdater) HasEventBeenSent(eventNID types.EventNID) (bool, error) {
+func (u *RoomUpdater) HasEventBeenSent(eventNID types.EventNID) (bool, error) {
 	return u.d.EventsTable.SelectEventSentToOutput(u.ctx, u.txn, eventNID)
 }
 
 // MarkEventAsSent implements types.RoomRecentEventsUpdater
-func (u *LatestEventsUpdater) MarkEventAsSent(eventNID types.EventNID) error {
+func (u *RoomUpdater) MarkEventAsSent(eventNID types.EventNID) error {
 	return u.d.Writer.Do(u.d.DB, u.txn, func(txn *sql.Tx) error {
 		return u.d.EventsTable.UpdateEventSentToOutput(u.ctx, txn, eventNID)
 	})
 }
 
-func (u *LatestEventsUpdater) MembershipUpdater(targetUserNID types.EventStateKeyNID, targetLocal bool) (*MembershipUpdater, error) {
+func (u *RoomUpdater) MembershipUpdater(targetUserNID types.EventStateKeyNID, targetLocal bool) (*MembershipUpdater, error) {
 	return u.d.membershipUpdaterTxn(u.ctx, u.txn, u.roomInfo.RoomNID, targetUserNID, targetLocal)
 }

--- a/roomserver/storage/shared/room_updater.go
+++ b/roomserver/storage/shared/room_updater.go
@@ -25,7 +25,16 @@ func rollback(txn *sql.Tx) {
 	txn.Rollback() // nolint: errcheck
 }
 
-func NewRoomUpdater(ctx context.Context, d *Database, txn *sql.Tx, roomInfo *types.RoomInfo) (*RoomUpdater, error) {
+func NewRoomUpdater(ctx context.Context, d *Database, roomInfo *types.RoomInfo) (*RoomUpdater, error) {
+	var txn *sql.Tx
+	if d.SupportsTransactionalIsolation() {
+		var err error
+		txn, err = d.DB.Begin()
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// If the roomInfo is nil then that means that the room doesn't exist
 	// yet, so we can't do `SelectLatestEventsNIDsForUpdate` because that
 	// would involve locking a row on the table that doesn't exist. Instead

--- a/roomserver/storage/shared/room_updater.go
+++ b/roomserver/storage/shared/room_updater.go
@@ -93,11 +93,43 @@ func (u *RoomUpdater) StorePreviousEvents(eventNID types.EventNID, previousEvent
 	})
 }
 
+func (u *RoomUpdater) Events(
+	ctx context.Context, eventNIDs []types.EventNID,
+) ([]types.Event, error) {
+	return u.d.events(ctx, u.txn, eventNIDs)
+}
+
+func (u *RoomUpdater) SnapshotNIDFromEventID(
+	ctx context.Context, eventID string,
+) (types.StateSnapshotNID, error) {
+	return u.d.snapshotNIDFromEventID(ctx, u.txn, eventID)
+}
+
 func (u *RoomUpdater) StoreEvent(
 	ctx context.Context, event *gomatrixserverlib.Event,
 	authEventNIDs []types.EventNID, isRejected bool,
 ) (types.EventNID, types.RoomNID, types.StateAtEvent, *gomatrixserverlib.Event, string, error) {
 	return u.d.storeEvent(ctx, u, event, authEventNIDs, isRejected)
+}
+
+func (u *RoomUpdater) StateBlockNIDs(
+	ctx context.Context, stateNIDs []types.StateSnapshotNID,
+) ([]types.StateBlockNIDList, error) {
+	return u.d.stateBlockNIDs(ctx, u.txn, stateNIDs)
+}
+
+func (u *RoomUpdater) StateEntries(
+	ctx context.Context, stateBlockNIDs []types.StateBlockNID,
+) ([]types.StateEntryList, error) {
+	return u.d.stateEntries(ctx, u.txn, stateBlockNIDs)
+}
+
+func (u *RoomUpdater) StateEntriesForTuples(
+	ctx context.Context,
+	stateBlockNIDs []types.StateBlockNID,
+	stateKeyTuples []types.StateKeyTuple,
+) ([]types.StateEntryList, error) {
+	return u.d.stateEntriesForTuples(ctx, u.txn, stateBlockNIDs, stateKeyTuples)
 }
 
 func (u *RoomUpdater) AddState(
@@ -115,6 +147,18 @@ func (u *RoomUpdater) SetState(
 	return u.d.Writer.Do(u.d.DB, u.txn, func(txn *sql.Tx) error {
 		return u.d.EventsTable.UpdateEventState(ctx, txn, eventNID, stateNID)
 	})
+}
+
+func (u *RoomUpdater) EventTypeNIDs(
+	ctx context.Context, eventTypes []string,
+) (map[string]types.EventTypeNID, error) {
+	return u.d.eventTypeNIDs(ctx, u.txn, eventTypes)
+}
+
+func (u *RoomUpdater) EventStateKeyNIDs(
+	ctx context.Context, eventStateKeys []string,
+) (map[string]types.EventStateKeyNID, error) {
+	return u.d.eventStateKeyNIDs(ctx, u.txn, eventStateKeys)
 }
 
 func (u *RoomUpdater) RoomInfo(ctx context.Context, roomID string) (*types.RoomInfo, error) {

--- a/roomserver/storage/shared/room_updater.go
+++ b/roomserver/storage/shared/room_updater.go
@@ -32,12 +32,8 @@ func NewRoomUpdater(ctx context.Context, d *Database, txn *sql.Tx, roomInfo *typ
 	// we will just run with a normal database transaction. It'll either
 	// succeed, processing a create event which creates the room, or it won't.
 	if roomInfo == nil {
-		tx, err := d.DB.Begin()
-		if err != nil {
-			return nil, fmt.Errorf("d.DB.Begin: %w", err)
-		}
 		return &RoomUpdater{
-			transaction{ctx, tx}, d, nil, nil, "", 0,
+			transaction{ctx, txn}, d, nil, nil, "", 0,
 		}, nil
 	}
 

--- a/roomserver/storage/shared/room_updater.go
+++ b/roomserver/storage/shared/room_updater.go
@@ -74,7 +74,7 @@ func (u *RoomUpdater) Rollback() error {
 	if u.txn == nil { // SQLite mode probably
 		return nil
 	}
-	return u.txn.Commit()
+	return u.txn.Rollback()
 }
 
 // RoomVersion implements types.RoomRecentEventsUpdater

--- a/roomserver/storage/shared/room_updater.go
+++ b/roomserver/storage/shared/room_updater.go
@@ -61,6 +61,22 @@ func NewRoomUpdater(ctx context.Context, d *Database, txn *sql.Tx, roomInfo *typ
 	}, nil
 }
 
+// Implements sqlutil.Transaction
+func (u *RoomUpdater) Commit() error {
+	if u.txn == nil { // SQLite mode probably
+		return nil
+	}
+	return u.txn.Commit()
+}
+
+// Implements sqlutil.Transaction
+func (u *RoomUpdater) Rollback() error {
+	if u.txn == nil { // SQLite mode probably
+		return nil
+	}
+	return u.txn.Commit()
+}
+
 // RoomVersion implements types.RoomRecentEventsUpdater
 func (u *RoomUpdater) RoomVersion() (version gomatrixserverlib.RoomVersion) {
 	return u.roomInfo.RoomVersion

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -45,7 +45,7 @@ type Database struct {
 	GetRoomUpdaterFn    func(ctx context.Context, roomInfo *types.RoomInfo) (*RoomUpdater, error)
 }
 
-func (d *Database) SupportsConcurrentRoomInputs() bool {
+func (d *Database) SupportsTransactionalIsolation() bool {
 	return true
 }
 
@@ -447,7 +447,7 @@ func (d *Database) events(
 	if err != nil {
 		return nil, err
 	}
-	eventIDs, _ := d.EventsTable.BulkSelectEventID(ctx, nil, eventNIDs)
+	eventIDs, _ := d.EventsTable.BulkSelectEventID(ctx, txn, eventNIDs)
 	if err != nil {
 		eventIDs = map[types.EventNID]string{}
 	}
@@ -501,16 +501,15 @@ func (d *Database) MembershipUpdater(
 	ctx context.Context, roomID, targetUserID string,
 	targetLocal bool, roomVersion gomatrixserverlib.RoomVersion,
 ) (*MembershipUpdater, error) {
-	txn, err := d.DB.Begin()
-	if err != nil {
-		return nil, err
+	var txn *sql.Tx
+	var err error
+	if d.SupportsTransactionalIsolation() {
+		txn, err = d.DB.Begin()
+		if err != nil {
+			return nil, err
+		}
 	}
-	var updater *MembershipUpdater
-	_ = d.Writer.Do(d.DB, txn, func(txn *sql.Tx) error {
-		updater, err = NewMembershipUpdater(ctx, d, txn, roomID, targetUserID, targetLocal, roomVersion)
-		return err
-	})
-	return updater, err
+	return NewMembershipUpdater(ctx, d, txn, roomID, targetUserID, targetLocal, roomVersion)
 }
 
 func (d *Database) GetRoomUpdater(
@@ -519,16 +518,7 @@ func (d *Database) GetRoomUpdater(
 	if d.GetRoomUpdaterFn != nil {
 		return d.GetRoomUpdaterFn(ctx, roomInfo)
 	}
-	txn, err := d.DB.Begin()
-	if err != nil {
-		return nil, err
-	}
-	var updater *RoomUpdater
-	_ = d.Writer.Do(d.DB, txn, func(txn *sql.Tx) error {
-		updater, err = NewRoomUpdater(ctx, d, txn, roomInfo)
-		return err
-	})
-	return updater, err
+	return NewRoomUpdater(ctx, d, roomInfo)
 }
 
 func (d *Database) StoreEvent(

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -649,7 +649,7 @@ func (d *Database) storeEvent(
 			if err != nil {
 				return 0, 0, types.StateAtEvent{}, nil, "", fmt.Errorf("GetRoomUpdater: %w", err)
 			}
-			defer sqlutil.EndTransactionWithCheck(updater.txn, &succeeded, &err)
+			defer sqlutil.EndTransactionWithCheck(updater, &succeeded, &err)
 		}
 		if err = updater.StorePreviousEvents(eventNID, prevEvents); err != nil {
 			return 0, 0, types.StateAtEvent{}, nil, "", fmt.Errorf("updater.StorePreviousEvents: %w", err)

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -447,7 +447,7 @@ func (d *Database) events(
 	if err != nil {
 		return nil, err
 	}
-	eventIDs, _ := d.EventsTable.BulkSelectEventID(ctx, nil, eventNIDs)
+	eventIDs, _ := d.EventsTable.BulkSelectEventID(ctx, txn, eventNIDs)
 	if err != nil {
 		eventIDs = map[types.EventNID]string{}
 	}

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -62,7 +62,7 @@ func (d *Database) EventTypeNIDs(
 		}
 	}
 	if len(remaining) > 0 {
-		nids, err := d.EventTypesTable.BulkSelectEventTypeNID(ctx, remaining)
+		nids, err := d.EventTypesTable.BulkSelectEventTypeNID(ctx, nil, remaining)
 		if err != nil {
 			return nil, err
 		}
@@ -77,7 +77,7 @@ func (d *Database) EventTypeNIDs(
 func (d *Database) EventStateKeys(
 	ctx context.Context, eventStateKeyNIDs []types.EventStateKeyNID,
 ) (map[types.EventStateKeyNID]string, error) {
-	return d.EventStateKeysTable.BulkSelectEventStateKey(ctx, eventStateKeyNIDs)
+	return d.EventStateKeysTable.BulkSelectEventStateKey(ctx, nil, eventStateKeyNIDs)
 }
 
 func (d *Database) EventStateKeyNIDs(
@@ -93,7 +93,7 @@ func (d *Database) EventStateKeyNIDs(
 		}
 	}
 	if len(remaining) > 0 {
-		nids, err := d.EventStateKeysTable.BulkSelectEventStateKeyNID(ctx, remaining)
+		nids, err := d.EventStateKeysTable.BulkSelectEventStateKeyNID(ctx, nil, remaining)
 		if err != nil {
 			return nil, err
 		}
@@ -980,7 +980,7 @@ func (d *Database) GetBulkStateContent(ctx context.Context, roomIDs []string, tu
 	}
 	// we don't bother failing the request if we get asked for event types we don't know about, as all that would result in is no matches which
 	// isn't a failure.
-	eventTypeNIDMap, err := d.EventTypesTable.BulkSelectEventTypeNID(ctx, eventTypes)
+	eventTypeNIDMap, err := d.EventTypesTable.BulkSelectEventTypeNID(ctx, nil, eventTypes)
 	if err != nil {
 		return nil, fmt.Errorf("GetBulkStateContent: failed to map event type nids: %w", err)
 	}
@@ -1000,7 +1000,7 @@ func (d *Database) GetBulkStateContent(ctx context.Context, roomIDs []string, tu
 
 	}
 
-	eventStateKeyNIDMap, err := d.EventStateKeysTable.BulkSelectEventStateKeyNID(ctx, eventStateKeys)
+	eventStateKeyNIDMap, err := d.EventStateKeysTable.BulkSelectEventStateKeyNID(ctx, nil, eventStateKeys)
 	if err != nil {
 		return nil, fmt.Errorf("GetBulkStateContent: failed to map state key nids: %w", err)
 	}
@@ -1076,7 +1076,7 @@ func (d *Database) JoinedUsersSetInRooms(ctx context.Context, roomIDs []string) 
 		stateKeyNIDs[i] = nid
 		i++
 	}
-	nidToUserID, err := d.EventStateKeysTable.BulkSelectEventStateKey(ctx, stateKeyNIDs)
+	nidToUserID, err := d.EventStateKeysTable.BulkSelectEventStateKey(ctx, nil, stateKeyNIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/roomserver/storage/sqlite3/event_json_table.go
+++ b/roomserver/storage/sqlite3/event_json_table.go
@@ -83,12 +83,13 @@ func (s *eventJSONStatements) BulkSelectEventJSON(
 		iEventNIDs[k] = v
 	}
 	selectOrig := strings.Replace(bulkSelectEventJSONSQL, "($1)", sqlutil.QueryVariadic(len(iEventNIDs)), 1)
-	selectStmt, err := s.db.Prepare(selectOrig)
-	if err != nil {
-		return nil, err
+	var rows *sql.Rows
+	var err error
+	if txn != nil {
+		rows, err = txn.QueryContext(ctx, selectOrig, iEventNIDs...)
+	} else {
+		rows, err = s.db.QueryContext(ctx, selectOrig, iEventNIDs...)
 	}
-	selectStmt = sqlutil.TxStmt(txn, selectStmt)
-	rows, err := selectStmt.QueryContext(ctx, iEventNIDs...)
 	if err != nil {
 		return nil, err
 	}

--- a/roomserver/storage/sqlite3/event_state_keys_table.go
+++ b/roomserver/storage/sqlite3/event_state_keys_table.go
@@ -112,15 +112,19 @@ func (s *eventStateKeyStatements) SelectEventStateKeyNID(
 }
 
 func (s *eventStateKeyStatements) BulkSelectEventStateKeyNID(
-	ctx context.Context, eventStateKeys []string,
+	ctx context.Context, txn *sql.Tx, eventStateKeys []string,
 ) (map[string]types.EventStateKeyNID, error) {
 	iEventStateKeys := make([]interface{}, len(eventStateKeys))
 	for k, v := range eventStateKeys {
 		iEventStateKeys[k] = v
 	}
 	selectOrig := strings.Replace(bulkSelectEventStateKeySQL, "($1)", sqlutil.QueryVariadic(len(eventStateKeys)), 1)
-
-	rows, err := s.db.QueryContext(ctx, selectOrig, iEventStateKeys...)
+	selectPrep, err := s.db.Prepare(selectOrig)
+	if err != nil {
+		return nil, err
+	}
+	stmt := sqlutil.TxStmt(txn, selectPrep)
+	rows, err := stmt.QueryContext(ctx, iEventStateKeys...)
 	if err != nil {
 		return nil, err
 	}
@@ -138,15 +142,19 @@ func (s *eventStateKeyStatements) BulkSelectEventStateKeyNID(
 }
 
 func (s *eventStateKeyStatements) BulkSelectEventStateKey(
-	ctx context.Context, eventStateKeyNIDs []types.EventStateKeyNID,
+	ctx context.Context, txn *sql.Tx, eventStateKeyNIDs []types.EventStateKeyNID,
 ) (map[types.EventStateKeyNID]string, error) {
 	iEventStateKeyNIDs := make([]interface{}, len(eventStateKeyNIDs))
 	for k, v := range eventStateKeyNIDs {
 		iEventStateKeyNIDs[k] = v
 	}
 	selectOrig := strings.Replace(bulkSelectEventStateKeyNIDSQL, "($1)", sqlutil.QueryVariadic(len(eventStateKeyNIDs)), 1)
-
-	rows, err := s.db.QueryContext(ctx, selectOrig, iEventStateKeyNIDs...)
+	selectPrep, err := s.db.Prepare(selectOrig)
+	if err != nil {
+		return nil, err
+	}
+	stmt := sqlutil.TxStmt(txn, selectPrep)
+	rows, err := stmt.QueryContext(ctx, iEventStateKeyNIDs...)
 	if err != nil {
 		return nil, err
 	}

--- a/roomserver/storage/sqlite3/event_state_keys_table.go
+++ b/roomserver/storage/sqlite3/event_state_keys_table.go
@@ -119,12 +119,13 @@ func (s *eventStateKeyStatements) BulkSelectEventStateKeyNID(
 		iEventStateKeys[k] = v
 	}
 	selectOrig := strings.Replace(bulkSelectEventStateKeySQL, "($1)", sqlutil.QueryVariadic(len(eventStateKeys)), 1)
-	selectPrep, err := s.db.Prepare(selectOrig)
-	if err != nil {
-		return nil, err
+	var rows *sql.Rows
+	var err error
+	if txn != nil {
+		rows, err = txn.QueryContext(ctx, selectOrig, iEventStateKeys...)
+	} else {
+		rows, err = s.db.QueryContext(ctx, selectOrig, iEventStateKeys...)
 	}
-	stmt := sqlutil.TxStmt(txn, selectPrep)
-	rows, err := stmt.QueryContext(ctx, iEventStateKeys...)
 	if err != nil {
 		return nil, err
 	}

--- a/roomserver/storage/sqlite3/event_types_table.go
+++ b/roomserver/storage/sqlite3/event_types_table.go
@@ -128,7 +128,7 @@ func (s *eventTypeStatements) SelectEventTypeNID(
 }
 
 func (s *eventTypeStatements) BulkSelectEventTypeNID(
-	ctx context.Context, eventTypes []string,
+	ctx context.Context, txn *sql.Tx, eventTypes []string,
 ) (map[string]types.EventTypeNID, error) {
 	///////////////
 	iEventTypes := make([]interface{}, len(eventTypes))
@@ -140,9 +140,10 @@ func (s *eventTypeStatements) BulkSelectEventTypeNID(
 	if err != nil {
 		return nil, err
 	}
+	stmt := sqlutil.TxStmt(txn, selectPrep)
 	///////////////
 
-	rows, err := selectPrep.QueryContext(ctx, iEventTypes...)
+	rows, err := stmt.QueryContext(ctx, iEventTypes...)
 	if err != nil {
 		return nil, err
 	}

--- a/roomserver/storage/sqlite3/invite_table.go
+++ b/roomserver/storage/sqlite3/invite_table.go
@@ -88,8 +88,8 @@ func prepareInvitesTable(db *sql.DB) (tables.Invites, error) {
 }
 
 func (s *inviteStatements) InsertInviteEvent(
-	ctx context.Context,
-	txn *sql.Tx, inviteEventID string, roomNID types.RoomNID,
+	ctx context.Context, txn *sql.Tx,
+	inviteEventID string, roomNID types.RoomNID,
 	targetUserNID, senderUserNID types.EventStateKeyNID,
 	inviteEventJSON []byte,
 ) (bool, error) {
@@ -109,8 +109,8 @@ func (s *inviteStatements) InsertInviteEvent(
 }
 
 func (s *inviteStatements) UpdateInviteRetired(
-	ctx context.Context,
-	txn *sql.Tx, roomNID types.RoomNID, targetUserNID types.EventStateKeyNID,
+	ctx context.Context, txn *sql.Tx,
+	roomNID types.RoomNID, targetUserNID types.EventStateKeyNID,
 ) (eventIDs []string, err error) {
 	// gather all the event IDs we will retire
 	stmt := sqlutil.TxStmt(txn, s.selectInvitesAboutToRetireStmt)
@@ -134,10 +134,11 @@ func (s *inviteStatements) UpdateInviteRetired(
 
 // selectInviteActiveForUserInRoom returns a list of sender state key NIDs
 func (s *inviteStatements) SelectInviteActiveForUserInRoom(
-	ctx context.Context,
+	ctx context.Context, txn *sql.Tx,
 	targetUserNID types.EventStateKeyNID, roomNID types.RoomNID,
 ) ([]types.EventStateKeyNID, []string, error) {
-	rows, err := s.selectInviteActiveForUserInRoomStmt.QueryContext(
+	stmt := sqlutil.TxStmt(txn, s.selectInviteActiveForUserInRoomStmt)
+	rows, err := stmt.QueryContext(
 		ctx, targetUserNID, roomNID,
 	)
 	if err != nil {

--- a/roomserver/storage/sqlite3/membership_table.go
+++ b/roomserver/storage/sqlite3/membership_table.go
@@ -184,17 +184,18 @@ func (s *membershipStatements) SelectMembershipForUpdate(
 }
 
 func (s *membershipStatements) SelectMembershipFromRoomAndTarget(
-	ctx context.Context,
+	ctx context.Context, txn *sql.Tx,
 	roomNID types.RoomNID, targetUserNID types.EventStateKeyNID,
 ) (eventNID types.EventNID, membership tables.MembershipState, forgotten bool, err error) {
-	err = s.selectMembershipFromRoomAndTargetStmt.QueryRowContext(
+	stmt := sqlutil.TxStmt(txn, s.selectMembershipFromRoomAndTargetStmt)
+	err = stmt.QueryRowContext(
 		ctx, roomNID, targetUserNID,
 	).Scan(&membership, &eventNID, &forgotten)
 	return
 }
 
 func (s *membershipStatements) SelectMembershipsFromRoom(
-	ctx context.Context,
+	ctx context.Context, txn *sql.Tx,
 	roomNID types.RoomNID, localOnly bool,
 ) (eventNIDs []types.EventNID, err error) {
 	var selectStmt *sql.Stmt
@@ -203,6 +204,7 @@ func (s *membershipStatements) SelectMembershipsFromRoom(
 	} else {
 		selectStmt = s.selectMembershipsFromRoomStmt
 	}
+	selectStmt = sqlutil.TxStmt(txn, selectStmt)
 	rows, err := selectStmt.QueryContext(ctx, roomNID)
 	if err != nil {
 		return nil, err
@@ -220,7 +222,7 @@ func (s *membershipStatements) SelectMembershipsFromRoom(
 }
 
 func (s *membershipStatements) SelectMembershipsFromRoomAndMembership(
-	ctx context.Context,
+	ctx context.Context, txn *sql.Tx,
 	roomNID types.RoomNID, membership tables.MembershipState, localOnly bool,
 ) (eventNIDs []types.EventNID, err error) {
 	var stmt *sql.Stmt
@@ -229,6 +231,7 @@ func (s *membershipStatements) SelectMembershipsFromRoomAndMembership(
 	} else {
 		stmt = s.selectMembershipsFromRoomAndMembershipStmt
 	}
+	stmt = sqlutil.TxStmt(txn, stmt)
 	rows, err := stmt.QueryContext(ctx, roomNID, membership)
 	if err != nil {
 		return
@@ -258,9 +261,10 @@ func (s *membershipStatements) UpdateMembership(
 }
 
 func (s *membershipStatements) SelectRoomsWithMembership(
-	ctx context.Context, userID types.EventStateKeyNID, membershipState tables.MembershipState,
+	ctx context.Context, txn *sql.Tx, userID types.EventStateKeyNID, membershipState tables.MembershipState,
 ) ([]types.RoomNID, error) {
-	rows, err := s.selectRoomsWithMembershipStmt.QueryContext(ctx, membershipState, userID)
+	stmt := sqlutil.TxStmt(txn, s.selectRoomsWithMembershipStmt)
+	rows, err := stmt.QueryContext(ctx, membershipState, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -276,13 +280,17 @@ func (s *membershipStatements) SelectRoomsWithMembership(
 	return roomNIDs, nil
 }
 
-func (s *membershipStatements) SelectJoinedUsersSetForRooms(ctx context.Context, roomNIDs []types.RoomNID) (map[types.EventStateKeyNID]int, error) {
+func (s *membershipStatements) SelectJoinedUsersSetForRooms(ctx context.Context, txn *sql.Tx, roomNIDs []types.RoomNID) (map[types.EventStateKeyNID]int, error) {
 	iRoomNIDs := make([]interface{}, len(roomNIDs))
 	for i, v := range roomNIDs {
 		iRoomNIDs[i] = v
 	}
 	query := strings.Replace(selectJoinedUsersSetForRoomsSQL, "($1)", sqlutil.QueryVariadic(len(iRoomNIDs)), 1)
-	rows, err := s.db.QueryContext(ctx, query, iRoomNIDs...)
+	stmt, err := s.db.Prepare(query)
+	if err != nil {
+		return nil, err
+	}
+	rows, err := sqlutil.TxStmt(txn, stmt).QueryContext(ctx, iRoomNIDs...)
 	if err != nil {
 		return nil, err
 	}
@@ -299,8 +307,9 @@ func (s *membershipStatements) SelectJoinedUsersSetForRooms(ctx context.Context,
 	return result, rows.Err()
 }
 
-func (s *membershipStatements) SelectKnownUsers(ctx context.Context, userID types.EventStateKeyNID, searchString string, limit int) ([]string, error) {
-	rows, err := s.selectKnownUsersStmt.QueryContext(ctx, userID, fmt.Sprintf("%%%s%%", searchString), limit)
+func (s *membershipStatements) SelectKnownUsers(ctx context.Context, txn *sql.Tx, userID types.EventStateKeyNID, searchString string, limit int) ([]string, error) {
+	stmt := sqlutil.TxStmt(txn, s.selectKnownUsersStmt)
+	rows, err := stmt.QueryContext(ctx, userID, fmt.Sprintf("%%%s%%", searchString), limit)
 	if err != nil {
 		return nil, err
 	}
@@ -317,8 +326,8 @@ func (s *membershipStatements) SelectKnownUsers(ctx context.Context, userID type
 }
 
 func (s *membershipStatements) UpdateForgetMembership(
-	ctx context.Context,
-	txn *sql.Tx, roomNID types.RoomNID, targetUserNID types.EventStateKeyNID,
+	ctx context.Context, txn *sql.Tx,
+	roomNID types.RoomNID, targetUserNID types.EventStateKeyNID,
 	forget bool,
 ) error {
 	_, err := sqlutil.TxStmt(txn, s.updateMembershipForgetRoomStmt).ExecContext(
@@ -327,9 +336,10 @@ func (s *membershipStatements) UpdateForgetMembership(
 	return err
 }
 
-func (s *membershipStatements) SelectLocalServerInRoom(ctx context.Context, roomNID types.RoomNID) (bool, error) {
+func (s *membershipStatements) SelectLocalServerInRoom(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID) (bool, error) {
 	var nid types.RoomNID
-	err := s.selectLocalServerInRoomStmt.QueryRowContext(ctx, tables.MembershipStateJoin, roomNID).Scan(&nid)
+	stmt := sqlutil.TxStmt(txn, s.selectLocalServerInRoomStmt)
+	err := stmt.QueryRowContext(ctx, tables.MembershipStateJoin, roomNID).Scan(&nid)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return false, nil
@@ -340,9 +350,10 @@ func (s *membershipStatements) SelectLocalServerInRoom(ctx context.Context, room
 	return found, nil
 }
 
-func (s *membershipStatements) SelectServerInRoom(ctx context.Context, roomNID types.RoomNID, serverName gomatrixserverlib.ServerName) (bool, error) {
+func (s *membershipStatements) SelectServerInRoom(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, serverName gomatrixserverlib.ServerName) (bool, error) {
 	var nid types.RoomNID
-	err := s.selectServerInRoomStmt.QueryRowContext(ctx, tables.MembershipStateJoin, roomNID, serverName).Scan(&nid)
+	stmt := sqlutil.TxStmt(txn, s.selectServerInRoomStmt)
+	err := stmt.QueryRowContext(ctx, tables.MembershipStateJoin, roomNID, serverName).Scan(&nid)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return false, nil

--- a/roomserver/storage/sqlite3/membership_table.go
+++ b/roomserver/storage/sqlite3/membership_table.go
@@ -286,11 +286,13 @@ func (s *membershipStatements) SelectJoinedUsersSetForRooms(ctx context.Context,
 		iRoomNIDs[i] = v
 	}
 	query := strings.Replace(selectJoinedUsersSetForRoomsSQL, "($1)", sqlutil.QueryVariadic(len(iRoomNIDs)), 1)
-	stmt, err := s.db.Prepare(query)
-	if err != nil {
-		return nil, err
+	var rows *sql.Rows
+	var err error
+	if txn != nil {
+		rows, err = txn.QueryContext(ctx, query, iRoomNIDs...)
+	} else {
+		rows, err = s.db.QueryContext(ctx, query, iRoomNIDs...)
 	}
-	rows, err := sqlutil.TxStmt(txn, stmt).QueryContext(ctx, iRoomNIDs...)
 	if err != nil {
 		return nil, err
 	}

--- a/roomserver/storage/sqlite3/published_table.go
+++ b/roomserver/storage/sqlite3/published_table.go
@@ -75,9 +75,10 @@ func (s *publishedStatements) UpsertRoomPublished(
 }
 
 func (s *publishedStatements) SelectPublishedFromRoomID(
-	ctx context.Context, roomID string,
+	ctx context.Context, txn *sql.Tx, roomID string,
 ) (published bool, err error) {
-	err = s.selectPublishedStmt.QueryRowContext(ctx, roomID).Scan(&published)
+	stmt := sqlutil.TxStmt(txn, s.selectPublishedStmt)
+	err = stmt.QueryRowContext(ctx, roomID).Scan(&published)
 	if err == sql.ErrNoRows {
 		return false, nil
 	}
@@ -85,9 +86,10 @@ func (s *publishedStatements) SelectPublishedFromRoomID(
 }
 
 func (s *publishedStatements) SelectAllPublishedRooms(
-	ctx context.Context, published bool,
+	ctx context.Context, txn *sql.Tx, published bool,
 ) ([]string, error) {
-	rows, err := s.selectAllPublishedStmt.QueryContext(ctx, published)
+	stmt := sqlutil.TxStmt(txn, s.selectAllPublishedStmt)
+	rows, err := stmt.QueryContext(ctx, published)
 	if err != nil {
 		return nil, err
 	}

--- a/roomserver/storage/sqlite3/room_aliases_table.go
+++ b/roomserver/storage/sqlite3/room_aliases_table.go
@@ -91,9 +91,10 @@ func (s *roomAliasesStatements) InsertRoomAlias(
 }
 
 func (s *roomAliasesStatements) SelectRoomIDFromAlias(
-	ctx context.Context, alias string,
+	ctx context.Context, txn *sql.Tx, alias string,
 ) (roomID string, err error) {
-	err = s.selectRoomIDFromAliasStmt.QueryRowContext(ctx, alias).Scan(&roomID)
+	stmt := sqlutil.TxStmt(txn, s.selectRoomIDFromAliasStmt)
+	err = stmt.QueryRowContext(ctx, alias).Scan(&roomID)
 	if err == sql.ErrNoRows {
 		return "", nil
 	}
@@ -101,10 +102,11 @@ func (s *roomAliasesStatements) SelectRoomIDFromAlias(
 }
 
 func (s *roomAliasesStatements) SelectAliasesFromRoomID(
-	ctx context.Context, roomID string,
+	ctx context.Context, txn *sql.Tx, roomID string,
 ) (aliases []string, err error) {
 	aliases = []string{}
-	rows, err := s.selectAliasesFromRoomIDStmt.QueryContext(ctx, roomID)
+	stmt := sqlutil.TxStmt(txn, s.selectAliasesFromRoomIDStmt)
+	rows, err := stmt.QueryContext(ctx, roomID)
 	if err != nil {
 		return
 	}
@@ -124,9 +126,10 @@ func (s *roomAliasesStatements) SelectAliasesFromRoomID(
 }
 
 func (s *roomAliasesStatements) SelectCreatorIDFromAlias(
-	ctx context.Context, alias string,
+	ctx context.Context, txn *sql.Tx, alias string,
 ) (creatorID string, err error) {
-	err = s.selectCreatorIDFromAliasStmt.QueryRowContext(ctx, alias).Scan(&creatorID)
+	stmt := sqlutil.TxStmt(txn, s.selectCreatorIDFromAliasStmt)
+	err = stmt.QueryRowContext(ctx, alias).Scan(&creatorID)
 	if err == sql.ErrNoRows {
 		return "", nil
 	}

--- a/roomserver/storage/sqlite3/rooms_table.go
+++ b/roomserver/storage/sqlite3/rooms_table.go
@@ -261,12 +261,13 @@ func (s *roomStatements) BulkSelectRoomIDs(ctx context.Context, txn *sql.Tx, roo
 		iRoomNIDs[i] = v
 	}
 	sqlQuery := strings.Replace(bulkSelectRoomIDsSQL, "($1)", sqlutil.QueryVariadic(len(roomNIDs)), 1)
-	sqlPrep, err := s.db.Prepare(sqlQuery)
-	if err != nil {
-		return nil, err
+	var rows *sql.Rows
+	var err error
+	if txn != nil {
+		rows, err = txn.QueryContext(ctx, sqlQuery, iRoomNIDs...)
+	} else {
+		rows, err = s.db.QueryContext(ctx, sqlQuery, iRoomNIDs...)
 	}
-	stmt := sqlutil.TxStmt(txn, sqlPrep)
-	rows, err := stmt.QueryContext(ctx, iRoomNIDs...)
 	if err != nil {
 		return nil, err
 	}
@@ -288,12 +289,13 @@ func (s *roomStatements) BulkSelectRoomNIDs(ctx context.Context, txn *sql.Tx, ro
 		iRoomIDs[i] = v
 	}
 	sqlQuery := strings.Replace(bulkSelectRoomNIDsSQL, "($1)", sqlutil.QueryVariadic(len(roomIDs)), 1)
-	sqlPrep, err := s.db.Prepare(sqlQuery)
-	if err != nil {
-		return nil, err
+	var rows *sql.Rows
+	var err error
+	if txn != nil {
+		rows, err = txn.QueryContext(ctx, sqlQuery, iRoomIDs...)
+	} else {
+		rows, err = s.db.QueryContext(ctx, sqlQuery, iRoomIDs...)
 	}
-	stmt := sqlutil.TxStmt(txn, sqlPrep)
-	rows, err := stmt.QueryContext(ctx, iRoomIDs...)
 	if err != nil {
 		return nil, err
 	}

--- a/roomserver/storage/sqlite3/rooms_table.go
+++ b/roomserver/storage/sqlite3/rooms_table.go
@@ -107,8 +107,9 @@ func prepareRoomsTable(db *sql.DB) (tables.Rooms, error) {
 	}.Prepare(db)
 }
 
-func (s *roomStatements) SelectRoomIDs(ctx context.Context) ([]string, error) {
-	rows, err := s.selectRoomIDsStmt.QueryContext(ctx)
+func (s *roomStatements) SelectRoomIDs(ctx context.Context, txn *sql.Tx) ([]string, error) {
+	stmt := sqlutil.TxStmt(txn, s.selectRoomIDsStmt)
+	rows, err := stmt.QueryContext(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -124,10 +125,11 @@ func (s *roomStatements) SelectRoomIDs(ctx context.Context) ([]string, error) {
 	return roomIDs, nil
 }
 
-func (s *roomStatements) SelectRoomInfo(ctx context.Context, roomID string) (*types.RoomInfo, error) {
+func (s *roomStatements) SelectRoomInfo(ctx context.Context, txn *sql.Tx, roomID string) (*types.RoomInfo, error) {
 	var info types.RoomInfo
 	var latestNIDsJSON string
-	err := s.selectRoomInfoStmt.QueryRowContext(ctx, roomID).Scan(
+	stmt := sqlutil.TxStmt(txn, s.selectRoomInfoStmt)
+	err := stmt.QueryRowContext(ctx, roomID).Scan(
 		&info.RoomVersion, &info.RoomNID, &info.StateSnapshotNID, &latestNIDsJSON,
 	)
 	if err != nil {
@@ -224,13 +226,14 @@ func (s *roomStatements) UpdateLatestEventNIDs(
 }
 
 func (s *roomStatements) SelectRoomVersionsForRoomNIDs(
-	ctx context.Context, roomNIDs []types.RoomNID,
+	ctx context.Context, txn *sql.Tx, roomNIDs []types.RoomNID,
 ) (map[types.RoomNID]gomatrixserverlib.RoomVersion, error) {
 	sqlStr := strings.Replace(selectRoomVersionsForRoomNIDsSQL, "($1)", sqlutil.QueryVariadic(len(roomNIDs)), 1)
 	sqlPrep, err := s.db.Prepare(sqlStr)
 	if err != nil {
 		return nil, err
 	}
+	sqlPrep = sqlutil.TxStmt(txn, sqlPrep)
 	iRoomNIDs := make([]interface{}, len(roomNIDs))
 	for i, v := range roomNIDs {
 		iRoomNIDs[i] = v
@@ -252,13 +255,18 @@ func (s *roomStatements) SelectRoomVersionsForRoomNIDs(
 	return result, nil
 }
 
-func (s *roomStatements) BulkSelectRoomIDs(ctx context.Context, roomNIDs []types.RoomNID) ([]string, error) {
+func (s *roomStatements) BulkSelectRoomIDs(ctx context.Context, txn *sql.Tx, roomNIDs []types.RoomNID) ([]string, error) {
 	iRoomNIDs := make([]interface{}, len(roomNIDs))
 	for i, v := range roomNIDs {
 		iRoomNIDs[i] = v
 	}
 	sqlQuery := strings.Replace(bulkSelectRoomIDsSQL, "($1)", sqlutil.QueryVariadic(len(roomNIDs)), 1)
-	rows, err := s.db.QueryContext(ctx, sqlQuery, iRoomNIDs...)
+	sqlPrep, err := s.db.Prepare(sqlQuery)
+	if err != nil {
+		return nil, err
+	}
+	stmt := sqlutil.TxStmt(txn, sqlPrep)
+	rows, err := stmt.QueryContext(ctx, iRoomNIDs...)
 	if err != nil {
 		return nil, err
 	}
@@ -274,13 +282,18 @@ func (s *roomStatements) BulkSelectRoomIDs(ctx context.Context, roomNIDs []types
 	return roomIDs, nil
 }
 
-func (s *roomStatements) BulkSelectRoomNIDs(ctx context.Context, roomIDs []string) ([]types.RoomNID, error) {
+func (s *roomStatements) BulkSelectRoomNIDs(ctx context.Context, txn *sql.Tx, roomIDs []string) ([]types.RoomNID, error) {
 	iRoomIDs := make([]interface{}, len(roomIDs))
 	for i, v := range roomIDs {
 		iRoomIDs[i] = v
 	}
 	sqlQuery := strings.Replace(bulkSelectRoomNIDsSQL, "($1)", sqlutil.QueryVariadic(len(roomIDs)), 1)
-	rows, err := s.db.QueryContext(ctx, sqlQuery, iRoomIDs...)
+	sqlPrep, err := s.db.Prepare(sqlQuery)
+	if err != nil {
+		return nil, err
+	}
+	stmt := sqlutil.TxStmt(txn, sqlPrep)
+	rows, err := stmt.QueryContext(ctx, iRoomIDs...)
 	if err != nil {
 		return nil, err
 	}

--- a/roomserver/storage/sqlite3/state_block_table.go
+++ b/roomserver/storage/sqlite3/state_block_table.go
@@ -93,7 +93,8 @@ func (s *stateBlockStatements) BulkInsertStateData(
 	if err != nil {
 		return 0, fmt.Errorf("json.Marshal: %w", err)
 	}
-	err = s.insertStateDataStmt.QueryRowContext(
+	stmt := sqlutil.TxStmt(txn, s.insertStateDataStmt)
+	err = stmt.QueryRowContext(
 		ctx, nids.Hash(), js,
 	).Scan(&id)
 	return

--- a/roomserver/storage/sqlite3/state_block_table.go
+++ b/roomserver/storage/sqlite3/state_block_table.go
@@ -81,8 +81,7 @@ func prepareStateBlockTable(db *sql.DB) (tables.StateBlock, error) {
 }
 
 func (s *stateBlockStatements) BulkInsertStateData(
-	ctx context.Context,
-	txn *sql.Tx,
+	ctx context.Context, txn *sql.Tx,
 	entries types.StateEntries,
 ) (id types.StateBlockNID, err error) {
 	entries = entries[:util.SortAndUnique(entries)]
@@ -101,7 +100,7 @@ func (s *stateBlockStatements) BulkInsertStateData(
 }
 
 func (s *stateBlockStatements) BulkSelectStateBlockEntries(
-	ctx context.Context, stateBlockNIDs types.StateBlockNIDs,
+	ctx context.Context, txn *sql.Tx, stateBlockNIDs types.StateBlockNIDs,
 ) ([][]types.EventNID, error) {
 	intfs := make([]interface{}, len(stateBlockNIDs))
 	for i := range stateBlockNIDs {
@@ -112,6 +111,7 @@ func (s *stateBlockStatements) BulkSelectStateBlockEntries(
 	if err != nil {
 		return nil, err
 	}
+	selectStmt = sqlutil.TxStmt(txn, selectStmt)
 	rows, err := selectStmt.QueryContext(ctx, intfs...)
 	if err != nil {
 		return nil, err

--- a/roomserver/storage/sqlite3/state_snapshot_table.go
+++ b/roomserver/storage/sqlite3/state_snapshot_table.go
@@ -106,7 +106,7 @@ func (s *stateSnapshotStatements) InsertState(
 }
 
 func (s *stateSnapshotStatements) BulkSelectStateBlockNIDs(
-	ctx context.Context, stateNIDs []types.StateSnapshotNID,
+	ctx context.Context, txn *sql.Tx, stateNIDs []types.StateSnapshotNID,
 ) ([]types.StateBlockNIDList, error) {
 	nids := make([]interface{}, len(stateNIDs))
 	for k, v := range stateNIDs {
@@ -117,6 +117,7 @@ func (s *stateSnapshotStatements) BulkSelectStateBlockNIDs(
 	if err != nil {
 		return nil, err
 	}
+	selectStmt = sqlutil.TxStmt(txn, selectStmt)
 
 	rows, err := selectStmt.QueryContext(ctx, nids...)
 	if err != nil {

--- a/roomserver/storage/sqlite3/storage.go
+++ b/roomserver/storage/sqlite3/storage.go
@@ -202,7 +202,7 @@ func (d *Database) SupportsConcurrentRoomInputs() bool {
 }
 
 func (d *Database) GetRoomUpdater(
-	ctx context.Context, roomInfo types.RoomInfo,
+	ctx context.Context, roomInfo *types.RoomInfo,
 ) (*shared.RoomUpdater, error) {
 	// TODO: Do not use transactions. We should be holding open this transaction but we cannot have
 	// multiple write transactions on sqlite. The code will perform additional

--- a/roomserver/storage/sqlite3/storage.go
+++ b/roomserver/storage/sqlite3/storage.go
@@ -23,7 +23,6 @@ import (
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/roomserver/storage/shared"
 	"github.com/matrix-org/dendrite/roomserver/storage/sqlite3/deltas"
-	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/gomatrixserverlib"
 )
@@ -193,24 +192,12 @@ func (d *Database) prepare(db *sql.DB, cache caching.RoomServerCaches) error {
 	return nil
 }
 
-func (d *Database) SupportsConcurrentRoomInputs() bool {
+func (d *Database) SupportsTransactionalIsolation() bool {
 	// This isn't supported in SQLite mode yet because of issues with
 	// database locks.
 	// TODO: Look at this again - the problem is probably to do with
 	// the membership updaters and latest events updaters.
 	return false
-}
-
-func (d *Database) GetRoomUpdater(
-	ctx context.Context, roomInfo *types.RoomInfo,
-) (*shared.RoomUpdater, error) {
-	// TODO: Do not use transactions. We should be holding open this transaction but we cannot have
-	// multiple write transactions on sqlite. The code will perform additional
-	// write transactions independent of this one which will consistently cause
-	// 'database is locked' errors. As sqlite doesn't support multi-process on the
-	// same DB anyway, and we only execute updates sequentially, the only worries
-	// are for rolling back when things go wrong. (atomicity)
-	return shared.NewRoomUpdater(ctx, &d.Database, nil, roomInfo)
 }
 
 func (d *Database) MembershipUpdater(

--- a/roomserver/storage/sqlite3/storage.go
+++ b/roomserver/storage/sqlite3/storage.go
@@ -172,23 +172,23 @@ func (d *Database) prepare(db *sql.DB, cache caching.RoomServerCaches) error {
 		return err
 	}
 	d.Database = shared.Database{
-		DB:                         db,
-		Cache:                      cache,
-		Writer:                     sqlutil.NewExclusiveWriter(),
-		EventsTable:                events,
-		EventTypesTable:            eventTypes,
-		EventStateKeysTable:        eventStateKeys,
-		EventJSONTable:             eventJSON,
-		RoomsTable:                 rooms,
-		StateBlockTable:            stateBlock,
-		StateSnapshotTable:         stateSnapshot,
-		PrevEventsTable:            prevEvents,
-		RoomAliasesTable:           roomAliases,
-		InvitesTable:               invites,
-		MembershipTable:            membership,
-		PublishedTable:             published,
-		RedactionsTable:            redactions,
-		GetLatestEventsForUpdateFn: d.GetLatestEventsForUpdate,
+		DB:                  db,
+		Cache:               cache,
+		Writer:              sqlutil.NewExclusiveWriter(),
+		EventsTable:         events,
+		EventTypesTable:     eventTypes,
+		EventStateKeysTable: eventStateKeys,
+		EventJSONTable:      eventJSON,
+		RoomsTable:          rooms,
+		StateBlockTable:     stateBlock,
+		StateSnapshotTable:  stateSnapshot,
+		PrevEventsTable:     prevEvents,
+		RoomAliasesTable:    roomAliases,
+		InvitesTable:        invites,
+		MembershipTable:     membership,
+		PublishedTable:      published,
+		RedactionsTable:     redactions,
+		GetRoomUpdaterFn:    d.GetRoomUpdater,
 	}
 	return nil
 }
@@ -201,16 +201,16 @@ func (d *Database) SupportsConcurrentRoomInputs() bool {
 	return false
 }
 
-func (d *Database) GetLatestEventsForUpdate(
+func (d *Database) GetRoomUpdater(
 	ctx context.Context, roomInfo types.RoomInfo,
-) (*shared.LatestEventsUpdater, error) {
+) (*shared.RoomUpdater, error) {
 	// TODO: Do not use transactions. We should be holding open this transaction but we cannot have
 	// multiple write transactions on sqlite. The code will perform additional
 	// write transactions independent of this one which will consistently cause
 	// 'database is locked' errors. As sqlite doesn't support multi-process on the
 	// same DB anyway, and we only execute updates sequentially, the only worries
 	// are for rolling back when things go wrong. (atomicity)
-	return shared.NewLatestEventsUpdater(ctx, &d.Database, nil, roomInfo)
+	return shared.NewRoomUpdater(ctx, &d.Database, nil, roomInfo)
 }
 
 func (d *Database) MembershipUpdater(

--- a/roomserver/storage/tables/interface.go
+++ b/roomserver/storage/tables/interface.go
@@ -18,7 +18,7 @@ type EventJSONPair struct {
 type EventJSON interface {
 	// Insert the event JSON. On conflict, replace the event JSON with the new value (for redactions).
 	InsertEventJSON(ctx context.Context, tx *sql.Tx, eventNID types.EventNID, eventJSON []byte) error
-	BulkSelectEventJSON(ctx context.Context, eventNIDs []types.EventNID) ([]EventJSONPair, error)
+	BulkSelectEventJSON(ctx context.Context, tx *sql.Tx, eventNIDs []types.EventNID) ([]EventJSONPair, error)
 }
 
 type EventTypes interface {
@@ -42,12 +42,12 @@ type Events interface {
 	SelectEvent(ctx context.Context, txn *sql.Tx, eventID string) (types.EventNID, types.StateSnapshotNID, error)
 	// bulkSelectStateEventByID lookups a list of state events by event ID.
 	// If any of the requested events are missing from the database it returns a types.MissingEventError
-	BulkSelectStateEventByID(ctx context.Context, eventIDs []string) ([]types.StateEntry, error)
-	BulkSelectStateEventByNID(ctx context.Context, eventNIDs []types.EventNID, stateKeyTuples []types.StateKeyTuple) ([]types.StateEntry, error)
+	BulkSelectStateEventByID(ctx context.Context, txn *sql.Tx, eventIDs []string) ([]types.StateEntry, error)
+	BulkSelectStateEventByNID(ctx context.Context, txn *sql.Tx, eventNIDs []types.EventNID, stateKeyTuples []types.StateKeyTuple) ([]types.StateEntry, error)
 	// BulkSelectStateAtEventByID lookups the state at a list of events by event ID.
 	// If any of the requested events are missing from the database it returns a types.MissingEventError.
 	// If we do not have the state for any of the requested events it returns a types.MissingEventError.
-	BulkSelectStateAtEventByID(ctx context.Context, eventIDs []string) ([]types.StateAtEvent, error)
+	BulkSelectStateAtEventByID(ctx context.Context, txn *sql.Tx, eventIDs []string) ([]types.StateAtEvent, error)
 	UpdateEventState(ctx context.Context, txn *sql.Tx, eventNID types.EventNID, stateNID types.StateSnapshotNID) error
 	SelectEventSentToOutput(ctx context.Context, txn *sql.Tx, eventNID types.EventNID) (sentToOutput bool, err error)
 	UpdateEventSentToOutput(ctx context.Context, txn *sql.Tx, eventNID types.EventNID) error
@@ -55,12 +55,12 @@ type Events interface {
 	BulkSelectStateAtEventAndReference(ctx context.Context, txn *sql.Tx, eventNIDs []types.EventNID) ([]types.StateAtEventAndReference, error)
 	BulkSelectEventReference(ctx context.Context, txn *sql.Tx, eventNIDs []types.EventNID) ([]gomatrixserverlib.EventReference, error)
 	// BulkSelectEventID returns a map from numeric event ID to string event ID.
-	BulkSelectEventID(ctx context.Context, eventNIDs []types.EventNID) (map[types.EventNID]string, error)
+	BulkSelectEventID(ctx context.Context, txn *sql.Tx, eventNIDs []types.EventNID) (map[types.EventNID]string, error)
 	// BulkSelectEventNIDs returns a map from string event ID to numeric event ID.
 	// If an event ID is not in the database then it is omitted from the map.
-	BulkSelectEventNID(ctx context.Context, eventIDs []string) (map[string]types.EventNID, error)
+	BulkSelectEventNID(ctx context.Context, txn *sql.Tx, eventIDs []string) (map[string]types.EventNID, error)
 	SelectMaxEventDepth(ctx context.Context, txn *sql.Tx, eventNIDs []types.EventNID) (int64, error)
-	SelectRoomNIDsForEventNIDs(ctx context.Context, eventNIDs []types.EventNID) (roomNIDs map[types.EventNID]types.RoomNID, err error)
+	SelectRoomNIDsForEventNIDs(ctx context.Context, txn *sql.Tx, eventNIDs []types.EventNID) (roomNIDs map[types.EventNID]types.RoomNID, err error)
 }
 
 type Rooms interface {
@@ -69,29 +69,29 @@ type Rooms interface {
 	SelectLatestEventNIDs(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID) ([]types.EventNID, types.StateSnapshotNID, error)
 	SelectLatestEventsNIDsForUpdate(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID) ([]types.EventNID, types.EventNID, types.StateSnapshotNID, error)
 	UpdateLatestEventNIDs(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, eventNIDs []types.EventNID, lastEventSentNID types.EventNID, stateSnapshotNID types.StateSnapshotNID) error
-	SelectRoomVersionsForRoomNIDs(ctx context.Context, roomNID []types.RoomNID) (map[types.RoomNID]gomatrixserverlib.RoomVersion, error)
-	SelectRoomInfo(ctx context.Context, roomID string) (*types.RoomInfo, error)
-	SelectRoomIDs(ctx context.Context) ([]string, error)
-	BulkSelectRoomIDs(ctx context.Context, roomNIDs []types.RoomNID) ([]string, error)
-	BulkSelectRoomNIDs(ctx context.Context, roomIDs []string) ([]types.RoomNID, error)
+	SelectRoomVersionsForRoomNIDs(ctx context.Context, txn *sql.Tx, roomNID []types.RoomNID) (map[types.RoomNID]gomatrixserverlib.RoomVersion, error)
+	SelectRoomInfo(ctx context.Context, txn *sql.Tx, roomID string) (*types.RoomInfo, error)
+	SelectRoomIDs(ctx context.Context, txn *sql.Tx) ([]string, error)
+	BulkSelectRoomIDs(ctx context.Context, txn *sql.Tx, roomNIDs []types.RoomNID) ([]string, error)
+	BulkSelectRoomNIDs(ctx context.Context, txn *sql.Tx, roomIDs []string) ([]types.RoomNID, error)
 }
 
 type StateSnapshot interface {
 	InsertState(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, stateBlockNIDs types.StateBlockNIDs) (stateNID types.StateSnapshotNID, err error)
-	BulkSelectStateBlockNIDs(ctx context.Context, stateNIDs []types.StateSnapshotNID) ([]types.StateBlockNIDList, error)
+	BulkSelectStateBlockNIDs(ctx context.Context, txn *sql.Tx, stateNIDs []types.StateSnapshotNID) ([]types.StateBlockNIDList, error)
 }
 
 type StateBlock interface {
 	BulkInsertStateData(ctx context.Context, txn *sql.Tx, entries types.StateEntries) (types.StateBlockNID, error)
-	BulkSelectStateBlockEntries(ctx context.Context, stateBlockNIDs types.StateBlockNIDs) ([][]types.EventNID, error)
+	BulkSelectStateBlockEntries(ctx context.Context, txn *sql.Tx, stateBlockNIDs types.StateBlockNIDs) ([][]types.EventNID, error)
 	//BulkSelectFilteredStateBlockEntries(ctx context.Context, stateBlockNIDs []types.StateBlockNID, stateKeyTuples []types.StateKeyTuple) ([]types.StateEntryList, error)
 }
 
 type RoomAliases interface {
 	InsertRoomAlias(ctx context.Context, txn *sql.Tx, alias string, roomID string, creatorUserID string) (err error)
-	SelectRoomIDFromAlias(ctx context.Context, alias string) (roomID string, err error)
-	SelectAliasesFromRoomID(ctx context.Context, roomID string) ([]string, error)
-	SelectCreatorIDFromAlias(ctx context.Context, alias string) (creatorID string, err error)
+	SelectRoomIDFromAlias(ctx context.Context, txn *sql.Tx, alias string) (roomID string, err error)
+	SelectAliasesFromRoomID(ctx context.Context, txn *sql.Tx, roomID string) ([]string, error)
+	SelectCreatorIDFromAlias(ctx context.Context, txn *sql.Tx, alias string) (creatorID string, err error)
 	DeleteRoomAlias(ctx context.Context, txn *sql.Tx, alias string) (err error)
 }
 
@@ -106,7 +106,7 @@ type Invites interface {
 	InsertInviteEvent(ctx context.Context, txn *sql.Tx, inviteEventID string, roomNID types.RoomNID, targetUserNID, senderUserNID types.EventStateKeyNID, inviteEventJSON []byte) (bool, error)
 	UpdateInviteRetired(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, targetUserNID types.EventStateKeyNID) ([]string, error)
 	// SelectInviteActiveForUserInRoom returns a list of sender state key NIDs and invite event IDs matching those nids.
-	SelectInviteActiveForUserInRoom(ctx context.Context, targetUserNID types.EventStateKeyNID, roomNID types.RoomNID) ([]types.EventStateKeyNID, []string, error)
+	SelectInviteActiveForUserInRoom(ctx context.Context, txn *sql.Tx, targetUserNID types.EventStateKeyNID, roomNID types.RoomNID) ([]types.EventStateKeyNID, []string, error)
 }
 
 type MembershipState int64
@@ -121,24 +121,24 @@ const (
 type Membership interface {
 	InsertMembership(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, targetUserNID types.EventStateKeyNID, localTarget bool) error
 	SelectMembershipForUpdate(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, targetUserNID types.EventStateKeyNID) (MembershipState, error)
-	SelectMembershipFromRoomAndTarget(ctx context.Context, roomNID types.RoomNID, targetUserNID types.EventStateKeyNID) (types.EventNID, MembershipState, bool, error)
-	SelectMembershipsFromRoom(ctx context.Context, roomNID types.RoomNID, localOnly bool) (eventNIDs []types.EventNID, err error)
-	SelectMembershipsFromRoomAndMembership(ctx context.Context, roomNID types.RoomNID, membership MembershipState, localOnly bool) (eventNIDs []types.EventNID, err error)
+	SelectMembershipFromRoomAndTarget(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, targetUserNID types.EventStateKeyNID) (types.EventNID, MembershipState, bool, error)
+	SelectMembershipsFromRoom(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, localOnly bool) (eventNIDs []types.EventNID, err error)
+	SelectMembershipsFromRoomAndMembership(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, membership MembershipState, localOnly bool) (eventNIDs []types.EventNID, err error)
 	UpdateMembership(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, targetUserNID types.EventStateKeyNID, senderUserNID types.EventStateKeyNID, membership MembershipState, eventNID types.EventNID, forgotten bool) error
-	SelectRoomsWithMembership(ctx context.Context, userID types.EventStateKeyNID, membershipState MembershipState) ([]types.RoomNID, error)
+	SelectRoomsWithMembership(ctx context.Context, txn *sql.Tx, userID types.EventStateKeyNID, membershipState MembershipState) ([]types.RoomNID, error)
 	// SelectJoinedUsersSetForRooms returns the set of all users in the rooms who are joined to any of these rooms, along with the
 	// counts of how many rooms they are joined.
-	SelectJoinedUsersSetForRooms(ctx context.Context, roomNIDs []types.RoomNID) (map[types.EventStateKeyNID]int, error)
-	SelectKnownUsers(ctx context.Context, userID types.EventStateKeyNID, searchString string, limit int) ([]string, error)
+	SelectJoinedUsersSetForRooms(ctx context.Context, txn *sql.Tx, roomNIDs []types.RoomNID) (map[types.EventStateKeyNID]int, error)
+	SelectKnownUsers(ctx context.Context, txn *sql.Tx, userID types.EventStateKeyNID, searchString string, limit int) ([]string, error)
 	UpdateForgetMembership(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, targetUserNID types.EventStateKeyNID, forget bool) error
-	SelectLocalServerInRoom(ctx context.Context, roomNID types.RoomNID) (bool, error)
-	SelectServerInRoom(ctx context.Context, roomNID types.RoomNID, serverName gomatrixserverlib.ServerName) (bool, error)
+	SelectLocalServerInRoom(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID) (bool, error)
+	SelectServerInRoom(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, serverName gomatrixserverlib.ServerName) (bool, error)
 }
 
 type Published interface {
 	UpsertRoomPublished(ctx context.Context, txn *sql.Tx, roomID string, published bool) (err error)
-	SelectPublishedFromRoomID(ctx context.Context, roomID string) (published bool, err error)
-	SelectAllPublishedRooms(ctx context.Context, published bool) ([]string, error)
+	SelectPublishedFromRoomID(ctx context.Context, txn *sql.Tx, roomID string) (published bool, err error)
+	SelectAllPublishedRooms(ctx context.Context, txn *sql.Tx, published bool) ([]string, error)
 }
 
 type RedactionInfo struct {

--- a/roomserver/storage/tables/interface.go
+++ b/roomserver/storage/tables/interface.go
@@ -24,14 +24,14 @@ type EventJSON interface {
 type EventTypes interface {
 	InsertEventTypeNID(ctx context.Context, tx *sql.Tx, eventType string) (types.EventTypeNID, error)
 	SelectEventTypeNID(ctx context.Context, tx *sql.Tx, eventType string) (types.EventTypeNID, error)
-	BulkSelectEventTypeNID(ctx context.Context, eventTypes []string) (map[string]types.EventTypeNID, error)
+	BulkSelectEventTypeNID(ctx context.Context, txn *sql.Tx, eventTypes []string) (map[string]types.EventTypeNID, error)
 }
 
 type EventStateKeys interface {
 	InsertEventStateKeyNID(ctx context.Context, txn *sql.Tx, eventStateKey string) (types.EventStateKeyNID, error)
 	SelectEventStateKeyNID(ctx context.Context, txn *sql.Tx, eventStateKey string) (types.EventStateKeyNID, error)
-	BulkSelectEventStateKeyNID(ctx context.Context, eventStateKeys []string) (map[string]types.EventStateKeyNID, error)
-	BulkSelectEventStateKey(ctx context.Context, eventStateKeyNIDs []types.EventStateKeyNID) (map[types.EventStateKeyNID]string, error)
+	BulkSelectEventStateKeyNID(ctx context.Context, txn *sql.Tx, eventStateKeys []string) (map[string]types.EventStateKeyNID, error)
+	BulkSelectEventStateKey(ctx context.Context, txn *sql.Tx, eventStateKeyNIDs []types.EventStateKeyNID) (map[types.EventStateKeyNID]string, error)
 }
 
 type Events interface {


### PR DESCRIPTION
This PR does the following things:

* renames the "latest events updater" to the "room updater"
* uses the room updater to perform all database tasks during the RS input process
* only acknowledges messages from NATS when the transaction is successfully committed
* fudges around the storage code so that all roomserver tables now take an optional `*sql.Tx`
* fudges some more storage code so that `*RoomUpdater` satisfies new subset interfaces needed for state res and checking auth/soft fail
* other various tweaks to fix bugs