### PR TITLE
Fix CPU spin from key change consumer when an invalid message is supplied

### DIFF
--- a/keyserver/consumers/cross_signing.go
+++ b/keyserver/consumers/cross_signing.go
@@ -114,7 +114,10 @@ func (s *OutputCrossSigningKeyUpdateConsumer) onCrossSigningMessage(m api.Device
 	uploadRes := &api.PerformUploadDeviceKeysResponse{}
 	s.keyAPI.PerformUploadDeviceKeys(context.TODO(), uploadReq, uploadRes)
 	if uploadRes.Error != nil {
-		return false
+		// If the error is due to a missing or invalid parameter then we'd might
+		// as well just acknowledge the message, because otherwise otherwise we'll
+		// just keep getting delivered a faulty message over and over again.
+		return uploadRes.Error.IsMissingParam || uploadRes.Error.IsInvalidParam
 	}
 	return true
 }


### PR DESCRIPTION
We were returning `false` here when the message was obviously faulty, which is causing the JetStream consumer to NAK and therefore we'd just get redelivered the message on loop.