### PR TITLE
Don't handle rejected retrieved events as fatal

### DIFF
--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -297,7 +297,7 @@ func (r *Inputer) processRoomEvent(
 			"soft_fail":    softfail,
 			"missing_prev": missingPrev,
 		}).Warn("Stored rejected event")
-		return commitTransaction, rejectionErr
+		return commitTransaction, types.RejectedError(rejectionErr.Error())
 	}
 
 	switch input.Kind {

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -297,7 +297,10 @@ func (r *Inputer) processRoomEvent(
 			"soft_fail":    softfail,
 			"missing_prev": missingPrev,
 		}).Warn("Stored rejected event")
-		return commitTransaction, types.RejectedError(rejectionErr.Error())
+		if err != nil {
+			return commitTransaction, types.RejectedError(err.Error())
+		}
+		return commitTransaction, nil
 	}
 
 	switch input.Kind {

--- a/roomserver/internal/input/input_missing.go
+++ b/roomserver/internal/input/input_missing.go
@@ -12,6 +12,7 @@ import (
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/roomserver/internal/query"
 	"github.com/matrix-org/dendrite/roomserver/storage/shared"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 	"github.com/sirupsen/logrus"
@@ -205,7 +206,9 @@ func (t *missingStateReq) processEventWithMissingState(
 		SendAsServer:  api.DoNotSendToOtherServers,
 	})
 	if err != nil {
-		return fmt.Errorf("t.inputer.processRoomEvent: %w", err)
+		if _, ok := err.(types.RejectedError); !ok {
+			return fmt.Errorf("t.inputer.processRoomEvent: %w", err)
+		}
 	}
 
 	// Then send all of the newer backfilled events, of which will all be newer
@@ -220,7 +223,9 @@ func (t *missingStateReq) processEventWithMissingState(
 			SendAsServer: api.DoNotSendToOtherServers,
 		})
 		if err != nil {
-			return fmt.Errorf("t.inputer.processRoomEvent: %w", err)
+			if _, ok := err.(types.RejectedError); !ok {
+				return fmt.Errorf("t.inputer.processRoomEvent: %w", err)
+			}
 		}
 	}
 

--- a/roomserver/storage/postgres/events_table.go
+++ b/roomserver/storage/postgres/events_table.go
@@ -316,7 +316,7 @@ func (s *eventStatements) BulkSelectStateAtEventByID(
 		}
 		// Genuine create events are the only case where it's OK to have no previous state.
 		isCreate := result.EventTypeNID == types.MRoomCreateNID && result.EventStateKeyNID == 1
-		if result.BeforeStateSnapshotNID == 0 && !isCreate {
+		if result.BeforeStateSnapshotNID == 0 && !result.IsRejected && !isCreate {
 			return nil, types.MissingEventError(
 				fmt.Sprintf("storage: missing state for event NID %d", result.EventNID),
 			)

--- a/roomserver/storage/sqlite3/events_table.go
+++ b/roomserver/storage/sqlite3/events_table.go
@@ -327,7 +327,7 @@ func (s *eventStatements) BulkSelectStateAtEventByID(
 		}
 		// Genuine create events are the only case where it's OK to have no previous state.
 		isCreate := result.EventTypeNID == types.MRoomCreateNID && result.EventStateKeyNID == 1
-		if result.BeforeStateSnapshotNID == 0 && !isCreate {
+		if result.BeforeStateSnapshotNID == 0 && !result.IsRejected && !isCreate {
 			return nil, types.MissingEventError(
 				fmt.Sprintf("storage: missing state for event NID %d", result.EventNID),
 			)

--- a/roomserver/types/types.go
+++ b/roomserver/types/types.go
@@ -209,6 +209,12 @@ type MissingEventError string
 
 func (e MissingEventError) Error() string { return string(e) }
 
+// A RejectedError is returned when an event is stored as rejected. The error
+// contains the reason why.
+type RejectedError string
+
+func (e RejectedError) Error() string { return string(e) }
+
 // RoomInfo contains metadata about a room
 type RoomInfo struct {
 	RoomNID          RoomNID


### PR DESCRIPTION
This could cause us to revert the whole input transaction if one of the events we fetched from `/get_missing_events` was rejected, even though this is often an unavoidable condition.