### PR TITLE
Allow events to be un-rejected

### DIFF
--- a/roomserver/storage/postgres/events_table.go
+++ b/roomserver/storage/postgres/events_table.go
@@ -74,7 +74,7 @@ const insertEventSQL = "" +
 	"INSERT INTO roomserver_events (room_nid, event_type_nid, event_state_key_nid, event_id, reference_sha256, auth_event_nids, depth, is_rejected)" +
 	" VALUES ($1, $2, $3, $4, $5, $6, $7, $8)" +
 	" ON CONFLICT ON CONSTRAINT roomserver_event_id_unique DO UPDATE" +
-	" SET is_rejected = $8" +
+	" SET is_rejected = $8 WHERE is_rejected = FALSE" +
 	" RETURNING event_nid, state_snapshot_nid"
 
 const selectEventSQL = "" +

--- a/roomserver/storage/postgres/events_table.go
+++ b/roomserver/storage/postgres/events_table.go
@@ -73,7 +73,7 @@ CREATE TABLE IF NOT EXISTS roomserver_events (
 const insertEventSQL = "" +
 	"INSERT INTO roomserver_events (room_nid, event_type_nid, event_state_key_nid, event_id, reference_sha256, auth_event_nids, depth, is_rejected)" +
 	" VALUES ($1, $2, $3, $4, $5, $6, $7, $8)" +
-	" ON CONFLICT ON CONSTRAINT roomserver_event_id_unique" +
+	" ON CONFLICT ON CONSTRAINT roomserver_event_id_unique DO UPDATE" +
 	" SET is_rejected = $8" +
 	" RETURNING event_nid, state_snapshot_nid"
 

--- a/roomserver/storage/postgres/events_table.go
+++ b/roomserver/storage/postgres/events_table.go
@@ -71,10 +71,10 @@ CREATE TABLE IF NOT EXISTS roomserver_events (
 `
 
 const insertEventSQL = "" +
-	"INSERT INTO roomserver_events (room_nid, event_type_nid, event_state_key_nid, event_id, reference_sha256, auth_event_nids, depth, is_rejected)" +
+	"INSERT INTO roomserver_events AS e (room_nid, event_type_nid, event_state_key_nid, event_id, reference_sha256, auth_event_nids, depth, is_rejected)" +
 	" VALUES ($1, $2, $3, $4, $5, $6, $7, $8)" +
 	" ON CONFLICT ON CONSTRAINT roomserver_event_id_unique DO UPDATE" +
-	" SET is_rejected = $8 WHERE is_rejected = FALSE" +
+	" SET is_rejected = $8 WHERE e.is_rejected = FALSE" +
 	" RETURNING event_nid, state_snapshot_nid"
 
 const selectEventSQL = "" +

--- a/roomserver/storage/postgres/events_table.go
+++ b/roomserver/storage/postgres/events_table.go
@@ -74,7 +74,7 @@ const insertEventSQL = "" +
 	"INSERT INTO roomserver_events (room_nid, event_type_nid, event_state_key_nid, event_id, reference_sha256, auth_event_nids, depth, is_rejected)" +
 	" VALUES ($1, $2, $3, $4, $5, $6, $7, $8)" +
 	" ON CONFLICT ON CONSTRAINT roomserver_event_id_unique" +
-	" DO NOTHING" +
+	" SET is_rejected = $8" +
 	" RETURNING event_nid, state_snapshot_nid"
 
 const selectEventSQL = "" +

--- a/roomserver/storage/sqlite3/events_table.go
+++ b/roomserver/storage/sqlite3/events_table.go
@@ -49,7 +49,7 @@ const eventsSchema = `
 const insertEventSQL = `
 	INSERT INTO roomserver_events (room_nid, event_type_nid, event_state_key_nid, event_id, reference_sha256, auth_event_nids, depth, is_rejected)
 	  VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-	  ON CONFLICT DO NOTHING
+	  ON CONFLICT SET is_rejected = $8
 	  RETURNING event_nid, state_snapshot_nid;
 `
 

--- a/roomserver/storage/sqlite3/events_table.go
+++ b/roomserver/storage/sqlite3/events_table.go
@@ -50,7 +50,7 @@ const insertEventSQL = `
 	INSERT INTO roomserver_events (room_nid, event_type_nid, event_state_key_nid, event_id, reference_sha256, auth_event_nids, depth, is_rejected)
 	  VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 	  ON CONFLICT DO UPDATE
-	  SET is_rejected = $8
+	  SET is_rejected = $8 WHERE is_rejected = 0
 	  RETURNING event_nid, state_snapshot_nid;
 `
 

--- a/roomserver/storage/sqlite3/events_table.go
+++ b/roomserver/storage/sqlite3/events_table.go
@@ -49,7 +49,8 @@ const eventsSchema = `
 const insertEventSQL = `
 	INSERT INTO roomserver_events (room_nid, event_type_nid, event_state_key_nid, event_id, reference_sha256, auth_event_nids, depth, is_rejected)
 	  VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-	  ON CONFLICT SET is_rejected = $8
+	  ON CONFLICT DO UPDATE
+	  SET is_rejected = $8
 	  RETURNING event_nid, state_snapshot_nid;
 `
 


### PR DESCRIPTION
Today, if an event is rejected, that is a permanent action. This PR changes it so that if we re-process the event later and it doesn't end up rejected after all, we can deal with that case by updating it in the database to un-reject it and then continue processing it fully.