### PR TITLE
More relaxed auth event fetching

### DIFF
--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -195,9 +195,26 @@ func (r *Inputer) processRoomEvent(
 	authEventNIDs := make([]types.EventNID, 0, len(authEventIDs))
 	for _, authEventID := range authEventIDs {
 		if _, ok := knownEvents[authEventID]; !ok {
-			return rollbackTransaction, fmt.Errorf("missing auth event %s", authEventID)
+			// Unknown auth events only really matter if the event actually failed
+			// auth. If it passed auth then we can assume that everything that was
+			// known was sufficient, even if extraneous auth events were specified
+			// but weren't found.
+			if isRejected {
+				if event.StateKey() != nil {
+					return commitTransaction, fmt.Errorf(
+						"missing auth event %s for state event %s (type %q, state key %q)",
+						authEventID, event.EventID(), event.Type(), *event.StateKey(),
+					)
+				} else {
+					return commitTransaction, fmt.Errorf(
+						"missing auth event %s for timeline event %s (type %q)",
+						authEventID, event.EventID(), event.Type(),
+					)
+				}
+			}
+		} else {
+			authEventNIDs = append(authEventNIDs, knownEvents[authEventID].EventNID)
 		}
-		authEventNIDs = append(authEventNIDs, knownEvents[authEventID].EventNID)
 	}
 
 	var softfail bool
@@ -416,6 +433,9 @@ func (r *Inputer) fetchAuthEvents(
 		return fmt.Errorf("no servers provided event auth for event ID %q, tried servers %v", event.EventID(), servers)
 	}
 
+	// Reuse these to reduce allocations.
+	authEventNIDs := make([]types.EventNID, 0, 5)
+	isRejected := false
 	for _, authEvent := range gomatrixserverlib.ReverseTopologicalOrdering(
 		res.AuthEvents,
 		gomatrixserverlib.TopologicalOrderByAuthEvents,
@@ -436,24 +456,17 @@ func (r *Inputer) fetchAuthEvents(
 
 		// In order to store the new auth event, we need to know its auth chain
 		// as NIDs for the `auth_event_nids` column. Let's see if we can find those.
-		authEventNIDs := make([]types.EventNID, 0, len(authEvent.AuthEventIDs()))
+		authEventNIDs = authEventNIDs[:0]
 		for _, eventID := range authEvent.AuthEventIDs() {
 			knownEvent, ok := known[eventID]
-			if !ok {
-				return fmt.Errorf("missing auth event %s for %s", eventID, authEvent.EventID())
+			if ok {
+				authEventNIDs = append(authEventNIDs, knownEvent.EventNID)
 			}
-			authEventNIDs = append(authEventNIDs, knownEvent.EventNID)
-		}
-
-		// Let's take a note of the fact that we now know about this event.
-		if err := auth.AddEvent(authEvent); err != nil {
-			return fmt.Errorf("auth.AddEvent: %w", err)
 		}
 
 		// Check if the auth event should be rejected.
-		isRejected := false
-		if err := gomatrixserverlib.Allowed(authEvent, auth); err != nil {
-			isRejected = true
+		err := gomatrixserverlib.Allowed(authEvent, auth)
+		if isRejected = err != nil; isRejected {
 			logger.WithError(err).Warnf("Auth event %s rejected", authEvent.EventID())
 		}
 
@@ -461,6 +474,14 @@ func (r *Inputer) fetchAuthEvents(
 		eventNID, _, _, _, _, err := updater.StoreEvent(ctx, authEvent, authEventNIDs, isRejected)
 		if err != nil {
 			return fmt.Errorf("updater.StoreEvent: %w", err)
+		}
+
+		// Let's take a note of the fact that we now know about this event for
+		// authenticating future events.
+		if !isRejected {
+			if err := auth.AddEvent(authEvent); err != nil {
+				return fmt.Errorf("auth.AddEvent: %w", err)
+			}
 		}
 
 		// Now we know about this event, it was stored and the signatures were OK.


### PR DESCRIPTION
This modifies the behaviour for fetching auth events to more of a best-effort attempt rather than strictly requiring every single event listed in the auth event IDs of the event. This is because sometimes there can be additional or unexpected auth event IDs that aren't strictly necessary for event auth.

Also, when event auth passes, we'll just store the auth event NIDs in the database that we actually knew about, since that was the minimum required subset.