### PR TITLE
Allow user to forget a room, even if they never were a member

### DIFF
--- a/clientapi/routing/membership.go
+++ b/clientapi/routing/membership.go
@@ -460,7 +460,7 @@ func SendForget(
 	if membershipRes.IsInRoom {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
-			JSON: jsonerror.Forbidden(fmt.Sprintf("User %s is in room %s", device.UserID, roomID)),
+			JSON: jsonerror.Unknown(fmt.Sprintf("User %s is in room %s", device.UserID, roomID)),
 		}
 	}
 

--- a/clientapi/routing/membership.go
+++ b/clientapi/routing/membership.go
@@ -17,6 +17,7 @@ package routing
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -459,13 +460,7 @@ func SendForget(
 	if membershipRes.IsInRoom {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
-			JSON: jsonerror.Forbidden("user is still a member of the room"),
-		}
-	}
-	if !membershipRes.HasBeenInRoom {
-		return util.JSONResponse{
-			Code: http.StatusBadRequest,
-			JSON: jsonerror.Forbidden("user did not belong to room"),
+			JSON: jsonerror.Forbidden(fmt.Sprintf("User %s is in room %s", device.UserID, roomID)),
 		}
 	}
 


### PR DESCRIPTION
The spec doesn't say anything about forgetting a room one has never been part of. So remove this part.
Also returns a better message if the user is still a member.
