### PR TITLE
Drop `m.room.create` events in federation `/send` transaction

### DIFF
--- a/federationapi/routing/send.go
+++ b/federationapi/routing/send.go
@@ -258,6 +258,9 @@ func (t *txnReq) processTransaction(ctx context.Context) (*gomatrixserverlib.Res
 			util.GetLogger(ctx).WithError(err).Debugf("Transaction: Failed to parse event JSON of event %s", string(pdu))
 			continue
 		}
+		if event.Type() == gomatrixserverlib.MRoomCreate && event.StateKeyEquals("") {
+			continue
+		}
 		if api.IsServerBannedFromRoom(ctx, t.rsAPI, event.RoomID(), t.Origin) {
 			results[event.EventID()] = gomatrixserverlib.PDUResult{
 				Error: "Forbidden by server ACLs",


### PR DESCRIPTION
There's no reason that a remote server should just gratuitously try to send us a `m.room.create` event via `/send`.