### PR TITLE
Implement server notices

### DIFF
--- a/clientapi/routing/createroom.go
+++ b/clientapi/routing/createroom.go
@@ -15,6 +15,7 @@
 package routing
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -140,33 +141,14 @@ func CreateRoom(
 	accountDB accounts.Database, rsAPI roomserverAPI.RoomserverInternalAPI,
 	asAPI appserviceAPI.AppServiceQueryAPI,
 ) util.JSONResponse {
-	// TODO (#267): Check room ID doesn't clash with an existing one, and we
-	//              probably shouldn't be using pseudo-random strings, maybe GUIDs?
-	roomID := fmt.Sprintf("!%s:%s", util.RandomString(16), cfg.Matrix.ServerName)
-	return createRoom(req, device, cfg, roomID, accountDB, rsAPI, asAPI)
-}
-
-// createRoom implements /createRoom
-// nolint: gocyclo
-func createRoom(
-	req *http.Request, device *api.Device,
-	cfg *config.ClientAPI, roomID string,
-	accountDB accounts.Database, rsAPI roomserverAPI.RoomserverInternalAPI,
-	asAPI appserviceAPI.AppServiceQueryAPI,
-) util.JSONResponse {
-	logger := util.GetLogger(req.Context())
-	userID := device.UserID
 	var r createRoomRequest
 	resErr := httputil.UnmarshalJSONRequest(req, &r)
 	if resErr != nil {
 		return *resErr
 	}
-	// TODO: apply rate-limit
-
 	if resErr = r.Validate(); resErr != nil {
 		return *resErr
 	}
-
 	evTime, err := httputil.ParseTSParam(req)
 	if err != nil {
 		return util.JSONResponse{
@@ -174,6 +156,25 @@ func createRoom(
 			JSON: jsonerror.InvalidArgumentValue(err.Error()),
 		}
 	}
+	return createRoom(req.Context(), r, device, cfg, accountDB, rsAPI, asAPI, evTime)
+}
+
+// createRoom implements /createRoom
+// nolint: gocyclo
+func createRoom(
+	ctx context.Context,
+	r createRoomRequest, device *api.Device,
+	cfg *config.ClientAPI,
+	accountDB accounts.Database, rsAPI roomserverAPI.RoomserverInternalAPI,
+	asAPI appserviceAPI.AppServiceQueryAPI,
+	evTime time.Time,
+) util.JSONResponse {
+	// TODO (#267): Check room ID doesn't clash with an existing one, and we
+	//              probably shouldn't be using pseudo-random strings, maybe GUIDs?
+	roomID := fmt.Sprintf("!%s:%s", util.RandomString(16), cfg.Matrix.ServerName)
+
+	logger := util.GetLogger(ctx)
+	userID := device.UserID
 
 	// Clobber keys: creator, room_version
 
@@ -200,16 +201,16 @@ func createRoom(
 		"roomVersion": roomVersion,
 	}).Info("Creating new room")
 
-	profile, err := appserviceAPI.RetrieveUserProfile(req.Context(), userID, asAPI, accountDB)
+	profile, err := appserviceAPI.RetrieveUserProfile(ctx, userID, asAPI, accountDB)
 	if err != nil {
-		util.GetLogger(req.Context()).WithError(err).Error("appserviceAPI.RetrieveUserProfile failed")
+		util.GetLogger(ctx).WithError(err).Error("appserviceAPI.RetrieveUserProfile failed")
 		return jsonerror.InternalServerError()
 	}
 
 	createContent := map[string]interface{}{}
 	if len(r.CreationContent) > 0 {
 		if err = json.Unmarshal(r.CreationContent, &createContent); err != nil {
-			util.GetLogger(req.Context()).WithError(err).Error("json.Unmarshal for creation_content failed")
+			util.GetLogger(ctx).WithError(err).Error("json.Unmarshal for creation_content failed")
 			return util.JSONResponse{
 				Code: http.StatusBadRequest,
 				JSON: jsonerror.BadJSON("invalid create content"),
@@ -230,7 +231,7 @@ func createRoom(
 		// Merge powerLevelContentOverride fields by unmarshalling it atop the defaults
 		err = json.Unmarshal(r.PowerLevelContentOverride, &powerLevelContent)
 		if err != nil {
-			util.GetLogger(req.Context()).WithError(err).Error("json.Unmarshal for power_level_content_override failed")
+			util.GetLogger(ctx).WithError(err).Error("json.Unmarshal for power_level_content_override failed")
 			return util.JSONResponse{
 				Code: http.StatusBadRequest,
 				JSON: jsonerror.BadJSON("malformed power_level_content_override"),
@@ -319,9 +320,9 @@ func createRoom(
 		}
 
 		var aliasResp roomserverAPI.GetRoomIDForAliasResponse
-		err = rsAPI.GetRoomIDForAlias(req.Context(), &hasAliasReq, &aliasResp)
+		err = rsAPI.GetRoomIDForAlias(ctx, &hasAliasReq, &aliasResp)
 		if err != nil {
-			util.GetLogger(req.Context()).WithError(err).Error("aliasAPI.GetRoomIDForAlias failed")
+			util.GetLogger(ctx).WithError(err).Error("aliasAPI.GetRoomIDForAlias failed")
 			return jsonerror.InternalServerError()
 		}
 		if aliasResp.RoomID != "" {
@@ -426,7 +427,7 @@ func createRoom(
 		}
 		err = builder.SetContent(e.Content)
 		if err != nil {
-			util.GetLogger(req.Context()).WithError(err).Error("builder.SetContent failed")
+			util.GetLogger(ctx).WithError(err).Error("builder.SetContent failed")
 			return jsonerror.InternalServerError()
 		}
 		if i > 0 {
@@ -435,12 +436,12 @@ func createRoom(
 		var ev *gomatrixserverlib.Event
 		ev, err = buildEvent(&builder, &authEvents, cfg, evTime, roomVersion)
 		if err != nil {
-			util.GetLogger(req.Context()).WithError(err).Error("buildEvent failed")
+			util.GetLogger(ctx).WithError(err).Error("buildEvent failed")
 			return jsonerror.InternalServerError()
 		}
 
 		if err = gomatrixserverlib.Allowed(ev, &authEvents); err != nil {
-			util.GetLogger(req.Context()).WithError(err).Error("gomatrixserverlib.Allowed failed")
+			util.GetLogger(ctx).WithError(err).Error("gomatrixserverlib.Allowed failed")
 			return jsonerror.InternalServerError()
 		}
 
@@ -448,7 +449,7 @@ func createRoom(
 		builtEvents = append(builtEvents, ev.Headered(roomVersion))
 		err = authEvents.AddEvent(ev)
 		if err != nil {
-			util.GetLogger(req.Context()).WithError(err).Error("authEvents.AddEvent failed")
+			util.GetLogger(ctx).WithError(err).Error("authEvents.AddEvent failed")
 			return jsonerror.InternalServerError()
 		}
 	}
@@ -462,8 +463,8 @@ func createRoom(
 			SendAsServer: roomserverAPI.DoNotSendToOtherServers,
 		})
 	}
-	if err = roomserverAPI.SendInputRoomEvents(req.Context(), rsAPI, inputs, false); err != nil {
-		util.GetLogger(req.Context()).WithError(err).Error("roomserverAPI.SendInputRoomEvents failed")
+	if err = roomserverAPI.SendInputRoomEvents(ctx, rsAPI, inputs, false); err != nil {
+		util.GetLogger(ctx).WithError(err).Error("roomserverAPI.SendInputRoomEvents failed")
 		return jsonerror.InternalServerError()
 	}
 
@@ -478,9 +479,9 @@ func createRoom(
 		}
 
 		var aliasResp roomserverAPI.SetRoomAliasResponse
-		err = rsAPI.SetRoomAlias(req.Context(), &aliasReq, &aliasResp)
+		err = rsAPI.SetRoomAlias(ctx, &aliasReq, &aliasResp)
 		if err != nil {
-			util.GetLogger(req.Context()).WithError(err).Error("aliasAPI.SetRoomAlias failed")
+			util.GetLogger(ctx).WithError(err).Error("aliasAPI.SetRoomAlias failed")
 			return jsonerror.InternalServerError()
 		}
 
@@ -519,11 +520,11 @@ func createRoom(
 		for _, invitee := range r.Invite {
 			// Build the invite event.
 			inviteEvent, err := buildMembershipEvent(
-				req.Context(), invitee, "", accountDB, device, gomatrixserverlib.Invite,
+				ctx, invitee, "", accountDB, device, gomatrixserverlib.Invite,
 				roomID, true, cfg, evTime, rsAPI, asAPI,
 			)
 			if err != nil {
-				util.GetLogger(req.Context()).WithError(err).Error("buildMembershipEvent failed")
+				util.GetLogger(ctx).WithError(err).Error("buildMembershipEvent failed")
 				continue
 			}
 			inviteStrippedState := append(
@@ -532,7 +533,7 @@ func createRoom(
 			)
 			// Send the invite event to the roomserver.
 			err = roomserverAPI.SendInvite(
-				req.Context(),
+				ctx,
 				rsAPI,
 				inviteEvent.Headered(roomVersion),
 				inviteStrippedState,   // invite room state
@@ -544,7 +545,7 @@ func createRoom(
 				return e.JSONResponse()
 			case nil:
 			default:
-				util.GetLogger(req.Context()).WithError(err).Error("roomserverAPI.SendInvite failed")
+				util.GetLogger(ctx).WithError(err).Error("roomserverAPI.SendInvite failed")
 				return util.JSONResponse{
 					Code: http.StatusInternalServerError,
 					JSON: jsonerror.InternalServerError(),
@@ -556,13 +557,13 @@ func createRoom(
 	if r.Visibility == "public" {
 		// expose this room in the published room list
 		var pubRes roomserverAPI.PerformPublishResponse
-		rsAPI.PerformPublish(req.Context(), &roomserverAPI.PerformPublishRequest{
+		rsAPI.PerformPublish(ctx, &roomserverAPI.PerformPublishRequest{
 			RoomID:     roomID,
 			Visibility: "public",
 		}, &pubRes)
 		if pubRes.Error != nil {
 			// treat as non-fatal since the room is already made by this point
-			util.GetLogger(req.Context()).WithError(pubRes.Error).Error("failed to visibility:public")
+			util.GetLogger(ctx).WithError(pubRes.Error).Error("failed to visibility:public")
 		}
 	}
 

--- a/clientapi/routing/server_notices.go
+++ b/clientapi/routing/server_notices.go
@@ -1,0 +1,311 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/matrix-org/gomatrix"
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/tokens"
+	"github.com/matrix-org/util"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+
+	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"
+	"github.com/matrix-org/dendrite/clientapi/httputil"
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"github.com/matrix-org/dendrite/internal/eventutil"
+	"github.com/matrix-org/dendrite/internal/transactions"
+	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/setup/config"
+	userapi "github.com/matrix-org/dendrite/userapi/api"
+	"github.com/matrix-org/dendrite/userapi/storage/accounts"
+)
+
+// Unspecced server notice request
+// https://github.com/matrix-org/synapse/blob/develop/docs/admin_api/server_notices.md
+type sendServerNoticeRequest struct {
+	UserID  string `json:"user_id,omitempty"`
+	Content struct {
+		MsgType string `json:"msgtype,omitempty"`
+		Body    string `json:"body,omitempty"`
+	} `json:"content,omitempty"`
+	Type     string `json:"type,omitempty"`
+	StateKey string `json:"state_key,omitempty"`
+}
+
+// SendServerNotice sends a message to a specific user. It can only be invoked by an admin.
+func SendServerNotice(
+	req *http.Request,
+	cfgNotices *config.ServerNotices,
+	cfgClient *config.ClientAPI,
+	userAPI userapi.UserInternalAPI,
+	rsAPI api.RoomserverInternalAPI,
+	accountsDB accounts.Database,
+	asAPI appserviceAPI.AppServiceQueryAPI,
+	device *userapi.Device,
+	txnID *string,
+	txnCache *transactions.Cache,
+) util.JSONResponse {
+	// TODO: Only allow admins to send notices
+	if !cfgNotices.Enabled {
+		return util.MessageResponse(http.StatusBadRequest, "Server notices are not enabled on this server.")
+	}
+
+	if txnID != nil {
+		// Try to fetch response from transactionsCache
+		if res, ok := txnCache.FetchTransaction(device.AccessToken, *txnID); ok {
+			return *res
+		}
+	}
+
+	ctx := req.Context()
+	var r sendServerNoticeRequest
+	resErr := httputil.UnmarshalJSONRequest(req, &r)
+	if resErr != nil {
+		return *resErr
+	}
+
+	// get rooms for specified user
+	allUserRooms := []string{}
+	userRooms := api.QueryRoomsForUserResponse{}
+	if err := rsAPI.QueryRoomsForUser(ctx, &api.QueryRoomsForUserRequest{
+		UserID:         r.UserID,
+		WantMembership: "join",
+	}, &userRooms); err != nil {
+		return util.ErrorResponse(err)
+	}
+	allUserRooms = append(allUserRooms, userRooms.RoomIDs...)
+	// get invites for specified user
+	if err := rsAPI.QueryRoomsForUser(ctx, &api.QueryRoomsForUserRequest{
+		UserID:         r.UserID,
+		WantMembership: "invite",
+	}, &userRooms); err != nil {
+		return util.ErrorResponse(err)
+	}
+	allUserRooms = append(allUserRooms, userRooms.RoomIDs...)
+
+	// get rooms of the sender
+	senderUserID := fmt.Sprintf("@%s:%s", cfgNotices.LocalPart, cfgClient.Matrix.ServerName)
+	senderRooms := api.QueryRoomsForUserResponse{}
+	if err := rsAPI.QueryRoomsForUser(ctx, &api.QueryRoomsForUserRequest{
+		UserID:         senderUserID,
+		WantMembership: "join",
+	}, &senderRooms); err != nil {
+		return util.ErrorResponse(err)
+	}
+
+	// check if we have rooms in common
+	commonRooms := []string{}
+	for _, userRoomID := range allUserRooms {
+		for _, senderRoomID := range senderRooms.RoomIDs {
+			if userRoomID == senderRoomID {
+				commonRooms = append(commonRooms, senderRoomID)
+			}
+		}
+	}
+
+	if len(commonRooms) > 1 {
+		return util.ErrorResponse(fmt.Errorf("expected to find one room, but got %d", len(commonRooms)))
+	}
+
+	var (
+		roomID      string
+		roomVersion = gomatrixserverlib.RoomVersionV6
+	)
+
+	adminDevice, err := getSenderDevice(ctx, userAPI, cfgClient)
+	if err != nil {
+		logrus.WithError(err).Error("unable to get device")
+		return util.ErrorResponse(err)
+	}
+	// create a new room for the user
+	if len(commonRooms) == 0 {
+		powerLevelContent := eventutil.InitialPowerLevelsContent(senderUserID)
+		powerLevelContent.Users[r.UserID] = -10
+		pl, err := json.Marshal(powerLevelContent)
+		if err != nil {
+			return util.ErrorResponse(err)
+		}
+		createContent := map[string]interface{}{}
+		createContent["m.federate"] = false
+		cc, err := json.Marshal(createContent)
+		if err != nil {
+			return util.ErrorResponse(err)
+		}
+		crReq := createRoomRequest{
+			Invite:                    []string{r.UserID},
+			Name:                      cfgNotices.RoomName,
+			Visibility:                "private",
+			Preset:                    presetPrivateChat,
+			CreationContent:           cc,
+			GuestCanJoin:              false,
+			RoomVersion:               roomVersion,
+			PowerLevelContentOverride: pl,
+		}
+
+		roomRes := createRoom(ctx, crReq, adminDevice, cfgClient, accountsDB, rsAPI, asAPI, time.Now())
+
+		switch data := roomRes.JSON.(type) {
+		case createRoomResponse:
+			roomID = data.RoomID
+
+			// tag the room, so we can later check if the user tries to reject an invite
+			serverAlertTag := gomatrix.TagContent{Tags: map[string]gomatrix.TagProperties{
+				"m.server_notice": {
+					Order: 1.0,
+				},
+			}}
+			if err = saveTagData(req, r.UserID, roomID, userAPI, serverAlertTag); err != nil {
+				util.GetLogger(req.Context()).WithError(err).Error("saveTagData failed")
+				return jsonerror.InternalServerError()
+			}
+
+		default:
+			return roomRes
+		}
+
+	} else {
+		roomID = commonRooms[0]
+	}
+
+	startedGeneratingEvent := time.Now()
+
+	request := map[string]interface{}{
+		"body":    r.Content.Body,
+		"msgtype": r.Content.MsgType,
+	}
+	e, resErr := generateSendEvent(ctx, request, adminDevice, roomID, "m.room.message", nil, cfgClient, rsAPI, time.Now())
+	if resErr != nil {
+		logrus.Errorf("failed to send message: %+v", resErr)
+		return *resErr
+	}
+	timeToGenerateEvent := time.Since(startedGeneratingEvent)
+
+	var txnAndSessionID *api.TransactionID
+	if txnID != nil {
+		txnAndSessionID = &api.TransactionID{
+			TransactionID: *txnID,
+			SessionID:     device.SessionID,
+		}
+	}
+
+	// pass the new event to the roomserver and receive the correct event ID
+	// event ID in case of duplicate transaction is discarded
+	startedSubmittingEvent := time.Now()
+	if err := api.SendEvents(
+		ctx, rsAPI,
+		api.KindNew,
+		[]*gomatrixserverlib.HeaderedEvent{
+			e.Headered(roomVersion),
+		},
+		cfgClient.Matrix.ServerName,
+		cfgClient.Matrix.ServerName,
+		txnAndSessionID,
+		false,
+	); err != nil {
+		util.GetLogger(ctx).WithError(err).Error("SendEvents failed")
+		return jsonerror.InternalServerError()
+	}
+	util.GetLogger(req.Context()).WithFields(logrus.Fields{
+		"event_id":     e.EventID(),
+		"room_id":      roomID,
+		"room_version": roomVersion,
+	}).Info("Sent event to roomserver")
+	timeToSubmitEvent := time.Since(startedSubmittingEvent)
+
+	res := util.JSONResponse{
+		Code: http.StatusOK,
+		JSON: sendEventResponse{e.EventID()},
+	}
+	// Add response to transactionsCache
+	if txnID != nil {
+		txnCache.AddTransaction(device.AccessToken, *txnID, &res)
+	}
+
+	// Take a note of how long it took to generate the event vs submit
+	// it to the roomserver.
+	sendEventDuration.With(prometheus.Labels{"action": "build"}).Observe(float64(timeToGenerateEvent.Milliseconds()))
+	sendEventDuration.With(prometheus.Labels{"action": "submit"}).Observe(float64(timeToSubmitEvent.Milliseconds()))
+
+	return res
+}
+
+func (r sendServerNoticeRequest) validate() (ok bool) {
+	if r.UserID == "" {
+		return false
+	}
+	if r.Content.MsgType == "" || r.Content.Body == "" {
+		return false
+	}
+	return true
+}
+
+// getSenderDevice creates a user account to be used when sending server notices.
+// It returns an userapi.Device, which is used for building the
+func getSenderDevice(ctx context.Context, userAPI userapi.UserInternalAPI, cfg *config.ClientAPI) (*userapi.Device, error) {
+	var accRes userapi.PerformAccountCreationResponse
+	// create account if it doesn't exist
+	err := userAPI.PerformAccountCreation(ctx, &userapi.PerformAccountCreationRequest{
+		AccountType: userapi.AccountTypeUser,
+		Localpart:   cfg.Matrix.ServerNotices.LocalPart,
+		OnConflict:  userapi.ConflictUpdate,
+	}, &accRes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if we got existing devices
+	deviceRes := &userapi.QueryDevicesResponse{}
+	err = userAPI.QueryDevices(ctx, &userapi.QueryDevicesRequest{
+		UserID: accRes.Account.UserID,
+	}, deviceRes)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(deviceRes.Devices) > 0 {
+		return &deviceRes.Devices[0], nil
+	}
+
+	// create an AccessToken
+	token, err := tokens.GenerateLoginToken(tokens.TokenOptions{
+		ServerPrivateKey: cfg.Matrix.PrivateKey.Seed(),
+		ServerName:       string(cfg.Matrix.ServerName),
+		UserID:           accRes.Account.UserID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// create a new device, if we didn't find any
+	var devRes userapi.PerformDeviceCreationResponse
+	err = userAPI.PerformDeviceCreation(ctx, &userapi.PerformDeviceCreationRequest{
+		Localpart:          cfg.Matrix.ServerNotices.LocalPart,
+		DeviceDisplayName:  &cfg.Matrix.ServerNotices.LocalPart,
+		AccessToken:        token,
+		NoDeviceListUpdate: true,
+	}, &devRes)
+
+	if err != nil {
+		return nil, err
+	}
+	return devRes.Device, nil
+}

--- a/clientapi/routing/server_notices.go
+++ b/clientapi/routing/server_notices.go
@@ -83,6 +83,14 @@ func SendServerNotice(
 		return *resErr
 	}
 
+	// check that all required fields are set
+	if !r.validate() {
+		return util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.BadJSON("Invalid request"),
+		}
+	}
+
 	// get rooms for specified user
 	allUserRooms := []string{}
 	userRooms := api.QueryRoomsForUserResponse{}

--- a/clientapi/routing/server_notices_test.go
+++ b/clientapi/routing/server_notices_test.go
@@ -1,0 +1,77 @@
+package routing
+
+import (
+	"testing"
+)
+
+func Test_sendServerNoticeRequest_validate(t *testing.T) {
+	type fields struct {
+		UserID  string `json:"user_id,omitempty"`
+		Content struct {
+			MsgType string `json:"msgtype,omitempty"`
+			Body    string `json:"body,omitempty"`
+		} `json:"content,omitempty"`
+		Type     string `json:"type,omitempty"`
+		StateKey string `json:"state_key,omitempty"`
+	}
+
+	content := struct {
+		MsgType string `json:"msgtype,omitempty"`
+		Body    string `json:"body,omitempty"`
+	}{
+		MsgType: "m.text",
+		Body:    "Hello world!",
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		wantOk bool
+	}{
+		{
+			name:   "empty request",
+			fields: fields{},
+		},
+		{
+			name: "msgtype empty",
+			fields: fields{
+				UserID: "@alice:localhost",
+			},
+		},
+		{
+			name: "msg body empty",
+			fields: fields{
+				UserID: "@alice:localhost",
+			},
+		},
+		{
+			name: "statekey empty",
+			fields: fields{
+				UserID:  "@alice:localhost",
+				Content: content,
+			},
+			wantOk: true,
+		},
+		{
+			name: "type empty",
+			fields: fields{
+				UserID:  "@alice:localhost",
+				Content: content,
+			},
+			wantOk: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := sendServerNoticeRequest{
+				UserID:   tt.fields.UserID,
+				Content:  tt.fields.Content,
+				Type:     tt.fields.Type,
+				StateKey: tt.fields.StateKey,
+			}
+			if gotOk := r.validate(); gotOk != tt.wantOk {
+				t.Errorf("validate() = %v, want %v", gotOk, tt.wantOk)
+			}
+		})
+	}
+}

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -132,6 +132,7 @@ func main() {
 	// dependency. Other components also need updating after their dependencies are up.
 	rsImpl.SetFederationAPI(fsAPI, keyRing)
 	rsImpl.SetAppserviceAPI(asAPI)
+	rsImpl.SetUserAPI(userAPI)
 	keyImpl.SetUserAPI(userAPI)
 
 	eduInputAPI := eduserver.NewInternalAPI(

--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -68,6 +68,17 @@ global:
   # to other servers and the federation API will not be exposed.
   disable_federation: false
 
+  # Server notices allows server admins to send messages to all users.
+  server_notices:
+    # The server localpart to be used when sending notices, ensure this is not yet take
+    local_part: "server"
+    # The displayname to be used when sending notices
+    display_name: "Server alerts"
+    # The avatar of this user
+    avatar: ""
+    # The roomname to be used when creating messages
+    room_name: "Server Alerts"
+
   # Configuration for NATS JetStream
   jetstream:
     # A list of NATS Server addresses to connect to. If none are specified, an

--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -70,6 +70,7 @@ global:
 
   # Server notices allows server admins to send messages to all users.
   server_notices:
+    enabled: false
     # The server localpart to be used when sending notices, ensure this is not yet take
     local_part: "server"
     # The displayname to be used when sending notices

--- a/roomserver/api/api.go
+++ b/roomserver/api/api.go
@@ -3,9 +3,11 @@ package api
 import (
 	"context"
 
+	"github.com/matrix-org/gomatrixserverlib"
+
 	asAPI "github.com/matrix-org/dendrite/appservice/api"
 	fsAPI "github.com/matrix-org/dendrite/federationapi/api"
-	"github.com/matrix-org/gomatrixserverlib"
+	userapi "github.com/matrix-org/dendrite/userapi/api"
 )
 
 // RoomserverInputAPI is used to write events to the room server.
@@ -14,6 +16,7 @@ type RoomserverInternalAPI interface {
 	// interdependencies between the roomserver and other input APIs
 	SetFederationAPI(fsAPI fsAPI.FederationInternalAPI, keyRing *gomatrixserverlib.KeyRing)
 	SetAppserviceAPI(asAPI asAPI.AppServiceQueryAPI)
+	SetUserAPI(userAPI userapi.UserInternalAPI)
 
 	InputRoomEvents(
 		ctx context.Context,

--- a/roomserver/api/api_trace.go
+++ b/roomserver/api/api_trace.go
@@ -5,10 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 
-	asAPI "github.com/matrix-org/dendrite/appservice/api"
-	fsAPI "github.com/matrix-org/dendrite/federationapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
+
+	asAPI "github.com/matrix-org/dendrite/appservice/api"
+	fsAPI "github.com/matrix-org/dendrite/federationapi/api"
+	userapi "github.com/matrix-org/dendrite/userapi/api"
 )
 
 // RoomserverInternalAPITrace wraps a RoomserverInternalAPI and logs the
@@ -23,6 +25,10 @@ func (t *RoomserverInternalAPITrace) SetFederationAPI(fsAPI fsAPI.FederationInte
 
 func (t *RoomserverInternalAPITrace) SetAppserviceAPI(asAPI asAPI.AppServiceQueryAPI) {
 	t.Impl.SetAppserviceAPI(asAPI)
+}
+
+func (t *RoomserverInternalAPITrace) SetUserAPI(userAPI userapi.UserInternalAPI) {
+	t.Impl.SetUserAPI(userAPI)
 }
 
 func (t *RoomserverInternalAPITrace) InputRoomEvents(

--- a/roomserver/internal/api.go
+++ b/roomserver/internal/api.go
@@ -4,6 +4,10 @@ import (
 	"context"
 
 	"github.com/getsentry/sentry-go"
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/nats-io/nats.go"
+	"github.com/sirupsen/logrus"
+
 	asAPI "github.com/matrix-org/dendrite/appservice/api"
 	fsAPI "github.com/matrix-org/dendrite/federationapi/api"
 	"github.com/matrix-org/dendrite/internal/caching"
@@ -14,9 +18,7 @@ import (
 	"github.com/matrix-org/dendrite/roomserver/internal/query"
 	"github.com/matrix-org/dendrite/roomserver/storage"
 	"github.com/matrix-org/dendrite/setup/config"
-	"github.com/matrix-org/gomatrixserverlib"
-	"github.com/nats-io/nats.go"
-	"github.com/sirupsen/logrus"
+	userapi "github.com/matrix-org/dendrite/userapi/api"
 )
 
 // RoomserverInternalAPI is an implementation of api.RoomserverInternalAPI
@@ -153,6 +155,10 @@ func (r *RoomserverInternalAPI) SetFederationAPI(fsAPI fsAPI.FederationInternalA
 	if err := r.Inputer.Start(); err != nil {
 		logrus.WithError(err).Panic("failed to start roomserver input API")
 	}
+}
+
+func (r *RoomserverInternalAPI) SetUserAPI(userAPI userapi.UserInternalAPI) {
+	r.Leaver.UserAPI = userAPI
 }
 
 func (r *RoomserverInternalAPI) SetAppserviceAPI(asAPI asAPI.AppServiceQueryAPI) {

--- a/roomserver/internal/perform/perform_leave.go
+++ b/roomserver/internal/perform/perform_leave.go
@@ -16,8 +16,14 @@ package perform
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
+
+	"github.com/matrix-org/gomatrix"
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/util"
+	"github.com/sirupsen/logrus"
 
 	fsAPI "github.com/matrix-org/dendrite/federationapi/api"
 	"github.com/matrix-org/dendrite/roomserver/api"
@@ -25,16 +31,14 @@ import (
 	"github.com/matrix-org/dendrite/roomserver/internal/input"
 	"github.com/matrix-org/dendrite/roomserver/storage"
 	"github.com/matrix-org/dendrite/setup/config"
-	"github.com/matrix-org/gomatrixserverlib"
-	"github.com/matrix-org/util"
-	"github.com/sirupsen/logrus"
+	userapi "github.com/matrix-org/dendrite/userapi/api"
 )
 
 type Leaver struct {
-	Cfg   *config.RoomServer
-	DB    storage.Database
-	FSAPI fsAPI.FederationInternalAPI
-
+	Cfg     *config.RoomServer
+	DB      storage.Database
+	FSAPI   fsAPI.FederationInternalAPI
+	UserAPI userapi.UserInternalAPI
 	Inputer *input.Inputer
 }
 
@@ -85,6 +89,27 @@ func (r *Leaver) performLeaveRoomByID(
 		if host != r.Cfg.Matrix.ServerName {
 			return r.performFederatedRejectInvite(ctx, req, res, senderUser, eventID)
 		}
+		// check that this is not a "server notice room"
+		accData := &userapi.QueryAccountDataResponse{}
+		if err := r.UserAPI.QueryAccountData(ctx, &userapi.QueryAccountDataRequest{
+			UserID:   req.UserID,
+			RoomID:   req.RoomID,
+			DataType: "m.tag",
+		}, accData); err != nil {
+			return nil, fmt.Errorf("unable to query account data")
+		}
+		roomData := accData.RoomAccountData[req.RoomID]
+		tagData, ok := roomData["m.tag"]
+		if ok {
+			tags := gomatrix.TagContent{}
+			if err = json.Unmarshal(tagData, &tags); err != nil {
+				return nil, fmt.Errorf("unable to unmarshal tag content")
+			}
+			if _, ok = tags.Tags["m.server_notice"]; ok {
+				return nil, fmt.Errorf("Unable to reject server notice invite")
+			}
+		}
+
 	}
 
 	// There's no invite pending, so first of all we want to find out

--- a/roomserver/inthttp/client.go
+++ b/roomserver/inthttp/client.go
@@ -11,6 +11,8 @@ import (
 	"github.com/matrix-org/dendrite/internal/caching"
 	"github.com/matrix-org/dendrite/internal/httputil"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	userapi "github.com/matrix-org/dendrite/userapi/api"
+
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/opentracing/opentracing-go"
 )
@@ -89,6 +91,10 @@ func (h *httpRoomserverInternalAPI) SetFederationAPI(fsAPI fsInputAPI.Federation
 
 // SetAppserviceAPI no-ops in HTTP client mode as there is no chicken/egg scenario
 func (h *httpRoomserverInternalAPI) SetAppserviceAPI(asAPI asAPI.AppServiceQueryAPI) {
+}
+
+// SetUserAPI no-ops in HTTP client mode as there is no chicken/egg scenario
+func (h *httpRoomserverInternalAPI) SetUserAPI(userAPI userapi.UserInternalAPI) {
 }
 
 // SetRoomAlias implements RoomserverAliasAPI

--- a/setup/config/config_global.go
+++ b/setup/config/config_global.go
@@ -129,6 +129,7 @@ func (c *Metrics) Verify(configErrs *ConfigErrors, isMonolith bool) {
 
 // ServerNotices defines the configuration used for sending server notices
 type ServerNotices struct {
+	Enabled bool `yaml:"enabled"`
 	// The localpart to be used when sending notices
 	LocalPart string `yaml:"local_part"`
 	// The displayname to be used when sending notices

--- a/setup/config/config_global.go
+++ b/setup/config/config_global.go
@@ -57,6 +57,9 @@ type Global struct {
 
 	// DNS caching options for all outbound HTTP requests
 	DNSCache DNSCacheOptions `yaml:"dns_cache"`
+
+	// ServerNotices configuration used for sending server notices
+	ServerNotices ServerNotices `yaml:"server_notices"`
 }
 
 func (c *Global) Defaults(generate bool) {
@@ -82,6 +85,7 @@ func (c *Global) Verify(configErrs *ConfigErrors, isMonolith bool) {
 	c.Metrics.Verify(configErrs, isMonolith)
 	c.Sentry.Verify(configErrs, isMonolith)
 	c.DNSCache.Verify(configErrs, isMonolith)
+	c.ServerNotices.Verify(configErrs, isMonolith)
 }
 
 type OldVerifyKeys struct {
@@ -122,6 +126,29 @@ func (c *Metrics) Defaults(generate bool) {
 
 func (c *Metrics) Verify(configErrs *ConfigErrors, isMonolith bool) {
 }
+
+// ServerNotices defines the configuration used for sending server notices
+type ServerNotices struct {
+	// The localpart to be used when sending notices
+	LocalPart string `yaml:"local_part"`
+	// The displayname to be used when sending notices
+	DisplayName string `yaml:"display_name"`
+	// The avatar of this user
+	Avatar string `yaml:"avatar"`
+	// The roomname to be used when creating messages
+	RoomName string `yaml:"room_name"`
+}
+
+func (c *ServerNotices) Defaults(generate bool) {
+	if generate {
+		c.LocalPart = "server"
+		c.DisplayName = "Server Alert"
+		c.RoomName = "Server Alert"
+		c.Avatar = ""
+	}
+}
+
+func (c *ServerNotices) Verify(errors *ConfigErrors, isMonolith bool) {}
 
 // The configuration to use for Sentry error reporting
 type Sentry struct {

--- a/setup/config/config_test.go
+++ b/setup/config/config_test.go
@@ -58,6 +58,11 @@ global:
     basic_auth:
       username: metrics
       password: metrics
+  server_notices:
+    local_part: "server"
+    display_name: "Server alerts"
+    avatar: ""
+    room_name: "Server Alerts"	
 app_service_api:
   internal_api:
     listen: http://localhost:7777


### PR DESCRIPTION
This adds the unspecced server notices.
Synapse Docs:
[admin api server_notices.md](https://github.com/matrix-org/synapse/blob/b65acead428653b988351ae8d7b22127a22039cd/docs/admin_api/server_notices.md) (for the request)
[server_notices](https://github.com/matrix-org/synapse/blob/b65acead428653b988351ae8d7b22127a22039cd/docs/server_notices.md) (for server side implementation details)

> When the user is first sent a server notice, they will get an invitation to a room (typically called 'Server Notices', though this is configurable in homeserver.yaml). They will be unable to reject this invitation - attempts to do so will receive an error.
> 
> Once they accept the invitation, they will see the notice message in the room history; it will appear to have come from the 'server notices user' (see below).
> 
> The user is prevented from sending any messages in this room by the power levels.
> 
> Having joined the room, the user can leave the room if they want. Subsequent server notices will then cause a new room to be created.

Due to not having the history visibility yet, a message is sent, but the user can't see it. :/