### PR TITLE
Don't panic on retiring an invite that we haven't seen yet

### DIFF
--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -16,6 +16,7 @@ package consumers
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 
@@ -307,7 +308,9 @@ func (s *OutputRoomEventConsumer) onRetireInviteEvent(
 	ctx context.Context, msg api.OutputRetireInviteEvent,
 ) {
 	pduPos, err := s.db.RetireInviteEvent(ctx, msg.EventID)
-	if err != nil {
+	// It's possible we just haven't heard of this invite yet, so
+	// we should not panic if we try to retire it.
+	if err != nil && err != sql.ErrNoRows {
 		sentry.CaptureException(err)
 		// panic rather than continue with an inconsistent database
 		log.WithFields(log.Fields{


### PR DESCRIPTION
This fixes a panic that can happen if the roomserver notifies us to retire an invite that the sync API hasn't seen yet.