### PR TITLE
Make `Device list doesn't change if remote server is down` happy

### DIFF
--- a/keyserver/internal/internal.go
+++ b/keyserver/internal/internal.go
@@ -513,6 +513,11 @@ func (a *KeyInternalAPI) queryRemoteKeysOnServer(
 		// drop the error as it's already a failure at this point
 		_ = a.populateResponseWithDeviceKeysFromDatabase(ctx, res, userID, dkeys)
 	}
+
+	// Sytest expects no failures, if we still could retrieve keys, e.g. from local cache
+	if len(res.DeviceKeys) > 0 {
+		delete(res.Failures, serverName)
+	}
 	respMu.Unlock()
 
 }


### PR DESCRIPTION
This will make `Device list doesn't change if remote server is down` pass, once https://github.com/matrix-org/sytest/pull/1188 is merged.