### PR TITLE
Remove outbound proxy

### DIFF
--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -204,13 +204,6 @@ federation_api:
   # enable this option in production as it presents a security risk!
   disable_tls_validation: false
 
-  # Use the following proxy server for outbound federation traffic.
-  proxy_outbound:
-    enabled: false
-    protocol: http
-    host: localhost
-    port: 8080
-
   # Perspective keyservers to use as a backup when direct key fetches fail. This may
   # be required to satisfy key requests for servers that are no longer online when
   # joining some rooms.

--- a/setup/config/config_federationapi.go
+++ b/setup/config/config_federationapi.go
@@ -29,8 +29,6 @@ type FederationAPI struct {
 	// on remote federation endpoints. This is not recommended in production!
 	DisableTLSValidation bool `yaml:"disable_tls_validation"`
 
-	Proxy Proxy `yaml:"proxy_outbound"`
-
 	// Perspective keyservers, to use as a backup when direct key fetch
 	// requests don't succeed
 	KeyPerspectives KeyPerspectives `yaml:"key_perspectives"`
@@ -50,8 +48,6 @@ func (c *FederationAPI) Defaults(generate bool) {
 
 	c.FederationMaxRetries = 16
 	c.DisableTLSValidation = false
-
-	c.Proxy.Defaults()
 }
 
 func (c *FederationAPI) Verify(configErrs *ConfigErrors, isMonolith bool) {

--- a/setup/config/config_test.go
+++ b/setup/config/config_test.go
@@ -118,11 +118,6 @@ federation_sender:
     conn_max_lifetime: -1
   send_max_retries: 16
   disable_tls_validation: false
-  proxy_outbound:
-    enabled: false
-    protocol: http
-    host: localhost
-    port: 8080
 key_server:
   internal_api:
     listen: http://localhost:7779


### PR DESCRIPTION
As of https://github.com/matrix-org/gomatrixserverlib/pull/289, the default of `http.ProxyFromEnvironment` is used.
Solves: https://github.com/matrix-org/dendrite/issues/2183