### PR TITLE
Raise waitTime for the DeviceListUpdater on failure

### DIFF
--- a/keyserver/internal/device_list_update.go
+++ b/keyserver/internal/device_list_update.go
@@ -367,6 +367,9 @@ func (u *DeviceListUpdater) processServer(serverName gomatrixserverlib.ServerNam
 					waitTime = fcerr.RetryAfter
 				} else if fcerr.Blacklisted {
 					waitTime = time.Hour * 8
+				} else {
+					// For all other errors (DNS resolution, network etc.) wait 1 hour.
+					waitTime = time.Hour
 				}
 			} else {
 				waitTime = time.Hour


### PR DESCRIPTION
Raises the `waitTime` for network related failures, otherwise you could get spammed with `failed to query device keys for some users` since the `waitTime` is set to 2 seconds.