### PR TITLE
Fix potential panic in `NewStreamTokenFromString` caused by off-by-one error

### DIFF
--- a/syncapi/types/types.go
+++ b/syncapi/types/types.go
@@ -279,7 +279,7 @@ func NewStreamTokenFromString(tok string) (token StreamingToken, err error) {
 	parts := strings.Split(tok[1:], "_")
 	var positions [7]StreamPosition
 	for i, p := range parts {
-		if i > len(positions) {
+		if i >= len(positions) {
 			break
 		}
 		var pos int


### PR DESCRIPTION
Line `positions[i] = StreamPosition(pos)` could panic when `i == len(positions)`.