### PR TITLE
Allow preventing guest registration

### DIFF
--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -532,6 +532,13 @@ func handleGuestRegistration(
 	cfg *config.ClientAPI,
 	userAPI userapi.UserInternalAPI,
 ) util.JSONResponse {
+	if cfg.RegistrationDisabled || cfg.GuestsDisabled {
+		return util.JSONResponse{
+			Code: http.StatusForbidden,
+			JSON: jsonerror.Forbidden("Guest registration is disabled"),
+		}
+	}
+
 	var res userapi.PerformAccountCreationResponse
 	err := userAPI.PerformAccountCreation(req.Context(), &userapi.PerformAccountCreationRequest{
 		AccountType: userapi.AccountTypeGuest,

--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -142,6 +142,10 @@ client_api:
   # using the registration shared secret below.
   registration_disabled: false
 
+  # Prevents new guest accounts from being created. Guest registration is also
+  # disabled implicitly by setting 'registration_disabled' above.
+  guests_disabled: false
+
   # If set, allows registration by anyone who knows the shared secret, regardless of
   # whether registration is otherwise disabled.
   registration_shared_secret: ""

--- a/dendrite-config.yaml
+++ b/dendrite-config.yaml
@@ -144,7 +144,7 @@ client_api:
 
   # Prevents new guest accounts from being created. Guest registration is also
   # disabled implicitly by setting 'registration_disabled' above.
-  guests_disabled: false
+  guests_disabled: true
 
   # If set, allows registration by anyone who knows the shared secret, regardless of
   # whether registration is otherwise disabled.

--- a/setup/config/config_clientapi.go
+++ b/setup/config/config_clientapi.go
@@ -18,6 +18,10 @@ type ClientAPI struct {
 	// If set, allows registration by anyone who also has the shared
 	// secret, even if registration is otherwise disabled.
 	RegistrationSharedSecret string `yaml:"registration_shared_secret"`
+	// If set, prevents guest accounts from being created. Only takes
+	// effect if registration is enabled, otherwise guests registration
+	// is forbidden either way.
+	GuestsDisabled bool `yaml:"guests_disabled"`
 
 	// Boolean stating whether catpcha registration is enabled
 	// and required


### PR DESCRIPTION
This PR adds the new config option `guests_disabled` in the client API and also ensures that guests can't be created if `registration_disabled` is set too.