### PR TITLE
Remove event type and state key caches

### DIFF
--- a/internal/caching/cache_roomservernids.go
+++ b/internal/caching/cache_roomservernids.go
@@ -7,14 +7,6 @@ import (
 )
 
 const (
-	RoomServerStateKeyNIDsCacheName       = "roomserver_statekey_nids"
-	RoomServerStateKeyNIDsCacheMaxEntries = 1024
-	RoomServerStateKeyNIDsCacheMutable    = false
-
-	RoomServerEventTypeNIDsCacheName       = "roomserver_eventtype_nids"
-	RoomServerEventTypeNIDsCacheMaxEntries = 64
-	RoomServerEventTypeNIDsCacheMutable    = false
-
 	RoomServerRoomIDsCacheName       = "roomserver_room_ids"
 	RoomServerRoomIDsCacheMaxEntries = 1024
 	RoomServerRoomIDsCacheMutable    = false
@@ -29,42 +21,8 @@ type RoomServerCaches interface {
 // RoomServerNIDsCache contains the subset of functions needed for
 // a roomserver NID cache.
 type RoomServerNIDsCache interface {
-	GetRoomServerStateKeyNID(stateKey string) (types.EventStateKeyNID, bool)
-	StoreRoomServerStateKeyNID(stateKey string, nid types.EventStateKeyNID)
-
-	GetRoomServerEventTypeNID(eventType string) (types.EventTypeNID, bool)
-	StoreRoomServerEventTypeNID(eventType string, nid types.EventTypeNID)
-
 	GetRoomServerRoomID(roomNID types.RoomNID) (string, bool)
 	StoreRoomServerRoomID(roomNID types.RoomNID, roomID string)
-}
-
-func (c Caches) GetRoomServerStateKeyNID(stateKey string) (types.EventStateKeyNID, bool) {
-	val, found := c.RoomServerStateKeyNIDs.Get(stateKey)
-	if found && val != nil {
-		if stateKeyNID, ok := val.(types.EventStateKeyNID); ok {
-			return stateKeyNID, true
-		}
-	}
-	return 0, false
-}
-
-func (c Caches) StoreRoomServerStateKeyNID(stateKey string, nid types.EventStateKeyNID) {
-	c.RoomServerStateKeyNIDs.Set(stateKey, nid)
-}
-
-func (c Caches) GetRoomServerEventTypeNID(eventType string) (types.EventTypeNID, bool) {
-	val, found := c.RoomServerEventTypeNIDs.Get(eventType)
-	if found && val != nil {
-		if eventTypeNID, ok := val.(types.EventTypeNID); ok {
-			return eventTypeNID, true
-		}
-	}
-	return 0, false
-}
-
-func (c Caches) StoreRoomServerEventTypeNID(eventType string, nid types.EventTypeNID) {
-	c.RoomServerEventTypeNIDs.Set(eventType, nid)
 }
 
 func (c Caches) GetRoomServerRoomID(roomNID types.RoomNID) (string, bool) {

--- a/internal/caching/caches.go
+++ b/internal/caching/caches.go
@@ -4,14 +4,12 @@ package caching
 // different implementations as long as they satisfy the Cache
 // interface.
 type Caches struct {
-	RoomVersions            Cache // RoomVersionCache
-	ServerKeys              Cache // ServerKeyCache
-	RoomServerStateKeyNIDs  Cache // RoomServerNIDsCache
-	RoomServerEventTypeNIDs Cache // RoomServerNIDsCache
-	RoomServerRoomNIDs      Cache // RoomServerNIDsCache
-	RoomServerRoomIDs       Cache // RoomServerNIDsCache
-	RoomInfos               Cache // RoomInfoCache
-	FederationEvents        Cache // FederationEventsCache
+	RoomVersions       Cache // RoomVersionCache
+	ServerKeys         Cache // ServerKeyCache
+	RoomServerRoomNIDs Cache // RoomServerNIDsCache
+	RoomServerRoomIDs  Cache // RoomServerNIDsCache
+	RoomInfos          Cache // RoomInfoCache
+	FederationEvents   Cache // FederationEventsCache
 }
 
 // Cache is the interface that an implementation must satisfy.

--- a/internal/caching/impl_inmemorylru.go
+++ b/internal/caching/impl_inmemorylru.go
@@ -28,24 +28,6 @@ func NewInMemoryLRUCache(enablePrometheus bool) (*Caches, error) {
 	if err != nil {
 		return nil, err
 	}
-	roomServerStateKeyNIDs, err := NewInMemoryLRUCachePartition(
-		RoomServerStateKeyNIDsCacheName,
-		RoomServerStateKeyNIDsCacheMutable,
-		RoomServerStateKeyNIDsCacheMaxEntries,
-		enablePrometheus,
-	)
-	if err != nil {
-		return nil, err
-	}
-	roomServerEventTypeNIDs, err := NewInMemoryLRUCachePartition(
-		RoomServerEventTypeNIDsCacheName,
-		RoomServerEventTypeNIDsCacheMutable,
-		RoomServerEventTypeNIDsCacheMaxEntries,
-		enablePrometheus,
-	)
-	if err != nil {
-		return nil, err
-	}
 	roomServerRoomIDs, err := NewInMemoryLRUCachePartition(
 		RoomServerRoomIDsCacheName,
 		RoomServerRoomIDsCacheMutable,
@@ -74,18 +56,15 @@ func NewInMemoryLRUCache(enablePrometheus bool) (*Caches, error) {
 		return nil, err
 	}
 	go cacheCleaner(
-		roomVersions, serverKeys, roomServerStateKeyNIDs,
-		roomServerEventTypeNIDs, roomServerRoomIDs,
+		roomVersions, serverKeys, roomServerRoomIDs,
 		roomInfos, federationEvents,
 	)
 	return &Caches{
-		RoomVersions:            roomVersions,
-		ServerKeys:              serverKeys,
-		RoomServerStateKeyNIDs:  roomServerStateKeyNIDs,
-		RoomServerEventTypeNIDs: roomServerEventTypeNIDs,
-		RoomServerRoomIDs:       roomServerRoomIDs,
-		RoomInfos:               roomInfos,
-		FederationEvents:        federationEvents,
+		RoomVersions:      roomVersions,
+		ServerKeys:        serverKeys,
+		RoomServerRoomIDs: roomServerRoomIDs,
+		RoomInfos:         roomInfos,
+		FederationEvents:  federationEvents,
 	}, nil
 }
 

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -731,9 +731,6 @@ func (d *Database) assignEventTypeNID(
 			eventTypeNID, err = d.EventTypesTable.SelectEventTypeNID(ctx, txn, eventType)
 		}
 	}
-	if err == nil {
-		d.Cache.StoreRoomServerEventTypeNID(eventType, eventTypeNID)
-	}
 	return eventTypeNID, err
 }
 
@@ -752,9 +749,6 @@ func (d *Database) assignStateKeyNID(
 			// We raced with another insert so run the select again.
 			eventStateKeyNID, err = d.EventStateKeysTable.SelectEventStateKeyNID(ctx, txn, eventStateKey)
 		}
-	}
-	if err == nil {
-		d.Cache.StoreRoomServerStateKeyNID(eventStateKey, eventStateKeyNID)
 	}
 	return eventStateKeyNID, err
 }

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -59,23 +59,12 @@ func (d *Database) eventTypeNIDs(
 	ctx context.Context, txn *sql.Tx, eventTypes []string,
 ) (map[string]types.EventTypeNID, error) {
 	result := make(map[string]types.EventTypeNID)
-	remaining := []string{}
-	for _, eventType := range eventTypes {
-		if nid, ok := d.Cache.GetRoomServerEventTypeNID(eventType); ok {
-			result[eventType] = nid
-		} else {
-			remaining = append(remaining, eventType)
-		}
+	nids, err := d.EventTypesTable.BulkSelectEventTypeNID(ctx, txn, eventTypes)
+	if err != nil {
+		return nil, err
 	}
-	if len(remaining) > 0 {
-		nids, err := d.EventTypesTable.BulkSelectEventTypeNID(ctx, txn, remaining)
-		if err != nil {
-			return nil, err
-		}
-		for eventType, nid := range nids {
-			result[eventType] = nid
-			d.Cache.StoreRoomServerEventTypeNID(eventType, nid)
-		}
+	for eventType, nid := range nids {
+		result[eventType] = nid
 	}
 	return result, nil
 }
@@ -96,23 +85,12 @@ func (d *Database) eventStateKeyNIDs(
 	ctx context.Context, txn *sql.Tx, eventStateKeys []string,
 ) (map[string]types.EventStateKeyNID, error) {
 	result := make(map[string]types.EventStateKeyNID)
-	remaining := []string{}
-	for _, eventStateKey := range eventStateKeys {
-		if nid, ok := d.Cache.GetRoomServerStateKeyNID(eventStateKey); ok {
-			result[eventStateKey] = nid
-		} else {
-			remaining = append(remaining, eventStateKey)
-		}
+	nids, err := d.EventStateKeysTable.BulkSelectEventStateKeyNID(ctx, txn, eventStateKeys)
+	if err != nil {
+		return nil, err
 	}
-	if len(remaining) > 0 {
-		nids, err := d.EventStateKeysTable.BulkSelectEventStateKeyNID(ctx, txn, remaining)
-		if err != nil {
-			return nil, err
-		}
-		for eventStateKey, nid := range nids {
-			result[eventStateKey] = nid
-			d.Cache.StoreRoomServerStateKeyNID(eventStateKey, nid)
-		}
+	for eventStateKey, nid := range nids {
+		result[eventStateKey] = nid
 	}
 	return result, nil
 }
@@ -718,9 +696,6 @@ func (d *Database) assignRoomNID(
 func (d *Database) assignEventTypeNID(
 	ctx context.Context, txn *sql.Tx, eventType string,
 ) (types.EventTypeNID, error) {
-	if eventTypeNID, ok := d.Cache.GetRoomServerEventTypeNID(eventType); ok {
-		return eventTypeNID, nil
-	}
 	// Check if we already have a numeric ID in the database.
 	eventTypeNID, err := d.EventTypesTable.SelectEventTypeNID(ctx, txn, eventType)
 	if err == sql.ErrNoRows {
@@ -737,9 +712,6 @@ func (d *Database) assignEventTypeNID(
 func (d *Database) assignStateKeyNID(
 	ctx context.Context, txn *sql.Tx, eventStateKey string,
 ) (types.EventStateKeyNID, error) {
-	if eventStateKeyNID, ok := d.Cache.GetRoomServerStateKeyNID(eventStateKey); ok {
-		return eventStateKeyNID, nil
-	}
 	// Check if we already have a numeric ID in the database.
 	eventStateKeyNID, err := d.EventStateKeysTable.SelectEventStateKeyNID(ctx, txn, eventStateKey)
 	if err == sql.ErrNoRows {


### PR DESCRIPTION
These caches may create races if a transaction that assigns them is rolled back, and honestly, they don't seem to make any measurable difference to event processing time anyway.