### PR TITLE
Return `ErrRoomNoExists` if insufficient state is available for a `buildEvent` to succeed when joining a room

### DIFF
--- a/roomserver/storage/postgres/state_snapshot_table.go
+++ b/roomserver/storage/postgres/state_snapshot_table.go
@@ -134,7 +134,7 @@ func (s *stateSnapshotStatements) BulkSelectStateBlockNIDs(
 		return nil, err
 	}
 	if i != len(stateNIDs) {
-		return nil, fmt.Errorf("storage: state NIDs missing from the database (%d != %d)", i, len(stateNIDs))
+		return nil, types.MissingStateError(fmt.Sprintf("storage: state NIDs missing from the database (%d != %d)", i, len(stateNIDs)))
 	}
 	return results, nil
 }

--- a/roomserver/storage/sqlite3/state_snapshot_table.go
+++ b/roomserver/storage/sqlite3/state_snapshot_table.go
@@ -137,7 +137,7 @@ func (s *stateSnapshotStatements) BulkSelectStateBlockNIDs(
 		}
 	}
 	if i != len(stateNIDs) {
-		return nil, fmt.Errorf("storage: state NIDs missing from the database (%d != %d)", i, len(stateNIDs))
+		return nil, types.MissingStateError(fmt.Sprintf("storage: state NIDs missing from the database (%d != %d)", i, len(stateNIDs)))
 	}
 	return results, nil
 }

--- a/roomserver/types/types.go
+++ b/roomserver/types/types.go
@@ -213,6 +213,12 @@ type MissingEventError string
 
 func (e MissingEventError) Error() string { return string(e) }
 
+// A MissingStateError is an error that happened because the roomserver was
+// missing requested state snapshots from its databases.
+type MissingStateError string
+
+func (e MissingStateError) Error() string { return string(e) }
+
 // A RejectedError is returned when an event is stored as rejected. The error
 // contains the reason why.
 type RejectedError string


### PR DESCRIPTION
This may help cases like #2206, since it should prompt us to try a federated join again instead.