### PR TITLE
Only emit key change notifications from federation when changes are made

### DIFF
--- a/keyserver/internal/device_list_update.go
+++ b/keyserver/internal/device_list_update.go
@@ -242,9 +242,8 @@ func (u *DeviceListUpdater) update(ctx context.Context, event gomatrixserverlib.
 			},
 		}
 
-		// DeviceKeysJSON will side-effect modify this, so we create it
-		// separately to above os that DeviceKeys isn't pointer'd to the
-		// same place in both "keys" and "existingKeys"
+		// DeviceKeysJSON will side-effect modify this, so it needs
+		// to be a copy, not sharing any pointers with the above.
 		deviceKeysCopy := *keys[0].DeviceKeys
 		existingKeys := []api.DeviceMessage{
 			{

--- a/keyserver/internal/device_list_update.go
+++ b/keyserver/internal/device_list_update.go
@@ -245,6 +245,7 @@ func (u *DeviceListUpdater) update(ctx context.Context, event gomatrixserverlib.
 		// DeviceKeysJSON will side-effect modify this, so it needs
 		// to be a copy, not sharing any pointers with the above.
 		deviceKeysCopy := *keys[0].DeviceKeys
+		deviceKeysCopy.KeyJSON = nil
 		existingKeys := []api.DeviceMessage{
 			{
 				Type:       keys[0].Type,

--- a/keyserver/internal/device_list_update.go
+++ b/keyserver/internal/device_list_update.go
@@ -241,14 +241,33 @@ func (u *DeviceListUpdater) update(ctx context.Context, event gomatrixserverlib.
 				StreamID: event.StreamID,
 			},
 		}
+
+		// DeviceKeysJSON will side-effect modify this, so we create it
+		// separately to above os that DeviceKeys isn't pointer'd to the
+		// same place in both "keys" and "existingKeys"
+		deviceKeysCopy := *keys[0].DeviceKeys
+		existingKeys := []api.DeviceMessage{
+			{
+				Type:       keys[0].Type,
+				DeviceKeys: &deviceKeysCopy,
+				StreamID:   keys[0].StreamID,
+			},
+		}
+
+		// fetch what keys we had already and only emit changes
+		if err = u.db.DeviceKeysJSON(ctx, existingKeys); err != nil {
+			// non-fatal, log and continue
+			util.GetLogger(ctx).WithError(err).WithField("user_id", event.UserID).Errorf(
+				"failed to query device keys json for calculating diffs",
+			)
+		}
+
 		err = u.db.StoreRemoteDeviceKeys(ctx, keys, nil)
 		if err != nil {
 			return false, fmt.Errorf("failed to store remote device keys for %s (%s): %w", event.UserID, event.DeviceID, err)
 		}
-		// ALWAYS emit key changes when we've been poked over federation even if there's no change
-		// just in case this poke is important for something.
-		err = u.producer.ProduceKeyChanges(keys)
-		if err != nil {
+
+		if err = emitDeviceKeyChanges(u.producer, existingKeys, keys); err != nil {
 			return false, fmt.Errorf("failed to produce device key changes for %s (%s): %w", event.UserID, event.DeviceID, err)
 		}
 		return false, nil

--- a/keyserver/internal/internal.go
+++ b/keyserver/internal/internal.go
@@ -711,6 +711,9 @@ func (a *KeyInternalAPI) uploadOneTimeKeys(ctx context.Context, req *api.Perform
 }
 
 func emitDeviceKeyChanges(producer KeyChangeProducer, existing, new []api.DeviceMessage) error {
+	logrus.Warnf("XXX: Existing: %+v", existing)
+	logrus.Warnf("XXX: New: %+v", new)
+
 	// find keys in new that are not in existing
 	var keysAdded []api.DeviceMessage
 	for _, newKey := range new {

--- a/keyserver/internal/internal.go
+++ b/keyserver/internal/internal.go
@@ -711,9 +711,6 @@ func (a *KeyInternalAPI) uploadOneTimeKeys(ctx context.Context, req *api.Perform
 }
 
 func emitDeviceKeyChanges(producer KeyChangeProducer, existing, new []api.DeviceMessage) error {
-	logrus.Warnf("XXX: Existing: %+v", existing)
-	logrus.Warnf("XXX: New: %+v", new)
-
 	// find keys in new that are not in existing
 	var keysAdded []api.DeviceMessage
 	for _, newKey := range new {


### PR DESCRIPTION
Otherwise we can increment the stream positions for device lists for no-op updates, which notifies clients which all hit `/keys/query` which in turn hits federation even more.