### PR TITLE
Add `DeviceKeysEqual`

### DIFF
--- a/keyserver/api/api.go
+++ b/keyserver/api/api.go
@@ -15,8 +15,10 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -71,6 +73,22 @@ type DeviceMessage struct {
 	// A monotonically increasing number which represents device changes for this user.
 	StreamID       int
 	DeviceChangeID int64
+}
+
+func (m1 *DeviceMessage) DeviceKeysEqual(m2 *DeviceMessage) (bool, error) {
+	if m1.DeviceKeys == nil || m2.DeviceKeys == nil {
+		return false, fmt.Errorf("not device keys")
+	}
+	if m1.UserID != m2.UserID || m1.DeviceID != m2.DeviceID {
+		return false, fmt.Errorf("different user ID or device ID")
+	}
+	if len(m1.KeyJSON) == 0 || len(m2.KeyJSON) == 0 {
+		return false, nil
+	}
+	if m1.DisplayName != m2.DisplayName {
+		return false, nil
+	}
+	return bytes.Equal(m1.KeyJSON, m2.KeyJSON), nil
 }
 
 // DeviceKeys represents a set of device keys for a single device

--- a/keyserver/api/api.go
+++ b/keyserver/api/api.go
@@ -88,10 +88,7 @@ func (m1 *DeviceMessage) DeviceKeysEqual(m2 *DeviceMessage) (bool, error) {
 	if len(m1.KeyJSON) == 0 && len(m2.KeyJSON) == 0 {
 		return true, nil // both are empty
 	}
-	if len(m1.KeyJSON) == 0 || len(m2.KeyJSON) == 0 {
-		return false, nil // only one is empty
-	}
-	return bytes.Equal(m1.KeyJSON, m2.KeyJSON), nil
+	return bytes.Equal(m1.KeyJSON, m2.KeyJSON) && len(m1.KeyJSON) > 0, nil
 }
 
 // DeviceKeys represents a set of device keys for a single device

--- a/keyserver/api/api.go
+++ b/keyserver/api/api.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"strings"
 	"time"
 
@@ -75,20 +74,24 @@ type DeviceMessage struct {
 	DeviceChangeID int64
 }
 
-func (m1 *DeviceMessage) DeviceKeysEqual(m2 *DeviceMessage) (bool, error) {
+// DeviceKeysEqual returns true if the device keys updates contain the
+// same display name and key JSON. This will return false if either of
+// the updates is not a device keys update, or if the user ID/device ID
+// differ between the two.
+func (m1 *DeviceMessage) DeviceKeysEqual(m2 *DeviceMessage) bool {
 	if m1.DeviceKeys == nil || m2.DeviceKeys == nil {
-		return false, fmt.Errorf("not device keys")
+		return false
 	}
 	if m1.UserID != m2.UserID || m1.DeviceID != m2.DeviceID {
-		return false, fmt.Errorf("different user ID or device ID")
+		return false
 	}
 	if m1.DisplayName != m2.DisplayName {
-		return false, nil // different display names
+		return false // different display names
 	}
 	if len(m1.KeyJSON) == 0 || len(m2.KeyJSON) == 0 {
-		return false, nil // either is empty
+		return false // either is empty
 	}
-	return bytes.Equal(m1.KeyJSON, m2.KeyJSON), nil
+	return bytes.Equal(m1.KeyJSON, m2.KeyJSON)
 }
 
 // DeviceKeys represents a set of device keys for a single device

--- a/keyserver/api/api.go
+++ b/keyserver/api/api.go
@@ -82,11 +82,14 @@ func (m1 *DeviceMessage) DeviceKeysEqual(m2 *DeviceMessage) (bool, error) {
 	if m1.UserID != m2.UserID || m1.DeviceID != m2.DeviceID {
 		return false, fmt.Errorf("different user ID or device ID")
 	}
-	if len(m1.KeyJSON) == 0 || len(m2.KeyJSON) == 0 {
-		return false, nil
-	}
 	if m1.DisplayName != m2.DisplayName {
-		return false, nil
+		return false, nil // different display names
+	}
+	if len(m1.KeyJSON) == 0 && len(m2.KeyJSON) == 0 {
+		return true, nil // both are empty
+	}
+	if len(m1.KeyJSON) == 0 || len(m2.KeyJSON) == 0 {
+		return false, nil // only one is empty
 	}
 	return bytes.Equal(m1.KeyJSON, m2.KeyJSON), nil
 }

--- a/keyserver/api/api.go
+++ b/keyserver/api/api.go
@@ -85,10 +85,10 @@ func (m1 *DeviceMessage) DeviceKeysEqual(m2 *DeviceMessage) (bool, error) {
 	if m1.DisplayName != m2.DisplayName {
 		return false, nil // different display names
 	}
-	if len(m1.KeyJSON) == 0 && len(m2.KeyJSON) == 0 {
-		return true, nil // both are empty
+	if len(m1.KeyJSON) == 0 || len(m2.KeyJSON) == 0 {
+		return false, nil // both are empty
 	}
-	return bytes.Equal(m1.KeyJSON, m2.KeyJSON) && len(m1.KeyJSON) > 0, nil
+	return bytes.Equal(m1.KeyJSON, m2.KeyJSON), nil
 }
 
 // DeviceKeys represents a set of device keys for a single device

--- a/keyserver/api/api.go
+++ b/keyserver/api/api.go
@@ -86,7 +86,7 @@ func (m1 *DeviceMessage) DeviceKeysEqual(m2 *DeviceMessage) (bool, error) {
 		return false, nil // different display names
 	}
 	if len(m1.KeyJSON) == 0 || len(m2.KeyJSON) == 0 {
-		return false, nil // both are empty
+		return false, nil // either is empty
 	}
 	return bytes.Equal(m1.KeyJSON, m2.KeyJSON), nil
 }

--- a/keyserver/internal/internal.go
+++ b/keyserver/internal/internal.go
@@ -718,8 +718,8 @@ func emitDeviceKeyChanges(producer KeyChangeProducer, existing, new []api.Device
 		for _, existingKey := range existing {
 			// Do not treat the absence of keys as equal, or else we will not emit key changes
 			// when users delete devices which never had a key to begin with as both KeyJSONs are nil.
-			// if bytes.Equal(existingKey.KeyJSON, newKey.KeyJSON) && len(existingKey.KeyJSON) > 0 {
 			if equal, err := existingKey.DeviceKeysEqual(&newKey); err != nil {
+				// One of the keys was not a DeviceKeys or the user ID/device ID did not match.
 				continue
 			} else if equal {
 				exists = true

--- a/keyserver/internal/internal.go
+++ b/keyserver/internal/internal.go
@@ -718,7 +718,10 @@ func emitDeviceKeyChanges(producer KeyChangeProducer, existing, new []api.Device
 		for _, existingKey := range existing {
 			// Do not treat the absence of keys as equal, or else we will not emit key changes
 			// when users delete devices which never had a key to begin with as both KeyJSONs are nil.
-			if bytes.Equal(existingKey.KeyJSON, newKey.KeyJSON) && len(existingKey.KeyJSON) > 0 {
+			// if bytes.Equal(existingKey.KeyJSON, newKey.KeyJSON) && len(existingKey.KeyJSON) > 0 {
+			if equal, err := existingKey.DeviceKeysEqual(&newKey); err != nil {
+				continue
+			} else if equal {
 				exists = true
 				break
 			}

--- a/keyserver/internal/internal.go
+++ b/keyserver/internal/internal.go
@@ -718,10 +718,7 @@ func emitDeviceKeyChanges(producer KeyChangeProducer, existing, new []api.Device
 		for _, existingKey := range existing {
 			// Do not treat the absence of keys as equal, or else we will not emit key changes
 			// when users delete devices which never had a key to begin with as both KeyJSONs are nil.
-			if equal, err := existingKey.DeviceKeysEqual(&newKey); err != nil {
-				// One of the keys was not a DeviceKeys or the user ID/device ID did not match.
-				continue
-			} else if equal {
+			if existingKey.DeviceKeysEqual(&newKey) {
 				exists = true
 				break
 			}


### PR DESCRIPTION
This just makes it a bit clearer for working out when we should be emitting device list updates via output key change events.