### PR TITLE
Set powerlevel.invite to 0, if `PowerLevelContentOverride` is empty

### DIFF
--- a/clientapi/routing/createroom.go
+++ b/clientapi/routing/createroom.go
@@ -227,6 +227,13 @@ func createRoom(
 		HistoryVisibility: historyVisibilityShared,
 	}
 
+	// NOTSPEC: The powerlevel for invite should be set to 50, according to the spec, but synapse sets it to 0 for invite.
+	// https://github.com/matrix-org/synapse/blob/6d14b3dabfe38c6ae487d0f663e294056b6cc056/synapse/handlers/room.py#L120-L133
+	isPrivateChat := r.Preset == presetPrivateChat || r.Preset == presetTrustedPrivateChat
+	if r.PowerLevelContentOverride == nil && isPrivateChat {
+		r.PowerLevelContentOverride = []byte(`{ "invite": 0 }`)
+	}
+
 	if r.PowerLevelContentOverride != nil {
 		// Merge powerLevelContentOverride fields by unmarshalling it atop the defaults
 		err = json.Unmarshal(r.PowerLevelContentOverride, &powerLevelContent)

--- a/sytest-blacklist
+++ b/sytest-blacklist
@@ -14,7 +14,6 @@ The only membership state included in a gapped incremental sync is for senders i
 # Blacklisted out of flakiness after #1479
 Invited user can reject local invite after originator leaves
 Invited user can reject invite for empty room
-If user leaves room, remote user changes device and rejoins we see update in /sync and /keys/changes
 
 # Blacklisted due to flakiness
 Forgotten room messages cannot be paginated

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -601,3 +601,4 @@ Can query remote device keys using POST after notification
 Device deletion propagates over federation
 Get left notifs in sync and /keys/changes when other user leaves
 Remote banned user is kicked and may not rejoin until unbanned
+If user leaves room, remote user changes device and rejoins we see update in /sync and /keys/changes


### PR DESCRIPTION
Synapse sets the default `powerlevel_content_override` to `{ "invite": 0 }` for `private_chat` and `trusted_private_chat`, but overwrites them when they are set by the user. ([source](https://github.com/matrix-org/synapse/blob/6d14b3dabfe38c6ae487d0f663e294056b6cc056/synapse/handlers/room.py#L120-L133))

This solves a timeout in Sytest when trying to invite to a room with the "wrong" powerlevel.invite of 50