### PR TITLE
State resolution v2 micro-optimisations

### DIFF
--- a/roomserver/state/state.go
+++ b/roomserver/state/state.go
@@ -814,6 +814,7 @@ func (v *StateResolution) resolveConflictsV2(
 	// events may be duplicated across these sets but that's OK.
 	authSets := make(map[string][]*gomatrixserverlib.Event, len(conflicted))
 	authEvents := make([]*gomatrixserverlib.Event, 0, estimate*3)
+	gotAuthEvents := make(map[string]struct{}, estimate*3)
 	authDifference := make([]*gomatrixserverlib.Event, 0, estimate)
 
 	// For each conflicted event, let's try and get the needed auth events.
@@ -850,8 +851,16 @@ func (v *StateResolution) resolveConflictsV2(
 		if err != nil {
 			return nil, err
 		}
-		authEvents = append(authEvents, authSets[key]...)
+		for _, event := range authSets[key] {
+			if _, ok := gotAuthEvents[event.EventID()]; !ok {
+				authEvents = append(authEvents, authSets[key]...)
+				gotAuthEvents[event.EventID()] = struct{}{}
+			}
+		}
 	}
+
+	// Let the GC get to this.
+	gotAuthEvents = nil // nolint:ineffassign
 
 	// This function helps us to work out whether an event exists in one of the
 	// auth sets.

--- a/roomserver/state/state.go
+++ b/roomserver/state/state.go
@@ -880,11 +880,12 @@ func (v *StateResolution) resolveConflictsV2(
 
 	// This function works out if an event exists in all of the auth sets.
 	isInAllAuthLists := func(event *gomatrixserverlib.Event) bool {
-		found := true
 		for k := range authSets {
-			found = found && isInAuthList(k, event)
+			if !isInAuthList(k, event) {
+				return false
+			}
 		}
-		return found
+		return true
 	}
 
 	// Look through all of the auth events that we've been given and work out if


### PR DESCRIPTION
This makes two minor tweaks that should help state resolution v2 performance slightly in big rooms:

* Only populate auth events once into the `authEvents` slice, which should:
  * reduce the number of iterations needed to calculate the auth difference
  * reduce the chance we'll outgrow the capacity bounds of the slice requiring a reallocation of the whole slice
  * avoid duplicate entries appearing in the auth difference which adds burden to the state res algorithm itself

* Refactors `isInAllAuthLists` to give up the moment we find an auth event that doesn't appear in all auth event lists rather than running unnecessary iterations