### PR TITLE
Fix read receipts

### DIFF
--- a/syncapi/storage/postgres/receipt_table.go
+++ b/syncapi/storage/postgres/receipt_table.go
@@ -96,7 +96,7 @@ func (r *receiptStatements) UpsertReceipt(ctx context.Context, txn *sql.Tx, room
 }
 
 func (r *receiptStatements) SelectRoomReceiptsAfter(ctx context.Context, roomIDs []string, streamPos types.StreamPosition) (types.StreamPosition, []api.OutputReceiptEvent, error) {
-	lastPos := streamPos
+	var lastPos types.StreamPosition
 	rows, err := r.selectRoomReceipts.QueryContext(ctx, pq.Array(roomIDs), streamPos)
 	if err != nil {
 		return 0, nil, fmt.Errorf("unable to query room receipts: %w", err)

--- a/syncapi/storage/sqlite3/receipt_table.go
+++ b/syncapi/storage/sqlite3/receipt_table.go
@@ -101,7 +101,7 @@ func (r *receiptStatements) UpsertReceipt(ctx context.Context, txn *sql.Tx, room
 // SelectRoomReceiptsAfter select all receipts for a given room after a specific timestamp
 func (r *receiptStatements) SelectRoomReceiptsAfter(ctx context.Context, roomIDs []string, streamPos types.StreamPosition) (types.StreamPosition, []api.OutputReceiptEvent, error) {
 	selectSQL := strings.Replace(selectRoomReceipts, "($2)", sqlutil.QueryVariadicOffset(len(roomIDs), 1), 1)
-	lastPos := streamPos
+	var lastPos types.StreamPosition
 	params := make([]interface{}, len(roomIDs)+1)
 	params[0] = streamPos
 	for k, v := range roomIDs {

--- a/syncapi/streams/stream_receipt.go
+++ b/syncapi/streams/stream_receipt.go
@@ -63,7 +63,6 @@ func (p *ReceiptStreamProvider) IncrementalSync(
 		if existing, ok := req.Response.Rooms.Join[roomID]; ok {
 			jr = existing
 		}
-		var ok bool
 
 		ev := gomatrixserverlib.ClientEvent{
 			Type:   gomatrixserverlib.MReceipt,
@@ -71,8 +70,8 @@ func (p *ReceiptStreamProvider) IncrementalSync(
 		}
 		content := make(map[string]eduAPI.ReceiptMRead)
 		for _, receipt := range receipts {
-			var read eduAPI.ReceiptMRead
-			if read, ok = content[receipt.EventID]; !ok {
+			read, ok := content[receipt.EventID]
+			if !ok {
 				read = eduAPI.ReceiptMRead{
 					User: make(map[string]eduAPI.ReceiptTS),
 				}


### PR DESCRIPTION
We were rewriting the `content` map with an empty value instead of reusing the previous one in some cases.

Also we should start with a `lastPos` of 0 so that it is easier to spot at the call site if there were no receipts in the range.