### PR TITLE
Return 404 if event given to `/context` was not found

### DIFF
--- a/syncapi/routing/context.go
+++ b/syncapi/routing/context.go
@@ -17,6 +17,7 @@ package routing
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -102,6 +103,12 @@ func Context(
 
 	id, requestedEvent, err := syncDB.SelectContextEvent(ctx, roomID, eventID)
 	if err != nil {
+		if err == sql.ErrNoRows {
+			return util.JSONResponse{
+				Code: http.StatusNotFound,
+				JSON: jsonerror.NotFound(fmt.Sprintf("Event %s not found", eventID)),
+			}
+		}
 		logrus.WithError(err).WithField("eventID", eventID).Error("unable to find requested event")
 		return jsonerror.InternalServerError()
 	}


### PR DESCRIPTION
Otherwise we return a 500 and that's sad-face.