### PR TITLE
Send profile updates asynchronously

### DIFF
--- a/clientapi/routing/profile.go
+++ b/clientapi/routing/profile.go
@@ -286,7 +286,7 @@ func SetDisplayName(
 		return jsonerror.InternalServerError()
 	}
 
-	if err := api.SendEvents(req.Context(), rsAPI, api.KindNew, events, cfg.Matrix.ServerName, cfg.Matrix.ServerName, nil, false); err != nil {
+	if err := api.SendEvents(req.Context(), rsAPI, api.KindNew, events, cfg.Matrix.ServerName, cfg.Matrix.ServerName, nil, true); err != nil {
 		util.GetLogger(req.Context()).WithError(err).Error("SendEvents failed")
 		return jsonerror.InternalServerError()
 	}


### PR DESCRIPTION
This sends profile updates to the roomserver asynchronously, so that display name and avatar updates don't block the client request forever.

Depends on matrix-org/sytest#1206.