### PR TITLE
Mark soft-failed events as rejected in `roomserver_events`

### DIFF
--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -294,7 +294,7 @@ func (r *Inputer) processRoomEvent(
 	}
 
 	// Store the event.
-	_, _, stateAtEvent, redactionEvent, redactedEventID, err := r.DB.StoreEvent(ctx, event, authEventNIDs, isRejected)
+	_, _, stateAtEvent, redactionEvent, redactedEventID, err := r.DB.StoreEvent(ctx, event, authEventNIDs, isRejected || softfail)
 	if err != nil {
 		return fmt.Errorf("updater.StoreEvent: %w", err)
 	}


### PR DESCRIPTION
... otherwise something later on might come along filtering on the `is_rejected` column and get soft-failed results unexpectedly.