### PR TITLE
Don't send `adds_state_events` in roomserver output events anymore

### DIFF
--- a/appservice/consumers/roomserver.go
+++ b/appservice/consumers/roomserver.go
@@ -87,12 +87,17 @@ func (s *OutputRoomEventConsumer) onMessage(ctx context.Context, msg *nats.Msg) 
 		return true
 	}
 
-	events, err := output.NewRoomEvent.AddsState(ctx, s.rsAPI)
-	if err != nil {
-		log.WithError(err).Errorf("roomserver output log: failed to get state events")
-		return false
+	events := []*gomatrixserverlib.HeaderedEvent{output.NewRoomEvent.Event}
+	if len(output.NewRoomEvent.AddsStateEventIDs) > 0 {
+		eventsReq := &api.QueryEventsByIDRequest{
+			EventIDs: output.NewRoomEvent.AddsStateEventIDs,
+		}
+		eventsRes := &api.QueryEventsByIDResponse{}
+		if err := s.rsAPI.QueryEventsByID(s.ctx, eventsReq, eventsRes); err != nil {
+			return false
+		}
+		events = append(events, eventsRes.Events...)
 	}
-	events = append(events, output.NewRoomEvent.Event)
 
 	// Send event to any relevant application services
 	if err := s.filterRoomserverEvents(context.TODO(), events); err != nil {

--- a/federationapi/consumers/roomserver.go
+++ b/federationapi/consumers/roomserver.go
@@ -146,7 +146,28 @@ func (s *OutputRoomEventConsumer) processInboundPeek(orp api.OutputNewInboundPee
 // processMessage updates the list of currently joined hosts in the room
 // and then sends the event to the hosts that were joined before the event.
 func (s *OutputRoomEventConsumer) processMessage(ore api.OutputNewRoomEvent) error {
-	addsJoinedHosts, err := joinedHostsFromEvents(gomatrixserverlib.UnwrapEventHeaders(ore.AddsState()))
+	eventsRes := &api.QueryEventsByIDResponse{}
+	if len(ore.AddsStateEventIDs) > 0 {
+		eventsReq := &api.QueryEventsByIDRequest{
+			EventIDs: ore.AddsStateEventIDs,
+		}
+		if err := s.rsAPI.QueryEventsByID(s.ctx, eventsReq, eventsRes); err != nil {
+			return fmt.Errorf("s.rsAPI.QueryEventsByID: %w", err)
+		}
+
+		found := false
+		for _, event := range eventsRes.Events {
+			if event.EventID() == ore.Event.EventID() {
+				found = true
+				break
+			}
+		}
+		if !found {
+			eventsRes.Events = append(eventsRes.Events, ore.Event)
+		}
+	}
+
+	addsJoinedHosts, err := joinedHostsFromEvents(gomatrixserverlib.UnwrapEventHeaders(eventsRes.Events))
 	if err != nil {
 		return err
 	}

--- a/federationapi/consumers/roomserver.go
+++ b/federationapi/consumers/roomserver.go
@@ -146,13 +146,28 @@ func (s *OutputRoomEventConsumer) processInboundPeek(orp api.OutputNewInboundPee
 // processMessage updates the list of currently joined hosts in the room
 // and then sends the event to the hosts that were joined before the event.
 func (s *OutputRoomEventConsumer) processMessage(ore api.OutputNewRoomEvent) error {
-	stateEvents, err := ore.AddsState(s.ctx, s.rsAPI)
-	if err != nil {
-		return fmt.Errorf("ore.AddsState: %w", err)
-	}
-	stateEvents = append(stateEvents, ore.Event)
+	eventsRes := &api.QueryEventsByIDResponse{}
+	if len(ore.AddsStateEventIDs) > 0 {
+		eventsReq := &api.QueryEventsByIDRequest{
+			EventIDs: ore.AddsStateEventIDs,
+		}
+		if err := s.rsAPI.QueryEventsByID(s.ctx, eventsReq, eventsRes); err != nil {
+			return fmt.Errorf("s.rsAPI.QueryEventsByID: %w", err)
+		}
 
-	addsJoinedHosts, err := joinedHostsFromEvents(gomatrixserverlib.UnwrapEventHeaders(stateEvents))
+		found := false
+		for _, event := range eventsRes.Events {
+			if event.EventID() == ore.Event.EventID() {
+				found = true
+				break
+			}
+		}
+		if !found {
+			eventsRes.Events = append(eventsRes.Events, ore.Event)
+		}
+	}
+
+	addsJoinedHosts, err := joinedHostsFromEvents(gomatrixserverlib.UnwrapEventHeaders(eventsRes.Events))
 	if err != nil {
 		return err
 	}

--- a/federationapi/consumers/roomserver.go
+++ b/federationapi/consumers/roomserver.go
@@ -146,28 +146,13 @@ func (s *OutputRoomEventConsumer) processInboundPeek(orp api.OutputNewInboundPee
 // processMessage updates the list of currently joined hosts in the room
 // and then sends the event to the hosts that were joined before the event.
 func (s *OutputRoomEventConsumer) processMessage(ore api.OutputNewRoomEvent) error {
-	eventsRes := &api.QueryEventsByIDResponse{}
-	if len(ore.AddsStateEventIDs) > 0 {
-		eventsReq := &api.QueryEventsByIDRequest{
-			EventIDs: ore.AddsStateEventIDs,
-		}
-		if err := s.rsAPI.QueryEventsByID(s.ctx, eventsReq, eventsRes); err != nil {
-			return fmt.Errorf("s.rsAPI.QueryEventsByID: %w", err)
-		}
-
-		found := false
-		for _, event := range eventsRes.Events {
-			if event.EventID() == ore.Event.EventID() {
-				found = true
-				break
-			}
-		}
-		if !found {
-			eventsRes.Events = append(eventsRes.Events, ore.Event)
-		}
+	stateEvents, err := ore.AddsState(s.ctx, s.rsAPI)
+	if err != nil {
+		return fmt.Errorf("ore.AddsState: %w", err)
 	}
+	stateEvents = append(stateEvents, ore.Event)
 
-	addsJoinedHosts, err := joinedHostsFromEvents(gomatrixserverlib.UnwrapEventHeaders(eventsRes.Events))
+	addsJoinedHosts, err := joinedHostsFromEvents(gomatrixserverlib.UnwrapEventHeaders(stateEvents))
 	if err != nil {
 		return err
 	}

--- a/roomserver/api/output.go
+++ b/roomserver/api/output.go
@@ -170,14 +170,16 @@ type OutputNewRoomEvent struct {
 // The slice returned contains the output room event itself in all cases.
 func (o *OutputNewRoomEvent) AddsState(ctx context.Context, rsAPI RoomserverInternalAPI) ([]*gomatrixserverlib.HeaderedEvent, error) {
 	events := make([]*gomatrixserverlib.HeaderedEvent, 0, len(o.AddsStateEventIDs))
-	eventsReq := &QueryEventsByIDRequest{
-		EventIDs: o.AddsStateEventIDs,
+	if len(o.AddsStateEventIDs) > 0 {
+		eventsReq := &QueryEventsByIDRequest{
+			EventIDs: o.AddsStateEventIDs,
+		}
+		eventsRes := &QueryEventsByIDResponse{}
+		if err := rsAPI.QueryEventsByID(ctx, eventsReq, eventsRes); err != nil {
+			return nil, fmt.Errorf("s.rsAPI.QueryEventsByID: %w", err)
+		}
+		events = append(events, eventsRes.Events...)
 	}
-	eventsRes := &QueryEventsByIDResponse{}
-	if err := rsAPI.QueryEventsByID(ctx, eventsReq, eventsRes); err != nil {
-		return nil, fmt.Errorf("s.rsAPI.QueryEventsByID: %w", err)
-	}
-	events = append(events, eventsRes.Events...)
 	return events, nil
 }
 

--- a/roomserver/api/output.go
+++ b/roomserver/api/output.go
@@ -15,9 +15,6 @@
 package api
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
@@ -164,21 +161,6 @@ type OutputNewRoomEvent struct {
 	// The transaction ID of the send request if sent by a local user and one
 	// was specified
 	TransactionID *TransactionID `json:"transaction_id,omitempty"`
-}
-
-// AddsState asks the roomserver API for events specified in `adds_state_event_ids`.
-// The slice returned contains the output room event itself in all cases.
-func (o *OutputNewRoomEvent) AddsState(ctx context.Context, rsAPI RoomserverInternalAPI) ([]*gomatrixserverlib.HeaderedEvent, error) {
-	events := make([]*gomatrixserverlib.HeaderedEvent, 0, len(o.AddsStateEventIDs))
-	eventsReq := &QueryEventsByIDRequest{
-		EventIDs: o.AddsStateEventIDs,
-	}
-	eventsRes := &QueryEventsByIDResponse{}
-	if err := rsAPI.QueryEventsByID(ctx, eventsReq, eventsRes); err != nil {
-		return nil, fmt.Errorf("s.rsAPI.QueryEventsByID: %w", err)
-	}
-	events = append(events, eventsRes.Events...)
-	return events, nil
 }
 
 // An OutputOldRoomEvent is written when the roomserver receives an old event.

--- a/roomserver/api/output.go
+++ b/roomserver/api/output.go
@@ -105,7 +105,7 @@ type OutputNewRoomEvent struct {
 	Event *gomatrixserverlib.HeaderedEvent `json:"event"`
 	// Does the event completely rewrite the room state? If so, then AddsStateEventIDs
 	// will contain the entire room state.
-	RewritesState bool `json:"rewrites_state"`
+	RewritesState bool `json:"rewrites_state,omitempty"`
 	// The latest events in the room after this event.
 	// This can be used to set the prev events for new events in the room.
 	// This also can be used to get the full current state after this event.
@@ -113,9 +113,9 @@ type OutputNewRoomEvent struct {
 	// The state event IDs that were added to the state of the room by this event.
 	// Together with RemovesStateEventIDs this allows the receiver to keep an up to date
 	// view of the current state of the room.
-	AddsStateEventIDs []string `json:"adds_state_event_ids"`
+	AddsStateEventIDs []string `json:"adds_state_event_ids,omitempty"`
 	// The state event IDs that were removed from the state of the room by this event.
-	RemovesStateEventIDs []string `json:"removes_state_event_ids"`
+	RemovesStateEventIDs []string `json:"removes_state_event_ids,omitempty"`
 	// The ID of the event that was output before this event.
 	// Or the empty string if this is the first event output for this room.
 	// This is used by consumers to check if they can safely update their
@@ -138,10 +138,10 @@ type OutputNewRoomEvent struct {
 	//
 	// The state is given as a delta against the current state because they are
 	// usually either the same state, or differ by just a couple of events.
-	StateBeforeAddsEventIDs []string `json:"state_before_adds_event_ids"`
+	StateBeforeAddsEventIDs []string `json:"state_before_adds_event_ids,omitempty"`
 	// The state event IDs that are part of the current state, but not part
 	// of the state at the event.
-	StateBeforeRemovesEventIDs []string `json:"state_before_removes_event_ids"`
+	StateBeforeRemovesEventIDs []string `json:"state_before_removes_event_ids,omitempty"`
 	// The server name to use to push this event to other servers.
 	// Or empty if this event shouldn't be pushed to other servers.
 	//
@@ -160,7 +160,7 @@ type OutputNewRoomEvent struct {
 	SendAsServer string `json:"send_as_server"`
 	// The transaction ID of the send request if sent by a local user and one
 	// was specified
-	TransactionID *TransactionID `json:"transaction_id"`
+	TransactionID *TransactionID `json:"transaction_id,omitempty"`
 }
 
 // An OutputOldRoomEvent is written when the roomserver receives an old event.

--- a/roomserver/api/output.go
+++ b/roomserver/api/output.go
@@ -170,16 +170,14 @@ type OutputNewRoomEvent struct {
 // The slice returned contains the output room event itself in all cases.
 func (o *OutputNewRoomEvent) AddsState(ctx context.Context, rsAPI RoomserverInternalAPI) ([]*gomatrixserverlib.HeaderedEvent, error) {
 	events := make([]*gomatrixserverlib.HeaderedEvent, 0, len(o.AddsStateEventIDs))
-	if len(o.AddsStateEventIDs) > 0 {
-		eventsReq := &QueryEventsByIDRequest{
-			EventIDs: o.AddsStateEventIDs,
-		}
-		eventsRes := &QueryEventsByIDResponse{}
-		if err := rsAPI.QueryEventsByID(ctx, eventsReq, eventsRes); err != nil {
-			return nil, fmt.Errorf("s.rsAPI.QueryEventsByID: %w", err)
-		}
-		events = append(events, eventsRes.Events...)
+	eventsReq := &QueryEventsByIDRequest{
+		EventIDs: o.AddsStateEventIDs,
 	}
+	eventsRes := &QueryEventsByIDResponse{}
+	if err := rsAPI.QueryEventsByID(ctx, eventsReq, eventsRes); err != nil {
+		return nil, fmt.Errorf("s.rsAPI.QueryEventsByID: %w", err)
+	}
+	events = append(events, eventsRes.Events...)
 	return events, nil
 }
 

--- a/roomserver/api/output.go
+++ b/roomserver/api/output.go
@@ -15,6 +15,9 @@
 package api
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
@@ -161,6 +164,21 @@ type OutputNewRoomEvent struct {
 	// The transaction ID of the send request if sent by a local user and one
 	// was specified
 	TransactionID *TransactionID `json:"transaction_id,omitempty"`
+}
+
+// AddsState asks the roomserver API for events specified in `adds_state_event_ids`.
+// The slice returned contains the output room event itself in all cases.
+func (o *OutputNewRoomEvent) AddsState(ctx context.Context, rsAPI RoomserverInternalAPI) ([]*gomatrixserverlib.HeaderedEvent, error) {
+	events := make([]*gomatrixserverlib.HeaderedEvent, 0, len(o.AddsStateEventIDs))
+	eventsReq := &QueryEventsByIDRequest{
+		EventIDs: o.AddsStateEventIDs,
+	}
+	eventsRes := &QueryEventsByIDResponse{}
+	if err := rsAPI.QueryEventsByID(ctx, eventsReq, eventsRes); err != nil {
+		return nil, fmt.Errorf("s.rsAPI.QueryEventsByID: %w", err)
+	}
+	events = append(events, eventsRes.Events...)
+	return events, nil
 }
 
 // An OutputOldRoomEvent is written when the roomserver receives an old event.

--- a/roomserver/api/output.go
+++ b/roomserver/api/output.go
@@ -114,13 +114,6 @@ type OutputNewRoomEvent struct {
 	// Together with RemovesStateEventIDs this allows the receiver to keep an up to date
 	// view of the current state of the room.
 	AddsStateEventIDs []string `json:"adds_state_event_ids"`
-	// All extra newly added state events. This is only set if there are *extra* events
-	// other than `Event`. This can happen when forks get merged because state resolution
-	// may decide a bunch of state events on one branch are now valid, so they will be
-	// present in this list. This is useful when trying to maintain the current state of a room
-	// as to do so you need to include both these events and `Event`.
-	AddStateEvents []*gomatrixserverlib.HeaderedEvent `json:"adds_state_events"`
-
 	// The state event IDs that were removed from the state of the room by this event.
 	RemovesStateEventIDs []string `json:"removes_state_event_ids"`
 	// The ID of the event that was output before this event.
@@ -168,26 +161,6 @@ type OutputNewRoomEvent struct {
 	// The transaction ID of the send request if sent by a local user and one
 	// was specified
 	TransactionID *TransactionID `json:"transaction_id"`
-}
-
-// AddsState returns all added state events from this event.
-//
-// This function is needed because `AddStateEvents` will not include a copy of
-// the original event to save space, so you cannot use that slice alone.
-// Instead, use this function which will add the original event if it is present
-// in `AddsStateEventIDs`.
-func (ore *OutputNewRoomEvent) AddsState() []*gomatrixserverlib.HeaderedEvent {
-	includeOutputEvent := false
-	for _, id := range ore.AddsStateEventIDs {
-		if id == ore.Event.EventID() {
-			includeOutputEvent = true
-			break
-		}
-	}
-	if !includeOutputEvent {
-		return ore.AddStateEvents
-	}
-	return append(ore.AddStateEvents, ore.Event)
 }
 
 // An OutputOldRoomEvent is written when the roomserver receives an old event.


### PR DESCRIPTION
Sending state events in the roomserver output can end up with huge NATS messages that get dropped because of the maximum message size, particularly when joining big rooms.

This refactors that so that they are no longer sent — only the event IDs are — and downstream consumers will just have to request the events they care about. 