### PR TITLE
Fix `GET /directory/list/room/{roomID}`

### DIFF
--- a/clientapi/routing/directory.go
+++ b/clientapi/routing/directory.go
@@ -26,6 +26,7 @@ import (
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
+	"github.com/sirupsen/logrus"
 )
 
 type roomDirectoryResponse struct {
@@ -244,6 +245,9 @@ func GetVisibility(
 	err := rsAPI.QueryPublishedRooms(req.Context(), &roomserverAPI.QueryPublishedRoomsRequest{
 		RoomID: roomID,
 	}, &res)
+	logrus.Infof("XXX: QueryPublishedRoomsRequest: %+v", req)
+	logrus.Infof("XXX: QueryPublishedRoomsResponse: %+v", res)
+	logrus.Infof("XXX: err: %+v", err)
 	if err != nil {
 		util.GetLogger(req.Context()).WithError(err).Error("QueryPublishedRooms failed")
 		return jsonerror.InternalServerError()

--- a/clientapi/routing/directory.go
+++ b/clientapi/routing/directory.go
@@ -240,7 +240,7 @@ func GetVisibility(
 	req *http.Request, rsAPI roomserverAPI.RoomserverInternalAPI,
 	roomID string,
 ) util.JSONResponse {
-	res := roomserverAPI.QueryPublishedRoomsResponse{}
+	var res roomserverAPI.QueryPublishedRoomsResponse
 	err := rsAPI.QueryPublishedRooms(req.Context(), &roomserverAPI.QueryPublishedRoomsRequest{
 		RoomID: roomID,
 	}, &res)

--- a/clientapi/routing/directory.go
+++ b/clientapi/routing/directory.go
@@ -238,18 +238,19 @@ type roomVisibility struct {
 
 // GetVisibility implements GET /directory/list/room/{roomID}
 func GetVisibility(
-	req *http.Request, rsAPI roomserverAPI.RoomserverInternalAPI,
+	httpReq *http.Request, rsAPI roomserverAPI.RoomserverInternalAPI,
 	roomID string,
 ) util.JSONResponse {
-	var res roomserverAPI.QueryPublishedRoomsResponse
-	err := rsAPI.QueryPublishedRooms(req.Context(), &roomserverAPI.QueryPublishedRoomsRequest{
+	req := &roomserverAPI.QueryPublishedRoomsRequest{
 		RoomID: roomID,
-	}, &res)
+	}
+	res := &roomserverAPI.QueryPublishedRoomsResponse{}
+	err := rsAPI.QueryPublishedRooms(httpReq.Context(), req, res)
 	logrus.Infof("XXX: QueryPublishedRoomsRequest: %+v", req)
 	logrus.Infof("XXX: QueryPublishedRoomsResponse: %+v", res)
 	logrus.Infof("XXX: err: %+v", err)
 	if err != nil {
-		util.GetLogger(req.Context()).WithError(err).Error("QueryPublishedRooms failed")
+		util.GetLogger(httpReq.Context()).WithError(err).Error("QueryPublishedRooms failed")
 		return jsonerror.InternalServerError()
 	}
 

--- a/clientapi/routing/directory.go
+++ b/clientapi/routing/directory.go
@@ -240,10 +240,10 @@ func GetVisibility(
 	req *http.Request, rsAPI roomserverAPI.RoomserverInternalAPI,
 	roomID string,
 ) util.JSONResponse {
-	res := &roomserverAPI.QueryPublishedRoomsResponse{}
+	res := roomserverAPI.QueryPublishedRoomsResponse{}
 	err := rsAPI.QueryPublishedRooms(req.Context(), &roomserverAPI.QueryPublishedRoomsRequest{
 		RoomID: roomID,
-	}, res)
+	}, &res)
 	if err != nil {
 		util.GetLogger(req.Context()).WithError(err).Error("QueryPublishedRooms failed")
 		return jsonerror.InternalServerError()

--- a/clientapi/routing/directory.go
+++ b/clientapi/routing/directory.go
@@ -26,7 +26,6 @@ import (
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
-	"github.com/sirupsen/logrus"
 )
 
 type roomDirectoryResponse struct {
@@ -238,19 +237,15 @@ type roomVisibility struct {
 
 // GetVisibility implements GET /directory/list/room/{roomID}
 func GetVisibility(
-	httpReq *http.Request, rsAPI roomserverAPI.RoomserverInternalAPI,
+	req *http.Request, rsAPI roomserverAPI.RoomserverInternalAPI,
 	roomID string,
 ) util.JSONResponse {
-	req := &roomserverAPI.QueryPublishedRoomsRequest{
-		RoomID: roomID,
-	}
 	res := &roomserverAPI.QueryPublishedRoomsResponse{}
-	err := rsAPI.QueryPublishedRooms(httpReq.Context(), req, res)
-	logrus.Infof("XXX: QueryPublishedRoomsRequest: %+v", req)
-	logrus.Infof("XXX: QueryPublishedRoomsResponse: %+v", res)
-	logrus.Infof("XXX: err: %+v", err)
+	err := rsAPI.QueryPublishedRooms(req.Context(), &roomserverAPI.QueryPublishedRoomsRequest{
+		RoomID: roomID,
+	}, res)
 	if err != nil {
-		util.GetLogger(httpReq.Context()).WithError(err).Error("QueryPublishedRooms failed")
+		util.GetLogger(req.Context()).WithError(err).Error("QueryPublishedRooms failed")
 		return jsonerror.InternalServerError()
 	}
 

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -610,6 +610,14 @@ func (r *Queryer) QueryPublishedRooms(
 	req *api.QueryPublishedRoomsRequest,
 	res *api.QueryPublishedRoomsResponse,
 ) error {
+	if req.RoomID != "" {
+		visible, err := r.DB.GetPublishedRoom(ctx, req.RoomID)
+		if err == nil && visible {
+			res.RoomIDs = []string{req.RoomID}
+			return nil
+		}
+		return err
+	}
 	rooms, err := r.DB.GetPublishedRooms(ctx)
 	if err != nil {
 		return err

--- a/roomserver/storage/interface.go
+++ b/roomserver/storage/interface.go
@@ -139,6 +139,8 @@ type Database interface {
 	PublishRoom(ctx context.Context, roomID string, publish bool) error
 	// Returns a list of room IDs for rooms which are published.
 	GetPublishedRooms(ctx context.Context) ([]string, error)
+	// Returns whether a given room is published or not.
+	GetPublishedRoom(ctx context.Context, roomID string) (bool, error)
 
 	// TODO: factor out - from currentstateserver
 

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -669,6 +669,10 @@ func (d *Database) PublishRoom(ctx context.Context, roomID string, publish bool)
 	})
 }
 
+func (d *Database) GetPublishedRoom(ctx context.Context, roomID string) (bool, error) {
+	return d.PublishedTable.SelectPublishedFromRoomID(ctx, nil, roomID)
+}
+
 func (d *Database) GetPublishedRooms(ctx context.Context) ([]string, error) {
 	return d.PublishedTable.SelectAllPublishedRooms(ctx, nil, true)
 }


### PR DESCRIPTION
This was previously not actually checking the supplied Room ID in `QueryPublishedRoomsRequest`, so it was often returning multiple room IDs. This would then fail the `len(res.RoomIDs) == 1` check, reporting the room as being unpublished when it actually was.