### PR TITLE
Fix /context with lazy_load_members

### DIFF
--- a/syncapi/routing/context.go
+++ b/syncapi/routing/context.go
@@ -66,7 +66,7 @@ func Context(
 	membershipRes := roomserver.QueryMembershipForUserResponse{}
 	membershipReq := roomserver.QueryMembershipForUserRequest{UserID: device.UserID, RoomID: roomID}
 	if err = rsAPI.QueryMembershipForUser(ctx, &membershipReq, &membershipRes); err != nil {
-		logrus.WithError(err).Error("unable to fo membership")
+		logrus.WithError(err).Error("unable to query membership")
 		return jsonerror.InternalServerError()
 	}
 
@@ -165,7 +165,7 @@ func applyLazyLoadMembers(filter *gomatrixserverlib.RoomEventFilter, eventsAfter
 		} else {
 			// did the user send an event?
 			if x[event.Sender()] {
-				membershipEvents = append(newState, event)
+				membershipEvents = append(membershipEvents, event)
 			}
 		}
 	}

--- a/syncapi/routing/context.go
+++ b/syncapi/routing/context.go
@@ -158,17 +158,19 @@ func applyLazyLoadMembers(filter *gomatrixserverlib.RoomEventFilter, eventsAfter
 	}
 
 	newState := []*gomatrixserverlib.HeaderedEvent{}
+	membershipEvents := []*gomatrixserverlib.HeaderedEvent{}
 	for _, event := range state {
 		if event.Type() != gomatrixserverlib.MRoomMember {
 			newState = append(newState, event)
 		} else {
 			// did the user send an event?
 			if x[event.Sender()] {
-				newState = append(newState, event)
+				membershipEvents = append(newState, event)
 			}
 		}
 	}
-	return newState
+	// Add the membershipEvents to the end of the list, to make Sytest happy
+	return append(newState, membershipEvents...)
 }
 
 func parseRoomEventFilter(req *http.Request) (*gomatrixserverlib.RoomEventFilter, error) {

--- a/sytest-blacklist
+++ b/sytest-blacklist
@@ -24,7 +24,6 @@ Local device key changes get to remote servers with correct prev_id
 
 # Flakey
 Local device key changes appear in /keys/changes
-/context/ with lazy_load_members filter works
 
 # we don't support groups
 Remove group category
@@ -32,7 +31,6 @@ Remove group role
 
 # Flakey
 AS-ghosted users can use rooms themselves
-/context/ with lazy_load_members filter works
 AS-ghosted users can use rooms via AS
 Events in rooms with AS-hosted room aliases are sent to AS server
 

--- a/sytest-blacklist
+++ b/sytest-blacklist
@@ -33,6 +33,8 @@ Remove group role
 AS-ghosted users can use rooms themselves
 AS-ghosted users can use rooms via AS
 Events in rooms with AS-hosted room aliases are sent to AS server
+Inviting an AS-hosted user asks the AS server
+Accesing an AS-hosted room alias asks the AS server
 
 # Flakey, need additional investigation
 Messages that notify from another user increment notification_count

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -664,3 +664,4 @@ Can delete canonical alias
 Multiple calls to /sync should not cause 500 errors
 AS can make room aliases
 Accesing an AS-hosted room alias asks the AS server
+/context/ with lazy_load_members filter works

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -515,7 +515,6 @@ AS can create a user with inhibit_login
 AS can set avatar for ghosted users
 AS can set displayname for ghosted users
 Ghost user must register before joining room
-Inviting an AS-hosted user asks the AS server
 Can generate a openid access_token that can be exchanged for information about a user
 Invalid openid access tokens are rejected
 Requests to userinfo without access tokens are rejected
@@ -661,7 +660,5 @@ Multiple calls to /sync should not cause 500 errors
 Canonical alias can be set
 Canonical alias can include alt_aliases
 Can delete canonical alias
-Multiple calls to /sync should not cause 500 errors
 AS can make room aliases
-Accesing an AS-hosted room alias asks the AS server
 /context/ with lazy_load_members filter works


### PR DESCRIPTION
This moves the membership events to the end of the list, so they are send correctly when a limit would remove them from the list again.