### PR TITLE
Get rooms where user is either a member or send an event

### DIFF
--- a/syncapi/storage/postgres/current_room_state_table.go
+++ b/syncapi/storage/postgres/current_room_state_table.go
@@ -75,7 +75,7 @@ const DeleteRoomStateForRoomSQL = "" +
 	"DELETE FROM syncapi_current_room_state WHERE event_id = $1"
 
 const selectRoomIDsWithMembershipSQL = "" +
-	"SELECT DISTINCT room_id FROM syncapi_current_room_state WHERE type = 'm.room.member' AND state_key = $1 AND membership = $2"
+	"SELECT DISTINCT room_id FROM syncapi_current_room_state WHERE (type = 'm.room.member' AND state_key = $1 AND membership = $2) OR sender = $1"
 
 const selectRoomIDsWithAnyMembershipSQL = "" +
 	"SELECT DISTINCT room_id, membership FROM syncapi_current_room_state WHERE type = 'm.room.member' AND state_key = $1"

--- a/syncapi/storage/sqlite3/current_room_state_table.go
+++ b/syncapi/storage/sqlite3/current_room_state_table.go
@@ -64,7 +64,7 @@ const DeleteRoomStateForRoomSQL = "" +
 	"DELETE FROM syncapi_current_room_state WHERE event_id = $1"
 
 const selectRoomIDsWithMembershipSQL = "" +
-	"SELECT DISTINCT room_id FROM syncapi_current_room_state WHERE type = 'm.room.member' AND state_key = $1 AND membership = $2"
+	"SELECT DISTINCT room_id FROM syncapi_current_room_state WHERE (type = 'm.room.member' AND state_key = $1 AND membership = $2) OR sender = $3"
 
 const selectRoomIDsWithAnyMembershipSQL = "" +
 	"SELECT DISTINCT room_id, membership FROM syncapi_current_room_state WHERE type = 'm.room.member' AND state_key = $1"
@@ -165,7 +165,7 @@ func (s *currentRoomStateStatements) SelectRoomIDsWithMembership(
 	membership string, // nolint: unparam
 ) ([]string, error) {
 	stmt := sqlutil.TxStmt(txn, s.selectRoomIDsWithMembershipStmt)
-	rows, err := stmt.QueryContext(ctx, userID, membership)
+	rows, err := stmt.QueryContext(ctx, userID, membership, userID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This should make `Room creation reports m.room.create to myself` more reliable.
We were hitting `/sync` before the membership event made it to the database, resulting in no data returned but the PDU stream being updated (not updating the PDU stream resulted in more tests failing..). Further `/sync` requests wouldn't get the `m.room.create` event and the test would fail.