### PR TITLE
Ensure we return a non-empty list

### DIFF
--- a/federationapi/routing/query.go
+++ b/federationapi/routing/query.go
@@ -70,7 +70,9 @@ func RoomAliasToID(
 				util.GetLogger(httpReq.Context()).WithError(err).Error("senderAPI.QueryJoinedHostServerNamesInRoom failed")
 				return jsonerror.InternalServerError()
 			}
-
+			if !serverQueryReq.ExcludeSelf && len(serverQueryRes.ServerNames) == 0 {
+				serverQueryRes.ServerNames = []gomatrixserverlib.ServerName{domain}
+			}
 			resp = gomatrixserverlib.RespDirectory{
 				RoomID:  queryRes.RoomID,
 				Servers: serverQueryRes.ServerNames,


### PR DESCRIPTION
Flakey test `Inbound federation can query room alias directory`.
If we're not excluding ourselves, we should be added to the list of servers even if the storage layer doesn't know about it yet.