### PR TITLE
Fix #2287 by trying to fetch account by lowercase localpart

### DIFF
--- a/userapi/storage/shared/storage.go
+++ b/userapi/storage/shared/storage.go
@@ -301,18 +301,10 @@ func (d *Database) GetAccountByLocalpart(ctx context.Context, localpart string,
 ) (*api.Account, error) {
 	// try to get the account with lowercase localpart (majority)
 	acc, err := d.Accounts.SelectAccountByLocalpart(ctx, strings.ToLower(localpart))
-	switch err {
-	case sql.ErrNoRows: // try with localpart as passed by the request
-		acc, err = d.Accounts.SelectAccountByLocalpart(ctx, localpart)
-		if err != nil {
-			return nil, err
-		}
-		return acc, nil
-	case nil:
-		return acc, nil
-	default:
-		return nil, err
+	if err == sql.ErrNoRows {
+		acc, err = d.Accounts.SelectAccountByLocalpart(ctx, localpart) // try with localpart as passed by the request
 	}
+	return acc, err
 }
 
 // SearchProfiles returns all profiles where the provided localpart or display name


### PR DESCRIPTION
When logging in we're returning the `user_id` as passed by the `/login` request (e.g. `@Alice:hs1`) which is then used by clients to do further requests.
When we're verifying the `AccessToken`, we are were using this `user_id` to check for the existence of the account, which would fail in case the `localpart` is lowercase in the database.

This first checks for the lowercase `localpart`, which should be the majority of the cases, and if not found tries it as passed by the request.