### PR TITLE
Hopefully fail `Initial tests passed` if they actually failed

### DIFF
--- a/.github/workflows/dendrite.yml
+++ b/.github/workflows/dendrite.yml
@@ -159,7 +159,6 @@ jobs:
   # Dummy step to gate other tests on without repeating the whole list
   initial-tests-done:
       name: Initial tests passed
-      if: ${{ !cancelled() }} # Run this even if prior jobs were skipped
       needs: [ lint, test, build, build_windows ]
       runs-on: ubuntu-latest
       steps:


### PR DESCRIPTION
... otherwise we can't use it for our branch protection rule.