### PR TITLE
Upload Docker images for releases to both Docker Hub and GitHub Container Registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,7 +57,7 @@ jobs:
           push: true
           tags: |
             ${{ env.DOCKER_NAMESPACE }}/dendrite-monolith:main
-            ghcr.io/${{ GHCR_NAMESPACE }}/dendrite-monolith:main
+            ghcr.io/${{ env.GHCR_NAMESPACE }}/dendrite-monolith:main
 
       - name: Build release monolith image
         if: github.event_name == 'release' # Only for GitHub releases
@@ -73,8 +73,8 @@ jobs:
           tags: |
             ${{ env.DOCKER_NAMESPACE }}/dendrite-monolith:latest
             ${{ env.DOCKER_NAMESPACE }}/dendrite-monolith:${{ env.RELEASE_VERSION }}
-            ghcr.io/${{ GHCR_NAMESPACE }}/dendrite-monolith:latest
-            ghcr.io/${{ GHCR_NAMESPACE }}/dendrite-monolith:${{ env.RELEASE_VERSION }}
+            ghcr.io/${{ env.GHCR_NAMESPACE }}/dendrite-monolith:latest
+            ghcr.io/${{ env.GHCR_NAMESPACE }}/dendrite-monolith:${{ env.RELEASE_VERSION }}
 
   polylith:
     name: Polylith image
@@ -116,7 +116,7 @@ jobs:
           push: true
           tags: |
             ${{ env.DOCKER_NAMESPACE }}/dendrite-polylith:main
-            ghcr.io/${{ GHCR_NAMESPACE }}/dendrite-polylith:main
+            ghcr.io/${{ env.GHCR_NAMESPACE }}/dendrite-polylith:main
 
       - name: Build release polylith image
         if: github.event_name == 'release' # Only for GitHub releases
@@ -132,5 +132,5 @@ jobs:
           tags: |
             ${{ env.DOCKER_NAMESPACE }}/dendrite-polylith:latest
             ${{ env.DOCKER_NAMESPACE }}/dendrite-polylith:${{ env.RELEASE_VERSION }}
-            ghcr.io/${{ GHCR_NAMESPACE }}/dendrite-polylith:latest
-            ghcr.io/${{ GHCR_NAMESPACE }}/dendrite-polylith:${{ env.RELEASE_VERSION }}
+            ghcr.io/${{ env.GHCR_NAMESPACE }}/dendrite-polylith:latest
+            ghcr.io/${{ env.GHCR_NAMESPACE }}/dendrite-polylith:${{ env.RELEASE_VERSION }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Get release tag
+        if: github.event_name == 'release' # Only for GitHub releases
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -59,7 +60,7 @@ jobs:
             ghcr.io/${{ GHCR_NAMESPACE }}/dendrite-monolith:main
 
       - name: Build release monolith image
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' # Only for GitHub releases
         id: docker_build_monolith
         uses: docker/build-push-action@v2
         with:
@@ -82,6 +83,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Get release tag
+        if: github.event_name == 'release' # Only for GitHub releases
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -117,7 +119,7 @@ jobs:
             ghcr.io/${{ GHCR_NAMESPACE }}/dendrite-polylith:main
 
       - name: Build release polylith image
-        if: ${{ github.event_name == 'release' }}
+        if: github.event_name == 'release' # Only for GitHub releases
         id: docker_build_polylith
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,9 @@ name: "Docker Hub"
 on:
   release:
     types: [published]
+  push:
+    branches:
+      - main
 
 env:
   DOCKER_NAMESPACE: matrixdotorg
@@ -13,7 +16,8 @@ env:
   PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
 
 jobs:
-  Monolith:
+  monolith:
+    name: Monolith image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -37,9 +41,27 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build monolith image
+        if: ${{ github.event_name == 'push' }}
         id: docker_build_monolith
         uses: docker/build-push-action@v2
         with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: .
+          file: ./build/docker/Dockerfile.monolith
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: |
+            ${{ env.DOCKER_NAMESPACE }}/dendrite-monolith:main
+            ghcr.io/${{ GHCR_NAMESPACE }}/dendrite-monolith:main
+
+      - name: Build release monolith image
+        if: ${{ github.event_name == 'release' }}
+        id: docker_build_monolith
+        uses: docker/build-push-action@v2
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           context: .
           file: ./build/docker/Dockerfile.monolith
           platforms: ${{ env.PLATFORMS }}
@@ -50,7 +72,8 @@ jobs:
             ghcr.io/${{ GHCR_NAMESPACE }}/dendrite-monolith:latest
             ghcr.io/${{ GHCR_NAMESPACE }}/dendrite-monolith:${{ env.RELEASE_VERSION }}
 
-  Polylith:
+  polylith:
+    name: Polylith image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -74,9 +97,27 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build polylith image
+        if: ${{ github.event_name == 'push' }}
         id: docker_build_polylith
         uses: docker/build-push-action@v2
         with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: .
+          file: ./build/docker/Dockerfile.polylith
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: |
+            ${{ env.DOCKER_NAMESPACE }}/dendrite-polylith:main
+            ghcr.io/${{ GHCR_NAMESPACE }}/dendrite-polylith:main
+
+      - name: Build release polylith image
+        if: ${{ github.event_name == 'release' }}
+        id: docker_build_polylith
+        uses: docker/build-push-action@v2
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           context: .
           file: ./build/docker/Dockerfile.polylith
           platforms: ${{ env.PLATFORMS }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,7 @@ on:
 env:
   DOCKER_NAMESPACE: matrixdotorg
   DOCKER_HUB_USER: dendritegithub
+  GHCR_NAMESPACE: matrix-org
   PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
 
 jobs:
@@ -24,10 +25,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to Docker Hub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           username: ${{ env.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Login to GitHub Containers
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build monolith image
         id: docker_build_monolith
@@ -40,6 +47,8 @@ jobs:
           tags: |
             ${{ env.DOCKER_NAMESPACE }}/dendrite-monolith:latest
             ${{ env.DOCKER_NAMESPACE }}/dendrite-monolith:${{ env.RELEASE_VERSION }}
+            ghcr.io/${{ GHCR_NAMESPACE }}/dendrite-monolith:latest
+            ghcr.io/${{ GHCR_NAMESPACE }}/dendrite-monolith:${{ env.RELEASE_VERSION }}
 
   Polylith:
     runs-on: ubuntu-latest
@@ -53,10 +62,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to Docker Hub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           username: ${{ env.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Login to GitHub Containers
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build polylith image
         id: docker_build_polylith
@@ -69,3 +84,5 @@ jobs:
           tags: |
             ${{ env.DOCKER_NAMESPACE }}/dendrite-polylith:latest
             ${{ env.DOCKER_NAMESPACE }}/dendrite-polylith:${{ env.RELEASE_VERSION }}
+            ghcr.io/${{ GHCR_NAMESPACE }}/dendrite-polylith:latest
+            ghcr.io/${{ GHCR_NAMESPACE }}/dendrite-polylith:${{ env.RELEASE_VERSION }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,11 +3,12 @@
 name: "Docker Hub"
 
 on:
-  release:
+  release: # A GitHub release was published
     types: [published]
-  push:
-    branches:
-      - main
+  workflow_run: # The Dendrite pipeline completed successfully on main
+    workflows: [Dendrite]
+    types: [completed]
+    branches: [main]
 
 env:
   DOCKER_NAMESPACE: matrixdotorg
@@ -41,7 +42,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build monolith image
-        if: ${{ github.event_name == 'push' }}
+        if: >-
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success'
         id: docker_build_monolith
         uses: docker/build-push-action@v2
         with:
@@ -56,7 +59,7 @@ jobs:
             ghcr.io/${{ GHCR_NAMESPACE }}/dendrite-monolith:main
 
       - name: Build release monolith image
-        if: ${{ github.event_name == 'release' }}
+        if: github.event_name == 'release'
         id: docker_build_monolith
         uses: docker/build-push-action@v2
         with:
@@ -97,7 +100,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build polylith image
-        if: ${{ github.event_name == 'push' }}
+        if: >-
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success'
         id: docker_build_polylith
         uses: docker/build-push-action@v2
         with:

--- a/build/docker/Dockerfile.monolith
+++ b/build/docker/Dockerfile.monolith
@@ -13,6 +13,10 @@ RUN go build -trimpath -o bin/ ./cmd/create-account
 RUN go build -trimpath -o bin/ ./cmd/generate-keys
 
 FROM alpine:latest
+LABEL org.opencontainers.image.title="Dendrite (Monolith)"
+LABEL org.opencontainers.image.description="Next-generation Matrix homeserver written in Go"
+LABEL org.opencontainers.image.source="https://github.com/matrix-org/dendrite"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 COPY --from=base /build/bin/* /usr/bin/
 

--- a/build/docker/Dockerfile.polylith
+++ b/build/docker/Dockerfile.polylith
@@ -13,6 +13,10 @@ RUN go build -trimpath -o bin/ ./cmd/create-account
 RUN go build -trimpath -o bin/ ./cmd/generate-keys
 
 FROM alpine:latest
+LABEL org.opencontainers.image.title="Dendrite (Polylith)"
+LABEL org.opencontainers.image.description="Next-generation Matrix homeserver written in Go"
+LABEL org.opencontainers.image.source="https://github.com/matrix-org/dendrite"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 COPY --from=base /build/bin/* /usr/bin/
 


### PR DESCRIPTION
This PR will also ensure that our Docker images are uploaded to GitHub Container Registry, and should hopefully show up [here](https://github.com/orgs/matrix-org/packages?repo_name=dendrite). Docker Hub is annoyingly inconsistent so it would be nice to have an alternative.

It also adds a new tag `:main`, which will be updated every time the CI pipeline on the `main` branch completes successfully, for those who want to track `main` more closely.