### PR TITLE
Healthcheck endpoints

### DIFF
--- a/internal/httputil/paths.go
+++ b/internal/httputil/paths.go
@@ -21,4 +21,6 @@ const (
 	PublicMediaPathPrefix      = "/_matrix/media/"
 	PublicWellKnownPrefix      = "/.well-known/matrix/"
 	InternalPathPrefix         = "/api/"
+	DendriteAdminPathPrefix    = "/_dendrite/"
+	SynapseAdminPathPrefix     = "/_synapse/"
 )

--- a/setup/base/base.go
+++ b/setup/base/base.go
@@ -76,6 +76,7 @@ type BaseDendrite struct {
 	PublicMediaAPIMux      *mux.Router
 	PublicWellKnownAPIMux  *mux.Router
 	InternalAPIMux         *mux.Router
+	DendriteAdminMux       *mux.Router
 	SynapseAdminMux        *mux.Router
 	UseHTTPAPIs            bool
 	apiHttpClient          *http.Client
@@ -208,7 +209,8 @@ func NewBaseDendrite(cfg *config.Dendrite, componentName string, options ...Base
 		PublicMediaAPIMux:      mux.NewRouter().SkipClean(true).PathPrefix(httputil.PublicMediaPathPrefix).Subrouter().UseEncodedPath(),
 		PublicWellKnownAPIMux:  mux.NewRouter().SkipClean(true).PathPrefix(httputil.PublicWellKnownPrefix).Subrouter().UseEncodedPath(),
 		InternalAPIMux:         mux.NewRouter().SkipClean(true).PathPrefix(httputil.InternalPathPrefix).Subrouter().UseEncodedPath(),
-		SynapseAdminMux:        mux.NewRouter().SkipClean(true).PathPrefix("/_synapse/").Subrouter().UseEncodedPath(),
+		DendriteAdminMux:       mux.NewRouter().SkipClean(true).PathPrefix(httputil.DendriteAdminPathPrefix).Subrouter().UseEncodedPath(),
+		SynapseAdminMux:        mux.NewRouter().SkipClean(true).PathPrefix(httputil.SynapseAdminPathPrefix).Subrouter().UseEncodedPath(),
 		apiHttpClient:          &apiClient,
 	}
 }
@@ -377,6 +379,17 @@ func (b *BaseDendrite) SetupAndServeHTTP(
 		internalRouter.Handle("/metrics", httputil.WrapHandlerInBasicAuth(promhttp.Handler(), b.Cfg.Global.Metrics.BasicAuth))
 	}
 
+	b.DendriteAdminMux.HandleFunc("/started", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})
+	b.DendriteAdminMux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		if b.ProcessContext.IsDegraded() {
+			w.WriteHeader(503)
+			return
+		}
+		w.WriteHeader(200)
+	})
+
 	var clientHandler http.Handler
 	clientHandler = b.PublicClientAPIMux
 	if b.Cfg.Global.Sentry.Enabled {
@@ -393,12 +406,13 @@ func (b *BaseDendrite) SetupAndServeHTTP(
 		})
 		federationHandler = sentryHandler.Handle(b.PublicFederationAPIMux)
 	}
+	internalRouter.PathPrefix(httputil.DendriteAdminPathPrefix).Handler(b.DendriteAdminMux)
 	externalRouter.PathPrefix(httputil.PublicClientPathPrefix).Handler(clientHandler)
 	if !b.Cfg.Global.DisableFederation {
 		externalRouter.PathPrefix(httputil.PublicKeyPathPrefix).Handler(b.PublicKeyAPIMux)
 		externalRouter.PathPrefix(httputil.PublicFederationPathPrefix).Handler(federationHandler)
 	}
-	externalRouter.PathPrefix("/_synapse/").Handler(b.SynapseAdminMux)
+	externalRouter.PathPrefix(httputil.SynapseAdminPathPrefix).Handler(b.SynapseAdminMux)
 	externalRouter.PathPrefix(httputil.PublicMediaPathPrefix).Handler(b.PublicMediaAPIMux)
 	externalRouter.PathPrefix(httputil.PublicWellKnownPrefix).Handler(b.PublicWellKnownAPIMux)
 

--- a/setup/base/base.go
+++ b/setup/base/base.go
@@ -379,10 +379,10 @@ func (b *BaseDendrite) SetupAndServeHTTP(
 		internalRouter.Handle("/metrics", httputil.WrapHandlerInBasicAuth(promhttp.Handler(), b.Cfg.Global.Metrics.BasicAuth))
 	}
 
-	b.DendriteAdminMux.HandleFunc("/started", func(w http.ResponseWriter, r *http.Request) {
+	b.DendriteAdminMux.HandleFunc("/monitor/up", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 	})
-	b.DendriteAdminMux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+	b.DendriteAdminMux.HandleFunc("/monitor/health", func(w http.ResponseWriter, r *http.Request) {
 		if b.ProcessContext.IsDegraded() {
 			w.WriteHeader(503)
 			return


### PR DESCRIPTION
This PR adds the following two health check endpoints:

* `/_dendrite/monitor/up` will return 200 when the server is up and ready to accept requests

* `/_dendrite/monitor/health` will return 200 if the server is healthy and will return 503 if there is a problem

On a polylith server, these endpoints will be exposed on the internal API port. On a monolith server, these endpoints will be exposed on the external API port except for when `-api` is in use, in which case it'll be exposed on the internal API port.

Currently the only thing that reports a degraded status is when a NATS stream is running in-memory when it should be running on disk (because of a problem with `AddStream`) but we will probably want to expand this to report issues with the database connection pool too.