### PR TITLE
Include joined and invite member counts in room summary

### DIFF
--- a/syncapi/storage/interface.go
+++ b/syncapi/storage/interface.go
@@ -37,6 +37,7 @@ type Database interface {
 	GetStateDeltasForFullStateSync(ctx context.Context, device *userapi.Device, r types.Range, userID string, stateFilter *gomatrixserverlib.StateFilter) ([]types.StateDelta, []string, error)
 	GetStateDeltas(ctx context.Context, device *userapi.Device, r types.Range, userID string, stateFilter *gomatrixserverlib.StateFilter) ([]types.StateDelta, []string, error)
 	RoomIDsWithMembership(ctx context.Context, userID string, membership string) ([]string, error)
+	MembershipCount(ctx context.Context, roomID, membership string, pos types.StreamPosition) (int, error)
 
 	RecentEvents(ctx context.Context, roomID string, r types.Range, eventFilter *gomatrixserverlib.RoomEventFilter, chronologicalOrder bool, onlySyncEvents bool) ([]types.StreamEvent, bool, error)
 

--- a/syncapi/storage/shared/syncserver.go
+++ b/syncapi/storage/shared/syncserver.go
@@ -118,6 +118,10 @@ func (d *Database) RoomIDsWithMembership(ctx context.Context, userID string, mem
 	return d.CurrentRoomState.SelectRoomIDsWithMembership(ctx, nil, userID, membership)
 }
 
+func (d *Database) MembershipCount(ctx context.Context, roomID, membership string, pos types.StreamPosition) (int, error) {
+	return d.Memberships.SelectMembershipCount(ctx, nil, roomID, membership, pos)
+}
+
 func (d *Database) RecentEvents(ctx context.Context, roomID string, r types.Range, eventFilter *gomatrixserverlib.RoomEventFilter, chronologicalOrder bool, onlySyncEvents bool) ([]types.StreamEvent, bool, error) {
 	return d.OutputEvents.SelectRecentEvents(ctx, nil, roomID, r, eventFilter, chronologicalOrder, onlySyncEvents)
 }

--- a/syncapi/storage/sqlite3/memberships_table.go
+++ b/syncapi/storage/sqlite3/memberships_table.go
@@ -63,9 +63,15 @@ const selectMembershipSQL = "" +
 	" ORDER BY stream_pos DESC" +
 	" LIMIT 1"
 
+const selectMembershipCountSQL = "" +
+	"SELECT COUNT(*) FROM (" +
+	" SELECT *, max(stream_pos) FROM syncapi_memberships WHERE room_id = $1 AND stream_pos <= $2 GROUP BY user_id" +
+	") t WHERE t.membership = $3"
+
 type membershipsStatements struct {
-	db                   *sql.DB
-	upsertMembershipStmt *sql.Stmt
+	db                        *sql.DB
+	upsertMembershipStmt      *sql.Stmt
+	selectMembershipCountStmt *sql.Stmt
 }
 
 func NewSqliteMembershipsTable(db *sql.DB) (tables.Memberships, error) {
@@ -77,6 +83,9 @@ func NewSqliteMembershipsTable(db *sql.DB) (tables.Memberships, error) {
 		return nil, err
 	}
 	if s.upsertMembershipStmt, err = db.Prepare(upsertMembershipSQL); err != nil {
+		return nil, err
+	}
+	if s.selectMembershipCountStmt, err = db.Prepare(selectMembershipCountSQL); err != nil {
 		return nil, err
 	}
 	return s, nil
@@ -115,5 +124,13 @@ func (s *membershipsStatements) SelectMembership(
 		return "", 0, 0, err
 	}
 	err = sqlutil.TxStmt(txn, stmt).QueryRowContext(ctx, params...).Scan(&eventID, &streamPos, &topologyPos)
+	return
+}
+
+func (s *membershipsStatements) SelectMembershipCount(
+	ctx context.Context, txn *sql.Tx, roomID, membership string, pos types.StreamPosition,
+) (count int, err error) {
+	stmt := sqlutil.TxStmt(txn, s.selectMembershipCountStmt)
+	err = stmt.QueryRowContext(ctx, roomID, pos, membership).Scan(&count)
 	return
 }

--- a/syncapi/storage/sqlite3/memberships_table.go
+++ b/syncapi/storage/sqlite3/memberships_table.go
@@ -65,7 +65,7 @@ const selectMembershipSQL = "" +
 
 const selectMembershipCountSQL = "" +
 	"SELECT COUNT(*) FROM (" +
-	" SELECT *, max(stream_pos) FROM syncapi_memberships WHERE room_id = $1 AND stream_pos <= $2 GROUP BY user_id" +
+	" SELECT * FROM syncapi_memberships WHERE room_id = $1 AND stream_pos <= $2 GROUP BY user_id HAVING(max(stream_pos))" +
 	") t WHERE t.membership = $3"
 
 type membershipsStatements struct {

--- a/syncapi/storage/tables/interface.go
+++ b/syncapi/storage/tables/interface.go
@@ -174,6 +174,7 @@ type Receipts interface {
 type Memberships interface {
 	UpsertMembership(ctx context.Context, txn *sql.Tx, event *gomatrixserverlib.HeaderedEvent, streamPos, topologicalPos types.StreamPosition) error
 	SelectMembership(ctx context.Context, txn *sql.Tx, roomID, userID, memberships []string) (eventID string, streamPos, topologyPos types.StreamPosition, err error)
+	SelectMembershipCount(ctx context.Context, txn *sql.Tx, roomID, membership string, pos types.StreamPosition) (count int, err error)
 }
 
 type NotificationData interface {

--- a/syncapi/streams/stream_pdu.go
+++ b/syncapi/streams/stream_pdu.go
@@ -255,7 +255,7 @@ func (p *PDUStreamProvider) addRoomDeltaToResponse(
 
 	hasMembershipChange := false
 	for _, recentEvent := range recentStreamEvents {
-		if recentEvent.Type() == gomatrixserverlib.MRoomMember {
+		if recentEvent.Type() == gomatrixserverlib.MRoomMember && recentEvent.StateKey() != nil {
 			hasMembershipChange = true
 			break
 		}

--- a/syncapi/streams/stream_pdu.go
+++ b/syncapi/streams/stream_pdu.go
@@ -253,9 +253,25 @@ func (p *PDUStreamProvider) addRoomDeltaToResponse(
 		updateLatestPosition(delta.StateEvents[len(delta.StateEvents)-1].EventID())
 	}
 
+	hasMembershipChange := false
+	for _, recentEvent := range recentStreamEvents {
+		if recentEvent.Type() == gomatrixserverlib.MRoomMember {
+			hasMembershipChange = true
+			break
+		}
+	}
+
+	// Work out how many members are in the room.
+	joinedCount, _ := p.DB.MembershipCount(ctx, delta.RoomID, gomatrixserverlib.Join, latestPosition)
+	invitedCount, _ := p.DB.MembershipCount(ctx, delta.RoomID, gomatrixserverlib.Invite, latestPosition)
+
 	switch delta.Membership {
 	case gomatrixserverlib.Join:
 		jr := types.NewJoinResponse()
+		if hasMembershipChange {
+			jr.Summary.JoinedMemberCount = &joinedCount
+			jr.Summary.InvitedMemberCount = &invitedCount
+		}
 		jr.Timeline.PrevBatch = &prevBatch
 		jr.Timeline.Events = gomatrixserverlib.HeaderedToClientEvents(recentEvents, gomatrixserverlib.FormatSync)
 		jr.Timeline.Limited = limited
@@ -367,12 +383,18 @@ func (p *PDUStreamProvider) getJoinResponseForCompleteSync(
 		prevBatch.Decrement()
 	}
 
+	// Work out how many members are in the room.
+	joinedCount, _ := p.DB.MembershipCount(ctx, roomID, gomatrixserverlib.Join, r.From)
+	invitedCount, _ := p.DB.MembershipCount(ctx, roomID, gomatrixserverlib.Invite, r.From)
+
 	// We don't include a device here as we don't need to send down
 	// transaction IDs for complete syncs, but we do it anyway because Sytest demands it for:
 	// "Can sync a room with a message with a transaction id" - which does a complete sync to check.
 	recentEvents := p.DB.StreamEventsToEvents(device, recentStreamEvents)
 	stateEvents = removeDuplicates(stateEvents, recentEvents)
 	jr = types.NewJoinResponse()
+	jr.Summary.JoinedMemberCount = &joinedCount
+	jr.Summary.InvitedMemberCount = &invitedCount
 	jr.Timeline.PrevBatch = prevBatch
 	jr.Timeline.Events = gomatrixserverlib.HeaderedToClientEvents(recentEvents, gomatrixserverlib.FormatSync)
 	jr.Timeline.Limited = limited

--- a/syncapi/types/types.go
+++ b/syncapi/types/types.go
@@ -377,6 +377,11 @@ func (r *Response) IsEmpty() bool {
 
 // JoinResponse represents a /sync response for a room which is under the 'join' or 'peek' key.
 type JoinResponse struct {
+	Summary struct {
+		Heroes             []string `json:"m.heroes,omitempty"`
+		JoinedMemberCount  *int     `json:"m.joined_member_count,omitempty"`
+		InvitedMemberCount *int     `json:"m.invited_member_count,omitempty"`
+	} `json:"summary"`
 	State struct {
 		Events []gomatrixserverlib.ClientEvent `json:"events"`
 	} `json:"state"`

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -661,3 +661,4 @@ Canonical alias can include alt_aliases
 Can delete canonical alias
 AS can make room aliases
 /context/ with lazy_load_members filter works
+Room summary counts change when membership changes


### PR DESCRIPTION
This should fix #2314 and also fix the problem where some clients like Element Android, Fluffychat etc would display the wrong member count for a given room.

It only includes `m.joined_member_count ` and `m.invited_member_count` on an incremental sync if a membership event was found in the response. They are always included on a complete sync.