### PR TITLE
Slower federation warm-up

### DIFF
--- a/federationapi/queue/queue.go
+++ b/federationapi/queue/queue.go
@@ -119,11 +119,11 @@ func NewOutgoingQueues(
 		} else {
 			log.WithError(err).Error("Failed to get EDU server names for destination queue hydration")
 		}
-		offset := time.Duration(5)
+		offset := time.Second * 5
 		for serverName := range serverNames {
 			if queue := queues.getQueue(serverName); queue != nil {
-				time.AfterFunc(time.Second*offset, queue.wakeQueueIfNeeded)
-				offset++
+				time.AfterFunc(offset, queue.wakeQueueIfNeeded)
+				offset += time.Second
 			}
 		}
 	}

--- a/federationapi/queue/queue.go
+++ b/federationapi/queue/queue.go
@@ -119,11 +119,14 @@ func NewOutgoingQueues(
 		} else {
 			log.WithError(err).Error("Failed to get EDU server names for destination queue hydration")
 		}
-		offset := time.Second * 5
+		offset, step := time.Second*5, time.Second
+		if max := len(serverNames); max > 120 {
+			step = (time.Second * 120) / time.Duration(max)
+		}
 		for serverName := range serverNames {
 			if queue := queues.getQueue(serverName); queue != nil {
 				time.AfterFunc(offset, queue.wakeQueueIfNeeded)
-				offset += time.Second
+				offset += step
 			}
 		}
 	}

--- a/keyserver/internal/device_list_update.go
+++ b/keyserver/internal/device_list_update.go
@@ -157,8 +157,12 @@ func (u *DeviceListUpdater) Start() error {
 	if err != nil {
 		return err
 	}
+	offset := time.Second * 10
 	for _, userID := range staleLists {
-		u.notifyWorkers(userID)
+		time.AfterFunc(offset, func() {
+			u.notifyWorkers(userID)
+		})
+		offset += time.Second
 	}
 	return nil
 }

--- a/keyserver/internal/device_list_update.go
+++ b/keyserver/internal/device_list_update.go
@@ -157,12 +157,15 @@ func (u *DeviceListUpdater) Start() error {
 	if err != nil {
 		return err
 	}
-	offset := time.Second * 10
+	offset, step := time.Second*10, time.Second
+	if max := len(staleLists); max > 120 {
+		step = (time.Second * 120) / time.Duration(max)
+	}
 	for _, userID := range staleLists {
 		time.AfterFunc(offset, func() {
 			u.notifyWorkers(userID)
 		})
-		offset += time.Second
+		offset += step
 	}
 	return nil
 }


### PR DESCRIPTION
Right now, at startup, the federation API tries to wake up destination queues and the key server tries to refresh stale device lists almost instantly. This can create a sudden spike in federation activity and CPU usage.

This PR adjusts things so that we wake up a bit more gradually — federation queues wake up after 5 seconds and the stale updater after 10 seconds — and each server is stepped by a second, to create much less of a sudden shock of traffic.