### PR TITLE
Reduce allocations in `/sync` presence stream

### DIFF
--- a/syncapi/notifier/notifier.go
+++ b/syncapi/notifier/notifier.go
@@ -258,6 +258,17 @@ func (n *Notifier) SharedUsers(userID string) (sharedUsers []string) {
 	return sharedUsers
 }
 
+func (n *Notifier) IsSharedUser(userA, userB string) bool {
+	for _, users := range n.roomIDToJoinedUsers {
+		_, okA := users[userA]
+		_, okB := users[userB]
+		if okA && okB {
+			return true
+		}
+	}
+	return false
+}
+
 // GetListener returns a UserStreamListener that can be used to wait for
 // updates for a user. Must be closed.
 // notify for anything before sincePos

--- a/syncapi/notifier/notifier.go
+++ b/syncapi/notifier/notifier.go
@@ -259,9 +259,10 @@ func (n *Notifier) SharedUsers(userID string) (sharedUsers []string) {
 }
 
 func (n *Notifier) IsSharedUser(userA, userB string) bool {
+	var okA, okB bool
 	for _, users := range n.roomIDToJoinedUsers {
-		_, okA := users[userA]
-		_, okB := users[userB]
+		_, okA = users[userA]
+		_, okB = users[userB]
 		if okA && okB {
 			return true
 		}

--- a/syncapi/notifier/notifier.go
+++ b/syncapi/notifier/notifier.go
@@ -250,6 +250,8 @@ func (n *Notifier) OnNewPresence(
 }
 
 func (n *Notifier) SharedUsers(userID string) (sharedUsers []string) {
+	n.mapLock.RLock()
+	defer n.mapLock.RUnlock()
 	for roomID, users := range n.roomIDToJoinedUsers {
 		if _, ok := users[userID]; ok {
 			sharedUsers = append(sharedUsers, n.JoinedUsers(roomID)...)
@@ -259,6 +261,8 @@ func (n *Notifier) SharedUsers(userID string) (sharedUsers []string) {
 }
 
 func (n *Notifier) IsSharedUser(userA, userB string) bool {
+	n.mapLock.RLock()
+	defer n.mapLock.RUnlock()
 	var okA, okB bool
 	for _, users := range n.roomIDToJoinedUsers {
 		_, okA = users[userA]

--- a/syncapi/notifier/notifier.go
+++ b/syncapi/notifier/notifier.go
@@ -509,6 +509,7 @@ func (s userIDSet) remove(str string) {
 }
 
 func (s userIDSet) values() (vals []string) {
+	vals = make([]string, 0, len(s))
 	for str := range s {
 		vals = append(vals, str)
 	}
@@ -529,6 +530,7 @@ func (s peekingDeviceSet) remove(d types.PeekingDevice) {
 }
 
 func (s peekingDeviceSet) values() (vals []types.PeekingDevice) {
+	vals = make([]types.PeekingDevice, 0, len(s))
 	for d := range s {
 		vals = append(vals, d)
 	}

--- a/syncapi/streams/stream_presence.go
+++ b/syncapi/streams/stream_presence.go
@@ -64,17 +64,6 @@ func (p *PresenceStreamProvider) IncrementalSync(
 		return to
 	}
 
-	// get all joined users
-	// TODO: SharedUsers might get out of sync
-	sharedUsers := p.notifier.SharedUsers(req.Device.UserID)
-
-	// convert array to a map for easier checking if a user exists
-	sharedUsersMap := make(map[string]bool, len(sharedUsers))
-	sharedUsersMap[req.Device.UserID] = true
-	for i := range sharedUsers {
-		sharedUsersMap[sharedUsers[i]] = true
-	}
-
 	// add newly joined rooms user presences
 	newlyJoined := joinedRooms(req.Response, req.Device.UserID)
 	if len(newlyJoined) > 0 {
@@ -87,7 +76,6 @@ func (p *PresenceStreamProvider) IncrementalSync(
 		for _, roomID := range newlyJoined {
 			roomUsers := p.notifier.JoinedUsers(roomID)
 			for i := range roomUsers {
-				sharedUsersMap[roomUsers[i]] = true
 				// we already got a presence from this user
 				if _, ok := presences[roomUsers[i]]; ok {
 					continue
@@ -108,7 +96,7 @@ func (p *PresenceStreamProvider) IncrementalSync(
 	for i := range presences {
 		presence := presences[i]
 		// Ignore users we don't share a room with
-		if !sharedUsersMap[presence.UserID] {
+		if req.Device.UserID != presence.UserID && !p.notifier.IsSharedUser(req.Device.UserID, presence.UserID) {
 			continue
 		}
 		cacheKey := req.Device.UserID + req.Device.ID + presence.UserID

--- a/syncapi/streams/stream_presence.go
+++ b/syncapi/streams/stream_presence.go
@@ -68,10 +68,9 @@ func (p *PresenceStreamProvider) IncrementalSync(
 	// TODO: SharedUsers might get out of sync
 	sharedUsers := p.notifier.SharedUsers(req.Device.UserID)
 
-	sharedUsersMap := map[string]bool{
-		req.Device.UserID: true,
-	}
 	// convert array to a map for easier checking if a user exists
+	sharedUsersMap := make(map[string]bool, len(sharedUsers))
+	sharedUsersMap[req.Device.UserID] = true
 	for i := range sharedUsers {
 		sharedUsersMap[sharedUsers[i]] = true
 	}


### PR DESCRIPTION
This PR means we don't need to create duplicates of the shared user lists/maps so we significantly reduce the number of allocations made to make this work, which also helps CPU usage somewhat.