### PR TITLE
Sync notifier tweaks

### DIFF
--- a/syncapi/notifier/notifier.go
+++ b/syncapi/notifier/notifier.go
@@ -60,6 +60,7 @@ func NewNotifier() *Notifier {
 		streamLock:             &sync.Mutex{},
 		mapLock:                &sync.RWMutex{},
 		lastCleanUpTime:        time.Now(),
+		_sharedUsers:           map[string]struct{}{},
 	}
 }
 

--- a/syncapi/notifier/notifier.go
+++ b/syncapi/notifier/notifier.go
@@ -267,7 +267,7 @@ func (n *Notifier) SharedUsers(userID string) []string {
 			n._sharedUsers[userID] = struct{}{}
 		}
 	}
-	sharedUsers := make([]string, 0, len(n._sharedUsers))
+	sharedUsers := make([]string, 0, len(n._sharedUsers)+1)
 	for userID := range n._sharedUsers {
 		sharedUsers = append(sharedUsers, userID)
 		delete(n._sharedUsers, userID)


### PR DESCRIPTION
This PR:

* optimises a few places we might be making unnecessary allocations;
* ensures that we don't return duplicate user IDs in calls for shared users;
* makes sure the lock is held when setting the initial notifier position.