### PR TITLE
Fix bug where state events could be requested twice in appservices

### DIFF
--- a/appservice/consumers/roomserver.go
+++ b/appservice/consumers/roomserver.go
@@ -100,10 +100,12 @@ func (s *OutputRoomEventConsumer) onMessage(ctx context.Context, msg *nats.Msg) 
 				eventsReq.EventIDs = append(eventsReq.EventIDs, eventID)
 			}
 		}
-		if err := s.rsAPI.QueryEventsByID(s.ctx, eventsReq, eventsRes); err != nil {
-			return false
+		if len(eventsReq.EventIDs) > 0 {
+			if err := s.rsAPI.QueryEventsByID(s.ctx, eventsReq, eventsRes); err != nil {
+				return false
+			}
+			events = append(events, eventsRes.Events...)
 		}
-		events = append(events, eventsRes.Events...)
 	}
 
 	// Send event to any relevant application services


### PR DESCRIPTION
This should fix #2305 as if the `adds_state_event_ids` contained the event ID of the original event (which is quite common) then we'd go and request it again and return it twice.