### PR TITLE
Add possibility to ignore users

### DIFF
--- a/syncapi/streams/stream_invite.go
+++ b/syncapi/streams/stream_invite.go
@@ -54,6 +54,10 @@ func (p *InviteStreamProvider) IncrementalSync(
 	}
 
 	for roomID, inviteEvent := range invites {
+		// skip ignored user events
+		if _, ok := req.IgnoredUsers[inviteEvent.Sender()]; ok {
+			continue
+		}
 		ir := types.NewInviteResponse(inviteEvent)
 		req.Response.Rooms.Invite[roomID] = *ir
 	}

--- a/syncapi/streams/stream_receipt.go
+++ b/syncapi/streams/stream_receipt.go
@@ -54,6 +54,10 @@ func (p *ReceiptStreamProvider) IncrementalSync(
 	// Group receipts by room, so we can create one ClientEvent for every room
 	receiptsByRoom := make(map[string][]types.OutputReceiptEvent)
 	for _, receipt := range receipts {
+		// skip ignored user events
+		if _, ok := req.IgnoredUsers[receipt.UserID]; ok {
+			continue
+		}
 		receiptsByRoom[receipt.RoomID] = append(receiptsByRoom[receipt.RoomID], receipt)
 	}
 

--- a/syncapi/streams/stream_sendtodevice.go
+++ b/syncapi/streams/stream_sendtodevice.go
@@ -48,6 +48,10 @@ func (p *SendToDeviceStreamProvider) IncrementalSync(
 
 		// Add the updates into the sync response.
 		for _, event := range events {
+			// skip ignored user events
+			if _, ok := req.IgnoredUsers[event.Sender]; ok {
+				continue
+			}
 			req.Response.ToDevice.Events = append(req.Response.ToDevice.Events, event.SendToDeviceEvent)
 		}
 	}

--- a/syncapi/streams/stream_typing.go
+++ b/syncapi/streams/stream_typing.go
@@ -40,11 +40,18 @@ func (p *TypingStreamProvider) IncrementalSync(
 		if users, updated := p.EDUCache.GetTypingUsersIfUpdatedAfter(
 			roomID, int64(from),
 		); updated {
+			typingUsers := make([]string, 0, len(users))
+			for i := range users {
+				// skip ignored user events
+				if _, ok := req.IgnoredUsers[users[i]]; !ok {
+					typingUsers = append(typingUsers, users[i])
+				}
+			}
 			ev := gomatrixserverlib.ClientEvent{
 				Type: gomatrixserverlib.MTyping,
 			}
 			ev.Content, err = json.Marshal(map[string]interface{}{
-				"user_ids": users,
+				"user_ids": typingUsers,
 			})
 			if err != nil {
 				req.Log.WithError(err).Error("json.Marshal failed")

--- a/syncapi/streams/streams.go
+++ b/syncapi/streams/streams.go
@@ -30,6 +30,7 @@ func NewSyncStreamProviders(
 	streams := &Streams{
 		PDUStreamProvider: &PDUStreamProvider{
 			StreamProvider: StreamProvider{DB: d},
+			userAPI:        userAPI,
 		},
 		TypingStreamProvider: &TypingStreamProvider{
 			StreamProvider: StreamProvider{DB: d},

--- a/syncapi/types/provider.go
+++ b/syncapi/types/provider.go
@@ -21,6 +21,8 @@ type SyncRequest struct {
 
 	// Updated by the PDU stream.
 	Rooms map[string]string
+	// Updated by the PDU stream.
+	IgnoredUsers map[string]interface{}
 }
 
 type StreamProvider interface {

--- a/syncapi/types/provider.go
+++ b/syncapi/types/provider.go
@@ -22,7 +22,7 @@ type SyncRequest struct {
 	// Updated by the PDU stream.
 	Rooms map[string]string
 	// Updated by the PDU stream.
-	IgnoredUsers map[string]interface{}
+	IgnoredUsers map[string]interface{} `json:"ignored_users"`
 }
 
 type StreamProvider interface {

--- a/sytest-blacklist
+++ b/sytest-blacklist
@@ -2,10 +2,6 @@
 
 Latest account data appears in v2 /sync
 
-# Blacklisted because we don't support ignores yet
-
-Ignore invite in incremental sync
-
 # Relies on a rejected PL event which will never be accepted into the DAG
 
 # Caused by <https://github.com/matrix-org/sytest/pull/911>

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -682,3 +682,6 @@ Room summary counts change when membership changes
 /upgrade copies >100 power levels to the new room
 Room state after a rejected message event is the same as before
 Room state after a rejected state event is the same as before
+Ignore user in existing room
+Ignore invite in full sync
+Ignore invite in incremental sync

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -284,8 +284,6 @@ local user can join room with version 4
 remote user can join room with version 3
 remote user can join room with version 4
 Remote user can backfill in a room with version 4
-# We don't support ignores yet, so ignore this for now - ha ha.
-# Ignore invite in incremental sync
 Outbound federation can send invites via v2 API
 User can invite local user to room with version 3
 User can invite local user to room with version 4


### PR DESCRIPTION
Implements https://spec.matrix.org/v1.2/client-server-api/#ignoring-users
Not too happy with getting the the ignored users on every `/sync` request.