### PR TITLE
Handle QueryAccountAvailabilityPath in internal user API

### DIFF
--- a/userapi/inthttp/server.go
+++ b/userapi/inthttp/server.go
@@ -369,6 +369,19 @@ func AddRoutes(internalAPIMux *mux.Router, s api.UserInternalAPI) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
+	internalAPIMux.Handle(QueryAccountAvailabilityPath,
+		httputil.MakeInternalAPI("queryAccountAvailability", func(req *http.Request) util.JSONResponse {
+			request := api.QueryAccountAvailabilityRequest{}
+			response := api.QueryAccountAvailabilityResponse{}
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.MessageResponse(http.StatusBadRequest, err.Error())
+			}
+			if err := s.QueryAccountAvailability(req.Context(), &request, &response); err != nil {
+				return util.ErrorResponse(err)
+			}
+			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
+		}),
+	)
 	internalAPIMux.Handle(QueryAccountByPasswordPath,
 		httputil.MakeInternalAPI("queryAccountByPassword", func(req *http.Request) util.JSONResponse {
 			request := api.QueryAccountByPasswordRequest{}


### PR DESCRIPTION
Seems like this one was skipped, I couldn't find test cases in sytest for `/register/available`. It would be perfect to write them, but it's out of this PR scope.

### Pull Request Checklist

<!-- Please read docs/CONTRIBUTING.md before submitting your pull request -->

* [x] I have added added tests for PR _or_ I have justified why this PR doesn't need tests.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/main/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `Piotr Kozimor <p1996k@gmail.com>`
