### PR TITLE
Prevent setting push rules via account data endpoint

### DIFF
--- a/clientapi/routing/account_data.go
+++ b/clientapi/routing/account_data.go
@@ -95,10 +95,10 @@ func SaveAccountData(
 		}
 	}
 
-	if dataType == "m.fully_read" {
+	if dataType == "m.fully_read" || dataType == "m.push_rules" {
 		return util.JSONResponse{
 			Code: http.StatusForbidden,
-			JSON: jsonerror.Forbidden("Unable to set read marker"),
+			JSON: jsonerror.Forbidden(fmt.Sprintf("Unable to modify %q using this API", dataType)),
 		}
 	}
 


### PR DESCRIPTION
This should fix #887, since we should be using the push rules endpoints to set those instead.