### PR TITLE
Implement lazy loading on `/sync`

### DIFF
--- a/internal/caching/cache_lazy_load_members.go
+++ b/internal/caching/cache_lazy_load_members.go
@@ -1,0 +1,49 @@
+package caching
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/matrix-org/gomatrixserverlib"
+)
+
+const (
+	LazyLoadCacheName       = "lazy_load_members"
+	LazyLoadCacheMaxEntries = 128
+	LazyLoadCacheMutable    = true
+	LazyLoadCacheMaxAge     = time.Minute * 30
+)
+
+type LazyLoadCache struct {
+	*InMemoryLRUCachePartition
+}
+
+// NewLazyLoadCache creates a new InMemoryLRUCachePartition.
+func NewLazyLoadCache() (*LazyLoadCache, error) {
+	cache, err := NewInMemoryLRUCachePartition(
+		LazyLoadCacheName,
+		LazyLoadCacheMutable,
+		LazyLoadCacheMaxEntries,
+		LazyLoadCacheMaxAge,
+		false,
+	)
+	if err != nil {
+		return nil, err
+	}
+	go cacheCleaner(cache)
+	return &LazyLoadCache{cache}, err
+}
+
+func (c *LazyLoadCache) StoreLazyLoadedMembers(reqUser, deviceID, roomID, userID string, event *gomatrixserverlib.HeaderedEvent) {
+	cacheKey := fmt.Sprintf("%s/%s/%s/%s", reqUser, deviceID, roomID, userID)
+	c.Set(cacheKey, event)
+}
+
+func (c *LazyLoadCache) GetLazyLoadedMembers(reqUser, deviceID, roomID, userID string) (*gomatrixserverlib.HeaderedEvent, bool) {
+	cacheKey := fmt.Sprintf("%s/%s/%s/%s", reqUser, deviceID, roomID, userID)
+	val, ok := c.Get(cacheKey)
+	if !ok {
+		return nil, ok
+	}
+	return val.(*gomatrixserverlib.HeaderedEvent), ok
+}

--- a/internal/caching/cache_lazy_load_members.go
+++ b/internal/caching/cache_lazy_load_members.go
@@ -32,13 +32,16 @@ func NewLazyLoadCache() (*LazyLoadCache, error) {
 	return &LazyLoadCache{cache}, err
 }
 
-func (c *LazyLoadCache) StoreLazyLoadedUser(reqUser, deviceID, roomID, userID string) {
+func (c *LazyLoadCache) StoreLazyLoadedUser(reqUser, deviceID, roomID, userID, eventID string) {
 	cacheKey := fmt.Sprintf("%s/%s/%s/%s", reqUser, deviceID, roomID, userID)
-	c.Set(cacheKey, true)
+	c.Set(cacheKey, eventID)
 }
 
-func (c *LazyLoadCache) IsLazyLoadedUserCached(reqUser, deviceID, roomID, userID string) bool {
+func (c *LazyLoadCache) IsLazyLoadedUserCached(reqUser, deviceID, roomID, userID string) (string, bool) {
 	cacheKey := fmt.Sprintf("%s/%s/%s/%s", reqUser, deviceID, roomID, userID)
-	_, ok := c.Get(cacheKey)
-	return ok
+	val, ok := c.Get(cacheKey)
+	if !ok {
+		return "", ok
+	}
+	return val.(string), ok
 }

--- a/internal/caching/cache_lazy_load_members.go
+++ b/internal/caching/cache_lazy_load_members.go
@@ -3,8 +3,6 @@ package caching
 import (
 	"fmt"
 	"time"
-
-	"github.com/matrix-org/gomatrixserverlib"
 )
 
 const (
@@ -34,16 +32,13 @@ func NewLazyLoadCache() (*LazyLoadCache, error) {
 	return &LazyLoadCache{cache}, err
 }
 
-func (c *LazyLoadCache) StoreLazyLoadedMembers(reqUser, deviceID, roomID, userID string, event *gomatrixserverlib.HeaderedEvent) {
+func (c *LazyLoadCache) StoreLazyLoadedUser(reqUser, deviceID, roomID, userID string) {
 	cacheKey := fmt.Sprintf("%s/%s/%s/%s", reqUser, deviceID, roomID, userID)
-	c.Set(cacheKey, event)
+	c.Set(cacheKey, true)
 }
 
-func (c *LazyLoadCache) GetLazyLoadedMembers(reqUser, deviceID, roomID, userID string) (*gomatrixserverlib.HeaderedEvent, bool) {
+func (c *LazyLoadCache) IsLazyLoadedUserCached(reqUser, deviceID, roomID, userID string) bool {
 	cacheKey := fmt.Sprintf("%s/%s/%s/%s", reqUser, deviceID, roomID, userID)
-	val, ok := c.Get(cacheKey)
-	if !ok {
-		return nil, ok
-	}
-	return val.(*gomatrixserverlib.HeaderedEvent), ok
+	_, ok := c.Get(cacheKey)
+	return ok
 }

--- a/internal/caching/cache_lazy_load_members.go
+++ b/internal/caching/cache_lazy_load_members.go
@@ -8,41 +8,56 @@ import (
 )
 
 const (
-	LazyLoadCacheName       = "lazy_load_members"
-	LazyLoadCacheMaxEntries = 128
-	LazyLoadCacheMutable    = true
-	LazyLoadCacheMaxAge     = time.Minute * 30
+	LazyLoadCacheName           = "lazy_load_members"
+	LazyLoadCacheMaxEntries     = 128
+	LazyLoadCacheMaxUserEntries = 128
+	LazyLoadCacheMutable        = true
+	LazyLoadCacheMaxAge         = time.Minute * 30
 )
 
 type LazyLoadCache struct {
-	// Mapping from userID/deviceID to InMemoryLRUCachePartition
-	userCaches map[string]*InMemoryLRUCachePartition
+	// InMemoryLRUCachePartition containing other InMemoryLRUCachePartitions
+	// with the actual cached members
+	userCaches *InMemoryLRUCachePartition
 }
 
 // NewLazyLoadCache creates a new LazyLoadCache.
-func NewLazyLoadCache() *LazyLoadCache {
-	return &LazyLoadCache{
-		userCaches: make(map[string]*InMemoryLRUCachePartition),
-	}
-}
-
-func (c *LazyLoadCache) lazyLoadCacheForUser(device *userapi.Device) (*InMemoryLRUCachePartition, error) {
-	cacheName := fmt.Sprintf("%s/%s", device.UserID, device.ID)
-	cache, ok := c.userCaches[cacheName]
-	if ok {
-		return cache, nil
-	}
+func NewLazyLoadCache() (*LazyLoadCache, error) {
 	cache, err := NewInMemoryLRUCachePartition(
 		LazyLoadCacheName,
 		LazyLoadCacheMutable,
 		LazyLoadCacheMaxEntries,
+		LazyLoadCacheMaxAge,
+		true,
+	)
+	if err != nil {
+		return nil, err
+	}
+	go cacheCleaner(cache)
+	return &LazyLoadCache{
+		userCaches: cache,
+	}, nil
+}
+
+func (c *LazyLoadCache) lazyLoadCacheForUser(device *userapi.Device) (*InMemoryLRUCachePartition, error) {
+	cacheName := fmt.Sprintf("%s/%s", device.UserID, device.ID)
+	userCache, ok := c.userCaches.Get(cacheName)
+	if ok && userCache != nil {
+		if cache, ok := userCache.(*InMemoryLRUCachePartition); ok {
+			return cache, nil
+		}
+	}
+	cache, err := NewInMemoryLRUCachePartition(
+		LazyLoadCacheName,
+		LazyLoadCacheMutable,
+		LazyLoadCacheMaxUserEntries,
 		LazyLoadCacheMaxAge,
 		false,
 	)
 	if err != nil {
 		return nil, err
 	}
-	c.userCaches[cacheName] = cache
+	c.userCaches.Set(cacheName, cache)
 	go cacheCleaner(cache)
 	return cache, nil
 }

--- a/syncapi/streams/stream_pdu.go
+++ b/syncapi/streams/stream_pdu.go
@@ -250,7 +250,8 @@ func (p *PDUStreamProvider) addRoomDeltaToResponse(
 	// room that were returned.
 	latestPosition := r.To
 	updateLatestPosition := func(mostRecentEventID string) {
-		if _, pos, err := p.DB.PositionInTopology(ctx, mostRecentEventID); err == nil {
+		var pos types.StreamPosition
+		if _, pos, err = p.DB.PositionInTopology(ctx, mostRecentEventID); err == nil {
 			switch {
 			case r.Backwards && pos > latestPosition:
 				fallthrough

--- a/syncapi/streams/stream_pdu.go
+++ b/syncapi/streams/stream_pdu.go
@@ -468,8 +468,9 @@ func (p *PDUStreamProvider) lazyLoadMembers(
 			timelineUsers[event.Sender()] = struct{}{}
 		}
 	}
+	// Preallocate with the same amount, even if it will end up with fewer values
+	newStateEvents := make([]*gomatrixserverlib.HeaderedEvent, 0, len(stateEvents))
 	// Remove existing membership events we don't care about, e.g. users not in the timeline.events
-	newStateEvents := []*gomatrixserverlib.HeaderedEvent{}
 	for _, event := range stateEvents {
 		if event.Type() == gomatrixserverlib.MRoomMember && event.StateKey() != nil {
 			// If this is a gapped incremental sync, we still want this membership

--- a/syncapi/streams/stream_pdu.go
+++ b/syncapi/streams/stream_pdu.go
@@ -459,7 +459,7 @@ func (p *PDUStreamProvider) lazyLoadMembers(
 			continue
 		}
 		// membership is not yet cached, add it to the list
-		if _, ok := cache.GetLazyLoadedMembers(device.UserID, device.ID, roomID, event.Sender()); !ok {
+		if !cache.IsLazyLoadedUserCached(device.UserID, device.ID, roomID, event.Sender()) {
 			timelineUsers[event.Sender()] = struct{}{}
 		}
 	}
@@ -471,7 +471,7 @@ func (p *PDUStreamProvider) lazyLoadMembers(
 			if _, ok := timelineUsers[event.Sender()]; ok {
 				newStateEvents = append(newStateEvents, event)
 				if !stateFilter.IncludeRedundantMembers {
-					cache.StoreLazyLoadedMembers(device.UserID, device.ID, roomID, event.Sender(), event)
+					cache.StoreLazyLoadedUser(device.UserID, device.ID, roomID, event.Sender())
 				}
 				delete(timelineUsers, event.Sender())
 			}
@@ -495,7 +495,7 @@ func (p *PDUStreamProvider) lazyLoadMembers(
 	}
 	// cache the membership events
 	for _, membership := range memberships {
-		cache.StoreLazyLoadedMembers(device.UserID, device.ID, roomID, membership.Sender(), membership)
+		cache.StoreLazyLoadedUser(device.UserID, device.ID, roomID, membership.Sender())
 	}
 	stateEvents = append(newStateEvents, memberships...)
 	return stateEvents, nil

--- a/syncapi/streams/streams.go
+++ b/syncapi/streams/streams.go
@@ -27,7 +27,7 @@ type Streams struct {
 func NewSyncStreamProviders(
 	d storage.Database, userAPI userapi.UserInternalAPI,
 	rsAPI rsapi.RoomserverInternalAPI, keyAPI keyapi.KeyInternalAPI,
-	eduCache *caching.EDUCache, lazyLoadCache map[string]*caching.LazyLoadCache, notifier *notifier.Notifier,
+	eduCache *caching.EDUCache, lazyLoadCache *caching.LazyLoadCache, notifier *notifier.Notifier,
 ) *Streams {
 	streams := &Streams{
 		PDUStreamProvider: &PDUStreamProvider{

--- a/syncapi/streams/streams.go
+++ b/syncapi/streams/streams.go
@@ -27,12 +27,12 @@ type Streams struct {
 func NewSyncStreamProviders(
 	d storage.Database, userAPI userapi.UserInternalAPI,
 	rsAPI rsapi.RoomserverInternalAPI, keyAPI keyapi.KeyInternalAPI,
-	eduCache *caching.EDUCache, notifier *notifier.Notifier,
+	eduCache *caching.EDUCache, lazyLoadCache map[string]*caching.LazyLoadCache, notifier *notifier.Notifier,
 ) *Streams {
 	streams := &Streams{
 		PDUStreamProvider: &PDUStreamProvider{
 			StreamProvider: StreamProvider{DB: d},
-			userAPI:        userAPI,
+			lazyLoadCache:  lazyLoadCache,
 		},
 		TypingStreamProvider: &TypingStreamProvider{
 			StreamProvider: StreamProvider{DB: d},

--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -337,10 +337,69 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request, device *userapi.
 		}
 	}
 
+	if syncReq.Filter.Room.State.LazyLoadMembers {
+		for roomID, jr := range syncReq.Response.Rooms.Join {
+			jr.State.Events = rp.applyLazyLoadMembers(req.Context(), syncReq.Since.IsEmpty(), roomID, syncReq.Device.UserID, jr.Timeline.Events, jr.State.Events)
+			syncReq.Response.Rooms.Join[roomID] = jr
+		}
+	}
+
 	return util.JSONResponse{
 		Code: http.StatusOK,
 		JSON: syncReq.Response,
 	}
+}
+
+func (rp *RequestPool) applyLazyLoadMembers(
+	ctx context.Context, isInitial bool, roomID, userID string, timelineEvents, stateEvents []gomatrixserverlib.ClientEvent,
+) []gomatrixserverlib.ClientEvent {
+	if len(stateEvents) == 0 || len(timelineEvents) == 0 {
+		return stateEvents
+	}
+	logrus.Debugf("before stateEvents: %d", len(stateEvents))
+
+	// First, get a list of users we need in the response
+	requiredUsers := make(map[string]bool)
+	if isInitial {
+		requiredUsers[userID] = true
+	}
+	for _, ev := range timelineEvents {
+		requiredUsers[ev.Sender] = true
+	}
+	// Filter out users who didn't send an event
+	newState := []gomatrixserverlib.ClientEvent{}
+	membershipEvents := []gomatrixserverlib.ClientEvent{}
+	for _, event := range stateEvents {
+		if event.Type != gomatrixserverlib.MRoomMember {
+			newState = append(newState, event)
+		} else {
+			// did the user send an event?
+			if requiredUsers[event.Sender] {
+				membershipEvents = append(membershipEvents, event)
+				delete(requiredUsers, event.Sender)
+			}
+		}
+	}
+	// Get all remaining users in the list
+	membershipToUser := make(map[string]*gomatrixserverlib.HeaderedEvent)
+	for userID := range requiredUsers {
+		membership, err := rp.db.GetStateEvent(ctx, roomID, gomatrixserverlib.MRoomMember, userID)
+		if err != nil {
+			util.GetLogger(ctx).WithError(err).Error("failed to get membership event for user")
+			continue
+		}
+		if membership != nil {
+			membershipToUser[userID] = membership
+		}
+	}
+	// Convert HeaderedEvent to ClientEvent
+	for _, evt := range membershipToUser {
+		newState = append(newState, gomatrixserverlib.HeaderedToClientEvent(evt, gomatrixserverlib.FormatSync))
+	}
+
+	result := append(newState, membershipEvents...)
+	logrus.Debugf("after stateEvents: %d", len(result))
+	return result
 }
 
 func (rp *RequestPool) OnIncomingKeyChangeRequest(req *http.Request, device *userapi.Device) util.JSONResponse {

--- a/syncapi/syncapi.go
+++ b/syncapi/syncapi.go
@@ -58,7 +58,8 @@ func AddPublicRoutes(
 
 	eduCache := caching.NewTypingCache()
 	notifier := notifier.NewNotifier()
-	streams := streams.NewSyncStreamProviders(syncDB, userAPI, rsAPI, keyAPI, eduCache, notifier)
+	lazyLoadCache := make(map[string]*caching.LazyLoadCache)
+	streams := streams.NewSyncStreamProviders(syncDB, userAPI, rsAPI, keyAPI, eduCache, lazyLoadCache, notifier)
 	notifier.SetCurrentPosition(streams.Latest(context.Background()))
 	if err = notifier.Load(context.Background(), syncDB); err != nil {
 		logrus.WithError(err).Panicf("failed to load notifier ")

--- a/syncapi/syncapi.go
+++ b/syncapi/syncapi.go
@@ -57,7 +57,10 @@ func AddPublicRoutes(
 	}
 
 	eduCache := caching.NewTypingCache()
-	lazyLoadCache := caching.NewLazyLoadCache()
+	lazyLoadCache, err := caching.NewLazyLoadCache()
+	if err != nil {
+		logrus.WithError(err).Panicf("failed to create lazy loading cache")
+	}
 	notifier := notifier.NewNotifier()
 	streams := streams.NewSyncStreamProviders(syncDB, userAPI, rsAPI, keyAPI, eduCache, lazyLoadCache, notifier)
 	notifier.SetCurrentPosition(streams.Latest(context.Background()))

--- a/syncapi/syncapi.go
+++ b/syncapi/syncapi.go
@@ -57,8 +57,8 @@ func AddPublicRoutes(
 	}
 
 	eduCache := caching.NewTypingCache()
+	lazyLoadCache := caching.NewLazyLoadCache()
 	notifier := notifier.NewNotifier()
-	lazyLoadCache := make(map[string]*caching.LazyLoadCache)
 	streams := streams.NewSyncStreamProviders(syncDB, userAPI, rsAPI, keyAPI, eduCache, lazyLoadCache, notifier)
 	notifier.SetCurrentPosition(streams.Latest(context.Background()))
 	if err = notifier.Load(context.Background(), syncDB); err != nil {

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -699,3 +699,8 @@ Ignore invite in full sync
 Ignore invite in incremental sync
 A filtered timeline reaches its limit
 A change to displayname should not result in a full state sync
+The only membership state included in an initial sync is for all the senders in the timeline
+The only membership state included in an incremental sync is for senders in the timeline
+Old members are included in gappy incr LL sync if they start speaking
+We do send redundant membership state across incremental syncs if asked
+Rejecting invite over federation doesn't break incremental /sync

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -704,3 +704,7 @@ The only membership state included in an incremental sync is for senders in the 
 Old members are included in gappy incr LL sync if they start speaking
 We do send redundant membership state across incremental syncs if asked
 Rejecting invite over federation doesn't break incremental /sync
+Gapped incremental syncs include all state changes
+Old leaves are present in gapped incremental syncs
+Leaves are present in non-gapped incremental syncs
+Members from the gap are included in gappy incr LL sync


### PR DESCRIPTION
Sync API                 :  91% (10/11 tests)
    ✅ Lazy loading parameters in the filter are strictly boolean
    ✅ The only membership state included in an initial sync is for all the senders in the timeline
    ✅ The only membership state included in an incremental sync is for senders in the timeline
    ❌ The only membership state included in a gapped incremental sync is for senders in the timeline
    ✅ Gapped incremental syncs include all state changes
    ✅ Old leaves are present in gapped incremental syncs
    ✅ Leaves are present in non-gapped incremental syncs
    ✅ Old members are included in gappy incr LL sync if they start speaking
    ✅ Members from the gap are included in gappy incr LL sync
    ✅ We don't send redundant membership state across incremental syncs by default
    ✅ We do send redundant membership state across incremental syncs if asked


`The only membership state included in a gapped incremental sync is for senders in the timeline` is also blacklisted on Synapse, as it conflicts with `Gapped incremental syncs include all state changes` afaict.