### PR TITLE
Precompute values for `userIDSet` in sync notifier

### DIFF
--- a/syncapi/notifier/notifier.go
+++ b/syncapi/notifier/notifier.go
@@ -283,6 +283,9 @@ func (n *Notifier) IsSharedUser(userA, userB string) bool {
 	var okA, okB bool
 	for _, users := range n.roomIDToJoinedUsers {
 		okA = users.isIn(userA)
+		if !okA {
+		    continue
+		}
 		okB = users.isIn(userB)
 		if okA && okB {
 			return true

--- a/syncapi/notifier/notifier.go
+++ b/syncapi/notifier/notifier.go
@@ -441,7 +441,7 @@ func (n *Notifier) _fetchUserStreams(userID string) []*UserDeviceStream {
 
 func (n *Notifier) _addJoinedUser(roomID, userID string) {
 	if _, ok := n.roomIDToJoinedUsers[roomID]; !ok {
-		n.roomIDToJoinedUsers[roomID] = newUserIDSet(32)
+		n.roomIDToJoinedUsers[roomID] = newUserIDSet(8)
 	}
 	n.roomIDToJoinedUsers[roomID].add(userID)
 	n.roomIDToJoinedUsers[roomID].precompute()
@@ -449,7 +449,7 @@ func (n *Notifier) _addJoinedUser(roomID, userID string) {
 
 func (n *Notifier) _removeJoinedUser(roomID, userID string) {
 	if _, ok := n.roomIDToJoinedUsers[roomID]; !ok {
-		n.roomIDToJoinedUsers[roomID] = newUserIDSet(7)
+		n.roomIDToJoinedUsers[roomID] = newUserIDSet(8)
 	}
 	n.roomIDToJoinedUsers[roomID].remove(userID)
 	n.roomIDToJoinedUsers[roomID].precompute()

--- a/syncapi/notifier/notifier.go
+++ b/syncapi/notifier/notifier.go
@@ -284,7 +284,7 @@ func (n *Notifier) IsSharedUser(userA, userB string) bool {
 	for _, users := range n.roomIDToJoinedUsers {
 		okA = users.isIn(userA)
 		if !okA {
-		    continue
+			continue
 		}
 		okB = users.isIn(userB)
 		if okA && okB {


### PR DESCRIPTION
This reduces the CPU burn on the hot paths that use `values()` by using precomputed arrays rather than calculating them each time. We now compute the slices on modify rather than on access.