### PR TITLE
Use default sync filter if specified filter is not found

### DIFF
--- a/syncapi/sync/request.go
+++ b/syncapi/sync/request.go
@@ -15,6 +15,7 @@
 package sync
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -60,10 +61,10 @@ func newSyncRequest(req *http.Request, device userapi.Device, syncDB storage.Dat
 				util.GetLogger(req.Context()).WithError(err).Error("gomatrixserverlib.SplitID failed")
 				return nil, fmt.Errorf("gomatrixserverlib.SplitID: %w", err)
 			}
-			if f, err := syncDB.GetFilter(req.Context(), localpart, filterQuery); err != nil {
+			if f, err := syncDB.GetFilter(req.Context(), localpart, filterQuery); err != nil && err != sql.ErrNoRows {
 				util.GetLogger(req.Context()).WithError(err).Error("syncDB.GetFilter failed")
 				return nil, fmt.Errorf("syncDB.GetFilter: %w", err)
-			} else {
+			} else if f != nil {
 				filter = *f
 			}
 		}


### PR DESCRIPTION
This should fix #2350 by not panicking the entire `/sync` request if the filter was not found. Nothing in the spec says to do anything else.