### PR TITLE
Change `pushkey_ts` to be seconds

### DIFF
--- a/internal/pushgateway/pushgateway.go
+++ b/internal/pushgateway/pushgateway.go
@@ -3,8 +3,6 @@ package pushgateway
 import (
 	"context"
 	"encoding/json"
-
-	"github.com/matrix-org/gomatrixserverlib"
 )
 
 // A Client is how interactions with a Push Gateway is done.
@@ -47,11 +45,11 @@ type Counts struct {
 }
 
 type Device struct {
-	AppID     string                      `json:"app_id"`  // Required
-	Data      map[string]interface{}      `json:"data"`    // Required. UNSPEC: Sytests require this to allow unknown keys.
-	PushKey   string                      `json:"pushkey"` // Required
-	PushKeyTS gomatrixserverlib.Timestamp `json:"pushkey_ts,omitempty"`
-	Tweaks    map[string]interface{}      `json:"tweaks,omitempty"`
+	AppID     string                 `json:"app_id"`  // Required
+	Data      map[string]interface{} `json:"data"`    // Required. UNSPEC: Sytests require this to allow unknown keys.
+	PushKey   string                 `json:"pushkey"` // Required
+	PushKeyTS int64                  `json:"pushkey_ts,omitempty"`
+	Tweaks    map[string]interface{} `json:"tweaks,omitempty"`
 }
 
 type Prio string

--- a/userapi/api/api.go
+++ b/userapi/api/api.go
@@ -492,16 +492,16 @@ type PerformPusherDeletionRequest struct {
 
 // Pusher represents a push notification subscriber
 type Pusher struct {
-	SessionID         int64                       `json:"session_id,omitempty"`
-	PushKey           string                      `json:"pushkey"`
-	PushKeyTS         gomatrixserverlib.Timestamp `json:"pushkey_ts,omitempty"`
-	Kind              PusherKind                  `json:"kind"`
-	AppID             string                      `json:"app_id"`
-	AppDisplayName    string                      `json:"app_display_name"`
-	DeviceDisplayName string                      `json:"device_display_name"`
-	ProfileTag        string                      `json:"profile_tag"`
-	Language          string                      `json:"lang"`
-	Data              map[string]interface{}      `json:"data"`
+	SessionID         int64                  `json:"session_id,omitempty"`
+	PushKey           string                 `json:"pushkey"`
+	PushKeyTS         int64                  `json:"pushkey_ts,omitempty"`
+	Kind              PusherKind             `json:"kind"`
+	AppID             string                 `json:"app_id"`
+	AppDisplayName    string                 `json:"app_display_name"`
+	DeviceDisplayName string                 `json:"device_display_name"`
+	ProfileTag        string                 `json:"profile_tag"`
+	Language          string                 `json:"lang"`
+	Data              map[string]interface{} `json:"data"`
 }
 
 type PusherKind string

--- a/userapi/internal/api.go
+++ b/userapi/internal/api.go
@@ -653,7 +653,7 @@ func (a *UserInternalAPI) PerformPusherSet(ctx context.Context, req *api.Perform
 		return a.DB.RemovePusher(ctx, req.Pusher.AppID, req.Pusher.PushKey, req.Localpart)
 	}
 	if req.Pusher.PushKeyTS == 0 {
-		req.Pusher.PushKeyTS = gomatrixserverlib.AsTimestamp(time.Now())
+		req.Pusher.PushKeyTS = int64(time.Now().Second())
 	}
 	return a.DB.UpsertPusher(ctx, req.Pusher, req.Localpart)
 }

--- a/userapi/storage/postgres/pusher_table.go
+++ b/userapi/storage/postgres/pusher_table.go
@@ -23,7 +23,6 @@ import (
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/dendrite/userapi/storage/tables"
-	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/sirupsen/logrus"
 )
 
@@ -95,7 +94,7 @@ type pushersStatements struct {
 // Returns nil error success.
 func (s *pushersStatements) InsertPusher(
 	ctx context.Context, txn *sql.Tx, session_id int64,
-	pushkey string, pushkeyTS gomatrixserverlib.Timestamp, kind api.PusherKind, appid, appdisplayname, devicedisplayname, profiletag, lang, data, localpart string,
+	pushkey string, pushkeyTS int64, kind api.PusherKind, appid, appdisplayname, devicedisplayname, profiletag, lang, data, localpart string,
 ) error {
 	_, err := sqlutil.TxStmt(txn, s.insertPusherStmt).ExecContext(ctx, localpart, session_id, pushkey, pushkeyTS, kind, appid, appdisplayname, devicedisplayname, profiletag, lang, data)
 	logrus.Debugf("Created pusher %d", session_id)

--- a/userapi/storage/sqlite3/pusher_table.go
+++ b/userapi/storage/sqlite3/pusher_table.go
@@ -23,7 +23,6 @@ import (
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/dendrite/userapi/storage/tables"
-	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/sirupsen/logrus"
 )
 
@@ -95,7 +94,7 @@ type pushersStatements struct {
 // Returns nil error success.
 func (s *pushersStatements) InsertPusher(
 	ctx context.Context, txn *sql.Tx, session_id int64,
-	pushkey string, pushkeyTS gomatrixserverlib.Timestamp, kind api.PusherKind, appid, appdisplayname, devicedisplayname, profiletag, lang, data, localpart string,
+	pushkey string, pushkeyTS int64, kind api.PusherKind, appid, appdisplayname, devicedisplayname, profiletag, lang, data, localpart string,
 ) error {
 	_, err := s.insertPusherStmt.ExecContext(ctx, localpart, session_id, pushkey, pushkeyTS, kind, appid, appdisplayname, devicedisplayname, profiletag, lang, data)
 	logrus.Debugf("Created pusher %d", session_id)

--- a/userapi/storage/tables/interface.go
+++ b/userapi/storage/tables/interface.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/userapi/api"
-	"github.com/matrix-org/gomatrixserverlib"
 )
 
 type AccountDataTable interface {
@@ -96,7 +95,7 @@ type ThreePIDTable interface {
 }
 
 type PusherTable interface {
-	InsertPusher(ctx context.Context, txn *sql.Tx, session_id int64, pushkey string, pushkeyTS gomatrixserverlib.Timestamp, kind api.PusherKind, appid, appdisplayname, devicedisplayname, profiletag, lang, data, localpart string) error
+	InsertPusher(ctx context.Context, txn *sql.Tx, session_id int64, pushkey string, pushkeyTS int64, kind api.PusherKind, appid, appdisplayname, devicedisplayname, profiletag, lang, data, localpart string) error
 	SelectPushers(ctx context.Context, txn *sql.Tx, localpart string) ([]api.Pusher, error)
 	DeletePusher(ctx context.Context, txn *sql.Tx, appid, pushkey, localpart string) error
 	DeletePushers(ctx context.Context, txn *sql.Tx, appid, pushkey string) error


### PR DESCRIPTION
This should fix #2354 by changing the `pushkey_ts` field to be seconds [as per the spec](https://github.com/matrix-org/matrix-spec/blob/ca466b5a572a867de79ba9077e6445265b841c96/data/api/push-gateway/push_notifier.yaml#L185-L189). The `gomatrixserverlib.Timestamp` time expects to be milliseconds, not seconds.