### PR TITLE
Return M_NOT_FOUND for rejected events

### DIFF
--- a/federationapi/routing/state.go
+++ b/federationapi/routing/state.go
@@ -129,6 +129,13 @@ func getState(
 		return nil, nil, &resErr
 	}
 
+	if response.IsRejected {
+		return nil, nil, &util.JSONResponse{
+			Code: http.StatusNotFound,
+			JSON: jsonerror.NotFound("Event not found"),
+		}
+	}
+
 	if !response.RoomExists {
 		return nil, nil, &util.JSONResponse{Code: http.StatusNotFound, JSON: nil}
 	}

--- a/roomserver/api/query.go
+++ b/roomserver/api/query.go
@@ -230,6 +230,8 @@ type QueryStateAndAuthChainResponse struct {
 	// The lists will be in an arbitrary order.
 	StateEvents     []*gomatrixserverlib.HeaderedEvent `json:"state_events"`
 	AuthChainEvents []*gomatrixserverlib.HeaderedEvent `json:"auth_chain_events"`
+	// True if the queried event was rejected earlier.
+	IsRejected bool `json:"is_rejected"`
 }
 
 // QueryRoomVersionCapabilitiesRequest asks for the default room version

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -441,11 +441,11 @@ func (r *Queryer) QueryStateAndAuthChain(
 	}
 
 	var stateEvents []*gomatrixserverlib.Event
-	stateEvents, err = r.loadStateAtEventIDs(ctx, info, request.PrevEventIDs)
+	stateEvents, rejected, err := r.loadStateAtEventIDs(ctx, info, request.PrevEventIDs)
 	if err != nil {
 		return err
 	}
-
+	response.IsRejected = rejected
 	response.PrevEventsExist = true
 
 	// add the auth event IDs for the current state events too
@@ -480,15 +480,23 @@ func (r *Queryer) QueryStateAndAuthChain(
 	return err
 }
 
-func (r *Queryer) loadStateAtEventIDs(ctx context.Context, roomInfo *types.RoomInfo, eventIDs []string) ([]*gomatrixserverlib.Event, error) {
+func (r *Queryer) loadStateAtEventIDs(ctx context.Context, roomInfo *types.RoomInfo, eventIDs []string) ([]*gomatrixserverlib.Event, bool, error) {
 	roomState := state.NewStateResolution(r.DB, roomInfo)
 	prevStates, err := r.DB.StateAtEventIDs(ctx, eventIDs)
 	if err != nil {
 		switch err.(type) {
 		case types.MissingEventError:
-			return nil, nil
+			return nil, false, nil
 		default:
-			return nil, err
+			return nil, false, err
+		}
+	}
+	// Currently only used on /state and /state_ids
+	rejected := false
+	for i := range prevStates {
+		if prevStates[i].IsRejected {
+			rejected = true
+			break
 		}
 	}
 
@@ -497,10 +505,12 @@ func (r *Queryer) loadStateAtEventIDs(ctx context.Context, roomInfo *types.RoomI
 		ctx, prevStates,
 	)
 	if err != nil {
-		return nil, err
+		return nil, rejected, err
 	}
 
-	return helpers.LoadStateEvents(ctx, r.DB, stateEntries)
+	events, err := helpers.LoadStateEvents(ctx, r.DB, stateEntries)
+
+	return events, rejected, err
 }
 
 type eventsFromIDs func(context.Context, []string) ([]types.Event, error)

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -710,3 +710,7 @@ Old leaves are present in gapped incremental syncs
 Leaves are present in non-gapped incremental syncs
 Members from the gap are included in gappy incr LL sync
 Presence can be set from sync
+/state returns M_NOT_FOUND for a rejected message event
+/state_ids returns M_NOT_FOUND for a rejected message event
+/state returns M_NOT_FOUND for a rejected state event
+/state_ids returns M_NOT_FOUND for a rejected state event


### PR DESCRIPTION
Makes the newly added tests pass.
Like mentioned, the outlier tests (`/state returns M_NOT_FOUND for an outlier` and `/state_ids returns M_NOT_FOUND for an outlier`) are waiting for requests to `/get_missing_events` and `/state_ids`, but Dendrite already fails when trying to GET `/event_auth` because Sytest doesn't "listen" on that endpoint.