### PR TITLE
Don't answer expensive federation requests for rooms we no longer belong to

### DIFF
--- a/federationapi/routing/backfill.go
+++ b/federationapi/routing/backfill.go
@@ -51,6 +51,12 @@ func Backfill(
 		}
 	}
 
+	// If we don't think we belong to this room then don't waste the effort
+	// responding to expensive requests for it.
+	if err := ErrorIfLocalServerNotInRoom(httpReq.Context(), rsAPI, roomID); err != nil {
+		return *err
+	}
+
 	// Check if all of the required parameters are there.
 	eIDs, exists = httpReq.URL.Query()["v"]
 	if !exists {

--- a/federationapi/routing/eventauth.go
+++ b/federationapi/routing/eventauth.go
@@ -30,6 +30,12 @@ func GetEventAuth(
 	roomID string,
 	eventID string,
 ) util.JSONResponse {
+	// If we don't think we belong to this room then don't waste the effort
+	// responding to expensive requests for it.
+	if err := ErrorIfLocalServerNotInRoom(ctx, rsAPI, roomID); err != nil {
+		return *err
+	}
+
 	event, resErr := fetchEvent(ctx, rsAPI, eventID)
 	if resErr != nil {
 		return *resErr

--- a/federationapi/routing/missingevents.go
+++ b/federationapi/routing/missingevents.go
@@ -45,6 +45,12 @@ func GetMissingEvents(
 		}
 	}
 
+	// If we don't think we belong to this room then don't waste the effort
+	// responding to expensive requests for it.
+	if err := ErrorIfLocalServerNotInRoom(httpReq.Context(), rsAPI, roomID); err != nil {
+		return *err
+	}
+
 	var eventsResponse api.QueryMissingEventsResponse
 	if err := rsAPI.QueryMissingEvents(
 		httpReq.Context(), &api.QueryMissingEventsRequest{

--- a/federationapi/routing/state.go
+++ b/federationapi/routing/state.go
@@ -101,6 +101,12 @@ func getState(
 	roomID string,
 	eventID string,
 ) (stateEvents, authEvents []*gomatrixserverlib.HeaderedEvent, errRes *util.JSONResponse) {
+	// If we don't think we belong to this room then don't waste the effort
+	// responding to expensive requests for it.
+	if err := ErrorIfLocalServerNotInRoom(ctx, rsAPI, roomID); err != nil {
+		return nil, nil, err
+	}
+
 	event, resErr := fetchEvent(ctx, rsAPI, eventID)
 	if resErr != nil {
 		return nil, nil, resErr


### PR DESCRIPTION
This includes `/state`, `/state_ids`, `/get_missing_events` and `/backfill`.

This should fix #2396.