### PR TITLE
Add `/_dendrite/admin/evacuateRoom/{roomID}`

### DIFF
--- a/build/gobind-pinecone/monolith.go
+++ b/build/gobind-pinecone/monolith.go
@@ -314,6 +314,7 @@ func (m *DendriteMonolith) Start() {
 		base.PublicWellKnownAPIMux,
 		base.PublicMediaAPIMux,
 		base.SynapseAdminMux,
+		base.DendriteAdminMux,
 	)
 
 	httpRouter := mux.NewRouter().SkipClean(true).UseEncodedPath()

--- a/build/gobind-yggdrasil/monolith.go
+++ b/build/gobind-yggdrasil/monolith.go
@@ -152,6 +152,7 @@ func (m *DendriteMonolith) Start() {
 		base.PublicWellKnownAPIMux,
 		base.PublicMediaAPIMux,
 		base.SynapseAdminMux,
+		base.DendriteAdminMux,
 	)
 
 	httpRouter := mux.NewRouter()

--- a/clientapi/clientapi.go
+++ b/clientapi/clientapi.go
@@ -36,6 +36,7 @@ func AddPublicRoutes(
 	process *process.ProcessContext,
 	router *mux.Router,
 	synapseAdminRouter *mux.Router,
+	dendriteAdminRouter *mux.Router,
 	cfg *config.ClientAPI,
 	federation *gomatrixserverlib.FederationClient,
 	rsAPI roomserverAPI.RoomserverInternalAPI,
@@ -62,7 +63,8 @@ func AddPublicRoutes(
 	}
 
 	routing.Setup(
-		router, synapseAdminRouter, cfg, rsAPI, asAPI,
+		router, synapseAdminRouter, dendriteAdminRouter,
+		cfg, rsAPI, asAPI,
 		userAPI, userDirectoryProvider, federation,
 		syncProducer, transactionsCache, fsAPI, keyAPI,
 		extRoomsProvider, mscCfg, natsClient,

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -120,7 +120,7 @@ func Setup(
 		).Methods(http.MethodGet, http.MethodPost, http.MethodOptions)
 	}
 
-	synapseAdminRouter.Handle("/admin/evacuateRoom",
+	dendriteAdminRouter.Handle("/admin/evacuateRoom",
 		httputil.MakeExternalAPI("admin_evacuate_room", func(req *http.Request) util.JSONResponse {
 			device, err := getSenderDevice(context.Background(), userAPI, cfg)
 			if err != nil {

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -152,6 +152,9 @@ func Setup(
 			}
 			return util.JSONResponse{
 				Code: 200,
+				JSON: map[string]interface{}{
+					"affected": res.Affected,
+				},
 			}
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -132,11 +132,18 @@ func Setup(
 			if err != nil {
 				return util.ErrorResponse(err)
 			}
+			roomID, ok := vars["room_id"]
+			if !ok {
+				return util.JSONResponse{
+					Code: http.StatusBadRequest,
+					JSON: jsonerror.MissingArgument("Expecting room_id argument."),
+				}
+			}
 			res := &roomserverAPI.PerformAdminEvacuateRoomResponse{}
 			rsAPI.PerformAdminEvacuateRoom(
 				req.Context(),
 				&roomserverAPI.PerformAdminEvacuateRoomRequest{
-					RoomID: vars["room_id"],
+					RoomID: roomID,
 				},
 				res,
 			)

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -122,6 +122,19 @@ func Setup(
 
 	synapseAdminRouter.Handle("/admin/evacuateRoom",
 		httputil.MakeExternalAPI("admin_evacuate_room", func(req *http.Request) util.JSONResponse {
+			device, err := getSenderDevice(context.Background(), userAPI, cfg)
+			if err != nil {
+				return util.JSONResponse{
+					Code: http.StatusForbidden,
+					JSON: jsonerror.Forbidden("Couldn't determine if you were an admin or not."),
+				}
+			}
+			if device.AccountType != userapi.AccountTypeAdmin {
+				return util.JSONResponse{
+					Code: http.StatusForbidden,
+					JSON: jsonerror.Forbidden("This API can only be used by admin users."),
+				}
+			}
 			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
 			if err != nil {
 				return util.ErrorResponse(err)

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -120,7 +120,7 @@ func Setup(
 		).Methods(http.MethodGet, http.MethodPost, http.MethodOptions)
 	}
 
-	dendriteAdminRouter.Handle("/admin/evacuateRoom",
+	dendriteAdminRouter.Handle("/admin/evacuateRoom/{roomID}",
 		httputil.MakeAuthAPI("admin_evacuate_room", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
 			if device.AccountType != userapi.AccountTypeAdmin {
 				return util.JSONResponse{
@@ -132,11 +132,11 @@ func Setup(
 			if err != nil {
 				return util.ErrorResponse(err)
 			}
-			roomID, ok := vars["room_id"]
+			roomID, ok := vars["roomID"]
 			if !ok {
 				return util.JSONResponse{
 					Code: http.StatusBadRequest,
-					JSON: jsonerror.MissingArgument("Expecting room_id argument."),
+					JSON: jsonerror.MissingArgument("Expecting room ID."),
 				}
 			}
 			res := &roomserverAPI.PerformAdminEvacuateRoomResponse{}

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -121,14 +121,7 @@ func Setup(
 	}
 
 	dendriteAdminRouter.Handle("/admin/evacuateRoom",
-		httputil.MakeExternalAPI("admin_evacuate_room", func(req *http.Request) util.JSONResponse {
-			device, err := getSenderDevice(context.Background(), userAPI, cfg)
-			if err != nil {
-				return util.JSONResponse{
-					Code: http.StatusForbidden,
-					JSON: jsonerror.Forbidden("Couldn't determine if you were an admin or not."),
-				}
-			}
+		httputil.MakeAuthAPI("admin_evacuate_room", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
 			if device.AccountType != userapi.AccountTypeAdmin {
 				return util.JSONResponse{
 					Code: http.StatusForbidden,

--- a/cmd/dendrite-demo-pinecone/main.go
+++ b/cmd/dendrite-demo-pinecone/main.go
@@ -193,6 +193,7 @@ func main() {
 		base.PublicWellKnownAPIMux,
 		base.PublicMediaAPIMux,
 		base.SynapseAdminMux,
+		base.DendriteAdminMux,
 	)
 
 	wsUpgrader := websocket.Upgrader{

--- a/cmd/dendrite-demo-yggdrasil/main.go
+++ b/cmd/dendrite-demo-yggdrasil/main.go
@@ -150,6 +150,7 @@ func main() {
 		base.PublicWellKnownAPIMux,
 		base.PublicMediaAPIMux,
 		base.SynapseAdminMux,
+		base.DendriteAdminMux,
 	)
 	if err := mscs.Enable(base, &monolith); err != nil {
 		logrus.WithError(err).Fatalf("Failed to enable MSCs")

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -153,6 +153,7 @@ func main() {
 		base.PublicWellKnownAPIMux,
 		base.PublicMediaAPIMux,
 		base.SynapseAdminMux,
+		base.DendriteAdminMux,
 	)
 
 	if len(base.Cfg.MSCs.MSCs) > 0 {

--- a/cmd/dendrite-polylith-multi/personalities/clientapi.go
+++ b/cmd/dendrite-polylith-multi/personalities/clientapi.go
@@ -31,8 +31,10 @@ func ClientAPI(base *basepkg.BaseDendrite, cfg *config.Dendrite) {
 	keyAPI := base.KeyServerHTTPClient()
 
 	clientapi.AddPublicRoutes(
-		base.ProcessContext, base.PublicClientAPIMux, base.SynapseAdminMux, &base.Cfg.ClientAPI,
-		federation, rsAPI, asQuery, transactions.New(), fsAPI, userAPI, userAPI,
+		base.ProcessContext, base.PublicClientAPIMux,
+		base.SynapseAdminMux, base.DendriteAdminMux,
+		&base.Cfg.ClientAPI, federation, rsAPI, asQuery,
+		transactions.New(), fsAPI, userAPI, userAPI,
 		keyAPI, nil, &cfg.MSCs,
 	)
 

--- a/cmd/dendritejs-pinecone/main.go
+++ b/cmd/dendritejs-pinecone/main.go
@@ -220,6 +220,7 @@ func startup() {
 		base.PublicWellKnownAPIMux,
 		base.PublicMediaAPIMux,
 		base.SynapseAdminMux,
+		base.DendriteAdminMux,
 	)
 
 	httpRouter := mux.NewRouter().SkipClean(true).UseEncodedPath()

--- a/roomserver/api/api.go
+++ b/roomserver/api/api.go
@@ -66,6 +66,12 @@ type RoomserverInternalAPI interface {
 		res *PerformInboundPeekResponse,
 	) error
 
+	PerformAdminEvacuateRoom(
+		ctx context.Context,
+		req *PerformAdminEvacuateRoomRequest,
+		res *PerformAdminEvacuateRoomResponse,
+	)
+
 	QueryPublishedRooms(
 		ctx context.Context,
 		req *QueryPublishedRoomsRequest,

--- a/roomserver/api/api_trace.go
+++ b/roomserver/api/api_trace.go
@@ -104,6 +104,15 @@ func (t *RoomserverInternalAPITrace) PerformPublish(
 	util.GetLogger(ctx).Infof("PerformPublish req=%+v res=%+v", js(req), js(res))
 }
 
+func (t *RoomserverInternalAPITrace) PerformAdminEvacuateRoom(
+	ctx context.Context,
+	req *PerformAdminEvacuateRoomRequest,
+	res *PerformAdminEvacuateRoomResponse,
+) {
+	t.Impl.PerformAdminEvacuateRoom(ctx, req, res)
+	util.GetLogger(ctx).Infof("PerformAdminEvacuateRoom req=%+v res=%+v", js(req), js(res))
+}
+
 func (t *RoomserverInternalAPITrace) PerformInboundPeek(
 	ctx context.Context,
 	req *PerformInboundPeekRequest,

--- a/roomserver/api/perform.go
+++ b/roomserver/api/perform.go
@@ -220,5 +220,6 @@ type PerformAdminEvacuateRoomRequest struct {
 }
 
 type PerformAdminEvacuateRoomResponse struct {
-	Error *PerformError
+	Affected []string `json:"affected"`
+	Error    *PerformError
 }

--- a/roomserver/api/perform.go
+++ b/roomserver/api/perform.go
@@ -214,3 +214,11 @@ type PerformRoomUpgradeResponse struct {
 	NewRoomID string
 	Error     *PerformError
 }
+
+type PerformAdminEvacuateRoomRequest struct {
+	RoomID string `json:"room_id"`
+}
+
+type PerformAdminEvacuateRoomResponse struct {
+	Error *PerformError
+}

--- a/roomserver/internal/api.go
+++ b/roomserver/internal/api.go
@@ -35,6 +35,7 @@ type RoomserverInternalAPI struct {
 	*perform.Backfiller
 	*perform.Forgetter
 	*perform.Upgrader
+	*perform.Admin
 	ProcessContext         *process.ProcessContext
 	DB                     storage.Database
 	Cfg                    *config.RoomServer
@@ -163,6 +164,10 @@ func (r *RoomserverInternalAPI) SetFederationAPI(fsAPI fsAPI.FederationInternalA
 	r.Upgrader = &perform.Upgrader{
 		Cfg:    r.Cfg,
 		URSAPI: r,
+	}
+	r.Admin = &perform.Admin{
+		DB:     r.DB,
+		Leaver: r.Leaver,
 	}
 
 	if err := r.Inputer.Start(); err != nil {

--- a/roomserver/internal/api.go
+++ b/roomserver/internal/api.go
@@ -166,8 +166,10 @@ func (r *RoomserverInternalAPI) SetFederationAPI(fsAPI fsAPI.FederationInternalA
 		URSAPI: r,
 	}
 	r.Admin = &perform.Admin{
-		DB:     r.DB,
-		Leaver: r.Leaver,
+		DB:      r.DB,
+		Cfg:     r.Cfg,
+		Inputer: r.Inputer,
+		Queryer: r.Queryer,
 	}
 
 	if err := r.Inputer.Start(); err != nil {

--- a/roomserver/internal/perform/perform_admin.go
+++ b/roomserver/internal/perform/perform_admin.go
@@ -127,7 +127,7 @@ func (r *Admin) PerformAdminEvacuateRoom(
 			return
 		}
 
-		event, err := eventutil.BuildEvent(ctx, fledglingEvent, nil, time.Now(), nil, latestRes)
+		event, err := eventutil.BuildEvent(ctx, fledglingEvent, r.Cfg.Matrix, time.Now(), nil, latestRes)
 		if err != nil {
 			res.Error = &api.PerformError{
 				Code: api.PerformErrorBadRequest,

--- a/roomserver/internal/perform/perform_admin.go
+++ b/roomserver/internal/perform/perform_admin.go
@@ -77,6 +77,7 @@ func (r *Admin) PerformAdminEvacuateRoom(
 	}
 
 	inputEvents := make([]api.InputRoomEvent, 0, len(memberEvents))
+	res.Affected = make([]string, 0, len(memberEvents))
 	latestReq := &api.QueryLatestEventsAndStateRequest{
 		RoomID: req.RoomID,
 	}
@@ -144,6 +145,7 @@ func (r *Admin) PerformAdminEvacuateRoom(
 			Origin:       r.Cfg.Matrix.ServerName,
 			SendAsServer: string(r.Cfg.Matrix.ServerName),
 		})
+		res.Affected = append(res.Affected, stateKey)
 	}
 
 	inputReq := &api.InputRoomEventsRequest{

--- a/roomserver/internal/perform/perform_admin.go
+++ b/roomserver/internal/perform/perform_admin.go
@@ -1,0 +1,88 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package perform
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/storage"
+)
+
+type Admin struct {
+	DB     storage.Database
+	Leaver *Leaver
+}
+
+// PerformEvacuateRoom will remove all local users from the given room.
+func (r *Admin) PerformAdminEvacuateRoom(
+	ctx context.Context,
+	req *api.PerformAdminEvacuateRoomRequest,
+	res *api.PerformAdminEvacuateRoomResponse,
+) {
+	roomInfo, err := r.DB.RoomInfo(ctx, req.RoomID)
+	if err != nil {
+		res.Error = &api.PerformError{
+			Code: api.PerformErrorBadRequest,
+			Msg:  fmt.Sprintf("r.DB.RoomInfo: %s", err),
+		}
+		return
+	}
+	if roomInfo.IsStub {
+		res.Error = &api.PerformError{
+			Code: api.PerformErrorBadRequest,
+			Msg:  "room is stub",
+		}
+		return
+	}
+
+	memberNIDs, err := r.DB.GetMembershipEventNIDsForRoom(ctx, roomInfo.RoomNID, true, true)
+	if err != nil {
+		res.Error = &api.PerformError{
+			Code: api.PerformErrorBadRequest,
+			Msg:  fmt.Sprintf("r.DB.GetMembershipEventNIDsForRoom: %s", err),
+		}
+		return
+	}
+
+	memberEvents, err := r.DB.Events(ctx, memberNIDs)
+	if err != nil {
+		res.Error = &api.PerformError{
+			Code: api.PerformErrorBadRequest,
+			Msg:  fmt.Sprintf("r.DB.Events: %s", err),
+		}
+		return
+	}
+
+	for _, memberEvent := range memberEvents {
+		if memberEvent.StateKey() == nil {
+			continue
+		}
+		userID := *memberEvent.StateKey()
+		leaveReq := &api.PerformLeaveRequest{
+			RoomID: req.RoomID,
+			UserID: userID,
+		}
+		leaveRes := &api.PerformLeaveResponse{}
+		if _, err = r.Leaver.PerformLeave(ctx, leaveReq, leaveRes); err != nil {
+			res.Error = &api.PerformError{
+				Code: api.PerformErrorBadRequest,
+				Msg:  fmt.Sprintf("r.Leaver.PerformLeave (%s): %s", userID, err),
+			}
+			return
+		}
+	}
+}

--- a/roomserver/internal/perform/perform_admin.go
+++ b/roomserver/internal/perform/perform_admin.go
@@ -90,6 +90,7 @@ func (r *Admin) PerformAdminEvacuateRoom(
 		return
 	}
 
+	prevEvents := latestRes.LatestEvents
 	for _, memberEvent := range memberEvents {
 		if memberEvent.StateKey() == nil {
 			continue
@@ -107,10 +108,11 @@ func (r *Admin) PerformAdminEvacuateRoom(
 
 		stateKey := *memberEvent.StateKey()
 		fledglingEvent := &gomatrixserverlib.EventBuilder{
-			RoomID:   req.RoomID,
-			Type:     gomatrixserverlib.MRoomMember,
-			StateKey: &stateKey,
-			Sender:   stateKey,
+			RoomID:     req.RoomID,
+			Type:       gomatrixserverlib.MRoomMember,
+			StateKey:   &stateKey,
+			Sender:     stateKey,
+			PrevEvents: prevEvents,
 		}
 
 		if fledglingEvent.Content, err = json.Marshal(memberContent); err != nil {
@@ -146,6 +148,9 @@ func (r *Admin) PerformAdminEvacuateRoom(
 			SendAsServer: string(r.Cfg.Matrix.ServerName),
 		})
 		res.Affected = append(res.Affected, stateKey)
+		prevEvents = []gomatrixserverlib.EventReference{
+			event.EventReference(),
+		}
 	}
 
 	inputReq := &api.InputRoomEventsRequest{

--- a/roomserver/internal/perform/perform_admin.go
+++ b/roomserver/internal/perform/perform_admin.go
@@ -41,10 +41,10 @@ func (r *Admin) PerformAdminEvacuateRoom(
 		}
 		return
 	}
-	if roomInfo.IsStub {
+	if roomInfo == nil || roomInfo.IsStub {
 		res.Error = &api.PerformError{
-			Code: api.PerformErrorBadRequest,
-			Msg:  "room is stub",
+			Code: api.PerformErrorNoRoom,
+			Msg:  fmt.Sprintf("Room %s not found", req.RoomID),
 		}
 		return
 	}

--- a/roomserver/inthttp/client.go
+++ b/roomserver/inthttp/client.go
@@ -29,17 +29,17 @@ const (
 	RoomserverInputRoomEventsPath = "/roomserver/inputRoomEvents"
 
 	// Perform operations
-	RoomserverPerformInvitePath        = "/roomserver/performInvite"
-	RoomserverPerformPeekPath          = "/roomserver/performPeek"
-	RoomserverPerformUnpeekPath        = "/roomserver/performUnpeek"
-	RoomserverPerformRoomUpgradePath   = "/roomserver/performRoomUpgrade"
-	RoomserverPerformJoinPath          = "/roomserver/performJoin"
-	RoomserverPerformLeavePath         = "/roomserver/performLeave"
-	RoomserverPerformBackfillPath      = "/roomserver/performBackfill"
-	RoomserverPerformPublishPath       = "/roomserver/performPublish"
-	RoomserverPerformInboundPeekPath   = "/roomserver/performInboundPeek"
-	RoomserverPerformForgetPath        = "/roomserver/performForget"
-	RoomserverPerformAdminEvacuateRoom = "/roomserver/performAdminEvacuateRoom"
+	RoomserverPerformInvitePath            = "/roomserver/performInvite"
+	RoomserverPerformPeekPath              = "/roomserver/performPeek"
+	RoomserverPerformUnpeekPath            = "/roomserver/performUnpeek"
+	RoomserverPerformRoomUpgradePath       = "/roomserver/performRoomUpgrade"
+	RoomserverPerformJoinPath              = "/roomserver/performJoin"
+	RoomserverPerformLeavePath             = "/roomserver/performLeave"
+	RoomserverPerformBackfillPath          = "/roomserver/performBackfill"
+	RoomserverPerformPublishPath           = "/roomserver/performPublish"
+	RoomserverPerformInboundPeekPath       = "/roomserver/performInboundPeek"
+	RoomserverPerformForgetPath            = "/roomserver/performForget"
+	RoomserverPerformAdminEvacuateRoomPath = "/roomserver/performAdminEvacuateRoom"
 
 	// Query operations
 	RoomserverQueryLatestEventsAndStatePath    = "/roomserver/queryLatestEventsAndState"
@@ -308,7 +308,7 @@ func (h *httpRoomserverInternalAPI) PerformAdminEvacuateRoom(
 	span, ctx := opentracing.StartSpanFromContext(ctx, "PerformAdminEvacuateRoom")
 	defer span.Finish()
 
-	apiURL := h.roomserverURL + RoomserverPerformAdminEvacuateRoom
+	apiURL := h.roomserverURL + RoomserverPerformAdminEvacuateRoomPath
 	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, req, res)
 	if err != nil {
 		res.Error = &api.PerformError{

--- a/roomserver/inthttp/client.go
+++ b/roomserver/inthttp/client.go
@@ -29,16 +29,17 @@ const (
 	RoomserverInputRoomEventsPath = "/roomserver/inputRoomEvents"
 
 	// Perform operations
-	RoomserverPerformInvitePath      = "/roomserver/performInvite"
-	RoomserverPerformPeekPath        = "/roomserver/performPeek"
-	RoomserverPerformUnpeekPath      = "/roomserver/performUnpeek"
-	RoomserverPerformRoomUpgradePath = "/roomserver/performRoomUpgrade"
-	RoomserverPerformJoinPath        = "/roomserver/performJoin"
-	RoomserverPerformLeavePath       = "/roomserver/performLeave"
-	RoomserverPerformBackfillPath    = "/roomserver/performBackfill"
-	RoomserverPerformPublishPath     = "/roomserver/performPublish"
-	RoomserverPerformInboundPeekPath = "/roomserver/performInboundPeek"
-	RoomserverPerformForgetPath      = "/roomserver/performForget"
+	RoomserverPerformInvitePath        = "/roomserver/performInvite"
+	RoomserverPerformPeekPath          = "/roomserver/performPeek"
+	RoomserverPerformUnpeekPath        = "/roomserver/performUnpeek"
+	RoomserverPerformRoomUpgradePath   = "/roomserver/performRoomUpgrade"
+	RoomserverPerformJoinPath          = "/roomserver/performJoin"
+	RoomserverPerformLeavePath         = "/roomserver/performLeave"
+	RoomserverPerformBackfillPath      = "/roomserver/performBackfill"
+	RoomserverPerformPublishPath       = "/roomserver/performPublish"
+	RoomserverPerformInboundPeekPath   = "/roomserver/performInboundPeek"
+	RoomserverPerformForgetPath        = "/roomserver/performForget"
+	RoomserverPerformAdminEvacuateRoom = "/roomserver/performAdminEvacuateRoom"
 
 	// Query operations
 	RoomserverQueryLatestEventsAndStatePath    = "/roomserver/queryLatestEventsAndState"
@@ -291,6 +292,23 @@ func (h *httpRoomserverInternalAPI) PerformPublish(
 	defer span.Finish()
 
 	apiURL := h.roomserverURL + RoomserverPerformPublishPath
+	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, req, res)
+	if err != nil {
+		res.Error = &api.PerformError{
+			Msg: fmt.Sprintf("failed to communicate with roomserver: %s", err),
+		}
+	}
+}
+
+func (h *httpRoomserverInternalAPI) PerformAdminEvacuateRoom(
+	ctx context.Context,
+	req *api.PerformAdminEvacuateRoomRequest,
+	res *api.PerformAdminEvacuateRoomResponse,
+) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "PerformAdminEvacuateRoom")
+	defer span.Finish()
+
+	apiURL := h.roomserverURL + RoomserverPerformAdminEvacuateRoom
 	err := httputil.PostJSON(ctx, span, h.httpClient, apiURL, req, res)
 	if err != nil {
 		res.Error = &api.PerformError{

--- a/roomserver/inthttp/server.go
+++ b/roomserver/inthttp/server.go
@@ -118,6 +118,17 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
+	internalAPIMux.Handle(RoomserverPerformAdminEvacuateRoom,
+		httputil.MakeInternalAPI("performAdminEvacuateRoom", func(req *http.Request) util.JSONResponse {
+			var request api.PerformAdminEvacuateRoomRequest
+			var response api.PerformAdminEvacuateRoomResponse
+			if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+				return util.MessageResponse(http.StatusBadRequest, err.Error())
+			}
+			r.PerformAdminEvacuateRoom(req.Context(), &request, &response)
+			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
+		}),
+	)
 	internalAPIMux.Handle(
 		RoomserverQueryPublishedRoomsPath,
 		httputil.MakeInternalAPI("queryPublishedRooms", func(req *http.Request) util.JSONResponse {

--- a/roomserver/inthttp/server.go
+++ b/roomserver/inthttp/server.go
@@ -118,7 +118,7 @@ func AddRoutes(r api.RoomserverInternalAPI, internalAPIMux *mux.Router) {
 			return util.JSONResponse{Code: http.StatusOK, JSON: &response}
 		}),
 	)
-	internalAPIMux.Handle(RoomserverPerformAdminEvacuateRoom,
+	internalAPIMux.Handle(RoomserverPerformAdminEvacuateRoomPath,
 		httputil.MakeInternalAPI("performAdminEvacuateRoom", func(req *http.Request) util.JSONResponse {
 			var request api.PerformAdminEvacuateRoomRequest
 			var response api.PerformAdminEvacuateRoomResponse

--- a/setup/monolith.go
+++ b/setup/monolith.go
@@ -54,13 +54,13 @@ type Monolith struct {
 }
 
 // AddAllPublicRoutes attaches all public paths to the given router
-func (m *Monolith) AddAllPublicRoutes(process *process.ProcessContext, csMux, ssMux, keyMux, wkMux, mediaMux, synapseMux *mux.Router) {
+func (m *Monolith) AddAllPublicRoutes(process *process.ProcessContext, csMux, ssMux, keyMux, wkMux, mediaMux, synapseMux, dendriteMux *mux.Router) {
 	userDirectoryProvider := m.ExtUserDirectoryProvider
 	if userDirectoryProvider == nil {
 		userDirectoryProvider = m.UserAPI
 	}
 	clientapi.AddPublicRoutes(
-		process, csMux, synapseMux, &m.Config.ClientAPI,
+		process, csMux, synapseMux, dendriteMux, &m.Config.ClientAPI,
 		m.FedClient, m.RoomserverAPI,
 		m.AppserviceAPI, transactions.New(),
 		m.FederationAPI, m.UserAPI, userDirectoryProvider, m.KeyAPI,


### PR DESCRIPTION
This is probably the first real Dendrite admin API endpoint which allows you to forcibly remove all local users from your server from a given room.