### PR TITLE
Return correct stream position, if we didn't return any presence events

### DIFF
--- a/syncapi/streams/stream_presence.go
+++ b/syncapi/streams/stream_presence.go
@@ -145,6 +145,10 @@ func (p *PresenceStreamProvider) IncrementalSync(
 		p.cache.Store(cacheKey, presence)
 	}
 
+	if len(req.Response.Presence.Events) == 0 {
+		return to
+	}
+
 	return lastPos
 }
 


### PR DESCRIPTION
... otherwise we keep on hammering `/sync`.