### PR TITLE
Return `null` if MaxFileSizeBytes is 0

### DIFF
--- a/mediaapi/routing/download.go
+++ b/mediaapi/routing/download.go
@@ -551,7 +551,7 @@ func (r *downloadRequest) getRemoteFile(
 			// If we do not have a record, we need to fetch the remote file first and then respond from the local file
 			err := r.fetchRemoteFileAndStoreMetadata(
 				ctx, client,
-				cfg.AbsBasePath, *cfg.MaxFileSizeBytes, db,
+				cfg.AbsBasePath, cfg.MaxFileSizeBytes, db,
 				cfg.ThumbnailSizes, activeThumbnailGeneration,
 				cfg.MaxThumbnailGenerators,
 			)

--- a/mediaapi/routing/routing.go
+++ b/mediaapi/routing/routing.go
@@ -74,7 +74,8 @@ func Setup(
 			return *r
 		}
 		respondSize := cfg.MaxFileSizeBytes
-		if *cfg.MaxFileSizeBytes == 0 {
+		// Shouldn't be nil, as this is checked at startup.
+		if cfg.MaxFileSizeBytes != nil && *cfg.MaxFileSizeBytes == 0 {
 			respondSize = nil
 		}
 		return util.JSONResponse{

--- a/mediaapi/routing/routing.go
+++ b/mediaapi/routing/routing.go
@@ -35,7 +35,7 @@ import (
 // configResponse is the response to GET /_matrix/media/r0/config
 // https://matrix.org/docs/spec/client_server/latest#get-matrix-media-r0-config
 type configResponse struct {
-	UploadSize config.FileSizeBytes `json:"m.upload.size"`
+	UploadSize *config.FileSizeBytes `json:"m.upload.size"`
 }
 
 // Setup registers the media API HTTP handlers
@@ -73,9 +73,13 @@ func Setup(
 		if r := rateLimits.Limit(req); r != nil {
 			return *r
 		}
+		respondSize := cfg.MaxFileSizeBytes
+		if *cfg.MaxFileSizeBytes == 0 {
+			respondSize = nil
+		}
 		return util.JSONResponse{
 			Code: http.StatusOK,
-			JSON: configResponse{UploadSize: *cfg.MaxFileSizeBytes},
+			JSON: configResponse{UploadSize: respondSize},
 		}
 	})
 

--- a/mediaapi/routing/routing.go
+++ b/mediaapi/routing/routing.go
@@ -73,9 +73,8 @@ func Setup(
 		if r := rateLimits.Limit(req); r != nil {
 			return *r
 		}
-		respondSize := cfg.MaxFileSizeBytes
-		// Shouldn't be nil, as this is checked at startup.
-		if cfg.MaxFileSizeBytes != nil && *cfg.MaxFileSizeBytes == 0 {
+		respondSize := &cfg.MaxFileSizeBytes
+		if cfg.MaxFileSizeBytes == 0 {
 			respondSize = nil
 		}
 		return util.JSONResponse{

--- a/mediaapi/routing/upload_test.go
+++ b/mediaapi/routing/upload_test.go
@@ -36,12 +36,11 @@ func Test_uploadRequest_doUpload(t *testing.T) {
 	}
 
 	maxSize := config.FileSizeBytes(8)
-	unlimitedSize := config.FileSizeBytes(0)
 	logger := log.New().WithField("mediaapi", "test")
 	testdataPath := filepath.Join(wd, "./testdata")
 
 	cfg := &config.MediaAPI{
-		MaxFileSizeBytes:  &maxSize,
+		MaxFileSizeBytes:  maxSize,
 		BasePath:          config.Path(testdataPath),
 		AbsBasePath:       config.Path(testdataPath),
 		DynamicThumbnails: false,
@@ -124,7 +123,7 @@ func Test_uploadRequest_doUpload(t *testing.T) {
 				ctx:       context.Background(),
 				reqReader: strings.NewReader("test test test"),
 				cfg: &config.MediaAPI{
-					MaxFileSizeBytes:  &unlimitedSize,
+					MaxFileSizeBytes:  config.FileSizeBytes(0),
 					BasePath:          config.Path(testdataPath),
 					AbsBasePath:       config.Path(testdataPath),
 					DynamicThumbnails: false,

--- a/setup/config/config_mediaapi.go
+++ b/setup/config/config_mediaapi.go
@@ -23,7 +23,7 @@ type MediaAPI struct {
 	// The maximum file size in bytes that is allowed to be stored on this server.
 	// Note: if max_file_size_bytes is set to 0, the size is unlimited.
 	// Note: if max_file_size_bytes is not set, it will default to 10485760 (10MB)
-	MaxFileSizeBytes *FileSizeBytes `yaml:"max_file_size_bytes,omitempty"`
+	MaxFileSizeBytes FileSizeBytes `yaml:"max_file_size_bytes,omitempty"`
 
 	// Whether to dynamically generate thumbnails on-the-fly if the requested resolution is not already generated
 	DynamicThumbnails bool `yaml:"dynamic_thumbnails"`
@@ -48,7 +48,7 @@ func (c *MediaAPI) Defaults(generate bool) {
 		c.BasePath = "./media_store"
 	}
 
-	c.MaxFileSizeBytes = &DefaultMaxFileSizeBytes
+	c.MaxFileSizeBytes = DefaultMaxFileSizeBytes
 	c.MaxThumbnailGenerators = 10
 }
 
@@ -61,7 +61,7 @@ func (c *MediaAPI) Verify(configErrs *ConfigErrors, isMonolith bool) {
 	checkNotEmpty(configErrs, "media_api.database.connection_string", string(c.Database.ConnectionString))
 
 	checkNotEmpty(configErrs, "media_api.base_path", string(c.BasePath))
-	checkPositive(configErrs, "media_api.max_file_size_bytes", int64(*c.MaxFileSizeBytes))
+	checkPositive(configErrs, "media_api.max_file_size_bytes", int64(c.MaxFileSizeBytes))
 	checkPositive(configErrs, "media_api.max_thumbnail_generators", int64(c.MaxThumbnailGenerators))
 
 	for i, size := range c.ThumbnailSizes {


### PR DESCRIPTION
This should fix #2408.

> The maximum size an upload can be in bytes. Clients SHOULD use this as a guide when uploading content. If not listed or null, the size limit should be treated as unknown.
