### PR TITLE
Skip tests that require a database if we can't connect to one

### DIFF
--- a/test/db.go
+++ b/test/db.go
@@ -33,6 +33,15 @@ var DBTypeSQLite DBType = 1
 var DBTypePostgres DBType = 2
 
 var Quiet = false
+var Required = os.Getenv("DENDRITE_SKIP_DB_TESTS") == ""
+
+func fatalError(t *testing.T, format string, args ...interface{}) {
+	if Required {
+		t.Fatalf(format, args...)
+	} else {
+		t.Skipf(format, args...)
+	}
+}
 
 func createLocalDB(t *testing.T, dbName string) {
 	if !Quiet {
@@ -45,14 +54,14 @@ func createLocalDB(t *testing.T, dbName string) {
 	}
 	err := createDB.Run()
 	if err != nil {
-		t.Skipf("createLocalDB returned error: %s", err)
+		fatalError(t, "createLocalDB returned error: %s", err)
 	}
 }
 
 func createRemoteDB(t *testing.T, dbName, user, connStr string) {
 	db, err := sql.Open("postgres", connStr+" dbname=postgres")
 	if err != nil {
-		t.Skipf("failed to open postgres conn with connstr=%s : %s", connStr, err)
+		fatalError(t, "failed to open postgres conn with connstr=%s : %s", connStr, err)
 	}
 	_, err = db.Exec(fmt.Sprintf(`CREATE DATABASE %s;`, dbName))
 	if err != nil {

--- a/test/db.go
+++ b/test/db.go
@@ -34,9 +34,9 @@ var DBTypePostgres DBType = 2
 
 var Quiet = false
 
-func createLocalDB(dbName string) {
+func createLocalDB(t *testing.T, dbName string) {
 	if !Quiet {
-		fmt.Println("Note: tests require a postgres install accessible to the current user")
+		t.Log("Note: tests require a postgres install accessible to the current user")
 	}
 	createDB := exec.Command("createdb", dbName)
 	if !Quiet {
@@ -44,15 +44,15 @@ func createLocalDB(dbName string) {
 		createDB.Stderr = os.Stderr
 	}
 	err := createDB.Run()
-	if err != nil && !Quiet {
-		fmt.Println("createLocalDB returned error:", err)
+	if err != nil {
+		t.Skipf("createLocalDB returned error: %s", err)
 	}
 }
 
 func createRemoteDB(t *testing.T, dbName, user, connStr string) {
 	db, err := sql.Open("postgres", connStr+" dbname=postgres")
 	if err != nil {
-		t.Fatalf("failed to open postgres conn with connstr=%s : %s", connStr, err)
+		t.Skipf("failed to open postgres conn with connstr=%s : %s", connStr, err)
 	}
 	_, err = db.Exec(fmt.Sprintf(`CREATE DATABASE %s;`, dbName))
 	if err != nil {
@@ -133,7 +133,7 @@ func PrepareDBConnectionString(t *testing.T, dbType DBType) (connStr string, clo
 	hash := sha256.Sum256([]byte(wd))
 	dbName := fmt.Sprintf("dendrite_test_%s", hex.EncodeToString(hash[:16]))
 	if postgresDB == "" { // local server, use createdb
-		createLocalDB(dbName)
+		createLocalDB(t, dbName)
 	} else { // remote server, shell into the postgres user and CREATE DATABASE
 		createRemoteDB(t, dbName, user, connStr)
 	}

--- a/test/db.go
+++ b/test/db.go
@@ -33,7 +33,7 @@ var DBTypeSQLite DBType = 1
 var DBTypePostgres DBType = 2
 
 var Quiet = false
-var Required = os.Getenv("DENDRITE_SKIP_DB_TESTS") == ""
+var Required = os.Getenv("DENDRITE_TEST_SKIP_NODB") == ""
 
 func fatalError(t *testing.T, format string, args ...interface{}) {
 	if Required {


### PR DESCRIPTION
This was causing local `go test` upsetti since I don't have a PostgreSQL locally that they can connect to.