### PR TITLE
Tweak ordering in `OnIncomingSyncRequest`

### DIFF
--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -265,6 +265,9 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request, device *userapi.
 		syncReq.Log.WithField("currentPos", currentPos).Debugln("Responding to sync immediately")
 	}
 
+	defer rp.updateLastSeen(req, device)
+	rp.updatePresence(req.Context(), rp.db, req.FormValue("set_presence"), device.UserID)
+
 	if syncReq.Since.IsEmpty() {
 		// Complete sync
 		syncReq.Response.NextBatch = types.StreamingToken{
@@ -337,9 +340,6 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request, device *userapi.
 			),
 		}
 	}
-
-	rp.updateLastSeen(req, device)
-	rp.updatePresence(req.Context(), rp.db, req.FormValue("set_presence"), device.UserID)
 
 	return util.JSONResponse{
 		Code: http.StatusOK,

--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -229,6 +229,9 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request, device *userapi.
 		}
 	}
 
+	rp.updateLastSeen(req, device)
+	rp.updatePresence(req.Context(), rp.db, req.FormValue("set_presence"), device.UserID)
+
 	activeSyncRequests.Inc()
 	defer activeSyncRequests.Dec()
 
@@ -264,9 +267,6 @@ func (rp *RequestPool) OnIncomingSyncRequest(req *http.Request, device *userapi.
 	} else {
 		syncReq.Log.WithField("currentPos", currentPos).Debugln("Responding to sync immediately")
 	}
-
-	defer rp.updateLastSeen(req, device)
-	rp.updatePresence(req.Context(), rp.db, req.FormValue("set_presence"), device.UserID)
 
 	if syncReq.Since.IsEmpty() {
 		// Complete sync

--- a/syncapi/sync/requestpool_test.go
+++ b/syncapi/sync/requestpool_test.go
@@ -118,7 +118,7 @@ func TestRequestPool_updatePresence(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			beforeCount := publisher.count
-			rp.updatePresence(db, tt.args.presence, tt.args.userID)
+			rp.updatePresence(context.Background(), db, tt.args.presence, tt.args.userID)
 			if tt.wantIncrease && publisher.count <= beforeCount {
 				t.Fatalf("expected count to increase: %d <= %d", publisher.count, beforeCount)
 			}


### PR DESCRIPTION
This means we look up the current position at the very beginning of the request rather than after potentially blocking operations.