### PR TITLE
Define component interfaces based on consumers (1/2)

### DIFF
--- a/appservice/api/query.go
+++ b/appservice/api/query.go
@@ -84,7 +84,7 @@ func RetrieveUserProfile(
 	ctx context.Context,
 	userID string,
 	asAPI AppServiceQueryAPI,
-	profileAPI userapi.UserProfileAPI,
+	profileAPI userapi.ClientUserAPI,
 ) (*authtypes.Profile, error) {
 	localpart, _, err := gomatrixserverlib.SplitID('@', userID)
 	if err != nil {

--- a/appservice/appservice.go
+++ b/appservice/appservice.go
@@ -47,8 +47,8 @@ func AddInternalRoutes(router *mux.Router, queryAPI appserviceAPI.AppServiceQuer
 // can call functions directly on the returned API or via an HTTP interface using AddInternalRoutes.
 func NewInternalAPI(
 	base *base.BaseDendrite,
-	userAPI userapi.UserInternalAPI,
-	rsAPI roomserverAPI.RoomserverInternalAPI,
+	userAPI userapi.AppserviceUserAPI,
+	rsAPI roomserverAPI.AppserviceRoomserverAPI,
 ) appserviceAPI.AppServiceQueryAPI {
 	client := &http.Client{
 		Timeout: time.Second * 30,
@@ -117,7 +117,7 @@ func NewInternalAPI(
 // `sender_localpart` field of each application service if it doesn't
 // exist already
 func generateAppServiceAccount(
-	userAPI userapi.UserInternalAPI,
+	userAPI userapi.AppserviceUserAPI,
 	as config.ApplicationService,
 ) error {
 	var accRes userapi.PerformAccountCreationResponse

--- a/appservice/consumers/roomserver.go
+++ b/appservice/consumers/roomserver.go
@@ -37,7 +37,7 @@ type OutputRoomEventConsumer struct {
 	durable      string
 	topic        string
 	asDB         storage.Database
-	rsAPI        api.RoomserverInternalAPI
+	rsAPI        api.AppserviceRoomserverAPI
 	serverName   string
 	workerStates []types.ApplicationServiceWorkerState
 }
@@ -49,7 +49,7 @@ func NewOutputRoomEventConsumer(
 	cfg *config.Dendrite,
 	js nats.JetStreamContext,
 	appserviceDB storage.Database,
-	rsAPI api.RoomserverInternalAPI,
+	rsAPI api.AppserviceRoomserverAPI,
 	workerStates []types.ApplicationServiceWorkerState,
 ) *OutputRoomEventConsumer {
 	return &OutputRoomEventConsumer{

--- a/clientapi/auth/login.go
+++ b/clientapi/auth/login.go
@@ -33,7 +33,7 @@ import (
 // called after authorization has completed, with the result of the authorization.
 // If the final return value is non-nil, an error occurred and the cleanup function
 // is nil.
-func LoginFromJSONReader(ctx context.Context, r io.Reader, useraccountAPI uapi.UserAccountAPI, userAPI UserInternalAPIForLogin, cfg *config.ClientAPI) (*Login, LoginCleanupFunc, *util.JSONResponse) {
+func LoginFromJSONReader(ctx context.Context, r io.Reader, useraccountAPI uapi.UserLoginAPI, userAPI UserInternalAPIForLogin, cfg *config.ClientAPI) (*Login, LoginCleanupFunc, *util.JSONResponse) {
 	reqBytes, err := ioutil.ReadAll(r)
 	if err != nil {
 		err := &util.JSONResponse{

--- a/clientapi/auth/login_test.go
+++ b/clientapi/auth/login_test.go
@@ -160,7 +160,6 @@ func TestBadLoginFromJSONReader(t *testing.T) {
 
 type fakeUserInternalAPI struct {
 	UserInternalAPIForLogin
-	uapi.UserAccountAPI
 	DeletedTokens []string
 }
 
@@ -176,6 +175,10 @@ func (ua *fakeUserInternalAPI) QueryAccountByPassword(ctx context.Context, req *
 
 func (ua *fakeUserInternalAPI) PerformLoginTokenDeletion(ctx context.Context, req *uapi.PerformLoginTokenDeletionRequest, res *uapi.PerformLoginTokenDeletionResponse) error {
 	ua.DeletedTokens = append(ua.DeletedTokens, req.Token)
+	return nil
+}
+
+func (ua *fakeUserInternalAPI) PerformLoginTokenCreation(ctx context.Context, req *uapi.PerformLoginTokenCreationRequest, res *uapi.PerformLoginTokenCreationResponse) error {
 	return nil
 }
 

--- a/clientapi/auth/user_interactive.go
+++ b/clientapi/auth/user_interactive.go
@@ -110,7 +110,7 @@ type UserInteractive struct {
 	Sessions map[string][]string
 }
 
-func NewUserInteractive(userAccountAPI api.UserAccountAPI, cfg *config.ClientAPI) *UserInteractive {
+func NewUserInteractive(userAccountAPI api.UserLoginAPI, cfg *config.ClientAPI) *UserInteractive {
 	typePassword := &LoginTypePassword{
 		GetAccountByPassword: userAccountAPI.QueryAccountByPassword,
 		Config:               cfg,

--- a/clientapi/auth/user_interactive_test.go
+++ b/clientapi/auth/user_interactive_test.go
@@ -24,9 +24,7 @@ var (
 	}
 )
 
-type fakeAccountDatabase struct {
-	api.UserAccountAPI
-}
+type fakeAccountDatabase struct{}
 
 func (d *fakeAccountDatabase) PerformPasswordUpdate(ctx context.Context, req *api.PerformPasswordUpdateRequest, res *api.PerformPasswordUpdateResponse) error {
 	return nil

--- a/clientapi/clientapi.go
+++ b/clientapi/clientapi.go
@@ -33,13 +33,13 @@ import (
 func AddPublicRoutes(
 	base *base.BaseDendrite,
 	federation *gomatrixserverlib.FederationClient,
-	rsAPI roomserverAPI.RoomserverInternalAPI,
+	rsAPI roomserverAPI.ClientRoomserverAPI,
 	asAPI appserviceAPI.AppServiceQueryAPI,
 	transactionsCache *transactions.Cache,
 	fsAPI federationAPI.FederationInternalAPI,
 	userAPI userapi.ClientUserAPI,
 	userDirectoryProvider userapi.UserDirectoryProvider,
-	keyAPI keyserverAPI.KeyInternalAPI,
+	keyAPI keyserverAPI.ClientKeyAPI,
 	extRoomsProvider api.ExtraPublicRoomsProvider,
 ) {
 	cfg := &base.Cfg.ClientAPI

--- a/clientapi/clientapi.go
+++ b/clientapi/clientapi.go
@@ -36,7 +36,7 @@ func AddPublicRoutes(
 	rsAPI roomserverAPI.ClientRoomserverAPI,
 	asAPI appserviceAPI.AppServiceQueryAPI,
 	transactionsCache *transactions.Cache,
-	fsAPI federationAPI.FederationInternalAPI,
+	fsAPI federationAPI.ClientFederationAPI,
 	userAPI userapi.ClientUserAPI,
 	userDirectoryProvider userapi.UserDirectoryProvider,
 	keyAPI keyserverAPI.ClientKeyAPI,

--- a/clientapi/clientapi.go
+++ b/clientapi/clientapi.go
@@ -37,7 +37,7 @@ func AddPublicRoutes(
 	asAPI appserviceAPI.AppServiceQueryAPI,
 	transactionsCache *transactions.Cache,
 	fsAPI federationAPI.FederationInternalAPI,
-	userAPI userapi.UserInternalAPI,
+	userAPI userapi.ClientUserAPI,
 	userDirectoryProvider userapi.UserDirectoryProvider,
 	keyAPI keyserverAPI.KeyInternalAPI,
 	extRoomsProvider api.ExtraPublicRoomsProvider,

--- a/clientapi/producers/syncapi.go
+++ b/clientapi/producers/syncapi.go
@@ -38,7 +38,7 @@ type SyncAPIProducer struct {
 	TopicPresenceEvent     string
 	JetStream              nats.JetStreamContext
 	ServerName             gomatrixserverlib.ServerName
-	UserAPI                userapi.UserInternalAPI
+	UserAPI                userapi.ClientUserAPI
 }
 
 // SendData sends account data to the sync API server

--- a/clientapi/routing/account_data.go
+++ b/clientapi/routing/account_data.go
@@ -33,7 +33,7 @@ import (
 
 // GetAccountData implements GET /user/{userId}/[rooms/{roomid}/]account_data/{type}
 func GetAccountData(
-	req *http.Request, userAPI api.UserInternalAPI, device *api.Device,
+	req *http.Request, userAPI api.ClientUserAPI, device *api.Device,
 	userID string, roomID string, dataType string,
 ) util.JSONResponse {
 	if userID != device.UserID {
@@ -76,7 +76,7 @@ func GetAccountData(
 
 // SaveAccountData implements PUT /user/{userId}/[rooms/{roomId}/]account_data/{type}
 func SaveAccountData(
-	req *http.Request, userAPI api.UserInternalAPI, device *api.Device,
+	req *http.Request, userAPI api.ClientUserAPI, device *api.Device,
 	userID string, roomID string, dataType string, syncProducer *producers.SyncAPIProducer,
 ) util.JSONResponse {
 	if userID != device.UserID {
@@ -152,7 +152,7 @@ type fullyReadEvent struct {
 // SaveReadMarker implements POST /rooms/{roomId}/read_markers
 func SaveReadMarker(
 	req *http.Request,
-	userAPI api.UserInternalAPI, rsAPI roomserverAPI.RoomserverInternalAPI,
+	userAPI api.ClientUserAPI, rsAPI roomserverAPI.RoomserverInternalAPI,
 	syncProducer *producers.SyncAPIProducer, device *api.Device, roomID string,
 ) util.JSONResponse {
 	// Verify that the user is a member of this room

--- a/clientapi/routing/account_data.go
+++ b/clientapi/routing/account_data.go
@@ -152,7 +152,7 @@ type fullyReadEvent struct {
 // SaveReadMarker implements POST /rooms/{roomId}/read_markers
 func SaveReadMarker(
 	req *http.Request,
-	userAPI api.ClientUserAPI, rsAPI roomserverAPI.RoomserverInternalAPI,
+	userAPI api.ClientUserAPI, rsAPI roomserverAPI.ClientRoomserverAPI,
 	syncProducer *producers.SyncAPIProducer, device *api.Device, roomID string,
 ) util.JSONResponse {
 	// Verify that the user is a member of this room

--- a/clientapi/routing/admin.go
+++ b/clientapi/routing/admin.go
@@ -11,7 +11,7 @@ import (
 	"github.com/matrix-org/util"
 )
 
-func AdminEvacuateRoom(req *http.Request, device *userapi.Device, rsAPI roomserverAPI.RoomserverInternalAPI) util.JSONResponse {
+func AdminEvacuateRoom(req *http.Request, device *userapi.Device, rsAPI roomserverAPI.ClientRoomserverAPI) util.JSONResponse {
 	if device.AccountType != userapi.AccountTypeAdmin {
 		return util.JSONResponse{
 			Code: http.StatusForbidden,

--- a/clientapi/routing/admin_whois.go
+++ b/clientapi/routing/admin_whois.go
@@ -44,7 +44,7 @@ type connectionInfo struct {
 
 // GetAdminWhois implements GET /admin/whois/{userId}
 func GetAdminWhois(
-	req *http.Request, userAPI api.UserInternalAPI, device *api.Device,
+	req *http.Request, userAPI api.ClientUserAPI, device *api.Device,
 	userID string,
 ) util.JSONResponse {
 	allowed := device.AccountType == api.AccountTypeAdmin || userID == device.UserID

--- a/clientapi/routing/aliases.go
+++ b/clientapi/routing/aliases.go
@@ -28,7 +28,7 @@ import (
 
 // GetAliases implements GET /_matrix/client/r0/rooms/{roomId}/aliases
 func GetAliases(
-	req *http.Request, rsAPI api.RoomserverInternalAPI, device *userapi.Device, roomID string,
+	req *http.Request, rsAPI api.ClientRoomserverAPI, device *userapi.Device, roomID string,
 ) util.JSONResponse {
 	stateTuple := gomatrixserverlib.StateKeyTuple{
 		EventType: gomatrixserverlib.MRoomHistoryVisibility,

--- a/clientapi/routing/capabilities.go
+++ b/clientapi/routing/capabilities.go
@@ -26,7 +26,7 @@ import (
 // GetCapabilities returns information about the server's supported feature set
 // and other relevant capabilities to an authenticated user.
 func GetCapabilities(
-	req *http.Request, rsAPI roomserverAPI.RoomserverInternalAPI,
+	req *http.Request, rsAPI roomserverAPI.ClientRoomserverAPI,
 ) util.JSONResponse {
 	roomVersionsQueryReq := roomserverAPI.QueryRoomVersionCapabilitiesRequest{}
 	roomVersionsQueryRes := roomserverAPI.QueryRoomVersionCapabilitiesResponse{}

--- a/clientapi/routing/createroom.go
+++ b/clientapi/routing/createroom.go
@@ -137,7 +137,7 @@ type fledglingEvent struct {
 func CreateRoom(
 	req *http.Request, device *api.Device,
 	cfg *config.ClientAPI,
-	profileAPI api.UserProfileAPI, rsAPI roomserverAPI.RoomserverInternalAPI,
+	profileAPI api.ClientUserAPI, rsAPI roomserverAPI.RoomserverInternalAPI,
 	asAPI appserviceAPI.AppServiceQueryAPI,
 ) util.JSONResponse {
 	var r createRoomRequest
@@ -164,7 +164,7 @@ func createRoom(
 	ctx context.Context,
 	r createRoomRequest, device *api.Device,
 	cfg *config.ClientAPI,
-	profileAPI api.UserProfileAPI, rsAPI roomserverAPI.RoomserverInternalAPI,
+	profileAPI api.ClientUserAPI, rsAPI roomserverAPI.RoomserverInternalAPI,
 	asAPI appserviceAPI.AppServiceQueryAPI,
 	evTime time.Time,
 ) util.JSONResponse {

--- a/clientapi/routing/deactivate.go
+++ b/clientapi/routing/deactivate.go
@@ -15,7 +15,7 @@ import (
 func Deactivate(
 	req *http.Request,
 	userInteractiveAuth *auth.UserInteractive,
-	accountAPI api.UserAccountAPI,
+	accountAPI api.ClientUserAPI,
 	deviceAPI *api.Device,
 ) util.JSONResponse {
 	ctx := req.Context()

--- a/clientapi/routing/device.go
+++ b/clientapi/routing/device.go
@@ -50,7 +50,7 @@ type devicesDeleteJSON struct {
 
 // GetDeviceByID handles /devices/{deviceID}
 func GetDeviceByID(
-	req *http.Request, userAPI api.UserInternalAPI, device *api.Device,
+	req *http.Request, userAPI api.ClientUserAPI, device *api.Device,
 	deviceID string,
 ) util.JSONResponse {
 	var queryRes api.QueryDevicesResponse
@@ -88,7 +88,7 @@ func GetDeviceByID(
 
 // GetDevicesByLocalpart handles /devices
 func GetDevicesByLocalpart(
-	req *http.Request, userAPI api.UserInternalAPI, device *api.Device,
+	req *http.Request, userAPI api.ClientUserAPI, device *api.Device,
 ) util.JSONResponse {
 	var queryRes api.QueryDevicesResponse
 	err := userAPI.QueryDevices(req.Context(), &api.QueryDevicesRequest{
@@ -118,7 +118,7 @@ func GetDevicesByLocalpart(
 
 // UpdateDeviceByID handles PUT on /devices/{deviceID}
 func UpdateDeviceByID(
-	req *http.Request, userAPI api.UserInternalAPI, device *api.Device,
+	req *http.Request, userAPI api.ClientUserAPI, device *api.Device,
 	deviceID string,
 ) util.JSONResponse {
 
@@ -161,7 +161,7 @@ func UpdateDeviceByID(
 
 // DeleteDeviceById handles DELETE requests to /devices/{deviceId}
 func DeleteDeviceById(
-	req *http.Request, userInteractiveAuth *auth.UserInteractive, userAPI api.UserInternalAPI, device *api.Device,
+	req *http.Request, userInteractiveAuth *auth.UserInteractive, userAPI api.ClientUserAPI, device *api.Device,
 	deviceID string,
 ) util.JSONResponse {
 	var (
@@ -242,7 +242,7 @@ func DeleteDeviceById(
 
 // DeleteDevices handles POST requests to /delete_devices
 func DeleteDevices(
-	req *http.Request, userAPI api.UserInternalAPI, device *api.Device,
+	req *http.Request, userAPI api.ClientUserAPI, device *api.Device,
 ) util.JSONResponse {
 	ctx := req.Context()
 	payload := devicesDeleteJSON{}

--- a/clientapi/routing/directory.go
+++ b/clientapi/routing/directory.go
@@ -46,7 +46,7 @@ func DirectoryRoom(
 	roomAlias string,
 	federation *gomatrixserverlib.FederationClient,
 	cfg *config.ClientAPI,
-	rsAPI roomserverAPI.RoomserverInternalAPI,
+	rsAPI roomserverAPI.ClientRoomserverAPI,
 	fedSenderAPI federationAPI.FederationInternalAPI,
 ) util.JSONResponse {
 	_, domain, err := gomatrixserverlib.SplitID('#', roomAlias)
@@ -117,7 +117,7 @@ func SetLocalAlias(
 	device *userapi.Device,
 	alias string,
 	cfg *config.ClientAPI,
-	rsAPI roomserverAPI.RoomserverInternalAPI,
+	rsAPI roomserverAPI.ClientRoomserverAPI,
 ) util.JSONResponse {
 	_, domain, err := gomatrixserverlib.SplitID('#', alias)
 	if err != nil {
@@ -199,7 +199,7 @@ func RemoveLocalAlias(
 	req *http.Request,
 	device *userapi.Device,
 	alias string,
-	rsAPI roomserverAPI.RoomserverInternalAPI,
+	rsAPI roomserverAPI.ClientRoomserverAPI,
 ) util.JSONResponse {
 	queryReq := roomserverAPI.RemoveRoomAliasRequest{
 		Alias:  alias,
@@ -237,7 +237,7 @@ type roomVisibility struct {
 
 // GetVisibility implements GET /directory/list/room/{roomID}
 func GetVisibility(
-	req *http.Request, rsAPI roomserverAPI.RoomserverInternalAPI,
+	req *http.Request, rsAPI roomserverAPI.ClientRoomserverAPI,
 	roomID string,
 ) util.JSONResponse {
 	var res roomserverAPI.QueryPublishedRoomsResponse
@@ -265,7 +265,7 @@ func GetVisibility(
 // SetVisibility implements PUT /directory/list/room/{roomID}
 // TODO: Allow admin users to edit the room visibility
 func SetVisibility(
-	req *http.Request, rsAPI roomserverAPI.RoomserverInternalAPI, dev *userapi.Device,
+	req *http.Request, rsAPI roomserverAPI.ClientRoomserverAPI, dev *userapi.Device,
 	roomID string,
 ) util.JSONResponse {
 	resErr := checkMemberInRoom(req.Context(), rsAPI, dev.UserID, roomID)

--- a/clientapi/routing/directory.go
+++ b/clientapi/routing/directory.go
@@ -47,7 +47,7 @@ func DirectoryRoom(
 	federation *gomatrixserverlib.FederationClient,
 	cfg *config.ClientAPI,
 	rsAPI roomserverAPI.ClientRoomserverAPI,
-	fedSenderAPI federationAPI.FederationInternalAPI,
+	fedSenderAPI federationAPI.ClientFederationAPI,
 ) util.JSONResponse {
 	_, domain, err := gomatrixserverlib.SplitID('#', roomAlias)
 	if err != nil {

--- a/clientapi/routing/directory_public.go
+++ b/clientapi/routing/directory_public.go
@@ -50,7 +50,7 @@ type filter struct {
 
 // GetPostPublicRooms implements GET and POST /publicRooms
 func GetPostPublicRooms(
-	req *http.Request, rsAPI roomserverAPI.RoomserverInternalAPI,
+	req *http.Request, rsAPI roomserverAPI.ClientRoomserverAPI,
 	extRoomsProvider api.ExtraPublicRoomsProvider,
 	federation *gomatrixserverlib.FederationClient,
 	cfg *config.ClientAPI,
@@ -91,7 +91,7 @@ func GetPostPublicRooms(
 }
 
 func publicRooms(
-	ctx context.Context, request PublicRoomReq, rsAPI roomserverAPI.RoomserverInternalAPI, extRoomsProvider api.ExtraPublicRoomsProvider,
+	ctx context.Context, request PublicRoomReq, rsAPI roomserverAPI.ClientRoomserverAPI, extRoomsProvider api.ExtraPublicRoomsProvider,
 ) (*gomatrixserverlib.RespPublicRooms, error) {
 
 	response := gomatrixserverlib.RespPublicRooms{
@@ -229,7 +229,7 @@ func sliceInto(slice []gomatrixserverlib.PublicRoom, since int64, limit int16) (
 }
 
 func refreshPublicRoomCache(
-	ctx context.Context, rsAPI roomserverAPI.RoomserverInternalAPI, extRoomsProvider api.ExtraPublicRoomsProvider,
+	ctx context.Context, rsAPI roomserverAPI.ClientRoomserverAPI, extRoomsProvider api.ExtraPublicRoomsProvider,
 ) []gomatrixserverlib.PublicRoom {
 	cacheMu.Lock()
 	defer cacheMu.Unlock()

--- a/clientapi/routing/getevent.go
+++ b/clientapi/routing/getevent.go
@@ -31,7 +31,6 @@ type getEventRequest struct {
 	roomID         string
 	eventID        string
 	cfg            *config.ClientAPI
-	federation     *gomatrixserverlib.FederationClient
 	requestedEvent *gomatrixserverlib.Event
 }
 
@@ -43,8 +42,7 @@ func GetEvent(
 	roomID string,
 	eventID string,
 	cfg *config.ClientAPI,
-	rsAPI api.RoomserverInternalAPI,
-	federation *gomatrixserverlib.FederationClient,
+	rsAPI api.ClientRoomserverAPI,
 ) util.JSONResponse {
 	eventsReq := api.QueryEventsByIDRequest{
 		EventIDs: []string{eventID},
@@ -72,7 +70,6 @@ func GetEvent(
 		roomID:         roomID,
 		eventID:        eventID,
 		cfg:            cfg,
-		federation:     federation,
 		requestedEvent: requestedEvent,
 	}
 

--- a/clientapi/routing/joinroom.go
+++ b/clientapi/routing/joinroom.go
@@ -30,7 +30,7 @@ func JoinRoomByIDOrAlias(
 	req *http.Request,
 	device *api.Device,
 	rsAPI roomserverAPI.RoomserverInternalAPI,
-	profileAPI api.UserProfileAPI,
+	profileAPI api.ClientUserAPI,
 	roomIDOrAlias string,
 ) util.JSONResponse {
 	// Prepare to ask the roomserver to perform the room join.

--- a/clientapi/routing/joinroom.go
+++ b/clientapi/routing/joinroom.go
@@ -29,7 +29,7 @@ import (
 func JoinRoomByIDOrAlias(
 	req *http.Request,
 	device *api.Device,
-	rsAPI roomserverAPI.RoomserverInternalAPI,
+	rsAPI roomserverAPI.ClientRoomserverAPI,
 	profileAPI api.ClientUserAPI,
 	roomIDOrAlias string,
 ) util.JSONResponse {

--- a/clientapi/routing/key_backup.go
+++ b/clientapi/routing/key_backup.go
@@ -55,7 +55,7 @@ type keyBackupSessionResponse struct {
 
 // Create a new key backup. Request must contain a `keyBackupVersion`. Returns a `keyBackupVersionCreateResponse`.
 // Implements  POST /_matrix/client/r0/room_keys/version
-func CreateKeyBackupVersion(req *http.Request, userAPI userapi.UserInternalAPI, device *userapi.Device) util.JSONResponse {
+func CreateKeyBackupVersion(req *http.Request, userAPI userapi.ClientUserAPI, device *userapi.Device) util.JSONResponse {
 	var kb keyBackupVersion
 	resErr := httputil.UnmarshalJSONRequest(req, &kb)
 	if resErr != nil {
@@ -89,7 +89,7 @@ func CreateKeyBackupVersion(req *http.Request, userAPI userapi.UserInternalAPI, 
 
 // KeyBackupVersion returns the key backup version specified. If `version` is empty, the latest `keyBackupVersionResponse` is returned.
 // Implements GET  /_matrix/client/r0/room_keys/version and GET /_matrix/client/r0/room_keys/version/{version}
-func KeyBackupVersion(req *http.Request, userAPI userapi.UserInternalAPI, device *userapi.Device, version string) util.JSONResponse {
+func KeyBackupVersion(req *http.Request, userAPI userapi.ClientUserAPI, device *userapi.Device, version string) util.JSONResponse {
 	var queryResp userapi.QueryKeyBackupResponse
 	userAPI.QueryKeyBackup(req.Context(), &userapi.QueryKeyBackupRequest{
 		UserID:  device.UserID,
@@ -118,7 +118,7 @@ func KeyBackupVersion(req *http.Request, userAPI userapi.UserInternalAPI, device
 
 // Modify the auth data of a key backup. Version must not be empty. Request must contain a `keyBackupVersion`
 // Implements PUT  /_matrix/client/r0/room_keys/version/{version}
-func ModifyKeyBackupVersionAuthData(req *http.Request, userAPI userapi.UserInternalAPI, device *userapi.Device, version string) util.JSONResponse {
+func ModifyKeyBackupVersionAuthData(req *http.Request, userAPI userapi.ClientUserAPI, device *userapi.Device, version string) util.JSONResponse {
 	var kb keyBackupVersion
 	resErr := httputil.UnmarshalJSONRequest(req, &kb)
 	if resErr != nil {
@@ -159,7 +159,7 @@ func ModifyKeyBackupVersionAuthData(req *http.Request, userAPI userapi.UserInter
 
 // Delete a version of key backup. Version must not be empty. If the key backup was previously deleted, will return 200 OK.
 // Implements DELETE  /_matrix/client/r0/room_keys/version/{version}
-func DeleteKeyBackupVersion(req *http.Request, userAPI userapi.UserInternalAPI, device *userapi.Device, version string) util.JSONResponse {
+func DeleteKeyBackupVersion(req *http.Request, userAPI userapi.ClientUserAPI, device *userapi.Device, version string) util.JSONResponse {
 	var performKeyBackupResp userapi.PerformKeyBackupResponse
 	if err := userAPI.PerformKeyBackup(req.Context(), &userapi.PerformKeyBackupRequest{
 		UserID:       device.UserID,
@@ -194,7 +194,7 @@ func DeleteKeyBackupVersion(req *http.Request, userAPI userapi.UserInternalAPI, 
 
 // Upload a bunch of session keys for a given `version`.
 func UploadBackupKeys(
-	req *http.Request, userAPI userapi.UserInternalAPI, device *userapi.Device, version string, keys *keyBackupSessionRequest,
+	req *http.Request, userAPI userapi.ClientUserAPI, device *userapi.Device, version string, keys *keyBackupSessionRequest,
 ) util.JSONResponse {
 	var performKeyBackupResp userapi.PerformKeyBackupResponse
 	if err := userAPI.PerformKeyBackup(req.Context(), &userapi.PerformKeyBackupRequest{
@@ -230,7 +230,7 @@ func UploadBackupKeys(
 
 // Get keys from a given backup version. Response returned varies depending on if roomID and sessionID are set.
 func GetBackupKeys(
-	req *http.Request, userAPI userapi.UserInternalAPI, device *userapi.Device, version, roomID, sessionID string,
+	req *http.Request, userAPI userapi.ClientUserAPI, device *userapi.Device, version, roomID, sessionID string,
 ) util.JSONResponse {
 	var queryResp userapi.QueryKeyBackupResponse
 	userAPI.QueryKeyBackup(req.Context(), &userapi.QueryKeyBackupRequest{

--- a/clientapi/routing/key_crosssigning.go
+++ b/clientapi/routing/key_crosssigning.go
@@ -34,7 +34,7 @@ type crossSigningRequest struct {
 
 func UploadCrossSigningDeviceKeys(
 	req *http.Request, userInteractiveAuth *auth.UserInteractive,
-	keyserverAPI api.KeyInternalAPI, device *userapi.Device,
+	keyserverAPI api.ClientKeyAPI, device *userapi.Device,
 	accountAPI userapi.ClientUserAPI, cfg *config.ClientAPI,
 ) util.JSONResponse {
 	uploadReq := &crossSigningRequest{}
@@ -105,7 +105,7 @@ func UploadCrossSigningDeviceKeys(
 	}
 }
 
-func UploadCrossSigningDeviceSignatures(req *http.Request, keyserverAPI api.KeyInternalAPI, device *userapi.Device) util.JSONResponse {
+func UploadCrossSigningDeviceSignatures(req *http.Request, keyserverAPI api.ClientKeyAPI, device *userapi.Device) util.JSONResponse {
 	uploadReq := &api.PerformUploadDeviceSignaturesRequest{}
 	uploadRes := &api.PerformUploadDeviceSignaturesResponse{}
 

--- a/clientapi/routing/key_crosssigning.go
+++ b/clientapi/routing/key_crosssigning.go
@@ -35,7 +35,7 @@ type crossSigningRequest struct {
 func UploadCrossSigningDeviceKeys(
 	req *http.Request, userInteractiveAuth *auth.UserInteractive,
 	keyserverAPI api.KeyInternalAPI, device *userapi.Device,
-	accountAPI userapi.UserAccountAPI, cfg *config.ClientAPI,
+	accountAPI userapi.ClientUserAPI, cfg *config.ClientAPI,
 ) util.JSONResponse {
 	uploadReq := &crossSigningRequest{}
 	uploadRes := &api.PerformUploadDeviceKeysResponse{}

--- a/clientapi/routing/keys.go
+++ b/clientapi/routing/keys.go
@@ -31,7 +31,7 @@ type uploadKeysRequest struct {
 	OneTimeKeys map[string]json.RawMessage `json:"one_time_keys"`
 }
 
-func UploadKeys(req *http.Request, keyAPI api.KeyInternalAPI, device *userapi.Device) util.JSONResponse {
+func UploadKeys(req *http.Request, keyAPI api.ClientKeyAPI, device *userapi.Device) util.JSONResponse {
 	var r uploadKeysRequest
 	resErr := httputil.UnmarshalJSONRequest(req, &r)
 	if resErr != nil {
@@ -100,7 +100,7 @@ func (r *queryKeysRequest) GetTimeout() time.Duration {
 	return time.Duration(r.Timeout) * time.Millisecond
 }
 
-func QueryKeys(req *http.Request, keyAPI api.KeyInternalAPI, device *userapi.Device) util.JSONResponse {
+func QueryKeys(req *http.Request, keyAPI api.ClientKeyAPI, device *userapi.Device) util.JSONResponse {
 	var r queryKeysRequest
 	resErr := httputil.UnmarshalJSONRequest(req, &r)
 	if resErr != nil {
@@ -138,7 +138,7 @@ func (r *claimKeysRequest) GetTimeout() time.Duration {
 	return time.Duration(r.TimeoutMS) * time.Millisecond
 }
 
-func ClaimKeys(req *http.Request, keyAPI api.KeyInternalAPI) util.JSONResponse {
+func ClaimKeys(req *http.Request, keyAPI api.ClientKeyAPI) util.JSONResponse {
 	var r claimKeysRequest
 	resErr := httputil.UnmarshalJSONRequest(req, &r)
 	if resErr != nil {

--- a/clientapi/routing/leaveroom.go
+++ b/clientapi/routing/leaveroom.go
@@ -26,7 +26,7 @@ import (
 func LeaveRoomByID(
 	req *http.Request,
 	device *api.Device,
-	rsAPI roomserverAPI.RoomserverInternalAPI,
+	rsAPI roomserverAPI.ClientRoomserverAPI,
 	roomID string,
 ) util.JSONResponse {
 	// Prepare to ask the roomserver to perform the room join.

--- a/clientapi/routing/login.go
+++ b/clientapi/routing/login.go
@@ -53,7 +53,7 @@ func passwordLogin() flows {
 
 // Login implements GET and POST /login
 func Login(
-	req *http.Request, userAPI userapi.UserInternalAPI,
+	req *http.Request, userAPI userapi.ClientUserAPI,
 	cfg *config.ClientAPI,
 ) util.JSONResponse {
 	if req.Method == http.MethodGet {
@@ -79,7 +79,7 @@ func Login(
 }
 
 func completeAuth(
-	ctx context.Context, serverName gomatrixserverlib.ServerName, userAPI userapi.UserInternalAPI, login *auth.Login,
+	ctx context.Context, serverName gomatrixserverlib.ServerName, userAPI userapi.ClientUserAPI, login *auth.Login,
 	ipAddr, userAgent string,
 ) util.JSONResponse {
 	token, err := auth.GenerateAccessToken()

--- a/clientapi/routing/logout.go
+++ b/clientapi/routing/logout.go
@@ -24,7 +24,7 @@ import (
 
 // Logout handles POST /logout
 func Logout(
-	req *http.Request, userAPI api.UserInternalAPI, device *api.Device,
+	req *http.Request, userAPI api.ClientUserAPI, device *api.Device,
 ) util.JSONResponse {
 	var performRes api.PerformDeviceDeletionResponse
 	err := userAPI.PerformDeviceDeletion(req.Context(), &api.PerformDeviceDeletionRequest{
@@ -44,7 +44,7 @@ func Logout(
 
 // LogoutAll handles POST /logout/all
 func LogoutAll(
-	req *http.Request, userAPI api.UserInternalAPI, device *api.Device,
+	req *http.Request, userAPI api.ClientUserAPI, device *api.Device,
 ) util.JSONResponse {
 	var performRes api.PerformDeviceDeletionResponse
 	err := userAPI.PerformDeviceDeletion(req.Context(), &api.PerformDeviceDeletionRequest{

--- a/clientapi/routing/membership.go
+++ b/clientapi/routing/membership.go
@@ -38,7 +38,7 @@ import (
 var errMissingUserID = errors.New("'user_id' must be supplied")
 
 func SendBan(
-	req *http.Request, profileAPI userapi.UserProfileAPI, device *userapi.Device,
+	req *http.Request, profileAPI userapi.ClientUserAPI, device *userapi.Device,
 	roomID string, cfg *config.ClientAPI,
 	rsAPI roomserverAPI.RoomserverInternalAPI, asAPI appserviceAPI.AppServiceQueryAPI,
 ) util.JSONResponse {
@@ -80,7 +80,7 @@ func SendBan(
 	return sendMembership(req.Context(), profileAPI, device, roomID, "ban", body.Reason, cfg, body.UserID, evTime, roomVer, rsAPI, asAPI)
 }
 
-func sendMembership(ctx context.Context, profileAPI userapi.UserProfileAPI, device *userapi.Device,
+func sendMembership(ctx context.Context, profileAPI userapi.ClientUserAPI, device *userapi.Device,
 	roomID, membership, reason string, cfg *config.ClientAPI, targetUserID string, evTime time.Time,
 	roomVer gomatrixserverlib.RoomVersion,
 	rsAPI roomserverAPI.RoomserverInternalAPI, asAPI appserviceAPI.AppServiceQueryAPI) util.JSONResponse {
@@ -124,7 +124,7 @@ func sendMembership(ctx context.Context, profileAPI userapi.UserProfileAPI, devi
 }
 
 func SendKick(
-	req *http.Request, profileAPI userapi.UserProfileAPI, device *userapi.Device,
+	req *http.Request, profileAPI userapi.ClientUserAPI, device *userapi.Device,
 	roomID string, cfg *config.ClientAPI,
 	rsAPI roomserverAPI.RoomserverInternalAPI, asAPI appserviceAPI.AppServiceQueryAPI,
 ) util.JSONResponse {
@@ -164,7 +164,7 @@ func SendKick(
 }
 
 func SendUnban(
-	req *http.Request, profileAPI userapi.UserProfileAPI, device *userapi.Device,
+	req *http.Request, profileAPI userapi.ClientUserAPI, device *userapi.Device,
 	roomID string, cfg *config.ClientAPI,
 	rsAPI roomserverAPI.RoomserverInternalAPI, asAPI appserviceAPI.AppServiceQueryAPI,
 ) util.JSONResponse {
@@ -199,7 +199,7 @@ func SendUnban(
 }
 
 func SendInvite(
-	req *http.Request, profileAPI userapi.UserProfileAPI, device *userapi.Device,
+	req *http.Request, profileAPI userapi.ClientUserAPI, device *userapi.Device,
 	roomID string, cfg *config.ClientAPI,
 	rsAPI roomserverAPI.RoomserverInternalAPI, asAPI appserviceAPI.AppServiceQueryAPI,
 ) util.JSONResponse {
@@ -233,7 +233,7 @@ func SendInvite(
 // sendInvite sends an invitation to a user. Returns a JSONResponse and an error
 func sendInvite(
 	ctx context.Context,
-	profileAPI userapi.UserProfileAPI,
+	profileAPI userapi.ClientUserAPI,
 	device *userapi.Device,
 	roomID, userID, reason string,
 	cfg *config.ClientAPI,
@@ -285,7 +285,7 @@ func sendInvite(
 
 func buildMembershipEvent(
 	ctx context.Context,
-	targetUserID, reason string, profileAPI userapi.UserProfileAPI,
+	targetUserID, reason string, profileAPI userapi.ClientUserAPI,
 	device *userapi.Device,
 	membership, roomID string, isDirect bool,
 	cfg *config.ClientAPI, evTime time.Time,
@@ -326,7 +326,7 @@ func loadProfile(
 	ctx context.Context,
 	userID string,
 	cfg *config.ClientAPI,
-	profileAPI userapi.UserProfileAPI,
+	profileAPI userapi.ClientUserAPI,
 	asAPI appserviceAPI.AppServiceQueryAPI,
 ) (*authtypes.Profile, error) {
 	_, serverName, err := gomatrixserverlib.SplitID('@', userID)
@@ -380,7 +380,7 @@ func checkAndProcessThreepid(
 	body *threepid.MembershipRequest,
 	cfg *config.ClientAPI,
 	rsAPI roomserverAPI.RoomserverInternalAPI,
-	profileAPI userapi.UserProfileAPI,
+	profileAPI userapi.ClientUserAPI,
 	roomID string,
 	evTime time.Time,
 ) (inviteStored bool, errRes *util.JSONResponse) {

--- a/clientapi/routing/memberships.go
+++ b/clientapi/routing/memberships.go
@@ -55,7 +55,7 @@ type databaseJoinedMember struct {
 func GetMemberships(
 	req *http.Request, device *userapi.Device, roomID string, joinedOnly bool,
 	_ *config.ClientAPI,
-	rsAPI api.RoomserverInternalAPI,
+	rsAPI api.ClientRoomserverAPI,
 ) util.JSONResponse {
 	queryReq := api.QueryMembershipsForRoomRequest{
 		JoinedOnly: joinedOnly,
@@ -100,7 +100,7 @@ func GetMemberships(
 func GetJoinedRooms(
 	req *http.Request,
 	device *userapi.Device,
-	rsAPI api.RoomserverInternalAPI,
+	rsAPI api.ClientRoomserverAPI,
 ) util.JSONResponse {
 	var res api.QueryRoomsForUserResponse
 	err := rsAPI.QueryRoomsForUser(req.Context(), &api.QueryRoomsForUserRequest{

--- a/clientapi/routing/notification.go
+++ b/clientapi/routing/notification.go
@@ -27,7 +27,7 @@ import (
 // GetNotifications handles /_matrix/client/r0/notifications
 func GetNotifications(
 	req *http.Request, device *userapi.Device,
-	userAPI userapi.UserInternalAPI,
+	userAPI userapi.ClientUserAPI,
 ) util.JSONResponse {
 	var limit int64
 	if limitStr := req.URL.Query().Get("limit"); limitStr != "" {

--- a/clientapi/routing/openid.go
+++ b/clientapi/routing/openid.go
@@ -34,7 +34,7 @@ type openIDTokenResponse struct {
 // can supply to an OpenID Relying Party to verify their identity
 func CreateOpenIDToken(
 	req *http.Request,
-	userAPI api.UserInternalAPI,
+	userAPI api.ClientUserAPI,
 	device *api.Device,
 	userID string,
 	cfg *config.ClientAPI,

--- a/clientapi/routing/password.go
+++ b/clientapi/routing/password.go
@@ -28,7 +28,7 @@ type newPasswordAuth struct {
 
 func Password(
 	req *http.Request,
-	userAPI api.UserInternalAPI,
+	userAPI api.ClientUserAPI,
 	device *api.Device,
 	cfg *config.ClientAPI,
 ) util.JSONResponse {

--- a/clientapi/routing/peekroom.go
+++ b/clientapi/routing/peekroom.go
@@ -26,7 +26,7 @@ import (
 func PeekRoomByIDOrAlias(
 	req *http.Request,
 	device *api.Device,
-	rsAPI roomserverAPI.RoomserverInternalAPI,
+	rsAPI roomserverAPI.ClientRoomserverAPI,
 	roomIDOrAlias string,
 ) util.JSONResponse {
 	// if this is a remote roomIDOrAlias, we have to ask the roomserver (or federation sender?) to
@@ -79,7 +79,7 @@ func PeekRoomByIDOrAlias(
 func UnpeekRoomByID(
 	req *http.Request,
 	device *api.Device,
-	rsAPI roomserverAPI.RoomserverInternalAPI,
+	rsAPI roomserverAPI.ClientRoomserverAPI,
 	roomID string,
 ) util.JSONResponse {
 	unpeekReq := roomserverAPI.PerformUnpeekRequest{

--- a/clientapi/routing/profile.go
+++ b/clientapi/routing/profile.go
@@ -35,7 +35,7 @@ import (
 
 // GetProfile implements GET /profile/{userID}
 func GetProfile(
-	req *http.Request, profileAPI userapi.UserProfileAPI, cfg *config.ClientAPI,
+	req *http.Request, profileAPI userapi.ClientUserAPI, cfg *config.ClientAPI,
 	userID string,
 	asAPI appserviceAPI.AppServiceQueryAPI,
 	federation *gomatrixserverlib.FederationClient,
@@ -64,7 +64,7 @@ func GetProfile(
 
 // GetAvatarURL implements GET /profile/{userID}/avatar_url
 func GetAvatarURL(
-	req *http.Request, profileAPI userapi.UserProfileAPI, cfg *config.ClientAPI,
+	req *http.Request, profileAPI userapi.ClientUserAPI, cfg *config.ClientAPI,
 	userID string, asAPI appserviceAPI.AppServiceQueryAPI,
 	federation *gomatrixserverlib.FederationClient,
 ) util.JSONResponse {
@@ -91,7 +91,7 @@ func GetAvatarURL(
 
 // SetAvatarURL implements PUT /profile/{userID}/avatar_url
 func SetAvatarURL(
-	req *http.Request, profileAPI userapi.UserProfileAPI,
+	req *http.Request, profileAPI userapi.ClientUserAPI,
 	device *userapi.Device, userID string, cfg *config.ClientAPI, rsAPI api.RoomserverInternalAPI,
 ) util.JSONResponse {
 	if userID != device.UserID {
@@ -193,7 +193,7 @@ func SetAvatarURL(
 
 // GetDisplayName implements GET /profile/{userID}/displayname
 func GetDisplayName(
-	req *http.Request, profileAPI userapi.UserProfileAPI, cfg *config.ClientAPI,
+	req *http.Request, profileAPI userapi.ClientUserAPI, cfg *config.ClientAPI,
 	userID string, asAPI appserviceAPI.AppServiceQueryAPI,
 	federation *gomatrixserverlib.FederationClient,
 ) util.JSONResponse {
@@ -220,7 +220,7 @@ func GetDisplayName(
 
 // SetDisplayName implements PUT /profile/{userID}/displayname
 func SetDisplayName(
-	req *http.Request, profileAPI userapi.UserProfileAPI,
+	req *http.Request, profileAPI userapi.ClientUserAPI,
 	device *userapi.Device, userID string, cfg *config.ClientAPI, rsAPI api.RoomserverInternalAPI,
 ) util.JSONResponse {
 	if userID != device.UserID {
@@ -325,7 +325,7 @@ func SetDisplayName(
 // Returns an error when something goes wrong or specifically
 // eventutil.ErrProfileNoExists when the profile doesn't exist.
 func getProfile(
-	ctx context.Context, profileAPI userapi.UserProfileAPI, cfg *config.ClientAPI,
+	ctx context.Context, profileAPI userapi.ClientUserAPI, cfg *config.ClientAPI,
 	userID string,
 	asAPI appserviceAPI.AppServiceQueryAPI,
 	federation *gomatrixserverlib.FederationClient,

--- a/clientapi/routing/profile.go
+++ b/clientapi/routing/profile.go
@@ -92,7 +92,7 @@ func GetAvatarURL(
 // SetAvatarURL implements PUT /profile/{userID}/avatar_url
 func SetAvatarURL(
 	req *http.Request, profileAPI userapi.ClientUserAPI,
-	device *userapi.Device, userID string, cfg *config.ClientAPI, rsAPI api.RoomserverInternalAPI,
+	device *userapi.Device, userID string, cfg *config.ClientAPI, rsAPI api.ClientRoomserverAPI,
 ) util.JSONResponse {
 	if userID != device.UserID {
 		return util.JSONResponse{
@@ -221,7 +221,7 @@ func GetDisplayName(
 // SetDisplayName implements PUT /profile/{userID}/displayname
 func SetDisplayName(
 	req *http.Request, profileAPI userapi.ClientUserAPI,
-	device *userapi.Device, userID string, cfg *config.ClientAPI, rsAPI api.RoomserverInternalAPI,
+	device *userapi.Device, userID string, cfg *config.ClientAPI, rsAPI api.ClientRoomserverAPI,
 ) util.JSONResponse {
 	if userID != device.UserID {
 		return util.JSONResponse{
@@ -366,7 +366,7 @@ func buildMembershipEvents(
 	ctx context.Context,
 	roomIDs []string,
 	newProfile authtypes.Profile, userID string, cfg *config.ClientAPI,
-	evTime time.Time, rsAPI api.RoomserverInternalAPI,
+	evTime time.Time, rsAPI api.ClientRoomserverAPI,
 ) ([]*gomatrixserverlib.HeaderedEvent, error) {
 	evs := []*gomatrixserverlib.HeaderedEvent{}
 

--- a/clientapi/routing/pusher.go
+++ b/clientapi/routing/pusher.go
@@ -28,7 +28,7 @@ import (
 // GetPushers handles /_matrix/client/r0/pushers
 func GetPushers(
 	req *http.Request, device *userapi.Device,
-	userAPI userapi.UserInternalAPI,
+	userAPI userapi.ClientUserAPI,
 ) util.JSONResponse {
 	var queryRes userapi.QueryPushersResponse
 	localpart, _, err := gomatrixserverlib.SplitID('@', device.UserID)
@@ -57,7 +57,7 @@ func GetPushers(
 // The behaviour of this endpoint varies depending on the values in the JSON body.
 func SetPusher(
 	req *http.Request, device *userapi.Device,
-	userAPI userapi.UserInternalAPI,
+	userAPI userapi.ClientUserAPI,
 ) util.JSONResponse {
 	localpart, _, err := gomatrixserverlib.SplitID('@', device.UserID)
 	if err != nil {

--- a/clientapi/routing/pushrules.go
+++ b/clientapi/routing/pushrules.go
@@ -30,7 +30,7 @@ func errorResponse(ctx context.Context, err error, msg string, args ...interface
 	return jsonerror.InternalServerError()
 }
 
-func GetAllPushRules(ctx context.Context, device *userapi.Device, userAPI userapi.UserInternalAPI) util.JSONResponse {
+func GetAllPushRules(ctx context.Context, device *userapi.Device, userAPI userapi.ClientUserAPI) util.JSONResponse {
 	ruleSets, err := queryPushRules(ctx, device.UserID, userAPI)
 	if err != nil {
 		return errorResponse(ctx, err, "queryPushRulesJSON failed")
@@ -41,7 +41,7 @@ func GetAllPushRules(ctx context.Context, device *userapi.Device, userAPI userap
 	}
 }
 
-func GetPushRulesByScope(ctx context.Context, scope string, device *userapi.Device, userAPI userapi.UserInternalAPI) util.JSONResponse {
+func GetPushRulesByScope(ctx context.Context, scope string, device *userapi.Device, userAPI userapi.ClientUserAPI) util.JSONResponse {
 	ruleSets, err := queryPushRules(ctx, device.UserID, userAPI)
 	if err != nil {
 		return errorResponse(ctx, err, "queryPushRulesJSON failed")
@@ -56,7 +56,7 @@ func GetPushRulesByScope(ctx context.Context, scope string, device *userapi.Devi
 	}
 }
 
-func GetPushRulesByKind(ctx context.Context, scope, kind string, device *userapi.Device, userAPI userapi.UserInternalAPI) util.JSONResponse {
+func GetPushRulesByKind(ctx context.Context, scope, kind string, device *userapi.Device, userAPI userapi.ClientUserAPI) util.JSONResponse {
 	ruleSets, err := queryPushRules(ctx, device.UserID, userAPI)
 	if err != nil {
 		return errorResponse(ctx, err, "queryPushRules failed")
@@ -75,7 +75,7 @@ func GetPushRulesByKind(ctx context.Context, scope, kind string, device *userapi
 	}
 }
 
-func GetPushRuleByRuleID(ctx context.Context, scope, kind, ruleID string, device *userapi.Device, userAPI userapi.UserInternalAPI) util.JSONResponse {
+func GetPushRuleByRuleID(ctx context.Context, scope, kind, ruleID string, device *userapi.Device, userAPI userapi.ClientUserAPI) util.JSONResponse {
 	ruleSets, err := queryPushRules(ctx, device.UserID, userAPI)
 	if err != nil {
 		return errorResponse(ctx, err, "queryPushRules failed")
@@ -98,7 +98,7 @@ func GetPushRuleByRuleID(ctx context.Context, scope, kind, ruleID string, device
 	}
 }
 
-func PutPushRuleByRuleID(ctx context.Context, scope, kind, ruleID, afterRuleID, beforeRuleID string, body io.Reader, device *userapi.Device, userAPI userapi.UserInternalAPI) util.JSONResponse {
+func PutPushRuleByRuleID(ctx context.Context, scope, kind, ruleID, afterRuleID, beforeRuleID string, body io.Reader, device *userapi.Device, userAPI userapi.ClientUserAPI) util.JSONResponse {
 	var newRule pushrules.Rule
 	if err := json.NewDecoder(body).Decode(&newRule); err != nil {
 		return errorResponse(ctx, err, "JSON Decode failed")
@@ -160,7 +160,7 @@ func PutPushRuleByRuleID(ctx context.Context, scope, kind, ruleID, afterRuleID, 
 	return util.JSONResponse{Code: http.StatusOK, JSON: struct{}{}}
 }
 
-func DeletePushRuleByRuleID(ctx context.Context, scope, kind, ruleID string, device *userapi.Device, userAPI userapi.UserInternalAPI) util.JSONResponse {
+func DeletePushRuleByRuleID(ctx context.Context, scope, kind, ruleID string, device *userapi.Device, userAPI userapi.ClientUserAPI) util.JSONResponse {
 	ruleSets, err := queryPushRules(ctx, device.UserID, userAPI)
 	if err != nil {
 		return errorResponse(ctx, err, "queryPushRules failed")
@@ -187,7 +187,7 @@ func DeletePushRuleByRuleID(ctx context.Context, scope, kind, ruleID string, dev
 	return util.JSONResponse{Code: http.StatusOK, JSON: struct{}{}}
 }
 
-func GetPushRuleAttrByRuleID(ctx context.Context, scope, kind, ruleID, attr string, device *userapi.Device, userAPI userapi.UserInternalAPI) util.JSONResponse {
+func GetPushRuleAttrByRuleID(ctx context.Context, scope, kind, ruleID, attr string, device *userapi.Device, userAPI userapi.ClientUserAPI) util.JSONResponse {
 	attrGet, err := pushRuleAttrGetter(attr)
 	if err != nil {
 		return errorResponse(ctx, err, "pushRuleAttrGetter failed")
@@ -216,7 +216,7 @@ func GetPushRuleAttrByRuleID(ctx context.Context, scope, kind, ruleID, attr stri
 	}
 }
 
-func PutPushRuleAttrByRuleID(ctx context.Context, scope, kind, ruleID, attr string, body io.Reader, device *userapi.Device, userAPI userapi.UserInternalAPI) util.JSONResponse {
+func PutPushRuleAttrByRuleID(ctx context.Context, scope, kind, ruleID, attr string, body io.Reader, device *userapi.Device, userAPI userapi.ClientUserAPI) util.JSONResponse {
 	var newPartialRule pushrules.Rule
 	if err := json.NewDecoder(body).Decode(&newPartialRule); err != nil {
 		return util.JSONResponse{
@@ -266,7 +266,7 @@ func PutPushRuleAttrByRuleID(ctx context.Context, scope, kind, ruleID, attr stri
 	return util.JSONResponse{Code: http.StatusOK, JSON: struct{}{}}
 }
 
-func queryPushRules(ctx context.Context, userID string, userAPI userapi.UserInternalAPI) (*pushrules.AccountRuleSets, error) {
+func queryPushRules(ctx context.Context, userID string, userAPI userapi.ClientUserAPI) (*pushrules.AccountRuleSets, error) {
 	var res userapi.QueryPushRulesResponse
 	if err := userAPI.QueryPushRules(ctx, &userapi.QueryPushRulesRequest{UserID: userID}, &res); err != nil {
 		util.GetLogger(ctx).WithError(err).Error("userAPI.QueryPushRules failed")
@@ -275,7 +275,7 @@ func queryPushRules(ctx context.Context, userID string, userAPI userapi.UserInte
 	return res.RuleSets, nil
 }
 
-func putPushRules(ctx context.Context, userID string, ruleSets *pushrules.AccountRuleSets, userAPI userapi.UserInternalAPI) error {
+func putPushRules(ctx context.Context, userID string, ruleSets *pushrules.AccountRuleSets, userAPI userapi.ClientUserAPI) error {
 	req := userapi.PerformPushRulesPutRequest{
 		UserID:   userID,
 		RuleSets: ruleSets,

--- a/clientapi/routing/redaction.go
+++ b/clientapi/routing/redaction.go
@@ -40,7 +40,7 @@ type redactionResponse struct {
 
 func SendRedaction(
 	req *http.Request, device *userapi.Device, roomID, eventID string, cfg *config.ClientAPI,
-	rsAPI roomserverAPI.RoomserverInternalAPI,
+	rsAPI roomserverAPI.ClientRoomserverAPI,
 	txnID *string,
 	txnCache *transactions.Cache,
 ) util.JSONResponse {

--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -518,7 +518,7 @@ func validateApplicationService(
 // http://matrix.org/speculator/spec/HEAD/client_server/unstable.html#post-matrix-client-unstable-register
 func Register(
 	req *http.Request,
-	userAPI userapi.UserRegisterAPI,
+	userAPI userapi.ClientUserAPI,
 	cfg *config.ClientAPI,
 ) util.JSONResponse {
 	defer req.Body.Close() // nolint: errcheck
@@ -614,7 +614,7 @@ func handleGuestRegistration(
 	req *http.Request,
 	r registerRequest,
 	cfg *config.ClientAPI,
-	userAPI userapi.UserRegisterAPI,
+	userAPI userapi.ClientUserAPI,
 ) util.JSONResponse {
 	if cfg.RegistrationDisabled || cfg.GuestsDisabled {
 		return util.JSONResponse{
@@ -679,7 +679,7 @@ func handleRegistrationFlow(
 	r registerRequest,
 	sessionID string,
 	cfg *config.ClientAPI,
-	userAPI userapi.UserRegisterAPI,
+	userAPI userapi.ClientUserAPI,
 	accessToken string,
 	accessTokenErr error,
 ) util.JSONResponse {
@@ -768,7 +768,7 @@ func handleApplicationServiceRegistration(
 	req *http.Request,
 	r registerRequest,
 	cfg *config.ClientAPI,
-	userAPI userapi.UserRegisterAPI,
+	userAPI userapi.ClientUserAPI,
 ) util.JSONResponse {
 	// Check if we previously had issues extracting the access token from the
 	// request.
@@ -806,7 +806,7 @@ func checkAndCompleteFlow(
 	r registerRequest,
 	sessionID string,
 	cfg *config.ClientAPI,
-	userAPI userapi.UserRegisterAPI,
+	userAPI userapi.ClientUserAPI,
 ) util.JSONResponse {
 	if checkFlowCompleted(flow, cfg.Derived.Registration.Flows) {
 		// This flow was completed, registration can continue
@@ -833,7 +833,7 @@ func checkAndCompleteFlow(
 // not all
 func completeRegistration(
 	ctx context.Context,
-	userAPI userapi.UserRegisterAPI,
+	userAPI userapi.ClientUserAPI,
 	username, password, appserviceID, ipAddr, userAgent, sessionID string,
 	inhibitLogin eventutil.WeakBoolean,
 	displayName, deviceID *string,
@@ -992,7 +992,7 @@ type availableResponse struct {
 func RegisterAvailable(
 	req *http.Request,
 	cfg *config.ClientAPI,
-	registerAPI userapi.UserRegisterAPI,
+	registerAPI userapi.ClientUserAPI,
 ) util.JSONResponse {
 	username := req.URL.Query().Get("username")
 
@@ -1040,7 +1040,7 @@ func RegisterAvailable(
 	}
 }
 
-func handleSharedSecretRegistration(userAPI userapi.UserInternalAPI, sr *SharedSecretRegistration, req *http.Request) util.JSONResponse {
+func handleSharedSecretRegistration(userAPI userapi.ClientUserAPI, sr *SharedSecretRegistration, req *http.Request) util.JSONResponse {
 	ssrr, err := NewSharedSecretRegistrationRequest(req.Body)
 	if err != nil {
 		return util.JSONResponse{

--- a/clientapi/routing/room_tagging.go
+++ b/clientapi/routing/room_tagging.go
@@ -31,7 +31,7 @@ import (
 // GetTags implements GET /_matrix/client/r0/user/{userID}/rooms/{roomID}/tags
 func GetTags(
 	req *http.Request,
-	userAPI api.UserInternalAPI,
+	userAPI api.ClientUserAPI,
 	device *api.Device,
 	userID string,
 	roomID string,
@@ -62,7 +62,7 @@ func GetTags(
 // the tag to the "map" and saving the new "map" to the DB
 func PutTag(
 	req *http.Request,
-	userAPI api.UserInternalAPI,
+	userAPI api.ClientUserAPI,
 	device *api.Device,
 	userID string,
 	roomID string,
@@ -113,7 +113,7 @@ func PutTag(
 // the "map" and then saving the new "map" in the DB
 func DeleteTag(
 	req *http.Request,
-	userAPI api.UserInternalAPI,
+	userAPI api.ClientUserAPI,
 	device *api.Device,
 	userID string,
 	roomID string,
@@ -167,7 +167,7 @@ func obtainSavedTags(
 	req *http.Request,
 	userID string,
 	roomID string,
-	userAPI api.UserInternalAPI,
+	userAPI api.ClientUserAPI,
 ) (tags gomatrix.TagContent, err error) {
 	dataReq := api.QueryAccountDataRequest{
 		UserID:   userID,
@@ -194,7 +194,7 @@ func saveTagData(
 	req *http.Request,
 	userID string,
 	roomID string,
-	userAPI api.UserInternalAPI,
+	userAPI api.ClientUserAPI,
 	Tag gomatrix.TagContent,
 ) error {
 	newTagData, err := json.Marshal(Tag)

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -50,7 +50,7 @@ import (
 func Setup(
 	publicAPIMux, synapseAdminRouter, dendriteAdminRouter *mux.Router,
 	cfg *config.ClientAPI,
-	rsAPI roomserverAPI.RoomserverInternalAPI,
+	rsAPI roomserverAPI.ClientRoomserverAPI,
 	asAPI appserviceAPI.AppServiceQueryAPI,
 	userAPI userapi.ClientUserAPI,
 	userDirectoryProvider userapi.UserDirectoryProvider,
@@ -58,7 +58,7 @@ func Setup(
 	syncProducer *producers.SyncAPIProducer,
 	transactionsCache *transactions.Cache,
 	federationSender federationAPI.FederationInternalAPI,
-	keyAPI keyserverAPI.KeyInternalAPI,
+	keyAPI keyserverAPI.ClientKeyAPI,
 	extRoomsProvider api.ExtraPublicRoomsProvider,
 	mscCfg *config.MSCs, natsClient *nats.Conn,
 ) {
@@ -325,7 +325,7 @@ func Setup(
 			if err != nil {
 				return util.ErrorResponse(err)
 			}
-			return GetEvent(req, device, vars["roomID"], vars["eventID"], cfg, rsAPI, federation)
+			return GetEvent(req, device, vars["roomID"], vars["eventID"], cfg, rsAPI)
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -52,7 +52,7 @@ func Setup(
 	cfg *config.ClientAPI,
 	rsAPI roomserverAPI.RoomserverInternalAPI,
 	asAPI appserviceAPI.AppServiceQueryAPI,
-	userAPI userapi.UserInternalAPI,
+	userAPI userapi.ClientUserAPI,
 	userDirectoryProvider userapi.UserDirectoryProvider,
 	federation *gomatrixserverlib.FederationClient,
 	syncProducer *producers.SyncAPIProducer,
@@ -897,7 +897,7 @@ func Setup(
 			if resErr := clientutil.UnmarshalJSONRequest(req, &postContent); resErr != nil {
 				return *resErr
 			}
-			return *SearchUserDirectory(
+			return SearchUserDirectory(
 				req.Context(),
 				device,
 				userAPI,

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -57,7 +57,7 @@ func Setup(
 	federation *gomatrixserverlib.FederationClient,
 	syncProducer *producers.SyncAPIProducer,
 	transactionsCache *transactions.Cache,
-	federationSender federationAPI.FederationInternalAPI,
+	federationSender federationAPI.ClientFederationAPI,
 	keyAPI keyserverAPI.ClientKeyAPI,
 	extRoomsProvider api.ExtraPublicRoomsProvider,
 	mscCfg *config.MSCs, natsClient *nats.Conn,

--- a/clientapi/routing/sendevent.go
+++ b/clientapi/routing/sendevent.go
@@ -70,7 +70,7 @@ func SendEvent(
 	device *userapi.Device,
 	roomID, eventType string, txnID, stateKey *string,
 	cfg *config.ClientAPI,
-	rsAPI api.RoomserverInternalAPI,
+	rsAPI api.ClientRoomserverAPI,
 	txnCache *transactions.Cache,
 ) util.JSONResponse {
 	verReq := api.QueryRoomVersionForRoomRequest{RoomID: roomID}
@@ -207,7 +207,7 @@ func generateSendEvent(
 	device *userapi.Device,
 	roomID, eventType string, stateKey *string,
 	cfg *config.ClientAPI,
-	rsAPI api.RoomserverInternalAPI,
+	rsAPI api.ClientRoomserverAPI,
 	evTime time.Time,
 ) (*gomatrixserverlib.Event, *util.JSONResponse) {
 	// parse the incoming http request

--- a/clientapi/routing/sendtyping.go
+++ b/clientapi/routing/sendtyping.go
@@ -32,7 +32,7 @@ type typingContentJSON struct {
 // sends the typing events to client API typingProducer
 func SendTyping(
 	req *http.Request, device *userapi.Device, roomID string,
-	userID string, rsAPI roomserverAPI.RoomserverInternalAPI,
+	userID string, rsAPI roomserverAPI.ClientRoomserverAPI,
 	syncProducer *producers.SyncAPIProducer,
 ) util.JSONResponse {
 	if device.UserID != userID {

--- a/clientapi/routing/server_notices.go
+++ b/clientapi/routing/server_notices.go
@@ -56,7 +56,7 @@ func SendServerNotice(
 	cfgNotices *config.ServerNotices,
 	cfgClient *config.ClientAPI,
 	userAPI userapi.ClientUserAPI,
-	rsAPI api.RoomserverInternalAPI,
+	rsAPI api.ClientRoomserverAPI,
 	asAPI appserviceAPI.AppServiceQueryAPI,
 	device *userapi.Device,
 	senderDevice *userapi.Device,

--- a/clientapi/routing/server_notices.go
+++ b/clientapi/routing/server_notices.go
@@ -55,7 +55,7 @@ func SendServerNotice(
 	req *http.Request,
 	cfgNotices *config.ServerNotices,
 	cfgClient *config.ClientAPI,
-	userAPI userapi.UserInternalAPI,
+	userAPI userapi.ClientUserAPI,
 	rsAPI api.RoomserverInternalAPI,
 	asAPI appserviceAPI.AppServiceQueryAPI,
 	device *userapi.Device,
@@ -281,7 +281,7 @@ func (r sendServerNoticeRequest) valid() (ok bool) {
 // It returns an userapi.Device, which is used for building the event
 func getSenderDevice(
 	ctx context.Context,
-	userAPI userapi.UserInternalAPI,
+	userAPI userapi.ClientUserAPI,
 	cfg *config.ClientAPI,
 ) (*userapi.Device, error) {
 	var accRes userapi.PerformAccountCreationResponse

--- a/clientapi/routing/state.go
+++ b/clientapi/routing/state.go
@@ -41,7 +41,7 @@ type stateEventInStateResp struct {
 // TODO: Check if the user is in the room. If not, check if the room's history
 // is publicly visible. Current behaviour is returning an empty array if the
 // user cannot see the room's history.
-func OnIncomingStateRequest(ctx context.Context, device *userapi.Device, rsAPI api.RoomserverInternalAPI, roomID string) util.JSONResponse {
+func OnIncomingStateRequest(ctx context.Context, device *userapi.Device, rsAPI api.ClientRoomserverAPI, roomID string) util.JSONResponse {
 	var worldReadable bool
 	var wantLatestState bool
 
@@ -162,7 +162,7 @@ func OnIncomingStateRequest(ctx context.Context, device *userapi.Device, rsAPI a
 // is then (by default) we return the content, otherwise a 404.
 // If eventFormat=true, sends the whole event else just the content.
 func OnIncomingStateTypeRequest(
-	ctx context.Context, device *userapi.Device, rsAPI api.RoomserverInternalAPI,
+	ctx context.Context, device *userapi.Device, rsAPI api.ClientRoomserverAPI,
 	roomID, evType, stateKey string, eventFormat bool,
 ) util.JSONResponse {
 	var worldReadable bool

--- a/clientapi/routing/threepid.go
+++ b/clientapi/routing/threepid.go
@@ -40,7 +40,7 @@ type threePIDsResponse struct {
 // RequestEmailToken implements:
 //     POST /account/3pid/email/requestToken
 //     POST /register/email/requestToken
-func RequestEmailToken(req *http.Request, threePIDAPI api.UserThreePIDAPI, cfg *config.ClientAPI) util.JSONResponse {
+func RequestEmailToken(req *http.Request, threePIDAPI api.ClientUserAPI, cfg *config.ClientAPI) util.JSONResponse {
 	var body threepid.EmailAssociationRequest
 	if reqErr := httputil.UnmarshalJSONRequest(req, &body); reqErr != nil {
 		return *reqErr
@@ -90,7 +90,7 @@ func RequestEmailToken(req *http.Request, threePIDAPI api.UserThreePIDAPI, cfg *
 
 // CheckAndSave3PIDAssociation implements POST /account/3pid
 func CheckAndSave3PIDAssociation(
-	req *http.Request, threePIDAPI api.UserThreePIDAPI, device *api.Device,
+	req *http.Request, threePIDAPI api.ClientUserAPI, device *api.Device,
 	cfg *config.ClientAPI,
 ) util.JSONResponse {
 	var body threepid.EmailAssociationCheckRequest
@@ -158,7 +158,7 @@ func CheckAndSave3PIDAssociation(
 
 // GetAssociated3PIDs implements GET /account/3pid
 func GetAssociated3PIDs(
-	req *http.Request, threepidAPI api.UserThreePIDAPI, device *api.Device,
+	req *http.Request, threepidAPI api.ClientUserAPI, device *api.Device,
 ) util.JSONResponse {
 	localpart, _, err := gomatrixserverlib.SplitID('@', device.UserID)
 	if err != nil {
@@ -182,7 +182,7 @@ func GetAssociated3PIDs(
 }
 
 // Forget3PID implements POST /account/3pid/delete
-func Forget3PID(req *http.Request, threepidAPI api.UserThreePIDAPI) util.JSONResponse {
+func Forget3PID(req *http.Request, threepidAPI api.ClientUserAPI) util.JSONResponse {
 	var body authtypes.ThreePID
 	if reqErr := httputil.UnmarshalJSONRequest(req, &body); reqErr != nil {
 		return *reqErr

--- a/clientapi/routing/upgrade_room.go
+++ b/clientapi/routing/upgrade_room.go
@@ -40,7 +40,7 @@ type upgradeRoomResponse struct {
 func UpgradeRoom(
 	req *http.Request, device *userapi.Device,
 	cfg *config.ClientAPI,
-	roomID string, profileAPI userapi.UserProfileAPI,
+	roomID string, profileAPI userapi.ClientUserAPI,
 	rsAPI roomserverAPI.RoomserverInternalAPI,
 	asAPI appserviceAPI.AppServiceQueryAPI,
 ) util.JSONResponse {

--- a/clientapi/routing/upgrade_room.go
+++ b/clientapi/routing/upgrade_room.go
@@ -41,7 +41,7 @@ func UpgradeRoom(
 	req *http.Request, device *userapi.Device,
 	cfg *config.ClientAPI,
 	roomID string, profileAPI userapi.ClientUserAPI,
-	rsAPI roomserverAPI.RoomserverInternalAPI,
+	rsAPI roomserverAPI.ClientRoomserverAPI,
 	asAPI appserviceAPI.AppServiceQueryAPI,
 ) util.JSONResponse {
 	var r upgradeRoomRequest

--- a/clientapi/routing/userdirectory.go
+++ b/clientapi/routing/userdirectory.go
@@ -35,7 +35,7 @@ func SearchUserDirectory(
 	ctx context.Context,
 	device *userapi.Device,
 	userAPI userapi.ClientUserAPI,
-	rsAPI api.RoomserverInternalAPI,
+	rsAPI api.ClientRoomserverAPI,
 	provider userapi.UserDirectoryProvider,
 	serverName gomatrixserverlib.ServerName,
 	searchString string,

--- a/clientapi/routing/userdirectory.go
+++ b/clientapi/routing/userdirectory.go
@@ -34,13 +34,13 @@ type UserDirectoryResponse struct {
 func SearchUserDirectory(
 	ctx context.Context,
 	device *userapi.Device,
-	userAPI userapi.UserInternalAPI,
+	userAPI userapi.ClientUserAPI,
 	rsAPI api.RoomserverInternalAPI,
 	provider userapi.UserDirectoryProvider,
 	serverName gomatrixserverlib.ServerName,
 	searchString string,
 	limit int,
-) *util.JSONResponse {
+) util.JSONResponse {
 	if limit < 10 {
 		limit = 10
 	}
@@ -58,8 +58,7 @@ func SearchUserDirectory(
 	}
 	userRes := &userapi.QuerySearchProfilesResponse{}
 	if err := provider.QuerySearchProfiles(ctx, userReq, userRes); err != nil {
-		errRes := util.ErrorResponse(fmt.Errorf("userAPI.QuerySearchProfiles: %w", err))
-		return &errRes
+		return util.ErrorResponse(fmt.Errorf("userAPI.QuerySearchProfiles: %w", err))
 	}
 
 	for _, user := range userRes.Profiles {
@@ -94,8 +93,7 @@ func SearchUserDirectory(
 		}
 		stateRes := &api.QueryKnownUsersResponse{}
 		if err := rsAPI.QueryKnownUsers(ctx, stateReq, stateRes); err != nil && err != sql.ErrNoRows {
-			errRes := util.ErrorResponse(fmt.Errorf("rsAPI.QueryKnownUsers: %w", err))
-			return &errRes
+			return util.ErrorResponse(fmt.Errorf("rsAPI.QueryKnownUsers: %w", err))
 		}
 
 		for _, user := range stateRes.Users {
@@ -114,7 +112,7 @@ func SearchUserDirectory(
 		response.Results = append(response.Results, result)
 	}
 
-	return &util.JSONResponse{
+	return util.JSONResponse{
 		Code: 200,
 		JSON: response,
 	}

--- a/clientapi/threepid/invites.go
+++ b/clientapi/threepid/invites.go
@@ -86,7 +86,7 @@ var (
 func CheckAndProcessInvite(
 	ctx context.Context,
 	device *userapi.Device, body *MembershipRequest, cfg *config.ClientAPI,
-	rsAPI api.RoomserverInternalAPI, db userapi.UserProfileAPI,
+	rsAPI api.RoomserverInternalAPI, db userapi.ClientUserAPI,
 	roomID string,
 	evTime time.Time,
 ) (inviteStoredOnIDServer bool, err error) {
@@ -136,7 +136,7 @@ func CheckAndProcessInvite(
 // Returns an error if a check or a request failed.
 func queryIDServer(
 	ctx context.Context,
-	db userapi.UserProfileAPI, cfg *config.ClientAPI, device *userapi.Device,
+	userAPI userapi.ClientUserAPI, cfg *config.ClientAPI, device *userapi.Device,
 	body *MembershipRequest, roomID string,
 ) (lookupRes *idServerLookupResponse, storeInviteRes *idServerStoreInviteResponse, err error) {
 	if err = isTrusted(body.IDServer, cfg); err != nil {
@@ -152,7 +152,7 @@ func queryIDServer(
 	if lookupRes.MXID == "" {
 		// No Matrix ID matches with the given 3PID, ask the server to store the
 		// invite and return a token
-		storeInviteRes, err = queryIDServerStoreInvite(ctx, db, cfg, device, body, roomID)
+		storeInviteRes, err = queryIDServerStoreInvite(ctx, userAPI, cfg, device, body, roomID)
 		return
 	}
 
@@ -163,7 +163,7 @@ func queryIDServer(
 	if lookupRes.NotBefore > now || now > lookupRes.NotAfter {
 		// If the current timestamp isn't in the time frame in which the association
 		// is known to be valid, re-run the query
-		return queryIDServer(ctx, db, cfg, device, body, roomID)
+		return queryIDServer(ctx, userAPI, cfg, device, body, roomID)
 	}
 
 	// Check the request signatures and send an error if one isn't valid
@@ -205,7 +205,7 @@ func queryIDServerLookup(ctx context.Context, body *MembershipRequest) (*idServe
 // Returns an error if the request failed to send or if the response couldn't be parsed.
 func queryIDServerStoreInvite(
 	ctx context.Context,
-	db userapi.UserProfileAPI, cfg *config.ClientAPI, device *userapi.Device,
+	userAPI userapi.ClientUserAPI, cfg *config.ClientAPI, device *userapi.Device,
 	body *MembershipRequest, roomID string,
 ) (*idServerStoreInviteResponse, error) {
 	// Retrieve the sender's profile to get their display name
@@ -217,7 +217,7 @@ func queryIDServerStoreInvite(
 	var profile *authtypes.Profile
 	if serverName == cfg.Matrix.ServerName {
 		res := &userapi.QueryProfileResponse{}
-		err = db.QueryProfile(ctx, &userapi.QueryProfileRequest{UserID: device.UserID}, res)
+		err = userAPI.QueryProfile(ctx, &userapi.QueryProfileRequest{UserID: device.UserID}, res)
 		if err != nil {
 			return nil, err
 		}

--- a/clientapi/threepid/invites.go
+++ b/clientapi/threepid/invites.go
@@ -86,7 +86,7 @@ var (
 func CheckAndProcessInvite(
 	ctx context.Context,
 	device *userapi.Device, body *MembershipRequest, cfg *config.ClientAPI,
-	rsAPI api.RoomserverInternalAPI, db userapi.ClientUserAPI,
+	rsAPI api.ClientRoomserverAPI, db userapi.ClientUserAPI,
 	roomID string,
 	evTime time.Time,
 ) (inviteStoredOnIDServer bool, err error) {
@@ -337,7 +337,7 @@ func emit3PIDInviteEvent(
 	ctx context.Context,
 	body *MembershipRequest, res *idServerStoreInviteResponse,
 	device *userapi.Device, roomID string, cfg *config.ClientAPI,
-	rsAPI api.RoomserverInternalAPI,
+	rsAPI api.ClientRoomserverAPI,
 	evTime time.Time,
 ) error {
 	builder := &gomatrixserverlib.EventBuilder{

--- a/federationapi/api/api.go
+++ b/federationapi/api/api.go
@@ -42,6 +42,7 @@ func (e *FederationClientError) Error() string {
 type FederationInternalAPI interface {
 	FederationClient
 	gomatrixserverlib.KeyDatabase
+	ClientFederationAPI
 
 	KeyRing() *gomatrixserverlib.KeyRing
 
@@ -98,6 +99,10 @@ type FederationInternalAPI interface {
 		request *PerformBroadcastEDURequest,
 		response *PerformBroadcastEDUResponse,
 	) error
+}
+
+type ClientFederationAPI interface {
+	QueryJoinedHostServerNamesInRoom(ctx context.Context, request *QueryJoinedHostServerNamesInRoomRequest, response *QueryJoinedHostServerNamesInRoomResponse) error
 }
 
 type QueryServerKeysRequest struct {

--- a/federationapi/routing/invite.go
+++ b/federationapi/routing/invite.go
@@ -166,31 +166,36 @@ func processInvite(
 	)
 
 	// Add the invite event to the roomserver.
-	err = api.SendInvite(
-		ctx, rsAPI, signedEvent.Headered(roomVer), strippedState, api.DoNotSendToOtherServers, nil,
-	)
-	switch e := err.(type) {
-	case *api.PerformError:
-		return e.JSONResponse()
-	case nil:
-		// Return the signed event to the originating server, it should then tell
-		// the other servers in the room that we have been invited.
-		if isInviteV2 {
-			return util.JSONResponse{
-				Code: http.StatusOK,
-				JSON: gomatrixserverlib.RespInviteV2{Event: signedEvent.JSON()},
-			}
-		} else {
-			return util.JSONResponse{
-				Code: http.StatusOK,
-				JSON: gomatrixserverlib.RespInvite{Event: signedEvent.JSON()},
-			}
-		}
-	default:
-		util.GetLogger(ctx).WithError(err).Error("api.SendInvite failed")
+	inviteEvent := signedEvent.Headered(roomVer)
+	request := &api.PerformInviteRequest{
+		Event:           inviteEvent,
+		InviteRoomState: strippedState,
+		RoomVersion:     inviteEvent.RoomVersion,
+		SendAsServer:    string(api.DoNotSendToOtherServers),
+		TransactionID:   nil,
+	}
+	response := &api.PerformInviteResponse{}
+	if err := rsAPI.PerformInvite(ctx, request, response); err != nil {
+		util.GetLogger(ctx).WithError(err).Error("PerformInvite failed")
 		return util.JSONResponse{
 			Code: http.StatusInternalServerError,
 			JSON: jsonerror.InternalServerError(),
+		}
+	}
+	if response.Error != nil {
+		return response.Error.JSONResponse()
+	}
+	// Return the signed event to the originating server, it should then tell
+	// the other servers in the room that we have been invited.
+	if isInviteV2 {
+		return util.JSONResponse{
+			Code: http.StatusOK,
+			JSON: gomatrixserverlib.RespInviteV2{Event: signedEvent.JSON()},
+		}
+	} else {
+		return util.JSONResponse{
+			Code: http.StatusOK,
+			JSON: gomatrixserverlib.RespInvite{Event: signedEvent.JSON()},
 		}
 	}
 }

--- a/internal/eventutil/events.go
+++ b/internal/eventutil/events.go
@@ -39,7 +39,7 @@ var ErrRoomNoExists = errors.New("room does not exist")
 func QueryAndBuildEvent(
 	ctx context.Context,
 	builder *gomatrixserverlib.EventBuilder, cfg *config.Global, evTime time.Time,
-	rsAPI api.RoomserverInternalAPI, queryRes *api.QueryLatestEventsAndStateResponse,
+	rsAPI api.QueryLatestEventsAndStateAPI, queryRes *api.QueryLatestEventsAndStateResponse,
 ) (*gomatrixserverlib.HeaderedEvent, error) {
 	if queryRes == nil {
 		queryRes = &api.QueryLatestEventsAndStateResponse{}
@@ -80,7 +80,7 @@ func BuildEvent(
 func queryRequiredEventsForBuilder(
 	ctx context.Context,
 	builder *gomatrixserverlib.EventBuilder,
-	rsAPI api.RoomserverInternalAPI, queryRes *api.QueryLatestEventsAndStateResponse,
+	rsAPI api.QueryLatestEventsAndStateAPI, queryRes *api.QueryLatestEventsAndStateResponse,
 ) (*gomatrixserverlib.StateNeeded, error) {
 	eventsNeeded, err := gomatrixserverlib.StateNeededForEventBuilder(builder)
 	if err != nil {

--- a/keyserver/api/api.go
+++ b/keyserver/api/api.go
@@ -28,19 +28,25 @@ import (
 
 type KeyInternalAPI interface {
 	SyncKeyAPI
+	ClientKeyAPI
 	// SetUserAPI assigns a user API to query when extracting device names.
 	SetUserAPI(i userapi.UserInternalAPI)
 	// InputDeviceListUpdate from a federated server EDU
 	InputDeviceListUpdate(ctx context.Context, req *InputDeviceListUpdateRequest, res *InputDeviceListUpdateResponse)
-	PerformUploadKeys(ctx context.Context, req *PerformUploadKeysRequest, res *PerformUploadKeysResponse)
-	// PerformClaimKeys claims one-time keys for use in pre-key messages
-	PerformClaimKeys(ctx context.Context, req *PerformClaimKeysRequest, res *PerformClaimKeysResponse)
+
 	PerformDeleteKeys(ctx context.Context, req *PerformDeleteKeysRequest, res *PerformDeleteKeysResponse)
-	PerformUploadDeviceKeys(ctx context.Context, req *PerformUploadDeviceKeysRequest, res *PerformUploadDeviceKeysResponse)
-	PerformUploadDeviceSignatures(ctx context.Context, req *PerformUploadDeviceSignaturesRequest, res *PerformUploadDeviceSignaturesResponse)
-	QueryKeys(ctx context.Context, req *QueryKeysRequest, res *QueryKeysResponse)
 	QueryDeviceMessages(ctx context.Context, req *QueryDeviceMessagesRequest, res *QueryDeviceMessagesResponse)
 	QuerySignatures(ctx context.Context, req *QuerySignaturesRequest, res *QuerySignaturesResponse)
+}
+
+// API functions required by the clientapi
+type ClientKeyAPI interface {
+	QueryKeys(ctx context.Context, req *QueryKeysRequest, res *QueryKeysResponse)
+	PerformUploadKeys(ctx context.Context, req *PerformUploadKeysRequest, res *PerformUploadKeysResponse)
+	PerformUploadDeviceKeys(ctx context.Context, req *PerformUploadDeviceKeysRequest, res *PerformUploadDeviceKeysResponse)
+	PerformUploadDeviceSignatures(ctx context.Context, req *PerformUploadDeviceSignaturesRequest, res *PerformUploadDeviceSignaturesResponse)
+	// PerformClaimKeys claims one-time keys for use in pre-key messages
+	PerformClaimKeys(ctx context.Context, req *PerformClaimKeysRequest, res *PerformClaimKeysResponse)
 }
 
 // API functions required by the syncapi

--- a/mediaapi/mediaapi.go
+++ b/mediaapi/mediaapi.go
@@ -26,7 +26,7 @@ import (
 // AddPublicRoutes sets up and registers HTTP handlers for the MediaAPI component.
 func AddPublicRoutes(
 	base *base.BaseDendrite,
-	userAPI userapi.UserInternalAPI,
+	userAPI userapi.MediaUserAPI,
 	client *gomatrixserverlib.Client,
 ) {
 	cfg := &base.Cfg.MediaAPI

--- a/mediaapi/routing/routing.go
+++ b/mediaapi/routing/routing.go
@@ -48,7 +48,7 @@ func Setup(
 	cfg *config.MediaAPI,
 	rateLimit *config.RateLimiting,
 	db storage.Database,
-	userAPI userapi.UserInternalAPI,
+	userAPI userapi.MediaUserAPI,
 	client *gomatrixserverlib.Client,
 ) {
 	rateLimits := httputil.NewRateLimits(rateLimit)

--- a/roomserver/api/api.go
+++ b/roomserver/api/api.go
@@ -13,6 +13,7 @@ import (
 // RoomserverInputAPI is used to write events to the room server.
 type RoomserverInternalAPI interface {
 	SyncRoomserverAPI
+	AppserviceRoomserverAPI
 
 	// needed to avoid chicken and egg scenario when setting up the
 	// interdependencies between the roomserver and other input APIs
@@ -78,13 +79,6 @@ type RoomserverInternalAPI interface {
 		ctx context.Context,
 		req *QueryPublishedRoomsRequest,
 		res *QueryPublishedRoomsResponse,
-	) error
-
-	// Query a list of membership events for a room
-	QueryMembershipsForRoom(
-		ctx context.Context,
-		request *QueryMembershipsForRoomRequest,
-		response *QueryMembershipsForRoomResponse,
 	) error
 
 	// Query if we think we're still in a room.
@@ -170,13 +164,6 @@ type RoomserverInternalAPI interface {
 		response *GetRoomIDForAliasResponse,
 	) error
 
-	// Get all known aliases for a room ID
-	GetAliasesForRoomID(
-		ctx context.Context,
-		req *GetAliasesForRoomIDRequest,
-		response *GetAliasesForRoomIDResponse,
-	) error
-
 	// Get the user ID of the creator of an alias
 	GetCreatorIDForAlias(
 		ctx context.Context,
@@ -229,5 +216,26 @@ type SyncRoomserverAPI interface {
 		ctx context.Context,
 		request *PerformBackfillRequest,
 		response *PerformBackfillResponse,
+	) error
+}
+
+type AppserviceRoomserverAPI interface {
+	// Query a list of events by event ID.
+	QueryEventsByID(
+		ctx context.Context,
+		request *QueryEventsByIDRequest,
+		response *QueryEventsByIDResponse,
+	) error
+	// Query a list of membership events for a room
+	QueryMembershipsForRoom(
+		ctx context.Context,
+		request *QueryMembershipsForRoomRequest,
+		response *QueryMembershipsForRoomResponse,
+	) error
+	// Get all known aliases for a room ID
+	GetAliasesForRoomID(
+		ctx context.Context,
+		req *GetAliasesForRoomIDRequest,
+		response *GetAliasesForRoomIDResponse,
 	) error
 }

--- a/roomserver/api/api.go
+++ b/roomserver/api/api.go
@@ -12,20 +12,19 @@ import (
 
 // RoomserverInputAPI is used to write events to the room server.
 type RoomserverInternalAPI interface {
+	InputRoomEventsAPI
+	QueryLatestEventsAndStateAPI
+	QueryEventsAPI
+
 	SyncRoomserverAPI
 	AppserviceRoomserverAPI
+	ClientRoomserverAPI
 
 	// needed to avoid chicken and egg scenario when setting up the
 	// interdependencies between the roomserver and other input APIs
 	SetFederationAPI(fsAPI fsAPI.FederationInternalAPI, keyRing *gomatrixserverlib.KeyRing)
 	SetAppserviceAPI(asAPI asAPI.AppServiceQueryAPI)
 	SetUserAPI(userAPI userapi.UserInternalAPI)
-
-	InputRoomEvents(
-		ctx context.Context,
-		request *InputRoomEventsRequest,
-		response *InputRoomEventsResponse,
-	)
 
 	PerformInvite(
 		ctx context.Context,
@@ -69,12 +68,6 @@ type RoomserverInternalAPI interface {
 		res *PerformInboundPeekResponse,
 	) error
 
-	PerformAdminEvacuateRoom(
-		ctx context.Context,
-		req *PerformAdminEvacuateRoomRequest,
-		res *PerformAdminEvacuateRoomResponse,
-	)
-
 	QueryPublishedRooms(
 		ctx context.Context,
 		req *QueryPublishedRoomsRequest,
@@ -84,22 +77,22 @@ type RoomserverInternalAPI interface {
 	// Query if we think we're still in a room.
 	QueryServerJoinedToRoom(
 		ctx context.Context,
-		request *QueryServerJoinedToRoomRequest,
-		response *QueryServerJoinedToRoomResponse,
+		req *QueryServerJoinedToRoomRequest,
+		res *QueryServerJoinedToRoomResponse,
 	) error
 
 	// Query whether a server is allowed to see an event
 	QueryServerAllowedToSeeEvent(
 		ctx context.Context,
-		request *QueryServerAllowedToSeeEventRequest,
-		response *QueryServerAllowedToSeeEventResponse,
+		req *QueryServerAllowedToSeeEventRequest,
+		res *QueryServerAllowedToSeeEventResponse,
 	) error
 
 	// Query missing events for a room from roomserver
 	QueryMissingEvents(
 		ctx context.Context,
-		request *QueryMissingEventsRequest,
-		response *QueryMissingEventsResponse,
+		req *QueryMissingEventsRequest,
+		res *QueryMissingEventsResponse,
 	) error
 
 	// Query to get state and auth chain for a (potentially hypothetical) event.
@@ -107,8 +100,8 @@ type RoomserverInternalAPI interface {
 	// the state and auth chain to return.
 	QueryStateAndAuthChain(
 		ctx context.Context,
-		request *QueryStateAndAuthChainRequest,
-		response *QueryStateAndAuthChainResponse,
+		req *QueryStateAndAuthChainRequest,
+		res *QueryStateAndAuthChainResponse,
 	) error
 
 	// QueryAuthChain returns the entire auth chain for the event IDs given.
@@ -116,22 +109,14 @@ type RoomserverInternalAPI interface {
 	// Omits without error for any missing auth events. There will be no duplicates.
 	QueryAuthChain(
 		ctx context.Context,
-		request *QueryAuthChainRequest,
-		response *QueryAuthChainResponse,
+		req *QueryAuthChainRequest,
+		res *QueryAuthChainResponse,
 	) error
 
-	// QueryCurrentState retrieves the requested state events. If state events are not found, they will be missing from
-	// the response.
-	QueryCurrentState(ctx context.Context, req *QueryCurrentStateRequest, res *QueryCurrentStateResponse) error
 	// QueryRoomsForUser retrieves a list of room IDs matching the given query.
 	QueryRoomsForUser(ctx context.Context, req *QueryRoomsForUserRequest, res *QueryRoomsForUserResponse) error
-	// QueryKnownUsers returns a list of users that we know about from our joined rooms.
-	QueryKnownUsers(ctx context.Context, req *QueryKnownUsersRequest, res *QueryKnownUsersResponse) error
 	// QueryServerBannedFromRoom returns whether a server is banned from a room by server ACLs.
 	QueryServerBannedFromRoom(ctx context.Context, req *QueryServerBannedFromRoomRequest, res *QueryServerBannedFromRoomResponse) error
-
-	// PerformForget forgets a rooms history for a specific user
-	PerformForget(ctx context.Context, req *PerformForgetRequest, resp *PerformForgetResponse) error
 
 	// PerformRoomUpgrade upgrades a room to a newer version
 	PerformRoomUpgrade(ctx context.Context, req *PerformRoomUpgradeRequest, resp *PerformRoomUpgradeResponse)
@@ -139,83 +124,107 @@ type RoomserverInternalAPI interface {
 	// Asks for the default room version as preferred by the server.
 	QueryRoomVersionCapabilities(
 		ctx context.Context,
-		request *QueryRoomVersionCapabilitiesRequest,
-		response *QueryRoomVersionCapabilitiesResponse,
+		req *QueryRoomVersionCapabilitiesRequest,
+		res *QueryRoomVersionCapabilitiesResponse,
 	) error
 
 	// Asks for the room version for a given room.
 	QueryRoomVersionForRoom(
 		ctx context.Context,
-		request *QueryRoomVersionForRoomRequest,
-		response *QueryRoomVersionForRoomResponse,
+		req *QueryRoomVersionForRoomRequest,
+		res *QueryRoomVersionForRoomResponse,
 	) error
 
 	// Set a room alias
 	SetRoomAlias(
 		ctx context.Context,
 		req *SetRoomAliasRequest,
-		response *SetRoomAliasResponse,
+		res *SetRoomAliasResponse,
 	) error
 
 	// Get the room ID for an alias
 	GetRoomIDForAlias(
 		ctx context.Context,
 		req *GetRoomIDForAliasRequest,
-		response *GetRoomIDForAliasResponse,
+		res *GetRoomIDForAliasResponse,
 	) error
 
 	// Get the user ID of the creator of an alias
 	GetCreatorIDForAlias(
 		ctx context.Context,
 		req *GetCreatorIDForAliasRequest,
-		response *GetCreatorIDForAliasResponse,
+		res *GetCreatorIDForAliasResponse,
 	) error
 
 	// Remove a room alias
 	RemoveRoomAlias(
 		ctx context.Context,
 		req *RemoveRoomAliasRequest,
-		response *RemoveRoomAliasResponse,
+		res *RemoveRoomAliasResponse,
 	) error
+}
+
+type InputRoomEventsAPI interface {
+	InputRoomEvents(
+		ctx context.Context,
+		req *InputRoomEventsRequest,
+		res *InputRoomEventsResponse,
+	)
+}
+
+// Query the latest events and state for a room from the room server.
+type QueryLatestEventsAndStateAPI interface {
+	QueryLatestEventsAndState(ctx context.Context, req *QueryLatestEventsAndStateRequest, res *QueryLatestEventsAndStateResponse) error
+}
+
+// QueryBulkStateContent does a bulk query for state event content in the given rooms.
+type QueryBulkStateContentAPI interface {
+	QueryBulkStateContent(ctx context.Context, req *QueryBulkStateContentRequest, res *QueryBulkStateContentResponse) error
+}
+
+type QueryEventsAPI interface {
+	// Query a list of events by event ID.
+	QueryEventsByID(
+		ctx context.Context,
+		req *QueryEventsByIDRequest,
+		res *QueryEventsByIDResponse,
+	) error
+	// QueryCurrentState retrieves the requested state events. If state events are not found, they will be missing from
+	// the response.
+	QueryCurrentState(ctx context.Context, req *QueryCurrentStateRequest, res *QueryCurrentStateResponse) error
 }
 
 // API functions required by the syncapi
 type SyncRoomserverAPI interface {
-	// Query the latest events and state for a room from the room server.
-	QueryLatestEventsAndState(
-		ctx context.Context,
-		request *QueryLatestEventsAndStateRequest,
-		response *QueryLatestEventsAndStateResponse,
-	) error
-	// QueryBulkStateContent does a bulk query for state event content in the given rooms.
-	QueryBulkStateContent(ctx context.Context, req *QueryBulkStateContentRequest, res *QueryBulkStateContentResponse) error
+	QueryLatestEventsAndStateAPI
+	QueryBulkStateContentAPI
 	// QuerySharedUsers returns a list of users who share at least 1 room in common with the given user.
 	QuerySharedUsers(ctx context.Context, req *QuerySharedUsersRequest, res *QuerySharedUsersResponse) error
 	// Query a list of events by event ID.
 	QueryEventsByID(
 		ctx context.Context,
-		request *QueryEventsByIDRequest,
-		response *QueryEventsByIDResponse,
+		req *QueryEventsByIDRequest,
+		res *QueryEventsByIDResponse,
 	) error
 	// Query the membership event for an user for a room.
 	QueryMembershipForUser(
 		ctx context.Context,
-		request *QueryMembershipForUserRequest,
-		response *QueryMembershipForUserResponse,
+		req *QueryMembershipForUserRequest,
+		res *QueryMembershipForUserResponse,
 	) error
 
 	// Query the state after a list of events in a room from the room server.
 	QueryStateAfterEvents(
 		ctx context.Context,
-		request *QueryStateAfterEventsRequest,
-		response *QueryStateAfterEventsResponse,
+		req *QueryStateAfterEventsRequest,
+		res *QueryStateAfterEventsResponse,
 	) error
 
 	// Query a given amount (or less) of events prior to a given set of events.
 	PerformBackfill(
 		ctx context.Context,
-		request *PerformBackfillRequest,
-		response *PerformBackfillResponse,
+		req *PerformBackfillRequest,
+		res *PerformBackfillResponse,
 	) error
 }
 
@@ -223,19 +232,56 @@ type AppserviceRoomserverAPI interface {
 	// Query a list of events by event ID.
 	QueryEventsByID(
 		ctx context.Context,
-		request *QueryEventsByIDRequest,
-		response *QueryEventsByIDResponse,
+		req *QueryEventsByIDRequest,
+		res *QueryEventsByIDResponse,
 	) error
 	// Query a list of membership events for a room
 	QueryMembershipsForRoom(
 		ctx context.Context,
-		request *QueryMembershipsForRoomRequest,
-		response *QueryMembershipsForRoomResponse,
+		req *QueryMembershipsForRoomRequest,
+		res *QueryMembershipsForRoomResponse,
 	) error
 	// Get all known aliases for a room ID
 	GetAliasesForRoomID(
 		ctx context.Context,
 		req *GetAliasesForRoomIDRequest,
-		response *GetAliasesForRoomIDResponse,
+		res *GetAliasesForRoomIDResponse,
 	) error
+}
+
+type ClientRoomserverAPI interface {
+	InputRoomEventsAPI
+	QueryLatestEventsAndStateAPI
+	QueryBulkStateContentAPI
+	QueryEventsAPI
+	QueryMembershipForUser(ctx context.Context, req *QueryMembershipForUserRequest, res *QueryMembershipForUserResponse) error
+	QueryMembershipsForRoom(ctx context.Context, req *QueryMembershipsForRoomRequest, res *QueryMembershipsForRoomResponse) error
+	QueryRoomsForUser(ctx context.Context, req *QueryRoomsForUserRequest, res *QueryRoomsForUserResponse) error
+	QueryStateAfterEvents(ctx context.Context, req *QueryStateAfterEventsRequest, res *QueryStateAfterEventsResponse) error
+	// QueryKnownUsers returns a list of users that we know about from our joined rooms.
+	QueryKnownUsers(ctx context.Context, req *QueryKnownUsersRequest, res *QueryKnownUsersResponse) error
+	QueryRoomVersionForRoom(ctx context.Context, req *QueryRoomVersionForRoomRequest, res *QueryRoomVersionForRoomResponse) error
+	QueryPublishedRooms(ctx context.Context, req *QueryPublishedRoomsRequest, res *QueryPublishedRoomsResponse) error
+	QueryRoomVersionCapabilities(ctx context.Context, req *QueryRoomVersionCapabilitiesRequest, res *QueryRoomVersionCapabilitiesResponse) error
+
+	GetRoomIDForAlias(ctx context.Context, req *GetRoomIDForAliasRequest, res *GetRoomIDForAliasResponse) error
+	GetAliasesForRoomID(ctx context.Context, req *GetAliasesForRoomIDRequest, res *GetAliasesForRoomIDResponse) error
+
+	// PerformRoomUpgrade upgrades a room to a newer version
+	PerformRoomUpgrade(ctx context.Context, req *PerformRoomUpgradeRequest, resp *PerformRoomUpgradeResponse)
+	PerformAdminEvacuateRoom(
+		ctx context.Context,
+		req *PerformAdminEvacuateRoomRequest,
+		res *PerformAdminEvacuateRoomResponse,
+	)
+	PerformPeek(ctx context.Context, req *PerformPeekRequest, res *PerformPeekResponse)
+	PerformUnpeek(ctx context.Context, req *PerformUnpeekRequest, res *PerformUnpeekResponse)
+	PerformInvite(ctx context.Context, req *PerformInviteRequest, res *PerformInviteResponse) error
+	PerformJoin(ctx context.Context, req *PerformJoinRequest, res *PerformJoinResponse)
+	PerformLeave(ctx context.Context, req *PerformLeaveRequest, res *PerformLeaveResponse) error
+	PerformPublish(ctx context.Context, req *PerformPublishRequest, res *PerformPublishResponse)
+	// PerformForget forgets a rooms history for a specific user
+	PerformForget(ctx context.Context, req *PerformForgetRequest, resp *PerformForgetResponse) error
+	SetRoomAlias(ctx context.Context, req *SetRoomAliasRequest, res *SetRoomAliasResponse) error
+	RemoveRoomAlias(ctx context.Context, req *RemoveRoomAliasRequest, res *RemoveRoomAliasResponse) error
 }

--- a/roomserver/api/wrapper.go
+++ b/roomserver/api/wrapper.go
@@ -16,7 +16,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
@@ -24,7 +23,7 @@ import (
 
 // SendEvents to the roomserver The events are written with KindNew.
 func SendEvents(
-	ctx context.Context, rsAPI RoomserverInternalAPI,
+	ctx context.Context, rsAPI InputRoomEventsAPI,
 	kind Kind, events []*gomatrixserverlib.HeaderedEvent,
 	origin gomatrixserverlib.ServerName,
 	sendAsServer gomatrixserverlib.ServerName, txnID *TransactionID,
@@ -47,7 +46,7 @@ func SendEvents(
 // with the state at the event as KindOutlier before it. Will not send any event that is
 // marked as `true` in haveEventIDs.
 func SendEventWithState(
-	ctx context.Context, rsAPI RoomserverInternalAPI, kind Kind,
+	ctx context.Context, rsAPI InputRoomEventsAPI, kind Kind,
 	state *gomatrixserverlib.RespState, event *gomatrixserverlib.HeaderedEvent,
 	origin gomatrixserverlib.ServerName, haveEventIDs map[string]bool, async bool,
 ) error {
@@ -83,7 +82,7 @@ func SendEventWithState(
 
 // SendInputRoomEvents to the roomserver.
 func SendInputRoomEvents(
-	ctx context.Context, rsAPI RoomserverInternalAPI,
+	ctx context.Context, rsAPI InputRoomEventsAPI,
 	ires []InputRoomEvent, async bool,
 ) error {
 	request := InputRoomEventsRequest{
@@ -95,37 +94,8 @@ func SendInputRoomEvents(
 	return response.Err()
 }
 
-// SendInvite event to the roomserver.
-// This should only be needed for invite events that occur outside of a known room.
-// If we are in the room then the event should be sent using the SendEvents method.
-func SendInvite(
-	ctx context.Context,
-	rsAPI RoomserverInternalAPI, inviteEvent *gomatrixserverlib.HeaderedEvent,
-	inviteRoomState []gomatrixserverlib.InviteV2StrippedState,
-	sendAsServer gomatrixserverlib.ServerName, txnID *TransactionID,
-) error {
-	// Start by sending the invite request into the roomserver. This will
-	// trigger the federation request amongst other things if needed.
-	request := &PerformInviteRequest{
-		Event:           inviteEvent,
-		InviteRoomState: inviteRoomState,
-		RoomVersion:     inviteEvent.RoomVersion,
-		SendAsServer:    string(sendAsServer),
-		TransactionID:   txnID,
-	}
-	response := &PerformInviteResponse{}
-	if err := rsAPI.PerformInvite(ctx, request, response); err != nil {
-		return fmt.Errorf("rsAPI.PerformInvite: %w", err)
-	}
-	if response.Error != nil {
-		return response.Error
-	}
-
-	return nil
-}
-
 // GetEvent returns the event or nil, even on errors.
-func GetEvent(ctx context.Context, rsAPI RoomserverInternalAPI, eventID string) *gomatrixserverlib.HeaderedEvent {
+func GetEvent(ctx context.Context, rsAPI QueryEventsAPI, eventID string) *gomatrixserverlib.HeaderedEvent {
 	var res QueryEventsByIDResponse
 	err := rsAPI.QueryEventsByID(ctx, &QueryEventsByIDRequest{
 		EventIDs: []string{eventID},
@@ -141,7 +111,7 @@ func GetEvent(ctx context.Context, rsAPI RoomserverInternalAPI, eventID string) 
 }
 
 // GetStateEvent returns the current state event in the room or nil.
-func GetStateEvent(ctx context.Context, rsAPI RoomserverInternalAPI, roomID string, tuple gomatrixserverlib.StateKeyTuple) *gomatrixserverlib.HeaderedEvent {
+func GetStateEvent(ctx context.Context, rsAPI QueryEventsAPI, roomID string, tuple gomatrixserverlib.StateKeyTuple) *gomatrixserverlib.HeaderedEvent {
 	var res QueryCurrentStateResponse
 	err := rsAPI.QueryCurrentState(ctx, &QueryCurrentStateRequest{
 		RoomID:      roomID,
@@ -175,7 +145,7 @@ func IsServerBannedFromRoom(ctx context.Context, rsAPI RoomserverInternalAPI, ro
 // PopulatePublicRooms extracts PublicRoom information for all the provided room IDs. The IDs are not checked to see if they are visible in the
 // published room directory.
 // due to lots of switches
-func PopulatePublicRooms(ctx context.Context, roomIDs []string, rsAPI RoomserverInternalAPI) ([]gomatrixserverlib.PublicRoom, error) {
+func PopulatePublicRooms(ctx context.Context, roomIDs []string, rsAPI QueryBulkStateContentAPI) ([]gomatrixserverlib.PublicRoom, error) {
 	avatarTuple := gomatrixserverlib.StateKeyTuple{EventType: "m.room.avatar", StateKey: ""}
 	nameTuple := gomatrixserverlib.StateKeyTuple{EventType: "m.room.name", StateKey: ""}
 	canonicalTuple := gomatrixserverlib.StateKeyTuple{EventType: gomatrixserverlib.MRoomCanonicalAlias, StateKey: ""}

--- a/userapi/api/api.go
+++ b/userapi/api/api.go
@@ -26,42 +26,70 @@ import (
 
 // UserInternalAPI is the internal API for information about users and devices.
 type UserInternalAPI interface {
-	LoginTokenInternalAPI
 	UserProfileAPI
-	UserRegisterAPI
-	UserAccountAPI
-	UserThreePIDAPI
 	QueryAcccessTokenAPI
+
+	AppserviceUserAPI
 	SyncUserAPI
-
-	InputAccountData(ctx context.Context, req *InputAccountDataRequest, res *InputAccountDataResponse) error
-
-	PerformOpenIDTokenCreation(ctx context.Context, req *PerformOpenIDTokenCreationRequest, res *PerformOpenIDTokenCreationResponse) error
-	PerformKeyBackup(ctx context.Context, req *PerformKeyBackupRequest, res *PerformKeyBackupResponse) error
-	PerformPusherSet(ctx context.Context, req *PerformPusherSetRequest, res *struct{}) error
-	PerformPusherDeletion(ctx context.Context, req *PerformPusherDeletionRequest, res *struct{}) error
-	PerformPushRulesPut(ctx context.Context, req *PerformPushRulesPutRequest, res *struct{}) error
-
-	QueryKeyBackup(ctx context.Context, req *QueryKeyBackupRequest, res *QueryKeyBackupResponse)
+	ClientUserAPI
 
 	QueryOpenIDToken(ctx context.Context, req *QueryOpenIDTokenRequest, res *QueryOpenIDTokenResponse) error
-	QueryPushers(ctx context.Context, req *QueryPushersRequest, res *QueryPushersResponse) error
-	QueryPushRules(ctx context.Context, req *QueryPushRulesRequest, res *QueryPushRulesResponse) error
-	QueryNotifications(ctx context.Context, req *QueryNotificationsRequest, res *QueryNotificationsResponse) error
 }
 
 type QueryAcccessTokenAPI interface {
 	QueryAccessToken(ctx context.Context, req *QueryAccessTokenRequest, res *QueryAccessTokenResponse) error
 }
 
+type UserLoginAPI interface {
+	QueryAccountByPassword(ctx context.Context, req *QueryAccountByPasswordRequest, res *QueryAccountByPasswordResponse) error
+}
+
+type AppserviceUserAPI interface {
+	PerformAccountCreation(ctx context.Context, req *PerformAccountCreationRequest, res *PerformAccountCreationResponse) error
+	PerformDeviceCreation(ctx context.Context, req *PerformDeviceCreationRequest, res *PerformDeviceCreationResponse) error
+}
+
 type SyncUserAPI interface {
+	QueryAcccessTokenAPI
 	QueryAccountData(ctx context.Context, req *QueryAccountDataRequest, res *QueryAccountDataResponse) error
-	QueryAccessToken(ctx context.Context, req *QueryAccessTokenRequest, res *QueryAccessTokenResponse) error
-	PerformDeviceDeletion(ctx context.Context, req *PerformDeviceDeletionRequest, res *PerformDeviceDeletionResponse) error
 	PerformLastSeenUpdate(ctx context.Context, req *PerformLastSeenUpdateRequest, res *PerformLastSeenUpdateResponse) error
 	PerformDeviceUpdate(ctx context.Context, req *PerformDeviceUpdateRequest, res *PerformDeviceUpdateResponse) error
 	QueryDevices(ctx context.Context, req *QueryDevicesRequest, res *QueryDevicesResponse) error
 	QueryDeviceInfos(ctx context.Context, req *QueryDeviceInfosRequest, res *QueryDeviceInfosResponse) error
+}
+
+type ClientUserAPI interface {
+	QueryAcccessTokenAPI
+	LoginTokenInternalAPI
+	UserLoginAPI
+	QueryNumericLocalpart(ctx context.Context, res *QueryNumericLocalpartResponse) error
+	QueryDevices(ctx context.Context, req *QueryDevicesRequest, res *QueryDevicesResponse) error
+	QueryProfile(ctx context.Context, req *QueryProfileRequest, res *QueryProfileResponse) error
+	QueryAccountData(ctx context.Context, req *QueryAccountDataRequest, res *QueryAccountDataResponse) error
+	QueryPushers(ctx context.Context, req *QueryPushersRequest, res *QueryPushersResponse) error
+	QueryPushRules(ctx context.Context, req *QueryPushRulesRequest, res *QueryPushRulesResponse) error
+	QueryAccountAvailability(ctx context.Context, req *QueryAccountAvailabilityRequest, res *QueryAccountAvailabilityResponse) error
+	PerformAccountCreation(ctx context.Context, req *PerformAccountCreationRequest, res *PerformAccountCreationResponse) error
+	PerformDeviceCreation(ctx context.Context, req *PerformDeviceCreationRequest, res *PerformDeviceCreationResponse) error
+	PerformDeviceUpdate(ctx context.Context, req *PerformDeviceUpdateRequest, res *PerformDeviceUpdateResponse) error
+	PerformDeviceDeletion(ctx context.Context, req *PerformDeviceDeletionRequest, res *PerformDeviceDeletionResponse) error
+	PerformPasswordUpdate(ctx context.Context, req *PerformPasswordUpdateRequest, res *PerformPasswordUpdateResponse) error
+	PerformPusherDeletion(ctx context.Context, req *PerformPusherDeletionRequest, res *struct{}) error
+	PerformPusherSet(ctx context.Context, req *PerformPusherSetRequest, res *struct{}) error
+	PerformPushRulesPut(ctx context.Context, req *PerformPushRulesPutRequest, res *struct{}) error
+	PerformAccountDeactivation(ctx context.Context, req *PerformAccountDeactivationRequest, res *PerformAccountDeactivationResponse) error
+	PerformOpenIDTokenCreation(ctx context.Context, req *PerformOpenIDTokenCreationRequest, res *PerformOpenIDTokenCreationResponse) error
+	SetAvatarURL(ctx context.Context, req *PerformSetAvatarURLRequest, res *PerformSetAvatarURLResponse) error
+	SetDisplayName(ctx context.Context, req *PerformUpdateDisplayNameRequest, res *struct{}) error
+	QueryNotifications(ctx context.Context, req *QueryNotificationsRequest, res *QueryNotificationsResponse) error
+	InputAccountData(ctx context.Context, req *InputAccountDataRequest, res *InputAccountDataResponse) error
+	PerformKeyBackup(ctx context.Context, req *PerformKeyBackupRequest, res *PerformKeyBackupResponse) error
+	QueryKeyBackup(ctx context.Context, req *QueryKeyBackupRequest, res *QueryKeyBackupResponse)
+
+	QueryThreePIDsForLocalpart(ctx context.Context, req *QueryThreePIDsForLocalpartRequest, res *QueryThreePIDsForLocalpartResponse) error
+	QueryLocalpartForThreePID(ctx context.Context, req *QueryLocalpartForThreePIDRequest, res *QueryLocalpartForThreePIDResponse) error
+	PerformForgetThreePID(ctx context.Context, req *PerformForgetThreePIDRequest, res *struct{}) error
+	PerformSaveThreePIDAssociation(ctx context.Context, req *PerformSaveThreePIDAssociationRequest, res *struct{}) error
 }
 
 type UserDirectoryProvider interface {
@@ -72,31 +100,6 @@ type UserDirectoryProvider interface {
 type UserProfileAPI interface {
 	QueryProfile(ctx context.Context, req *QueryProfileRequest, res *QueryProfileResponse) error
 	QuerySearchProfiles(ctx context.Context, req *QuerySearchProfilesRequest, res *QuerySearchProfilesResponse) error
-	SetAvatarURL(ctx context.Context, req *PerformSetAvatarURLRequest, res *PerformSetAvatarURLResponse) error
-	SetDisplayName(ctx context.Context, req *PerformUpdateDisplayNameRequest, res *struct{}) error
-}
-
-// UserRegisterAPI defines functions for registering accounts
-type UserRegisterAPI interface {
-	QueryNumericLocalpart(ctx context.Context, res *QueryNumericLocalpartResponse) error
-	QueryAccountAvailability(ctx context.Context, req *QueryAccountAvailabilityRequest, res *QueryAccountAvailabilityResponse) error
-	PerformAccountCreation(ctx context.Context, req *PerformAccountCreationRequest, res *PerformAccountCreationResponse) error
-	PerformDeviceCreation(ctx context.Context, req *PerformDeviceCreationRequest, res *PerformDeviceCreationResponse) error
-}
-
-// UserAccountAPI defines functions for changing an account
-type UserAccountAPI interface {
-	PerformPasswordUpdate(ctx context.Context, req *PerformPasswordUpdateRequest, res *PerformPasswordUpdateResponse) error
-	PerformAccountDeactivation(ctx context.Context, req *PerformAccountDeactivationRequest, res *PerformAccountDeactivationResponse) error
-	QueryAccountByPassword(ctx context.Context, req *QueryAccountByPasswordRequest, res *QueryAccountByPasswordResponse) error
-}
-
-// UserThreePIDAPI defines functions for 3PID
-type UserThreePIDAPI interface {
-	QueryLocalpartForThreePID(ctx context.Context, req *QueryLocalpartForThreePIDRequest, res *QueryLocalpartForThreePIDResponse) error
-	QueryThreePIDsForLocalpart(ctx context.Context, req *QueryThreePIDsForLocalpartRequest, res *QueryThreePIDsForLocalpartResponse) error
-	PerformForgetThreePID(ctx context.Context, req *PerformForgetThreePIDRequest, res *struct{}) error
-	PerformSaveThreePIDAssociation(ctx context.Context, req *PerformSaveThreePIDAssociationRequest, res *struct{}) error
 }
 
 type PerformKeyBackupRequest struct {

--- a/userapi/api/api.go
+++ b/userapi/api/api.go
@@ -32,6 +32,7 @@ type UserInternalAPI interface {
 	AppserviceUserAPI
 	SyncUserAPI
 	ClientUserAPI
+	MediaUserAPI
 
 	QueryOpenIDToken(ctx context.Context, req *QueryOpenIDTokenRequest, res *QueryOpenIDTokenResponse) error
 }
@@ -47,6 +48,10 @@ type UserLoginAPI interface {
 type AppserviceUserAPI interface {
 	PerformAccountCreation(ctx context.Context, req *PerformAccountCreationRequest, res *PerformAccountCreationResponse) error
 	PerformDeviceCreation(ctx context.Context, req *PerformDeviceCreationRequest, res *PerformDeviceCreationResponse) error
+}
+
+type MediaUserAPI interface {
+	QueryAcccessTokenAPI
 }
 
 type SyncUserAPI interface {


### PR DESCRIPTION
- Convert `clientapi`, `mediaapi` and `appservice` to define the interfaces they need in order to function.
- Remove the helper function `SendInvite` as it just proxies `PerformInvite`.

Part 2 will contain conversions for `federationapi` and `userapi`. After this point, the interfaces will be cleaned up such that the internal API interfaces are just composed of functions required by consumers.