### PR TITLE
Don't try to re-fetch the event if it is listed in `adds_state_event_ids`

### DIFF
--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -161,7 +161,12 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 	// in the sync API database or we'll need to ask the roomserver.
 	knownEventIDs := make(map[string]bool, len(msg.AddsStateEventIDs))
 	for _, eventID := range msg.AddsStateEventIDs {
-		knownEventIDs[eventID] = eventID == ev.EventID()
+		if eventID == ev.EventID() {
+			knownEventIDs[eventID] = true
+			addsStateEvents = append(addsStateEvents, ev)
+		} else {
+			knownEventIDs[eventID] = false
+		}
 	}
 
 	// Work out which events we want to look up in the sync API database.

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -154,49 +154,71 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 	ctx context.Context, msg api.OutputNewRoomEvent,
 ) error {
 	ev := msg.Event
-
 	addsStateEvents := []*gomatrixserverlib.HeaderedEvent{}
-	missingAddStateEventIDs := make([]string, 0, len(msg.AddsStateEventIDs))
-	foundEventIDs := map[string]bool{
-		msg.Event.EventID(): true,
+
+	// Work out the list of events we need to find out about. Either
+	// they will be the event supplied in the request, we will find it
+	// in the sync API database or we'll need to ask the roomserver.
+	knownEventIDs := make(map[string]bool, len(msg.AddsStateEventIDs))
+	for _, eventID := range msg.AddsStateEventIDs {
+		knownEventIDs[eventID] = eventID == ev.EventID()
 	}
-	if len(msg.AddsStateEventIDs) > 0 {
-		for _, eventID := range msg.AddsStateEventIDs {
-			if _, ok := foundEventIDs[eventID]; !ok {
-				foundEventIDs[eventID] = false
-				missingAddStateEventIDs = append(missingAddStateEventIDs, eventID)
-			}
+
+	// Work out which events we want to look up in the sync API database.
+	// At this stage the only event that should be excluded is the event
+	// supplied in the request, if it appears in the adds_state_event_ids.
+	missingEventIDs := make([]string, 0, len(msg.AddsStateEventIDs))
+	for eventID, known := range knownEventIDs {
+		if !known {
+			missingEventIDs = append(missingEventIDs, eventID)
 		}
 	}
-	if len(missingAddStateEventIDs) > 0 {
-		foundEvents, err := s.db.Events(ctx, missingAddStateEventIDs)
+
+	// Look the events up in the database. If we know them, add them into
+	// the set of adds state events.
+	if len(missingEventIDs) > 0 {
+		alreadyKnown, err := s.db.Events(ctx, msg.AddsStateEventIDs)
 		if err != nil {
 			return fmt.Errorf("s.db.Events: %w", err)
 		}
-		for _, event := range foundEvents {
-			foundEventIDs[event.EventID()] = true
+		for _, knownEvent := range alreadyKnown {
+			knownEventIDs[knownEvent.EventID()] = true
+			addsStateEvents = append(addsStateEvents, knownEvent)
 		}
-		eventsReq := &api.QueryEventsByIDRequest{}
+	}
+
+	// Now work out if there are any remaining events we don't know. For
+	// these we will need to ask the roomserver for help.
+	missingEventIDs = missingEventIDs[:0]
+	for eventID, known := range knownEventIDs {
+		if !known {
+			missingEventIDs = append(missingEventIDs, eventID)
+		}
+	}
+
+	// Ask the roomserver and add in the rest of the results into the set.
+	// Finally, work out if there are any more events missing.
+	if len(missingEventIDs) > 0 {
+		eventsReq := &api.QueryEventsByIDRequest{
+			EventIDs: missingEventIDs,
+		}
 		eventsRes := &api.QueryEventsByIDResponse{}
-		for eventID, found := range foundEventIDs {
-			if !found {
-				eventsReq.EventIDs = append(eventsReq.EventIDs, eventID)
-			}
-		}
-		if err = s.rsAPI.QueryEventsByID(ctx, eventsReq, eventsRes); err != nil {
+		if err := s.rsAPI.QueryEventsByID(ctx, eventsReq, eventsRes); err != nil {
 			return fmt.Errorf("s.rsAPI.QueryEventsByID: %w", err)
 		}
 		for _, event := range eventsRes.Events {
-			eventID := event.EventID()
-			foundEvents = append(foundEvents, event)
-			foundEventIDs[eventID] = true
+			addsStateEvents = append(addsStateEvents, event)
+			knownEventIDs[event.EventID()] = true
 		}
-		for eventID, found := range foundEventIDs {
+
+		// This should never happen because this would imply that the
+		// roomserver has sent us adds_state_event_ids for events that it
+		// also doesn't know about, but let's just be sure.
+		for eventID, found := range knownEventIDs {
 			if !found {
 				return fmt.Errorf("event %s is missing", eventID)
 			}
 		}
-		addsStateEvents = foundEvents
 	}
 
 	ev, err := s.updateStateEvent(ev)


### PR DESCRIPTION
This stops the sync API from trying to fetch the event in the output message itself if it references itself in `adds_state_event_ids` and otherwise treating it like it is missing.