### PR TITLE
More syncapi tests

### DIFF
--- a/syncapi/syncapi_test.go
+++ b/syncapi/syncapi_test.go
@@ -167,12 +167,9 @@ func testSyncAccessTokens(t *testing.T, dbType test.DBType) {
 // Tests what happens when we create a room and then /sync before all events from /createRoom have
 // been sent to the syncapi
 func TestSyncAPICreateRoomSyncEarly(t *testing.T) {
-	testSyncAPICreateRoomSyncEarly(t, test.DBTypePostgres)
-	/*
-		test.WithAllDatabases(t, func(t *testing.T, dbType test.DBType) {
-			testSyncAPICreateRoomSyncEarly(t, dbType)
-		})
-	*/
+	test.WithAllDatabases(t, func(t *testing.T, dbType test.DBType) {
+		testSyncAPICreateRoomSyncEarly(t, dbType)
+	})
 }
 
 func testSyncAPICreateRoomSyncEarly(t *testing.T, dbType test.DBType) {

--- a/test/event.go
+++ b/test/event.go
@@ -64,7 +64,8 @@ func Reversed(in []*gomatrixserverlib.HeaderedEvent) []*gomatrixserverlib.Header
 func AssertEventIDsEqual(t *testing.T, gotEventIDs []string, wants []*gomatrixserverlib.HeaderedEvent) {
 	t.Helper()
 	if len(gotEventIDs) != len(wants) {
-		t.Fatalf("length mismatch: got %d events, want %d", len(gotEventIDs), len(wants))
+		t.Errorf("length mismatch: got %d events, want %d", len(gotEventIDs), len(wants))
+		return
 	}
 	for i := range wants {
 		w := wants[i].EventID()


### PR DESCRIPTION
Added a test which demonstrates the ability to slowly inject messages and do some other stuff in the meantime. This was trying to reproduce the flakey tests with `RoomCreationReportsEventsToMyself` in Complement.

This test demonstrates current (arguably correct) behaviour, but this may need to change to meet client expectations. There are two specific expectations:
 - If I `/createRoom` whilst spamming `/sync`, I should see all events in the `timeline` section of the room. This is reasonable as you're keeping up-to-date in your sync loop. However, a brand new room has no members, so when the `m.room.create` event is processed and stored by the syncapi, it does not deliver it to clients. Only the first `m.room.member` event will be. We can mitigate this by sending `m.room.create` events to clients based on the `sender`?
 - If I `/createRoom` then hit `/sync` after it 200 OKs, I should see all initial room events in the response. Tests like `TestSendAndFetchMessage` reasonably assume this. To fix this, these tests would need to sync until they see the last of the initial set of events which feels very error-prone (do you know what that is? It varies on the create content!)