### PR TITLE
Resolve over old and new extremities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/matrix-org/dugong v0.0.0-20210921133753-66e6b1c67e2e
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91
 	github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20220513091948-6171afad7d08
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20220513103617-eee8fd528433
 	github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4
 	github.com/mattn/go-sqlite3 v1.14.10

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/matrix-org/dugong v0.0.0-20210921133753-66e6b1c67e2e
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91
 	github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20220512154543-2313dfe3136c
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20220513091948-6171afad7d08
 	github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4
 	github.com/mattn/go-sqlite3 v1.14.10

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/matrix-org/dugong v0.0.0-20210921133753-66e6b1c67e2e
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91
 	github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20220509120958-8d818048c34c
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20220512154543-2313dfe3136c
 	github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4
 	github.com/mattn/go-sqlite3 v1.14.10

--- a/go.sum
+++ b/go.sum
@@ -795,8 +795,8 @@ github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91/go.mod h1
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16 h1:ZtO5uywdd5dLDCud4r0r55eP4j9FuUNpl60Gmntcop4=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20220509120958-8d818048c34c h1:KqzqFWxvs90pcDaW9QEveW+Q5JcEYuNnKyaqXc+ohno=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20220509120958-8d818048c34c/go.mod h1:V5eO8rn/C3rcxig37A/BCeKerLFS+9Avg/77FIeTZ48=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20220512154543-2313dfe3136c h1:UWbarvm+mKJ8tVqfbPS/Y7IdqfoxAHYVXJ4FjgY21HQ=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20220512154543-2313dfe3136c/go.mod h1:V5eO8rn/C3rcxig37A/BCeKerLFS+9Avg/77FIeTZ48=
 github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48 h1:W0sjjC6yjskHX4mb0nk3p0fXAlbU5bAFUFeEtlrPASE=
 github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48/go.mod h1:ulJzsVOTssIVp1j/m5eI//4VpAGDkMt5NrRuAVX7wpc=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7/go.mod h1:vVQlW/emklohkZnOPwD3LrZUBqdfsbiyO3p1lNV8F6U=

--- a/go.sum
+++ b/go.sum
@@ -795,8 +795,8 @@ github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91/go.mod h1
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16 h1:ZtO5uywdd5dLDCud4r0r55eP4j9FuUNpl60Gmntcop4=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20220513091948-6171afad7d08 h1:nkNbTqWh/Ypu135j1A4FV8Q7hGYQJUEQOXEEHw3tzkQ=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20220513091948-6171afad7d08/go.mod h1:V5eO8rn/C3rcxig37A/BCeKerLFS+9Avg/77FIeTZ48=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20220513103617-eee8fd528433 h1:nwAlThHGPI2EAAJklXvgMcdhXF6ZiHp60+fmaYMoaDA=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20220513103617-eee8fd528433/go.mod h1:V5eO8rn/C3rcxig37A/BCeKerLFS+9Avg/77FIeTZ48=
 github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48 h1:W0sjjC6yjskHX4mb0nk3p0fXAlbU5bAFUFeEtlrPASE=
 github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48/go.mod h1:ulJzsVOTssIVp1j/m5eI//4VpAGDkMt5NrRuAVX7wpc=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7/go.mod h1:vVQlW/emklohkZnOPwD3LrZUBqdfsbiyO3p1lNV8F6U=

--- a/go.sum
+++ b/go.sum
@@ -795,8 +795,8 @@ github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91/go.mod h1
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16 h1:ZtO5uywdd5dLDCud4r0r55eP4j9FuUNpl60Gmntcop4=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20220512154543-2313dfe3136c h1:UWbarvm+mKJ8tVqfbPS/Y7IdqfoxAHYVXJ4FjgY21HQ=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20220512154543-2313dfe3136c/go.mod h1:V5eO8rn/C3rcxig37A/BCeKerLFS+9Avg/77FIeTZ48=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20220513091948-6171afad7d08 h1:nkNbTqWh/Ypu135j1A4FV8Q7hGYQJUEQOXEEHw3tzkQ=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20220513091948-6171afad7d08/go.mod h1:V5eO8rn/C3rcxig37A/BCeKerLFS+9Avg/77FIeTZ48=
 github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48 h1:W0sjjC6yjskHX4mb0nk3p0fXAlbU5bAFUFeEtlrPASE=
 github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48/go.mod h1:ulJzsVOTssIVp1j/m5eI//4VpAGDkMt5NrRuAVX7wpc=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7/go.mod h1:vVQlW/emklohkZnOPwD3LrZUBqdfsbiyO3p1lNV8F6U=

--- a/roomserver/internal/input/input_latest_events.go
+++ b/roomserver/internal/input/input_latest_events.go
@@ -236,8 +236,10 @@ func (u *latestEventsUpdater) latestState() error {
 	// Get a list of the current latest events. This may or may not
 	// include the new event from the input path, depending on whether
 	// it is a forward extremity or not.
-	latestStateAtEvents := make([]types.StateAtEvent, len(u.latest))
-	for i := range append(u.latest, u.oldLatest...) {
+	combinedExtremities := types.StateAtEventAndReferences(append(u.latest, u.oldLatest...))
+	util.Unique(combinedExtremities)
+	latestStateAtEvents := make([]types.StateAtEvent, len(combinedExtremities))
+	for i := range combinedExtremities {
 		latestStateAtEvents[i] = u.latest[i].StateAtEvent
 	}
 

--- a/roomserver/internal/input/input_latest_events.go
+++ b/roomserver/internal/input/input_latest_events.go
@@ -233,11 +233,16 @@ func (u *latestEventsUpdater) latestState() error {
 		}
 	}
 
-	// Get a list of the current latest events. This may or may not
-	// include the new event from the input path, depending on whether
-	// it is a forward extremity or not.
-	combinedExtremities := types.StateAtEventAndReferences(append(u.latest, u.oldLatest...))
-	util.Unique(combinedExtremities)
+	// Take the old set of extremities and the new set of extremities and
+	// mash them together into a list. This may or may not include the new event
+	// from the input path, depending on whether it became a forward extremity
+	// or not. We'll then run state resolution across all of them to determine
+	// the new current state of the room. Including the old extremities here
+	// ensures that new forward extremities with bad state snapshots (from
+	// possible malicious actors) can't completely corrupt the room state
+	// away from what it was before.
+	combinedExtremities := types.StateAtEventAndReferences(append(u.oldLatest, u.latest...))
+	util.SortAndUnique(combinedExtremities)
 	latestStateAtEvents := make([]types.StateAtEvent, len(combinedExtremities))
 	for i := range combinedExtremities {
 		latestStateAtEvents[i] = combinedExtremities[i].StateAtEvent

--- a/roomserver/internal/input/input_latest_events.go
+++ b/roomserver/internal/input/input_latest_events.go
@@ -240,7 +240,7 @@ func (u *latestEventsUpdater) latestState() error {
 	util.Unique(combinedExtremities)
 	latestStateAtEvents := make([]types.StateAtEvent, len(combinedExtremities))
 	for i := range combinedExtremities {
-		latestStateAtEvents[i] = u.latest[i].StateAtEvent
+		latestStateAtEvents[i] = combinedExtremities[i].StateAtEvent
 	}
 
 	// Takes the NIDs of the latest events and creates a state snapshot

--- a/roomserver/internal/input/input_latest_events.go
+++ b/roomserver/internal/input/input_latest_events.go
@@ -242,7 +242,7 @@ func (u *latestEventsUpdater) latestState() error {
 	// possible malicious actors) can't completely corrupt the room state
 	// away from what it was before.
 	combinedExtremities := types.StateAtEventAndReferences(append(u.oldLatest, u.latest...))
-	util.SortAndUnique(combinedExtremities)
+	combinedExtremities = combinedExtremities[:util.SortAndUnique(combinedExtremities)]
 	latestStateAtEvents := make([]types.StateAtEvent, len(combinedExtremities))
 	for i := range combinedExtremities {
 		latestStateAtEvents[i] = combinedExtremities[i].StateAtEvent

--- a/roomserver/internal/input/input_latest_events.go
+++ b/roomserver/internal/input/input_latest_events.go
@@ -237,7 +237,7 @@ func (u *latestEventsUpdater) latestState() error {
 	// include the new event from the input path, depending on whether
 	// it is a forward extremity or not.
 	latestStateAtEvents := make([]types.StateAtEvent, len(u.latest))
-	for i := range u.latest {
+	for i := range append(u.latest, u.oldLatest...) {
 		latestStateAtEvents[i] = u.latest[i].StateAtEvent
 	}
 

--- a/roomserver/types/types.go
+++ b/roomserver/types/types.go
@@ -18,6 +18,7 @@ package types
 import (
 	"encoding/json"
 	"sort"
+	"strings"
 
 	"github.com/matrix-org/gomatrixserverlib"
 	"golang.org/x/crypto/blake2b"
@@ -164,6 +165,20 @@ func (s StateAtEvent) IsStateEvent() bool {
 type StateAtEventAndReference struct {
 	StateAtEvent
 	gomatrixserverlib.EventReference
+}
+
+type StateAtEventAndReferences []StateAtEventAndReference
+
+func (s StateAtEventAndReferences) Less(a, b int) bool {
+	return strings.Compare(s[a].EventID, s[b].EventID) < 0
+}
+
+func (s StateAtEventAndReferences) Len() int {
+	return len(s)
+}
+
+func (s StateAtEventAndReferences) Swap(a, b int) {
+	s[a], s[b] = s[b], s[a]
 }
 
 // An Event is a gomatrixserverlib.Event with the numeric event ID attached.


### PR DESCRIPTION
Combined with matrix-org/gomatrixserverlib#308, I am rather hoping that this will fix some of the more painful state resets that we have seen happening recently. The latest events updater will now feed in both the state after the old extremities and the state after the new extremities into state res, so that if there are bad state snapshots being brought into the new extremities, we shouldn't lose all of the old state and should hopefully end up resolving the correct state either way.