### PR TITLE
Really SKIP_NODB

### DIFF
--- a/test/db.go
+++ b/test/db.go
@@ -55,7 +55,7 @@ func createLocalDB(t *testing.T, dbName string) {
 	}
 	err := createDB.Run()
 	if err != nil && !Quiet {
-		fmt.Println(t, "createLocalDB returned error: %s", err)
+		fmt.Println("createLocalDB returned error:", err)
 	}
 }
 

--- a/test/db.go
+++ b/test/db.go
@@ -54,7 +54,7 @@ func createLocalDB(t *testing.T, dbName string) {
 	}
 	err := createDB.Run()
 	if err != nil && !Quiet {
-		fmt.Println("createLocalDB returned error:", err)
+		fatalError(t, "createLocalDB returned error: %s", err)
 	}
 }
 

--- a/test/db.go
+++ b/test/db.go
@@ -63,6 +63,9 @@ func createRemoteDB(t *testing.T, dbName, user, connStr string) {
 	if err != nil {
 		fatalError(t, "failed to open postgres conn with connstr=%s : %s", connStr, err)
 	}
+	if err = db.Ping(); err != nil {
+		fatalError(t, "failed to open postgres conn with connstr=%s : %s", connStr, err)
+	}
 	_, err = db.Exec(fmt.Sprintf(`CREATE DATABASE %s;`, dbName))
 	if err != nil {
 		pqErr, ok := err.(*pq.Error)

--- a/test/db.go
+++ b/test/db.go
@@ -44,7 +44,7 @@ func fatalError(t *testing.T, format string, args ...interface{}) {
 }
 
 func createLocalDB(t *testing.T, dbName string) {
-	if _, err := exec.LookPath("createdb"); err != nil && !Quiet {
+	if _, err := exec.LookPath("createdb"); err != nil {
 		fatalError(t, "Note: tests require a postgres install accessible to the current user")
 		return
 	}

--- a/test/db.go
+++ b/test/db.go
@@ -44,8 +44,9 @@ func fatalError(t *testing.T, format string, args ...interface{}) {
 }
 
 func createLocalDB(t *testing.T, dbName string) {
-	if !Quiet {
-		t.Log("Note: tests require a postgres install accessible to the current user")
+	if _, err := exec.LookPath("createdb"); err != nil && !Quiet {
+		fatalError(t, "Note: tests require a postgres install accessible to the current user")
+		return
 	}
 	createDB := exec.Command("createdb", dbName)
 	if !Quiet {
@@ -54,7 +55,7 @@ func createLocalDB(t *testing.T, dbName string) {
 	}
 	err := createDB.Run()
 	if err != nil && !Quiet {
-		fatalError(t, "createLocalDB returned error: %s", err)
+		fmt.Println(t, "createLocalDB returned error: %s", err)
 	}
 }
 


### PR DESCRIPTION
It's not enough to check the error returned from `sql.Open` as:
> Open may just validate its arguments without creating a connection
to the database. To verify that the data source name is valid, call
Ping.