### PR TITLE
Preserve content from `/make_join` as well as supplied content in the request

### DIFF
--- a/federationapi/internal/perform.go
+++ b/federationapi/internal/perform.go
@@ -166,7 +166,8 @@ func (r *FederationInternalAPI) performJoinUsingServer(
 	if content == nil {
 		content = map[string]interface{}{}
 	}
-	content["membership"] = "join"
+	_ = json.Unmarshal(respMakeJoin.JoinEvent.Content, &content)
+	content["membership"] = gomatrixserverlib.Join
 	if err = respMakeJoin.JoinEvent.SetContent(content); err != nil {
 		return fmt.Errorf("respMakeJoin.JoinEvent.SetContent: %w", err)
 	}


### PR DESCRIPTION
This is quite important as otherwise the `join_authorised_by_users_server` key from the remote server goes missing and that upsets event auth when trying to join a restricted room.