### PR TITLE
Strip `join_authorised_by_users_server` when updating membership events using `/rooms/{roomID}/state`

### DIFF
--- a/clientapi/routing/sendevent.go
+++ b/clientapi/routing/sendevent.go
@@ -104,6 +104,13 @@ func SendEvent(
 		return *resErr
 	}
 
+	// If we're sending a membership update, make sure to strip the authorised
+	// via key if it is present, otherwise other servers won't be able to auth
+	// the event if the room is set to the "restricted" join rule.
+	if eventType == gomatrixserverlib.MRoomMember {
+		delete(r, "join_authorised_by_users_server")
+	}
+
 	evTime, err := httputil.ParseTSParam(req)
 	if err != nil {
 		return util.JSONResponse{


### PR DESCRIPTION
In rooms with the `"restricted"` join rule, this is necessary so that subsequent state updates for that membership event won't incorrectly hit the path for signature checking restricted joins, resulting in the update being rejected incorrectly.

This is important for things like `/myroomnick` to work.