### PR TITLE
Correctly redact events over federation

### DIFF
--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -833,7 +833,7 @@ func (d *Database) handleRedactions(
 		return nil, "", fmt.Errorf("unable to get powerlevels for room: %w", err)
 	}
 	redactPL := pl.Redact
-	redactUser := pl.Users[redactionEvent.Sender()]
+	redactUser := pl.UserLevel(redactionEvent.Sender())
 	// The power level of the redaction event’s sender is greater than or equal to the redact level.
 	userAllowed := redactUser >= redactPL
 	// The domain of the redaction event’s sender matches that of the original event’s sender.

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -823,13 +823,38 @@ func (d *Database) handleRedactions(
 		return nil, "", nil
 	}
 
+	// Get the power level from the database, so we can verify the user is allowed to redact the event
+	powerLevels, err := d.GetStateEvent(ctx, event.RoomID(), gomatrixserverlib.MRoomPowerLevels, "")
+	if err != nil {
+		return nil, "", fmt.Errorf("d.GetStateEvent: %w", err)
+	}
+	pl, err := powerLevels.PowerLevels()
+	if err != nil {
+		return nil, "", fmt.Errorf("unable to get powerlevels for room: %w", err)
+	}
+	redactPL := pl.Redact
+	redactUser := pl.Users[redactionEvent.Sender()]
+	// The power level of the redaction event’s sender is greater than or equal to the redact level.
+	userAllowed := redactUser >= redactPL
+	// The domain of the redaction event’s sender matches that of the original event’s sender.
+	originAllowed := redactedEvent.Origin() == redactionEvent.Origin()
+	if !originAllowed && !userAllowed {
+		return nil, "", nil
+	}
+
 	// mark the event as redacted
+	if redactionsArePermanent {
+		redactedEvent.Event = redactedEvent.Redact()
+	}
+
 	err = redactedEvent.SetUnsignedField("redacted_because", redactionEvent)
 	if err != nil {
 		return nil, "", fmt.Errorf("redactedEvent.SetUnsignedField: %w", err)
 	}
-	if redactionsArePermanent {
-		redactedEvent.Event = redactedEvent.Redact()
+	// NOTSPEC: sytest relies on this unspecced field existing :(
+	err = redactedEvent.SetUnsignedField("redacted_by", redactionEvent.EventID())
+	if err != nil {
+		return nil, "", fmt.Errorf("redactedEvent.SetUnsignedField: %w", err)
 	}
 	// overwrite the eventJSON table
 	err = d.EventJSONTable.InsertEventJSON(ctx, txn, redactedEvent.EventNID, redactedEvent.JSON())

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -832,13 +832,14 @@ func (d *Database) handleRedactions(
 	if err != nil {
 		return nil, "", fmt.Errorf("unable to get powerlevels for room: %w", err)
 	}
-	redactPL := pl.Redact
+
 	redactUser := pl.UserLevel(redactionEvent.Sender())
-	// The power level of the redaction event’s sender is greater than or equal to the redact level.
-	userAllowed := redactUser >= redactPL
-	// The domain of the redaction event’s sender matches that of the original event’s sender.
-	originAllowed := redactedEvent.Origin() == redactionEvent.Origin()
-	if !originAllowed && !userAllowed {
+	switch {
+	case redactUser >= pl.Redact:
+		// The power level of the redaction event’s sender is greater than or equal to the redact level.
+	case redactedEvent.Origin() == redactionEvent.Origin() && redactedEvent.Sender() == redactionEvent.Sender():
+		// The domain of the redaction event’s sender matches that of the original event’s sender.
+	default:
 		return nil, "", nil
 	}
 

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -720,3 +720,4 @@ registration is idempotent, with username specified
 Setting state twice is idempotent
 Joining room twice is idempotent
 Inbound federation can return missing events for shared visibility
+Inbound federation ignores redactions from invalid servers room > v3


### PR DESCRIPTION
Implements the checks as defined by the spec:

>  The power level of the redaction event’s `sender` is greater than or equal to the _redact level_.
The domain of the redaction event’s `sender` matches that of the original event’s sender.
