### PR TITLE
Fix rare panic when returning user devices over federation

### DIFF
--- a/federationapi/routing/devices.go
+++ b/federationapi/routing/devices.go
@@ -85,6 +85,9 @@ func GetUserDevices(
 			if targetKey, ok := targetUser[gomatrixserverlib.KeyID(dev.DeviceID)]; ok {
 				for sourceUserID, forSourceUser := range targetKey {
 					for sourceKeyID, sourceKey := range forSourceUser {
+						if device.Keys.Signatures == nil {
+							device.Keys.Signatures = map[string]map[gomatrixserverlib.KeyID]gomatrixserverlib.Base64Bytes{}
+						}
 						if _, ok := device.Keys.Signatures[sourceUserID]; !ok {
 							device.Keys.Signatures[sourceUserID] = map[gomatrixserverlib.KeyID]gomatrixserverlib.Base64Bytes{}
 						}


### PR DESCRIPTION
Discovered during a Sytest run, `panic="assignment to entry in nil map"`

```
github.com/matrix-org/dendrite/federationapi/routing.GetUserDevices(0xc003057100, 0x7fb594204398, 0xc00008b360, 0xc000212ac4, 0x28, 0x0, 0x0, 0x0, 0x4000105)
	/src/federationapi/routing/devices.go:89 +0xe28
```