### PR TITLE
More useful errors when joining federated rooms

### DIFF
--- a/roomserver/api/perform.go
+++ b/roomserver/api/perform.go
@@ -75,10 +75,11 @@ const (
 )
 
 type PerformJoinRequest struct {
-	RoomIDOrAlias string                         `json:"room_id_or_alias"`
-	UserID        string                         `json:"user_id"`
-	Content       map[string]interface{}         `json:"content"`
-	ServerNames   []gomatrixserverlib.ServerName `json:"server_names"`
+	RoomIDOrAlias  string                         `json:"room_id_or_alias"`
+	UserID         string                         `json:"user_id"`
+	Content        map[string]interface{}         `json:"content"`
+	ServerNames    []gomatrixserverlib.ServerName `json:"server_names"`
+	ForceFederated bool                           `json:"force_federated"`
 }
 
 type PerformJoinResponse struct {


### PR DESCRIPTION
This should make it clearer when a forced federated join is to happen, and also to return more useful errors when a room join doesn't go to plan.