### PR TITLE
Return clearer error when no state NID exists for an event

### DIFF
--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -263,6 +263,12 @@ func (d *Database) snapshotNIDFromEventID(
 	ctx context.Context, txn *sql.Tx, eventID string,
 ) (types.StateSnapshotNID, error) {
 	_, stateNID, err := d.EventsTable.SelectEvent(ctx, txn, eventID)
+	if err != nil {
+		return 0, err
+	}
+	if stateNID == 0 {
+		return 0, sql.ErrNoRows // effectively there's no state entry
+	}
 	return stateNID, err
 }
 


### PR DESCRIPTION
Since `CheckServerAllowedToSeeEvent` is checking for a `sql.ErrNoRows`, it makes sense to return that when no state NID exists so that we can return a 403 instead of a 500.