### PR TITLE
Fix nil pointer access when redacting events

### DIFF
--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -834,6 +834,9 @@ func (d *Database) handleRedactions(
 	if err != nil {
 		return nil, "", fmt.Errorf("d.GetStateEvent: %w", err)
 	}
+	if powerLevels == nil {
+		return nil, "", fmt.Errorf("unable to fetch m.room.power_levels event from database for room %s", event.RoomID())
+	}
 	pl, err := powerLevels.PowerLevels()
 	if err != nil {
 		return nil, "", fmt.Errorf("unable to get powerlevels for room: %w", err)


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/matrix-org/dendrite/pull/2526
`GetStateEvent` might return no event and no error, e.g. if the room is a stub or no events were found in the database.

Not sure if we should ignore cases where we don't have powerlevels (as before #2526) or return an error.

Fixes #2559