### PR TITLE
Fix issue `uint64 values with high bit are not supported` in presence

### DIFF
--- a/syncapi/consumers/presence.go
+++ b/syncapi/consumers/presence.go
@@ -144,7 +144,7 @@ func (s *PresenceConsumer) onMessage(ctx context.Context, msg *nats.Msg) bool {
 		return true
 	}
 
-	ts, err := strconv.Atoi(timestamp)
+	ts, err := strconv.ParseInt(timestamp, 10, 64)
 	if err != nil {
 		return true
 	}
@@ -161,7 +161,7 @@ func (s *PresenceConsumer) onMessage(ctx context.Context, msg *nats.Msg) bool {
 	return true
 }
 
-func (s *PresenceConsumer) EmitPresence(ctx context.Context, userID string, presence types.Presence, statusMsg *string, ts int, fromSync bool) {
+func (s *PresenceConsumer) EmitPresence(ctx context.Context, userID string, presence types.Presence, statusMsg *string, ts int64, fromSync bool) {
 	pos, err := s.db.UpdatePresence(ctx, userID, presence, statusMsg, gomatrixserverlib.Timestamp(ts), fromSync)
 	if err != nil {
 		logrus.WithError(err).WithField("user", userID).WithField("presence", presence).Warn("failed to updated presence for user")

--- a/syncapi/sync/requestpool.go
+++ b/syncapi/sync/requestpool.go
@@ -61,7 +61,7 @@ type PresencePublisher interface {
 }
 
 type PresenceConsumer interface {
-	EmitPresence(ctx context.Context, userID string, presence types.Presence, statusMsg *string, ts int, fromSync bool)
+	EmitPresence(ctx context.Context, userID string, presence types.Presence, statusMsg *string, ts int64, fromSync bool)
 }
 
 // NewRequestPool makes a new RequestPool
@@ -171,7 +171,7 @@ func (rp *RequestPool) updatePresence(db storage.Presence, presence string, user
 	// the /sync response else we may not return presence: online immediately.
 	rp.consumer.EmitPresence(
 		context.Background(), userID, presenceID, newPresence.ClientFields.StatusMsg,
-		int(gomatrixserverlib.AsTimestamp(time.Now())), true,
+		int64(gomatrixserverlib.AsTimestamp(time.Now())), true,
 	)
 }
 

--- a/syncapi/sync/requestpool_test.go
+++ b/syncapi/sync/requestpool_test.go
@@ -40,7 +40,7 @@ func (d dummyDB) MaxStreamPositionForPresence(ctx context.Context) (types.Stream
 
 type dummyConsumer struct{}
 
-func (d dummyConsumer) EmitPresence(ctx context.Context, userID string, presence types.Presence, statusMsg *string, ts int, fromSync bool) {
+func (d dummyConsumer) EmitPresence(ctx context.Context, userID string, presence types.Presence, statusMsg *string, ts int64, fromSync bool) {
 
 }
 


### PR DESCRIPTION
In addition to #2557, this seems to fix #2528

```log
time="2022-07-07T13:09:10.431572288Z" level=warning msg="failed to updated presence for user" error="sql: converting argument $4 type: uint64 values with high bit set are not supported" presence=online user="@6:test"
```