### PR TITLE
Ristretto cache

### DIFF
--- a/.github/workflows/dendrite.yml
+++ b/.github/workflows/dendrite.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.18
 
       - uses: actions/cache@v2
         with:
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.16", "1.17", "1.18"]
+        go: ["1.18"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup go
@@ -127,7 +127,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.16", "1.17", "1.18"]
+        go: ["1.18"]
         goos: ["linux"]
         goarch: ["amd64", "386"]
     steps:
@@ -160,7 +160,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.16", "1.17", "1.18"]
+        go: ["1.18"]
         goos: ["windows"]
         goarch: ["amd64"]
     steps:
@@ -209,7 +209,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.16"
+          go-version: "1.18"
       - uses: actions/cache@v3
         with:
           path: |

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you have further questions, please take a look at [our FAQ](docs/FAQ.md) or j
 
 ## Requirements
 
-To build Dendrite, you will need Go 1.16 or later.
+To build Dendrite, you will need Go 1.18 or later.
 
 For a usable federating Dendrite deployment, you will also need:
 

--- a/build/scripts/Complement.Dockerfile
+++ b/build/scripts/Complement.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-stretch as build
+FROM golang:1.18-stretch as build
 RUN apt-get update && apt-get install -y sqlite3
 WORKDIR /build
 
@@ -27,6 +27,6 @@ EXPOSE 8008 8448
 # At runtime, generate TLS cert based on the CA now mounted at /ca
 # At runtime, replace the SERVER_NAME with what we are told
 CMD ./generate-keys --server $SERVER_NAME --tls-cert server.crt --tls-key server.key --tls-authority-cert /complement/ca/ca.crt --tls-authority-key /complement/ca/ca.key && \
- ./generate-config -server $SERVER_NAME --ci > dendrite.yaml && \
- cp /complement/ca/ca.crt /usr/local/share/ca-certificates/ && update-ca-certificates && \
- ./dendrite-monolith-server --really-enable-open-registration --tls-cert server.crt --tls-key server.key --config dendrite.yaml -api=${API:-0}
+    ./generate-config -server $SERVER_NAME --ci > dendrite.yaml && \
+    cp /complement/ca/ca.crt /usr/local/share/ca-certificates/ && update-ca-certificates && \
+    ./dendrite-monolith-server --really-enable-open-registration --tls-cert server.crt --tls-key server.key --config dendrite.yaml -api=${API:-0}

--- a/build/scripts/ComplementLocal.Dockerfile
+++ b/build/scripts/ComplementLocal.Dockerfile
@@ -6,7 +6,7 @@
 #
 # Use these mounts to make use of this dockerfile:
 # COMPLEMENT_HOST_MOUNTS='/your/local/dendrite:/dendrite:ro;/your/go/path:/go:ro'
-FROM golang:1.16-stretch
+FROM golang:1.18-stretch
 RUN apt-get update && apt-get install -y sqlite3
 
 WORKDIR /runtime
@@ -16,24 +16,24 @@ EXPOSE 8008 8448
 
 # This script compiles Dendrite for us.
 RUN echo '\
-#!/bin/bash -eux \n\
-if test -f "/runtime/dendrite-monolith-server"; then \n\
+    #!/bin/bash -eux \n\
+    if test -f "/runtime/dendrite-monolith-server"; then \n\
     echo "Skipping compilation; binaries exist" \n\
     exit 0 \n\
-fi \n\
-cd /dendrite \n\
-go build -v -o /runtime /dendrite/cmd/dendrite-monolith-server \n\
-' > compile.sh && chmod +x compile.sh
+    fi \n\
+    cd /dendrite \n\
+    go build -v -o /runtime /dendrite/cmd/dendrite-monolith-server \n\
+    ' > compile.sh && chmod +x compile.sh
 
 # This script runs Dendrite for us. Must be run in the /runtime directory.
 RUN echo '\
-#!/bin/bash -eu \n\
-./generate-keys --private-key matrix_key.pem \n\
-./generate-keys --server $SERVER_NAME --tls-cert server.crt --tls-key server.key --tls-authority-cert /complement/ca/ca.crt --tls-authority-key /complement/ca/ca.key \n\
-./generate-config -server $SERVER_NAME --ci > dendrite.yaml \n\
-cp /complement/ca/ca.crt /usr/local/share/ca-certificates/ && update-ca-certificates \n\
-./dendrite-monolith-server --really-enable-open-registration --tls-cert server.crt --tls-key server.key --config dendrite.yaml \n\
-' > run.sh && chmod +x run.sh
+    #!/bin/bash -eu \n\
+    ./generate-keys --private-key matrix_key.pem \n\
+    ./generate-keys --server $SERVER_NAME --tls-cert server.crt --tls-key server.key --tls-authority-cert /complement/ca/ca.crt --tls-authority-key /complement/ca/ca.key \n\
+    ./generate-config -server $SERVER_NAME --ci > dendrite.yaml \n\
+    cp /complement/ca/ca.crt /usr/local/share/ca-certificates/ && update-ca-certificates \n\
+    ./dendrite-monolith-server --really-enable-open-registration --tls-cert server.crt --tls-key server.key --config dendrite.yaml \n\
+    ' > run.sh && chmod +x run.sh
 
 
 WORKDIR /cache

--- a/cmd/dendrite-demo-yggdrasil/README.md
+++ b/cmd/dendrite-demo-yggdrasil/README.md
@@ -1,6 +1,6 @@
 # Yggdrasil Demo
 
-This is the Dendrite Yggdrasil demo! It's easy to get started - all you need is Go 1.16 or later.
+This is the Dendrite Yggdrasil demo! It's easy to get started - all you need is Go 1.18 or later.
 
 To run the homeserver, start at the root of the Dendrite repository and run:
 
@@ -13,7 +13,7 @@ The following command line arguments are accepted:
 * `-peer tcp://a.b.c.d:e` to specify a static Yggdrasil peer to connect to - you will need to supply this if you do not have another Yggdrasil node on your network
 * `-port 12345` to specify a port to listen on for client connections
 
-If you need to find an internet peer, take a look at [this list](https://publicpeers.neilalexander.dev/). 
+If you need to find an internet peer, take a look at [this list](https://publicpeers.neilalexander.dev/).
 
 Then point your favourite Matrix client to  the homeserver URL`http://localhost:8008` (or whichever `-port` you specified), create an account and log in.
 

--- a/cmd/dendrite-upgrade-tests/main.go
+++ b/cmd/dendrite-upgrade-tests/main.go
@@ -48,7 +48,7 @@ const HEAD = "HEAD"
 // due to the error:
 //   When using COPY with more than one source file, the destination must be a directory and end with a /
 // We need to run a postgres anyway, so use the dockerfile associated with Complement instead.
-const Dockerfile = `FROM golang:1.16-stretch as build
+const Dockerfile = `FROM golang:1.18-stretch as build
 RUN apt-get update && apt-get install -y postgresql
 WORKDIR /build
 

--- a/cmd/resolve-state/main.go
+++ b/cmd/resolve-state/main.go
@@ -54,12 +54,10 @@ func main() {
 
 	fmt.Println("Fetching", len(snapshotNIDs), "snapshot NIDs")
 
-	cache, err := caching.NewRistrettoCache(128*1024*1024, time.Hour, true)
-	if err != nil {
-		panic(err)
-	}
-
-	roomserverDB, err := storage.Open(base, &cfg.RoomServer.Database, cache)
+	roomserverDB, err := storage.Open(
+		base, &cfg.RoomServer.Database,
+		caching.NewRistrettoCache(128*1024*1024, time.Hour, true),
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/resolve-state/main.go
+++ b/cmd/resolve-state/main.go
@@ -53,7 +53,7 @@ func main() {
 
 	fmt.Println("Fetching", len(snapshotNIDs), "snapshot NIDs")
 
-	cache, err := caching.NewRistrettoCache(128*caching.MB, true)
+	cache, err := caching.NewRistrettoCache(128*1024*1024, true)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/resolve-state/main.go
+++ b/cmd/resolve-state/main.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/matrix-org/dendrite/internal/caching"
 	"github.com/matrix-org/dendrite/roomserver/state"
@@ -53,7 +54,7 @@ func main() {
 
 	fmt.Println("Fetching", len(snapshotNIDs), "snapshot NIDs")
 
-	cache, err := caching.NewRistrettoCache(128*1024*1024, true)
+	cache, err := caching.NewRistrettoCache(128*1024*1024, time.Hour, true)
 	if err != nil {
 		panic(err)
 	}

--- a/dendrite-sample.monolith.yaml
+++ b/dendrite-sample.monolith.yaml
@@ -44,10 +44,18 @@ global:
   # Configuration for in-process caches, to help speed up processing transactions
   # and reducing load on the database.
   cache:
-    # The estimated maximum size for the global cache in bytes. Note that this is
-    # not a hard limit, nor is it a memory limit for the entire process. A cache that
-    # is too small may end up yielding little benefit.
-    max_bytes_est: 1073741824
+    # The estimated maximum size for the global cache in bytes, or in terabytes,
+    # gigabytes, megabytes or kilobytes when the appropriate 'tb', 'gb', 'mb' or
+    # 'kb' suffix is specified. Note that this is not a hard limit, nor is it a
+    # memory limit for the entire process. A cache that is too small may ultimately
+    # provide little or no benefit.
+    max_bytes_est: 1gb
+
+    # The maximum amount of time that a cache entry can live for in memory before
+    # it will be evicted and/or refreshed from the database. Lower values result in
+    # easier admission of new cache entries but may also increase database load in
+    # comparison to higher values, so adjust conservatively.
+    max_age: 1h
 
   # The server name to delegate server-server communications to, with optional port
   # e.g. localhost:443

--- a/dendrite-sample.monolith.yaml
+++ b/dendrite-sample.monolith.yaml
@@ -41,15 +41,16 @@ global:
     max_idle_conns: 5
     conn_max_lifetime: -1
 
-  # Configuration for in-process caches, to help speed up processing transactions
-  # and reducing load on the database.
+  # Configuration for in-memory caches. Caches can often improve performance by
+  # keeping frequently accessed items (like events, identifiers etc.) in memory
+  # rather than having to read them from the database.
   cache:
     # The estimated maximum size for the global cache in bytes, or in terabytes,
     # gigabytes, megabytes or kilobytes when the appropriate 'tb', 'gb', 'mb' or
     # 'kb' suffix is specified. Note that this is not a hard limit, nor is it a
     # memory limit for the entire process. A cache that is too small may ultimately
     # provide little or no benefit.
-    max_bytes_est: 1gb
+    max_size_est: 1gb
 
     # The maximum amount of time that a cache entry can live for in memory before
     # it will be evicted and/or refreshed from the database. Lower values result in

--- a/dendrite-sample.monolith.yaml
+++ b/dendrite-sample.monolith.yaml
@@ -55,7 +55,9 @@ global:
     # The maximum amount of time that a cache entry can live for in memory before
     # it will be evicted and/or refreshed from the database. Lower values result in
     # easier admission of new cache entries but may also increase database load in
-    # comparison to higher values, so adjust conservatively.
+    # comparison to higher values, so adjust conservatively. Higher values may make
+    # it harder for new items to make it into the cache, e.g. if new rooms suddenly
+    # become popular.
     max_age: 1h
 
   # The server name to delegate server-server communications to, with optional port

--- a/dendrite-sample.monolith.yaml
+++ b/dendrite-sample.monolith.yaml
@@ -41,6 +41,14 @@ global:
     max_idle_conns: 5
     conn_max_lifetime: -1
 
+  # Configuration for in-process caches, to help speed up processing transactions
+  # and reducing load on the database.
+  cache:
+    # The estimated maximum size for the global cache in bytes. Note that this is
+    # not a hard limit, nor is it a memory limit for the entire process. A cache that
+    # is too small may end up yielding little benefit.
+    max_bytes_est: 1073741824
+
   # The server name to delegate server-server communications to, with optional port
   # e.g. localhost:443
   well_known_server_name: ""

--- a/dendrite-sample.monolith.yaml
+++ b/dendrite-sample.monolith.yaml
@@ -50,7 +50,7 @@ global:
     # 'kb' suffix is specified. Note that this is not a hard limit, nor is it a
     # memory limit for the entire process. A cache that is too small may ultimately
     # provide little or no benefit.
-    max_size_est: 1gb
+    max_size_estimated: 1gb
 
     # The maximum amount of time that a cache entry can live for in memory before
     # it will be evicted and/or refreshed from the database. Lower values result in

--- a/dendrite-sample.polylith.yaml
+++ b/dendrite-sample.polylith.yaml
@@ -45,7 +45,9 @@ global:
     # The maximum amount of time that a cache entry can live for in memory before
     # it will be evicted and/or refreshed from the database. Lower values result in
     # easier admission of new cache entries but may also increase database load in
-    # comparison to higher values, so adjust conservatively.
+    # comparison to higher values, so adjust conservatively. Higher values may make
+    # it harder for new items to make it into the cache, e.g. if new rooms suddenly
+    # become popular.
     max_age: 1h
 
   # The server name to delegate server-server communications to, with optional port

--- a/dendrite-sample.polylith.yaml
+++ b/dendrite-sample.polylith.yaml
@@ -40,7 +40,7 @@ global:
     # 'kb' suffix is specified. Note that this is not a hard limit, nor is it a
     # memory limit for the entire process. A cache that is too small may ultimately
     # provide little or no benefit.
-    max_size_est: 1gb
+    max_size_estimated: 1gb
 
     # The maximum amount of time that a cache entry can live for in memory before
     # it will be evicted and/or refreshed from the database. Lower values result in

--- a/dendrite-sample.polylith.yaml
+++ b/dendrite-sample.polylith.yaml
@@ -31,6 +31,14 @@ global:
   # considered valid by other homeservers.
   key_validity_period: 168h0m0s
 
+  # Configuration for in-process caches, to help speed up processing transactions
+  # and reducing load on the database.
+  cache:
+    # The estimated maximum size for the global cache in bytes. Note that this is
+    # not a hard limit, nor is it a memory limit for the entire process. A cache that
+    # is too small may end up yielding little benefit.
+    max_bytes_est: 1073741824
+
   # The server name to delegate server-server communications to, with optional port
   # e.g. localhost:443
   well_known_server_name: ""

--- a/dendrite-sample.polylith.yaml
+++ b/dendrite-sample.polylith.yaml
@@ -31,15 +31,16 @@ global:
   # considered valid by other homeservers.
   key_validity_period: 168h0m0s
 
-  # Configuration for in-process caches, to help speed up processing transactions
-  # and reducing load on the database.
+  # Configuration for in-memory caches. Caches can often improve performance by
+  # keeping frequently accessed items (like events, identifiers etc.) in memory
+  # rather than having to read them from the database.
   cache:
     # The estimated maximum size for the global cache in bytes, or in terabytes,
     # gigabytes, megabytes or kilobytes when the appropriate 'tb', 'gb', 'mb' or
     # 'kb' suffix is specified. Note that this is not a hard limit, nor is it a
     # memory limit for the entire process. A cache that is too small may ultimately
     # provide little or no benefit.
-    max_bytes_est: 1gb
+    max_size_est: 1gb
 
     # The maximum amount of time that a cache entry can live for in memory before
     # it will be evicted and/or refreshed from the database. Lower values result in

--- a/dendrite-sample.polylith.yaml
+++ b/dendrite-sample.polylith.yaml
@@ -34,10 +34,18 @@ global:
   # Configuration for in-process caches, to help speed up processing transactions
   # and reducing load on the database.
   cache:
-    # The estimated maximum size for the global cache in bytes. Note that this is
-    # not a hard limit, nor is it a memory limit for the entire process. A cache that
-    # is too small may end up yielding little benefit.
-    max_bytes_est: 1073741824
+    # The estimated maximum size for the global cache in bytes, or in terabytes,
+    # gigabytes, megabytes or kilobytes when the appropriate 'tb', 'gb', 'mb' or
+    # 'kb' suffix is specified. Note that this is not a hard limit, nor is it a
+    # memory limit for the entire process. A cache that is too small may ultimately
+    # provide little or no benefit.
+    max_bytes_est: 1gb
+
+    # The maximum amount of time that a cache entry can live for in memory before
+    # it will be evicted and/or refreshed from the database. Lower values result in
+    # easier admission of new cache entries but may also increase database load in
+    # comparison to higher values, so adjust conservatively.
+    max_age: 1h
 
   # The server name to delegate server-server communications to, with optional port
   # e.g. localhost:443

--- a/docs/installation/1_planning.md
+++ b/docs/installation/1_planning.md
@@ -75,7 +75,7 @@ In order to install Dendrite, you will need to satisfy the following dependencie
 
 ### Go
 
-At this time, Dendrite supports being built with Go 1.16 or later. We do not support building
+At this time, Dendrite supports being built with Go 1.18 or later. We do not support building
 Dendrite with older versions of Go than this. If you are installing Go using a package manager,
 you should check (by running `go version`) that you are using a suitable version before you start.
 

--- a/federationapi/federationapi_keys_test.go
+++ b/federationapi/federationapi_keys_test.go
@@ -64,10 +64,7 @@ func TestMain(m *testing.M) {
 			}
 
 			// Create a new cache but don't enable prometheus!
-			s.cache, err = caching.NewRistrettoCache(8*1024*1024, time.Hour, false)
-			if err != nil {
-				panic("can't create cache: " + err.Error())
-			}
+			s.cache = caching.NewRistrettoCache(8*1024*1024, time.Hour, false)
 
 			// Create a temporary directory for JetStream.
 			d, err := ioutil.TempDir("./", "jetstream*")

--- a/federationapi/federationapi_keys_test.go
+++ b/federationapi/federationapi_keys_test.go
@@ -64,7 +64,7 @@ func TestMain(m *testing.M) {
 			}
 
 			// Create a new cache but don't enable prometheus!
-			s.cache, err = caching.NewRistrettoCache(8*caching.MB, false)
+			s.cache, err = caching.NewRistrettoCache(8*1024*1024, false)
 			if err != nil {
 				panic("can't create cache: " + err.Error())
 			}

--- a/federationapi/federationapi_keys_test.go
+++ b/federationapi/federationapi_keys_test.go
@@ -64,7 +64,7 @@ func TestMain(m *testing.M) {
 			}
 
 			// Create a new cache but don't enable prometheus!
-			s.cache, err = caching.NewRistrettoCache(8*1024*1024, false)
+			s.cache, err = caching.NewRistrettoCache(8*1024*1024, time.Hour, false)
 			if err != nil {
 				panic("can't create cache: " + err.Error())
 			}

--- a/federationapi/producers/syncapi.go
+++ b/federationapi/producers/syncapi.go
@@ -54,7 +54,7 @@ func (p *SyncAPIProducer) SendReceipt(
 	m.Header.Set("timestamp", strconv.Itoa(int(timestamp)))
 
 	log.WithFields(log.Fields{}).Tracef("Producing to topic '%s'", p.TopicReceiptEvent)
-	_, err := p.JetStream.PublishMsg(m, nats.Context(ctx))
+	_, err := p.JetStream.PublishMsgAsync(m, nats.Context(ctx))
 	return err
 }
 
@@ -122,7 +122,7 @@ func (p *SyncAPIProducer) SendToDevice(
 		m.Header.Set("sender", sender)
 		m.Header.Set(jetstream.UserID, userID)
 
-		if _, err = p.JetStream.PublishMsg(m, nats.Context(ctx)); err != nil {
+		if _, err = p.JetStream.PublishMsgAsync(m, nats.Context(ctx)); err != nil {
 			log.WithError(err).Error("sendToDevice failed t.Producer.SendMessage")
 			return err
 		}
@@ -141,7 +141,7 @@ func (p *SyncAPIProducer) SendTyping(
 	m.Header.Set(jetstream.RoomID, roomID)
 	m.Header.Set("typing", strconv.FormatBool(typing))
 	m.Header.Set("timeout_ms", strconv.Itoa(int(timeoutMS)))
-	_, err := p.JetStream.PublishMsg(m, nats.Context(ctx))
+	_, err := p.JetStream.PublishMsgAsync(m, nats.Context(ctx))
 	return err
 }
 
@@ -158,6 +158,6 @@ func (p *SyncAPIProducer) SendPresence(
 
 	m.Header.Set("last_active_ts", strconv.Itoa(int(lastActiveTS)))
 	log.Debugf("Sending presence to syncAPI: %+v", m.Header)
-	_, err := p.JetStream.PublishMsg(m, nats.Context(ctx))
+	_, err := p.JetStream.PublishMsgAsync(m, nats.Context(ctx))
 	return err
 }

--- a/federationapi/producers/syncapi.go
+++ b/federationapi/producers/syncapi.go
@@ -54,7 +54,7 @@ func (p *SyncAPIProducer) SendReceipt(
 	m.Header.Set("timestamp", strconv.Itoa(int(timestamp)))
 
 	log.WithFields(log.Fields{}).Tracef("Producing to topic '%s'", p.TopicReceiptEvent)
-	_, err := p.JetStream.PublishMsgAsync(m, nats.Context(ctx))
+	_, err := p.JetStream.PublishMsg(m, nats.Context(ctx))
 	return err
 }
 
@@ -122,7 +122,7 @@ func (p *SyncAPIProducer) SendToDevice(
 		m.Header.Set("sender", sender)
 		m.Header.Set(jetstream.UserID, userID)
 
-		if _, err = p.JetStream.PublishMsgAsync(m, nats.Context(ctx)); err != nil {
+		if _, err = p.JetStream.PublishMsg(m, nats.Context(ctx)); err != nil {
 			log.WithError(err).Error("sendToDevice failed t.Producer.SendMessage")
 			return err
 		}
@@ -141,7 +141,7 @@ func (p *SyncAPIProducer) SendTyping(
 	m.Header.Set(jetstream.RoomID, roomID)
 	m.Header.Set("typing", strconv.FormatBool(typing))
 	m.Header.Set("timeout_ms", strconv.Itoa(int(timeoutMS)))
-	_, err := p.JetStream.PublishMsgAsync(m, nats.Context(ctx))
+	_, err := p.JetStream.PublishMsg(m, nats.Context(ctx))
 	return err
 }
 
@@ -158,6 +158,6 @@ func (p *SyncAPIProducer) SendPresence(
 
 	m.Header.Set("last_active_ts", strconv.Itoa(int(lastActiveTS)))
 	log.Debugf("Sending presence to syncAPI: %+v", m.Header)
-	_, err := p.JetStream.PublishMsgAsync(m, nats.Context(ctx))
+	_, err := p.JetStream.PublishMsg(m, nats.Context(ctx))
 	return err
 }

--- a/federationapi/routing/invite.go
+++ b/federationapi/routing/invite.go
@@ -26,6 +26,7 @@ import (
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
+	"github.com/sirupsen/logrus"
 )
 
 // InviteV2 implements /_matrix/federation/v2/invite/{roomID}/{eventID}
@@ -141,10 +142,17 @@ func processInvite(
 	}
 
 	// Check that the event is signed by the server sending the request.
-	redacted := event.Redact()
+	redacted, err := gomatrixserverlib.RedactEventJSON(event.JSON(), event.Version())
+	if err != nil {
+		logrus.WithError(err).Errorf("XXX: invite.go")
+		return util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.BadJSON("The event JSON could not be redacted"),
+		}
+	}
 	verifyRequests := []gomatrixserverlib.VerifyJSONRequest{{
 		ServerName:             event.Origin(),
-		Message:                redacted.JSON(),
+		Message:                redacted,
 		AtTS:                   event.OriginServerTS(),
 		StrictValidityChecking: true,
 	}}

--- a/federationapi/routing/join.go
+++ b/federationapi/routing/join.go
@@ -266,10 +266,17 @@ func SendJoin(
 	}
 
 	// Check that the event is signed by the server sending the request.
-	redacted := event.Redact()
+	redacted, err := gomatrixserverlib.RedactEventJSON(event.JSON(), event.Version())
+	if err != nil {
+		logrus.WithError(err).Errorf("XXX: join.go")
+		return util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.BadJSON("The event JSON could not be redacted"),
+		}
+	}
 	verifyRequests := []gomatrixserverlib.VerifyJSONRequest{{
 		ServerName:             event.Origin(),
-		Message:                redacted.JSON(),
+		Message:                redacted,
 		AtTS:                   event.OriginServerTS(),
 		StrictValidityChecking: true,
 	}}

--- a/federationapi/routing/leave.go
+++ b/federationapi/routing/leave.go
@@ -231,10 +231,17 @@ func SendLeave(
 	}
 
 	// Check that the event is signed by the server sending the request.
-	redacted := event.Redact()
+	redacted, err := gomatrixserverlib.RedactEventJSON(event.JSON(), event.Version())
+	if err != nil {
+		logrus.WithError(err).Errorf("XXX: leave.go")
+		return util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.BadJSON("The event JSON could not be redacted"),
+		}
+	}
 	verifyRequests := []gomatrixserverlib.VerifyJSONRequest{{
 		ServerName:             event.Origin(),
-		Message:                redacted.JSON(),
+		Message:                redacted,
 		AtTS:                   event.OriginServerTS(),
 		StrictValidityChecking: true,
 	}}

--- a/go.mod
+++ b/go.mod
@@ -102,11 +102,11 @@ require (
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
-	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/text v0.3.8-0.20211004125949-5bd84dd9b33b // indirect
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 // indirect
-	golang.org/x/tools v0.1.8-0.20211022200916-316ba0b74098 // indirect
+	golang.org/x/tools v0.1.10 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/macaroon.v2 v2.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/matrix-org/dugong v0.0.0-20210921133753-66e6b1c67e2e
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91
 	github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20220701090733-da53994b0c7f
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20220701095609-8997d4460e3e
 	github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4
 	github.com/mattn/go-sqlite3 v1.14.13

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/matrix-org/dugong v0.0.0-20210921133753-66e6b1c67e2e
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91
 	github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20220708142704-f2d0a5187303
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20220711125303-3bb2e997a44c
 	github.com/matrix-org/pinecone v0.0.0-20220708135211-1ce778fcde6a
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4
 	github.com/mattn/go-sqlite3 v1.14.13

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/matrix-org/dugong v0.0.0-20210921133753-66e6b1c67e2e
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91
 	github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20220615144844-8535862e3770
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20220616095912-8306e9da1829
 	github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4
 	github.com/mattn/go-sqlite3 v1.14.13

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/MFAshby/stdemuxerhook v1.0.0
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/codeclysm/extract v2.2.0+incompatible
-	github.com/dgraph-io/ristretto v0.1.0
+	github.com/dgraph-io/ristretto v0.1.1-0.20220403145359-8e850b710d6d
 	github.com/docker/docker v20.10.16+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/getsentry/sentry-go v0.13.0

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/matrix-org/dugong v0.0.0-20210921133753-66e6b1c67e2e
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91
 	github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20220614141330-dff20984ec15
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20220615144844-8535862e3770
 	github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4
 	github.com/mattn/go-sqlite3 v1.14.13

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/matrix-org/dugong v0.0.0-20210921133753-66e6b1c67e2e
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91
 	github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20220614130013-8c0189596b9d
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20220614141330-dff20984ec15
 	github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4
 	github.com/mattn/go-sqlite3 v1.14.13

--- a/go.sum
+++ b/go.sum
@@ -341,8 +341,8 @@ github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91/go.mod h1
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16 h1:ZtO5uywdd5dLDCud4r0r55eP4j9FuUNpl60Gmntcop4=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20220615144844-8535862e3770 h1:1czNJFGVb2K6kvpU7j9DYdmBmEe1/rDRffDj//BD3/Q=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20220615144844-8535862e3770/go.mod h1:jX38yp3SSLJNftBg3PXU1ayd0PCLIiDHQ4xAc9DIixk=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20220616095912-8306e9da1829 h1:LkZSD1GXtmNHDwa7TfI8CrvoTNvFGhdGHSLDQ4Za/P8=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20220616095912-8306e9da1829/go.mod h1:jX38yp3SSLJNftBg3PXU1ayd0PCLIiDHQ4xAc9DIixk=
 github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48 h1:W0sjjC6yjskHX4mb0nk3p0fXAlbU5bAFUFeEtlrPASE=
 github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48/go.mod h1:ulJzsVOTssIVp1j/m5eI//4VpAGDkMt5NrRuAVX7wpc=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7/go.mod h1:vVQlW/emklohkZnOPwD3LrZUBqdfsbiyO3p1lNV8F6U=

--- a/go.sum
+++ b/go.sum
@@ -341,8 +341,8 @@ github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91/go.mod h1
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16 h1:ZtO5uywdd5dLDCud4r0r55eP4j9FuUNpl60Gmntcop4=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20220614130013-8c0189596b9d h1:SsCAIua84NbIy9VEabisd4ljAQn9Q7t6dSgzvOwDxIM=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20220614130013-8c0189596b9d/go.mod h1:jX38yp3SSLJNftBg3PXU1ayd0PCLIiDHQ4xAc9DIixk=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20220614141330-dff20984ec15 h1:hfOBccdH5cIp8EQCbKx64XOaQ3ExDnR9P864N+qYaEo=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20220614141330-dff20984ec15/go.mod h1:jX38yp3SSLJNftBg3PXU1ayd0PCLIiDHQ4xAc9DIixk=
 github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48 h1:W0sjjC6yjskHX4mb0nk3p0fXAlbU5bAFUFeEtlrPASE=
 github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48/go.mod h1:ulJzsVOTssIVp1j/m5eI//4VpAGDkMt5NrRuAVX7wpc=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7/go.mod h1:vVQlW/emklohkZnOPwD3LrZUBqdfsbiyO3p1lNV8F6U=

--- a/go.sum
+++ b/go.sum
@@ -341,8 +341,8 @@ github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91/go.mod h1
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16 h1:ZtO5uywdd5dLDCud4r0r55eP4j9FuUNpl60Gmntcop4=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20220614141330-dff20984ec15 h1:hfOBccdH5cIp8EQCbKx64XOaQ3ExDnR9P864N+qYaEo=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20220614141330-dff20984ec15/go.mod h1:jX38yp3SSLJNftBg3PXU1ayd0PCLIiDHQ4xAc9DIixk=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20220615144844-8535862e3770 h1:1czNJFGVb2K6kvpU7j9DYdmBmEe1/rDRffDj//BD3/Q=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20220615144844-8535862e3770/go.mod h1:jX38yp3SSLJNftBg3PXU1ayd0PCLIiDHQ4xAc9DIixk=
 github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48 h1:W0sjjC6yjskHX4mb0nk3p0fXAlbU5bAFUFeEtlrPASE=
 github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48/go.mod h1:ulJzsVOTssIVp1j/m5eI//4VpAGDkMt5NrRuAVX7wpc=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7/go.mod h1:vVQlW/emklohkZnOPwD3LrZUBqdfsbiyO3p1lNV8F6U=

--- a/go.sum
+++ b/go.sum
@@ -341,8 +341,8 @@ github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91/go.mod h1
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16 h1:ZtO5uywdd5dLDCud4r0r55eP4j9FuUNpl60Gmntcop4=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20220708142704-f2d0a5187303 h1:xsVE4UdC1Cq8qAMP8ET1ly3J3KdyQDUZsUwtMuwXb7g=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20220708142704-f2d0a5187303/go.mod h1:jX38yp3SSLJNftBg3PXU1ayd0PCLIiDHQ4xAc9DIixk=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20220711125303-3bb2e997a44c h1:mt30TDK8kXKV+nCmVfnqoXsh842N+74kvZw7DXuS/JQ=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20220711125303-3bb2e997a44c/go.mod h1:jX38yp3SSLJNftBg3PXU1ayd0PCLIiDHQ4xAc9DIixk=
 github.com/matrix-org/pinecone v0.0.0-20220708135211-1ce778fcde6a h1:DdG8vXMlZ65EAtc4V+3t7zHZ2Gqs24pSnyXS+4BRHUs=
 github.com/matrix-org/pinecone v0.0.0-20220708135211-1ce778fcde6a/go.mod h1:ulJzsVOTssIVp1j/m5eI//4VpAGDkMt5NrRuAVX7wpc=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7/go.mod h1:vVQlW/emklohkZnOPwD3LrZUBqdfsbiyO3p1lNV8F6U=

--- a/go.sum
+++ b/go.sum
@@ -341,8 +341,8 @@ github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91/go.mod h1
 github.com/matrix-org/gomatrix v0.0.0-20190528120928-7df988a63f26/go.mod h1:3fxX6gUjWyI/2Bt7J1OLhpCzOfO/bB3AiX0cJtEKud0=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16 h1:ZtO5uywdd5dLDCud4r0r55eP4j9FuUNpl60Gmntcop4=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20220701090733-da53994b0c7f h1:XF2+J6sOq07yhK1I7ItwsgRwXorjj7gqiCvgZ4dn8W8=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20220701090733-da53994b0c7f/go.mod h1:jX38yp3SSLJNftBg3PXU1ayd0PCLIiDHQ4xAc9DIixk=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20220701095609-8997d4460e3e h1:DyzI11igPdbmxTy+Fpvnqgh/2gP3S13Me/bhOGOkar4=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20220701095609-8997d4460e3e/go.mod h1:jX38yp3SSLJNftBg3PXU1ayd0PCLIiDHQ4xAc9DIixk=
 github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48 h1:W0sjjC6yjskHX4mb0nk3p0fXAlbU5bAFUFeEtlrPASE=
 github.com/matrix-org/pinecone v0.0.0-20220408153826-2999ea29ed48/go.mod h1:ulJzsVOTssIVp1j/m5eI//4VpAGDkMt5NrRuAVX7wpc=
 github.com/matrix-org/util v0.0.0-20190711121626-527ce5ddefc7/go.mod h1:vVQlW/emklohkZnOPwD3LrZUBqdfsbiyO3p1lNV8F6U=

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,8 @@ github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/LuerPI=
-github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
+github.com/dgraph-io/ristretto v0.1.1-0.20220403145359-8e850b710d6d h1:Wrc3UKTS+cffkOx0xRGFC+ZesNuTfn0ThvEC72N0krk=
+github.com/dgraph-io/ristretto v0.1.1-0.20220403145359-8e850b710d6d/go.mod h1:RAy2GVV4sTWVlNMavv3xhLsk18rxhfhDnombTe6EF5c=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=

--- a/go.sum
+++ b/go.sum
@@ -614,8 +614,9 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 h1:kQgndtyPBW/JIYERgdxfwMYh3AVStj88WQTlNDi2a+o=
+golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -819,8 +820,9 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.6-0.20210726203631-07bc1bf47fb2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
-golang.org/x/tools v0.1.8-0.20211022200916-316ba0b74098 h1:YuekqPskqwCCPM79F1X5Dhv4ezTCj+Ki1oNwiafxkA0=
 golang.org/x/tools v0.1.8-0.20211022200916-316ba0b74098/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
+golang.org/x/tools v0.1.10 h1:QjFRCZxdOhBJ/UNgnBZLbNV13DlbnK0quyivTnXJM20=
+golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/caching/cache_federationevents.go
+++ b/internal/caching/cache_federationevents.go
@@ -4,13 +4,6 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
-const (
-	FederationEventCacheName       = "federation_event"
-	FederationEventCacheMaxEntries = 256
-	FederationEventCacheMutable    = true // to allow use of Unset only
-	FederationEventCacheMaxAge     = CacheNoMaxAge
-)
-
 // FederationCache contains the subset of functions needed for
 // a federation event cache.
 type FederationCache interface {

--- a/internal/caching/cache_lazy_load_members.go
+++ b/internal/caching/cache_lazy_load_members.go
@@ -4,61 +4,32 @@ import (
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 )
 
+type lazyLoadingCacheKey struct {
+	UserID       string // the user we're querying on behalf of
+	DeviceID     string // the user we're querying on behalf of
+	RoomID       string // the room in question
+	TargetUserID string // the user whose membership we're asking about
+}
+
 type LazyLoadCache interface {
 	StoreLazyLoadedUser(device *userapi.Device, roomID, userID, eventID string)
 	IsLazyLoadedUserCached(device *userapi.Device, roomID, userID string) (string, bool)
 }
 
-func (c Caches) lazyLoadCacheForUser(device *userapi.Device) (*RistrettoCachePartition[string, any], error) {
-	return nil, nil
-	/*
-		cacheName := fmt.Sprintf("%s/%s", device.UserID, device.ID)
-		userCache, ok := c.LazyLoading.Get(cacheName)
-		if ok && userCache != nil {
-			if cache, ok := userCache.(*InMemoryLRUCachePartition); ok {
-				return cache, nil
-			}
-		}
-		cache, err := NewInMemoryLRUCachePartition(
-			LazyLoadCacheName,
-			LazyLoadCacheMutable,
-			LazyLoadCacheMaxUserEntries,
-			LazyLoadCacheMaxAge,
-			false,
-		)
-		if err != nil {
-			return nil, err
-		}
-		c.LazyLoading.Set(cacheName, cache)
-		go cacheCleaner(cache)
-		return cache, nil
-	*/
-}
-
 func (c Caches) StoreLazyLoadedUser(device *userapi.Device, roomID, userID, eventID string) {
-	/*
-		cache, err := c.lazyLoadCacheForUser(device)
-		if err != nil {
-			return
-		}
-		cacheKey := fmt.Sprintf("%s/%s/%s/%s", device.UserID, device.ID, roomID, userID)
-		cache.Set(cacheKey, eventID)
-	*/
+	c.LazyLoading.Set(lazyLoadingCacheKey{
+		UserID:       device.UserID,
+		DeviceID:     device.ID,
+		RoomID:       roomID,
+		TargetUserID: userID,
+	}, eventID)
 }
 
 func (c Caches) IsLazyLoadedUserCached(device *userapi.Device, roomID, userID string) (string, bool) {
-	return "", false
-	/*
-		cache, err := c.lazyLoadCacheForUser(device)
-		if err != nil {
-			return "", false
-		}
-
-		cacheKey := fmt.Sprintf("%s/%s/%s/%s", device.UserID, device.ID, roomID, userID)
-		val, ok := cache.Get(cacheKey)
-		if !ok {
-			return "", ok
-		}
-		return val.(string), ok
-	*/
+	return c.LazyLoading.Get(lazyLoadingCacheKey{
+		UserID:       device.UserID,
+		DeviceID:     device.ID,
+		RoomID:       roomID,
+		TargetUserID: userID,
+	})
 }

--- a/internal/caching/cache_lazy_load_members.go
+++ b/internal/caching/cache_lazy_load_members.go
@@ -1,17 +1,7 @@
 package caching
 
 import (
-	"time"
-
 	userapi "github.com/matrix-org/dendrite/userapi/api"
-)
-
-const (
-	LazyLoadCacheName           = "lazy_load_members"
-	LazyLoadCacheMaxEntries     = 128
-	LazyLoadCacheMaxUserEntries = 128
-	LazyLoadCacheMutable        = true
-	LazyLoadCacheMaxAge         = time.Minute * 30
 )
 
 type LazyLoadCache interface {

--- a/internal/caching/cache_roomevents.go
+++ b/internal/caching/cache_roomevents.go
@@ -1,0 +1,21 @@
+package caching
+
+import (
+	"github.com/matrix-org/dendrite/roomserver/types"
+	"github.com/matrix-org/gomatrixserverlib"
+)
+
+// RoomServerNIDsCache contains the subset of functions needed for
+// a roomserver NID cache.
+type RoomServerEventsCache interface {
+	GetRoomServerEvent(eventNID types.EventNID) (*gomatrixserverlib.Event, bool)
+	StoreRoomServerEvent(eventNID types.EventNID, event *gomatrixserverlib.Event)
+}
+
+func (c Caches) GetRoomServerEvent(eventNID types.EventNID) (*gomatrixserverlib.Event, bool) {
+	return c.RoomServerEvents.Get(int64(eventNID))
+}
+
+func (c Caches) StoreRoomServerEvent(eventNID types.EventNID, event *gomatrixserverlib.Event) {
+	c.RoomServerEvents.Set(int64(eventNID), event)
+}

--- a/internal/caching/cache_roomevents.go
+++ b/internal/caching/cache_roomevents.go
@@ -17,7 +17,5 @@ func (c Caches) GetRoomServerEvent(eventNID types.EventNID) (*gomatrixserverlib.
 }
 
 func (c Caches) StoreRoomServerEvent(eventNID types.EventNID, event *gomatrixserverlib.Event) {
-	if event != nil {
-		c.RoomServerEvents.Set(int64(eventNID), event)
-	}
+	c.RoomServerEvents.Set(int64(eventNID), event)
 }

--- a/internal/caching/cache_roomevents.go
+++ b/internal/caching/cache_roomevents.go
@@ -17,5 +17,7 @@ func (c Caches) GetRoomServerEvent(eventNID types.EventNID) (*gomatrixserverlib.
 }
 
 func (c Caches) StoreRoomServerEvent(eventNID types.EventNID, event *gomatrixserverlib.Event) {
-	c.RoomServerEvents.Set(int64(eventNID), event)
+	if event != nil {
+		c.RoomServerEvents.Set(int64(eventNID), event)
+	}
 }

--- a/internal/caching/cache_roomevents.go
+++ b/internal/caching/cache_roomevents.go
@@ -5,8 +5,8 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
-// RoomServerNIDsCache contains the subset of functions needed for
-// a roomserver NID cache.
+// RoomServerEventsCache contains the subset of functions needed for
+// a roomserver event cache.
 type RoomServerEventsCache interface {
 	GetRoomServerEvent(eventNID types.EventNID) (*gomatrixserverlib.Event, bool)
 	StoreRoomServerEvent(eventNID types.EventNID, event *gomatrixserverlib.Event)

--- a/internal/caching/cache_roominfo.go
+++ b/internal/caching/cache_roominfo.go
@@ -1,8 +1,6 @@
 package caching
 
 import (
-	"time"
-
 	"github.com/matrix-org/dendrite/roomserver/types"
 )
 
@@ -13,13 +11,6 @@ import (
 // will be kept up-to-date by the latest events updater. It MUST NOT be
 // used from other components as we currently have no way to invalidate
 // the cache in downstream components.
-
-const (
-	RoomInfoCacheName       = "roominfo"
-	RoomInfoCacheMaxEntries = 1024
-	RoomInfoCacheMutable    = true
-	RoomInfoCacheMaxAge     = time.Minute * 5
-)
 
 // RoomInfosCache contains the subset of functions needed for
 // a room Info cache. It must only be used from the roomserver only

--- a/internal/caching/cache_roomservernids.go
+++ b/internal/caching/cache_roomservernids.go
@@ -4,13 +4,6 @@ import (
 	"github.com/matrix-org/dendrite/roomserver/types"
 )
 
-const (
-	RoomServerRoomIDsCacheName       = "roomserver_room_ids"
-	RoomServerRoomIDsCacheMaxEntries = 1024
-	RoomServerRoomIDsCacheMutable    = false
-	RoomServerRoomIDsCacheMaxAge     = CacheNoMaxAge
-)
-
 type RoomServerCaches interface {
 	RoomServerNIDsCache
 	RoomVersionCache

--- a/internal/caching/cache_roomservernids.go
+++ b/internal/caching/cache_roomservernids.go
@@ -15,6 +15,7 @@ type RoomServerCaches interface {
 	RoomServerNIDsCache
 	RoomVersionCache
 	RoomInfoCache
+	RoomServerEventsCache
 }
 
 // RoomServerNIDsCache contains the subset of functions needed for

--- a/internal/caching/cache_roomversions.go
+++ b/internal/caching/cache_roomversions.go
@@ -2,13 +2,6 @@ package caching
 
 import "github.com/matrix-org/gomatrixserverlib"
 
-const (
-	RoomVersionCacheName       = "room_versions"
-	RoomVersionCacheMaxEntries = 1024
-	RoomVersionCacheMutable    = false
-	RoomVersionCacheMaxAge     = CacheNoMaxAge
-)
-
 // RoomVersionsCache contains the subset of functions needed for
 // a room version cache.
 type RoomVersionCache interface {

--- a/internal/caching/cache_serverkeys.go
+++ b/internal/caching/cache_serverkeys.go
@@ -6,13 +6,6 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
-const (
-	ServerKeyCacheName       = "server_key"
-	ServerKeyCacheMaxEntries = 4096
-	ServerKeyCacheMutable    = true
-	ServerKeyCacheMaxAge     = CacheNoMaxAge
-)
-
 // ServerKeyCache contains the subset of functions needed for
 // a server key cache.
 type ServerKeyCache interface {

--- a/internal/caching/cache_space_rooms.go
+++ b/internal/caching/cache_space_rooms.go
@@ -1,16 +1,7 @@
 package caching
 
 import (
-	"time"
-
 	"github.com/matrix-org/gomatrixserverlib"
-)
-
-const (
-	SpaceSummaryRoomsCacheName       = "space_summary_rooms"
-	SpaceSummaryRoomsCacheMaxEntries = 100
-	SpaceSummaryRoomsCacheMutable    = true
-	SpaceSummaryRoomsCacheMaxAge     = time.Minute * 5
 )
 
 type SpaceSummaryRoomsCache interface {

--- a/internal/caching/caches.go
+++ b/internal/caching/caches.go
@@ -15,6 +15,7 @@ type Caches struct {
 	ServerKeys         Cache[string, gomatrixserverlib.PublicKeyLookupResult]
 	RoomServerRoomNIDs Cache[string, types.RoomNID]
 	RoomServerRoomIDs  Cache[int64, string]
+	RoomServerEvents   Cache[int64, *gomatrixserverlib.Event]
 	RoomInfos          Cache[string, types.RoomInfo]
 	FederationPDUs     Cache[int64, *gomatrixserverlib.HeaderedEvent]
 	FederationEDUs     Cache[int64, *gomatrixserverlib.EDU]

--- a/internal/caching/caches.go
+++ b/internal/caching/caches.go
@@ -38,10 +38,6 @@ type costable interface {
 	CacheCost() int64
 }
 
-type equatable interface {
-	comparable
-}
-
 type CacheSize int64
 
 const (

--- a/internal/caching/caches.go
+++ b/internal/caching/caches.go
@@ -23,16 +23,16 @@ import (
 // different implementations as long as they satisfy the Cache
 // interface.
 type Caches struct {
-	RoomVersions       Cache[string, gomatrixserverlib.RoomVersion]
-	ServerKeys         Cache[string, gomatrixserverlib.PublicKeyLookupResult]
-	RoomServerRoomNIDs Cache[string, types.RoomNID]
-	RoomServerRoomIDs  Cache[int64, string]
-	RoomServerEvents   Cache[int64, *gomatrixserverlib.Event]
-	RoomInfos          Cache[string, types.RoomInfo]
-	FederationPDUs     Cache[int64, *gomatrixserverlib.HeaderedEvent]
-	FederationEDUs     Cache[int64, *gomatrixserverlib.EDU]
-	SpaceSummaryRooms  Cache[string, gomatrixserverlib.MSC2946SpacesResponse]
-	LazyLoading        Cache[lazyLoadingCacheKey, string]
+	RoomVersions       Cache[string, gomatrixserverlib.RoomVersion]           // room ID -> room version
+	ServerKeys         Cache[string, gomatrixserverlib.PublicKeyLookupResult] // server name -> server keys
+	RoomServerRoomNIDs Cache[string, types.RoomNID]                           // room ID -> room NID
+	RoomServerRoomIDs  Cache[int64, string]                                   // room NID -> room ID
+	RoomServerEvents   Cache[int64, *gomatrixserverlib.Event]                 // event NID -> event
+	RoomInfos          Cache[string, types.RoomInfo]                          // room ID -> room info
+	FederationPDUs     Cache[int64, *gomatrixserverlib.HeaderedEvent]         // queue NID -> PDU
+	FederationEDUs     Cache[int64, *gomatrixserverlib.EDU]                   // queue NID -> EDU
+	SpaceSummaryRooms  Cache[string, gomatrixserverlib.MSC2946SpacesResponse] // room ID -> space response
+	LazyLoading        Cache[lazyLoadingCacheKey, string]                     // composite key -> event ID
 }
 
 // Cache is the interface that an implementation must satisfy.

--- a/internal/caching/caches.go
+++ b/internal/caching/caches.go
@@ -18,7 +18,7 @@ type Caches struct {
 	FederationPDUs     Cache[int64, *gomatrixserverlib.HeaderedEvent]
 	FederationEDUs     Cache[int64, *gomatrixserverlib.EDU]
 	SpaceSummaryRooms  Cache[string, gomatrixserverlib.MSC2946SpacesResponse]
-	LazyLoading        Cache[string, any]
+	LazyLoading        Cache[lazyLoadingCacheKey, string]
 }
 
 // Cache is the interface that an implementation must satisfy.
@@ -30,7 +30,7 @@ type Cache[K keyable, T any] interface {
 
 type keyable interface {
 	// from https://github.com/dgraph-io/ristretto/blob/8e850b710d6df0383c375ec6a7beae4ce48fc8d5/z/z.go#L34
-	uint64 | string | []byte | byte | int | int32 | uint32 | int64
+	uint64 | string | []byte | byte | int | int32 | uint32 | int64 | lazyLoadingCacheKey
 }
 
 type costable interface {

--- a/internal/caching/caches.go
+++ b/internal/caching/caches.go
@@ -1,3 +1,17 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package caching
 
 import (

--- a/internal/caching/caches.go
+++ b/internal/caching/caches.go
@@ -38,6 +38,10 @@ type costable interface {
 	CacheCost() int64
 }
 
+type equatable interface {
+	comparable
+}
+
 type CacheSize int64
 
 const (

--- a/internal/caching/caches.go
+++ b/internal/caching/caches.go
@@ -36,7 +36,7 @@ type keyable interface {
 }
 
 type costable interface {
-	CacheCost() int64
+	CacheCost() int
 }
 
 type CacheSize int64

--- a/internal/caching/caches.go
+++ b/internal/caching/caches.go
@@ -1,8 +1,6 @@
 package caching
 
 import (
-	"time"
-
 	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib"
 )
@@ -38,15 +36,3 @@ type keyable interface {
 type costable interface {
 	CacheCost() int
 }
-
-type CacheSize int64
-
-const (
-	_            = iota
-	KB CacheSize = 1 << (10 * iota)
-	MB
-	GB
-	TB
-)
-
-const CacheNoMaxAge = time.Duration(0)

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -52,8 +52,9 @@ func NewRistrettoCache(maxCost CacheSize, enablePrometheus bool) (*Caches, error
 			Name:  "room_ids",
 		},
 		RoomServerEvents: &RistrettoCachePartition[int64, *gomatrixserverlib.Event]{
-			cache: cache,
-			Name:  "room_events",
+			cache:   cache,
+			Name:    "room_events",
+			Mutable: true,
 		},
 		RoomInfos: &RistrettoCachePartition[string, types.RoomInfo]{
 			cache:   cache,

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -44,38 +44,46 @@ func NewRistrettoCache(maxCost CacheSize, enablePrometheus bool) (*Caches, error
 
 	return &Caches{
 		RoomVersions: &RistrettoCachePartition[string, gomatrixserverlib.RoomVersion]{
-			cache: MustCreateCache("room_versions", 1*MB, enablePrometheus),
+			cache:  MustCreateCache("room_versions", 1*MB, enablePrometheus),
+			MaxAge: time.Hour,
 		},
 		ServerKeys: &RistrettoCachePartition[string, gomatrixserverlib.PublicKeyLookupResult]{
 			cache:   MustCreateCache("server_keys", 32*MB, enablePrometheus),
 			Mutable: true,
+			MaxAge:  time.Hour,
 		},
 		RoomServerRoomIDs: &RistrettoCachePartition[int64, string]{
-			cache: MustCreateCache("room_ids", 1*MB, enablePrometheus),
+			cache:  MustCreateCache("room_ids", 1*MB, enablePrometheus),
+			MaxAge: time.Hour,
 		},
 		RoomServerEvents: &RistrettoCachePartition[int64, *gomatrixserverlib.Event]{
-			cache: MustCreateCache("room_events", 1*GB, enablePrometheus),
+			cache:  MustCreateCache("room_events", 1*GB, enablePrometheus),
+			MaxAge: time.Hour,
 		},
 		RoomInfos: &RistrettoCachePartition[string, types.RoomInfo]{
 			cache:   MustCreateCache("room_infos", 16*MB, enablePrometheus),
 			Mutable: true,
-			MaxAge:  time.Minute * 5,
+			MaxAge:  time.Hour,
 		},
 		FederationPDUs: &RistrettoCachePartition[int64, *gomatrixserverlib.HeaderedEvent]{
 			cache:   MustCreateCache("federation_pdus", 128*MB, enablePrometheus),
 			Mutable: true,
+			MaxAge:  time.Hour / 2,
 		},
 		FederationEDUs: &RistrettoCachePartition[int64, *gomatrixserverlib.EDU]{
 			cache:   MustCreateCache("federation_edus", 128*MB, enablePrometheus),
 			Mutable: true,
+			MaxAge:  time.Hour / 2,
 		},
 		SpaceSummaryRooms: &RistrettoCachePartition[string, gomatrixserverlib.MSC2946SpacesResponse]{
 			cache:   MustCreateCache("space_summary_rooms", 128, enablePrometheus), // TODO: not costed
 			Mutable: true,
+			MaxAge:  time.Hour,
 		},
 		LazyLoading: &RistrettoCachePartition[string, any]{ // TODO: type
 			cache:   MustCreateCache("lazy_loading", 256, enablePrometheus), // TODO: not costed
 			Mutable: true,
+			MaxAge:  time.Hour,
 		},
 	}, nil
 }

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -14,10 +14,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-func MustCreateCache(maxCost CacheSize, enablePrometheus bool) *ristretto.Cache {
+func MustCreateCache(maxCost int64, enablePrometheus bool) *ristretto.Cache {
 	cache, err := ristretto.NewCache(&ristretto.Config{
 		NumCounters: 1e5,
-		MaxCost:     int64(maxCost),
+		MaxCost:     maxCost,
 		BufferItems: 64,
 		Metrics:     true,
 		KeyToHash: func(key interface{}) (uint64, uint64) {
@@ -56,7 +56,7 @@ const (
 	lazyLoadingCache
 )
 
-func NewRistrettoCache(maxCost CacheSize, enablePrometheus bool) (*Caches, error) {
+func NewRistrettoCache(maxCost int64, enablePrometheus bool) (*Caches, error) {
 	cache := MustCreateCache(maxCost, enablePrometheus)
 	return &Caches{
 		RoomVersions: &RistrettoCachePartition[string, gomatrixserverlib.RoomVersion]{

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -15,7 +15,7 @@ import (
 
 func NewRistrettoCache(maxCost CacheSize, enablePrometheus bool) (*Caches, error) {
 	cache, err := ristretto.NewCache(&ristretto.Config{
-		NumCounters: 1e7,
+		NumCounters: 1e6,
 		MaxCost:     int64(maxCost),
 		BufferItems: 64,
 		Metrics:     true,

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -1,3 +1,17 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package caching
 
 import (
@@ -15,7 +29,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-func MustCreateCache(maxCost config.DataUnit, enablePrometheus bool) *ristretto.Cache {
+func mustCreateCache(maxCost config.DataUnit, enablePrometheus bool) *ristretto.Cache {
 	cache, err := ristretto.NewCache(&ristretto.Config{
 		NumCounters: 1e5,
 		MaxCost:     int64(maxCost),
@@ -60,7 +74,7 @@ const (
 )
 
 func NewRistrettoCache(maxCost config.DataUnit, maxAge time.Duration, enablePrometheus bool) (*Caches, error) {
-	cache := MustCreateCache(maxCost, enablePrometheus)
+	cache := mustCreateCache(maxCost, enablePrometheus)
 	return &Caches{
 		RoomVersions: &RistrettoCachePartition[string, gomatrixserverlib.RoomVersion]{
 			cache:  cache,

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -147,13 +147,19 @@ func (c *RistrettoCachePartition[K, V]) setWithCost(key K, value V, cost int64) 
 }
 
 func (c *RistrettoCachePartition[K, V]) Set(key K, value V) {
-	var cost int64
-	if cv, ok := any(value).(string); ok {
-		cost = int64(len(cv))
+	var keyCost int64
+	var valueCost int64
+	if ck, ok := any(key).(string); ok {
+		keyCost = int64(len(ck))
 	} else {
-		cost = int64(unsafe.Sizeof(value))
+		keyCost = int64(unsafe.Sizeof(key))
 	}
-	c.setWithCost(key, value, cost)
+	if cv, ok := any(value).(string); ok {
+		valueCost = int64(len(cv))
+	} else {
+		valueCost = int64(unsafe.Sizeof(value))
+	}
+	c.setWithCost(key, value, keyCost+valueCost)
 }
 
 func (c *RistrettoCachePartition[K, V]) Unset(key K) {

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -50,12 +50,14 @@ func NewRistrettoCache(maxCost CacheSize, enablePrometheus bool) (*Caches, error
 			MaxAge:  time.Minute * 5,
 		},
 		FederationPDUs: &RistrettoCachePartition[int64, *gomatrixserverlib.HeaderedEvent]{
-			cache: cache,
-			Name:  "federation_events_pdu",
+			cache:   cache,
+			Name:    "federation_events_pdu",
+			Mutable: true,
 		},
 		FederationEDUs: &RistrettoCachePartition[int64, *gomatrixserverlib.EDU]{
-			cache: cache,
-			Name:  "federation_events_edu",
+			cache:   cache,
+			Name:    "federation_events_edu",
+			Mutable: true,
 		},
 		SpaceSummaryRooms: &RistrettoCachePartition[string, gomatrixserverlib.MSC2946SpacesResponse]{
 			cache:   cache,

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -28,20 +28,22 @@ func MustCreateCache(maxCost config.DataUnit, enablePrometheus bool) *ristretto.
 	if err != nil {
 		panic(err)
 	}
-	promauto.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace: "dendrite",
-		Subsystem: "caching_ristretto",
-		Name:      "ratio",
-	}, func() float64 {
-		return float64(cache.Metrics.Ratio())
-	})
-	promauto.NewGaugeFunc(prometheus.GaugeOpts{
-		Namespace: "dendrite",
-		Subsystem: "caching_ristretto",
-		Name:      "cost",
-	}, func() float64 {
-		return float64(cache.Metrics.CostAdded() - cache.Metrics.CostEvicted())
-	})
+	if enablePrometheus {
+		promauto.NewGaugeFunc(prometheus.GaugeOpts{
+			Namespace: "dendrite",
+			Subsystem: "caching_ristretto",
+			Name:      "ratio",
+		}, func() float64 {
+			return float64(cache.Metrics.Ratio())
+		})
+		promauto.NewGaugeFunc(prometheus.GaugeOpts{
+			Namespace: "dendrite",
+			Subsystem: "caching_ristretto",
+			Name:      "cost",
+		}, func() float64 {
+			return float64(cache.Metrics.CostAdded() - cache.Metrics.CostEvicted())
+		})
+	}
 	return cache
 }
 

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -78,27 +78,30 @@ type RistrettoCachePartition[K keyable, V any] struct {
 }
 
 func (c *RistrettoCachePartition[K, V]) Set(key K, value V) {
+	strkey := fmt.Sprintf("%s_%v", c.Name, key)
 	if !c.Mutable {
-		if v, ok := c.cache.Get(key); ok && v != nil && !reflect.DeepEqual(v, value) {
-			panic(fmt.Sprintf("invalid use of immutable cache tries to change value of %v from %v to %v", key, v, value))
+		if v, ok := c.cache.Get(strkey); ok && v != nil && !reflect.DeepEqual(v, value) {
+			panic(fmt.Sprintf("invalid use of immutable cache tries to change value of %v from %v to %v", strkey, v, value))
 		}
 	}
 	cost := int64(1)
 	if cv, ok := any(value).(costable); ok {
 		cost = int64(cv.CacheCost())
 	}
-	c.cache.SetWithTTL(key, value, cost, c.MaxAge)
+	c.cache.SetWithTTL(strkey, value, cost, c.MaxAge)
 }
 
 func (c *RistrettoCachePartition[K, V]) Unset(key K) {
+	strkey := fmt.Sprintf("%s_%v", c.Name, key)
 	if !c.Mutable {
-		panic(fmt.Sprintf("invalid use of immutable cache tries to unset value of %v", key))
+		panic(fmt.Sprintf("invalid use of immutable cache tries to unset value of %v", strkey))
 	}
-	c.cache.Del(key)
+	c.cache.Del(strkey)
 }
 
 func (c *RistrettoCachePartition[K, V]) Get(key K) (value V, ok bool) {
-	v, ok := c.cache.Get(key)
+	strkey := fmt.Sprintf("%s_%v", c.Name, key)
+	v, ok := c.cache.Get(strkey)
 	if !ok || v == nil {
 		var empty V
 		return empty, false

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -16,7 +16,7 @@ import (
 
 func MustCreateCache(maxCost CacheSize, enablePrometheus bool) *ristretto.Cache {
 	cache, err := ristretto.NewCache(&ristretto.Config{
-		NumCounters: 1e6,
+		NumCounters: 1e5,
 		MaxCost:     int64(maxCost),
 		BufferItems: 64,
 		Metrics:     true,

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -143,23 +143,17 @@ func (c *RistrettoCachePartition[K, V]) setWithCost(key K, value V, cost int64) 
 			panic(fmt.Sprintf("invalid use of immutable cache tries to change value of %v from %v to %v", key, v, value))
 		}
 	}
-	c.cache.SetWithTTL(bkey, value, cost, c.MaxAge)
+	c.cache.SetWithTTL(bkey, value, int64(len(bkey))+cost, c.MaxAge)
 }
 
 func (c *RistrettoCachePartition[K, V]) Set(key K, value V) {
-	var keyCost int64
-	var valueCost int64
-	if ck, ok := any(key).(string); ok {
-		keyCost = int64(len(ck))
-	} else {
-		keyCost = int64(unsafe.Sizeof(key))
-	}
+	var cost int64
 	if cv, ok := any(value).(string); ok {
-		valueCost = int64(len(cv))
+		cost = int64(len(cv))
 	} else {
-		valueCost = int64(unsafe.Sizeof(value))
+		cost = int64(unsafe.Sizeof(value))
 	}
-	c.setWithCost(key, value, keyCost+valueCost)
+	c.setWithCost(key, value, cost)
 }
 
 func (c *RistrettoCachePartition[K, V]) Unset(key K) {

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -57,37 +57,37 @@ const (
 	lazyLoadingCache
 )
 
-func NewRistrettoCache(maxCost config.DataUnit, enablePrometheus bool) (*Caches, error) {
+func NewRistrettoCache(maxCost config.DataUnit, maxAge time.Duration, enablePrometheus bool) (*Caches, error) {
 	cache := MustCreateCache(maxCost, enablePrometheus)
 	return &Caches{
 		RoomVersions: &RistrettoCachePartition[string, gomatrixserverlib.RoomVersion]{
 			cache:  cache,
 			Prefix: roomVersionsCache,
-			MaxAge: time.Hour,
+			MaxAge: maxAge,
 		},
 		ServerKeys: &RistrettoCachePartition[string, gomatrixserverlib.PublicKeyLookupResult]{
 			cache:   cache,
 			Prefix:  serverKeysCache,
 			Mutable: true,
-			MaxAge:  time.Hour,
+			MaxAge:  maxAge,
 		},
 		RoomServerRoomIDs: &RistrettoCachePartition[int64, string]{
 			cache:  cache,
 			Prefix: roomIDsCache,
-			MaxAge: time.Hour,
+			MaxAge: maxAge,
 		},
 		RoomServerEvents: &RistrettoCostedCachePartition[int64, *gomatrixserverlib.Event]{
 			&RistrettoCachePartition[int64, *gomatrixserverlib.Event]{
 				cache:  cache,
 				Prefix: roomEventsCache,
-				MaxAge: time.Hour,
+				MaxAge: maxAge,
 			},
 		},
 		RoomInfos: &RistrettoCachePartition[string, types.RoomInfo]{
 			cache:   cache,
 			Prefix:  roomInfosCache,
 			Mutable: true,
-			MaxAge:  time.Hour,
+			MaxAge:  maxAge,
 		},
 		FederationPDUs: &RistrettoCostedCachePartition[int64, *gomatrixserverlib.HeaderedEvent]{
 			&RistrettoCachePartition[int64, *gomatrixserverlib.HeaderedEvent]{
@@ -109,13 +109,13 @@ func NewRistrettoCache(maxCost config.DataUnit, enablePrometheus bool) (*Caches,
 			cache:   cache,
 			Prefix:  spaceSummaryRoomsCache,
 			Mutable: true,
-			MaxAge:  time.Hour,
+			MaxAge:  maxAge,
 		},
 		LazyLoading: &RistrettoCachePartition[string, any]{ // TODO: type
 			cache:   cache,
 			Prefix:  lazyLoadingCache,
 			Mutable: true,
-			MaxAge:  time.Hour,
+			MaxAge:  maxAge,
 		},
 	}, nil
 }

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -79,8 +79,8 @@ type RistrettoCachePartition[K keyable, V any] struct {
 
 func (c *RistrettoCachePartition[K, V]) Set(key K, value V) {
 	if !c.Mutable {
-		if v, ok := c.cache.Get(key); ok && !reflect.DeepEqual(v, value) {
-			panic(fmt.Sprintf("invalid use of immutable cache tries to replace value of %v", key))
+		if v, ok := c.cache.Get(key); ok && v != nil && !reflect.DeepEqual(v, value) {
+			panic(fmt.Sprintf("invalid use of immutable cache tries to change value of %v from %v to %v", key, v, value))
 		}
 	}
 	cost := int64(1)
@@ -91,9 +91,6 @@ func (c *RistrettoCachePartition[K, V]) Set(key K, value V) {
 }
 
 func (c *RistrettoCachePartition[K, V]) Unset(key K) {
-	if c.cache == nil {
-		return
-	}
 	if !c.Mutable {
 		panic(fmt.Sprintf("invalid use of immutable cache tries to unset value of %v", key))
 	}
@@ -101,11 +98,11 @@ func (c *RistrettoCachePartition[K, V]) Unset(key K) {
 }
 
 func (c *RistrettoCachePartition[K, V]) Get(key K) (value V, ok bool) {
-	if c.cache == nil {
+	v, ok := c.cache.Get(key)
+	if !ok || v == nil {
 		var empty V
 		return empty, false
 	}
-	v, ok := c.cache.Get(key)
 	value, ok = v.(V)
 	return
 }

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -94,7 +94,7 @@ func NewRistrettoCache(maxCost config.DataUnit, maxAge time.Duration, enableProm
 				cache:   cache,
 				Prefix:  federationPDUsCache,
 				Mutable: true,
-				MaxAge:  time.Hour / 2,
+				MaxAge:  lesserOf(time.Hour/2, maxAge),
 			},
 		},
 		FederationEDUs: &RistrettoCostedCachePartition[int64, *gomatrixserverlib.EDU]{
@@ -102,7 +102,7 @@ func NewRistrettoCache(maxCost config.DataUnit, maxAge time.Duration, enableProm
 				cache:   cache,
 				Prefix:  federationEDUsCache,
 				Mutable: true,
-				MaxAge:  time.Hour / 2,
+				MaxAge:  lesserOf(time.Hour/2, maxAge),
 			},
 		},
 		SpaceSummaryRooms: &RistrettoCachePartition[string, gomatrixserverlib.MSC2946SpacesResponse]{
@@ -173,4 +173,11 @@ func (c *RistrettoCachePartition[K, V]) Get(key K) (value V, ok bool) {
 	}
 	value, ok = v.(V)
 	return
+}
+
+func lesserOf(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -9,15 +9,16 @@ import (
 	"github.com/dgraph-io/ristretto"
 	"github.com/dgraph-io/ristretto/z"
 	"github.com/matrix-org/dendrite/roomserver/types"
+	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-func MustCreateCache(maxCost int64, enablePrometheus bool) *ristretto.Cache {
+func MustCreateCache(maxCost config.DataUnit, enablePrometheus bool) *ristretto.Cache {
 	cache, err := ristretto.NewCache(&ristretto.Config{
 		NumCounters: 1e5,
-		MaxCost:     maxCost,
+		MaxCost:     int64(maxCost),
 		BufferItems: 64,
 		Metrics:     true,
 		KeyToHash: func(key interface{}) (uint64, uint64) {
@@ -56,7 +57,7 @@ const (
 	lazyLoadingCache
 )
 
-func NewRistrettoCache(maxCost int64, enablePrometheus bool) (*Caches, error) {
+func NewRistrettoCache(maxCost config.DataUnit, enablePrometheus bool) (*Caches, error) {
 	cache := MustCreateCache(maxCost, enablePrometheus)
 	return &Caches{
 		RoomVersions: &RistrettoCachePartition[string, gomatrixserverlib.RoomVersion]{

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -13,72 +13,68 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-func NewRistrettoCache(maxCost CacheSize, enablePrometheus bool) (*Caches, error) {
+func MustCreateCache(name string, maxCost CacheSize, enablePrometheus bool) *ristretto.Cache {
 	cache, err := ristretto.NewCache(&ristretto.Config{
-		NumCounters: 1e7,
+		NumCounters: 1e6,
 		MaxCost:     int64(maxCost),
 		BufferItems: 64,
 		Metrics:     true,
 	})
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 	promauto.NewGaugeFunc(prometheus.GaugeOpts{
 		Namespace: "dendrite",
 		Subsystem: "caching_ristretto",
-		Name:      "ratio",
+		Name:      name + "_ratio",
 	}, func() float64 {
 		return float64(cache.Metrics.Ratio())
 	})
 	promauto.NewGaugeFunc(prometheus.GaugeOpts{
 		Namespace: "dendrite",
 		Subsystem: "caching_ristretto",
-		Name:      "cost",
+		Name:      name + "_cost",
 	}, func() float64 {
 		return float64(cache.Metrics.CostAdded() - cache.Metrics.CostEvicted())
 	})
+	return cache
+}
+
+func NewRistrettoCache(maxCost CacheSize, enablePrometheus bool) (*Caches, error) {
+
 	return &Caches{
 		RoomVersions: &RistrettoCachePartition[string, gomatrixserverlib.RoomVersion]{
-			cache: cache,
-			Name:  "room_versions",
+			cache: MustCreateCache("room_versions", 1*MB, enablePrometheus),
 		},
 		ServerKeys: &RistrettoCachePartition[string, gomatrixserverlib.PublicKeyLookupResult]{
-			cache:   cache,
-			Name:    "server_keys",
+			cache:   MustCreateCache("server_keys", 32*MB, enablePrometheus),
 			Mutable: true,
 		},
 		RoomServerRoomIDs: &RistrettoCachePartition[int64, string]{
-			cache: cache,
-			Name:  "room_ids",
+			cache: MustCreateCache("room_ids", 1*MB, enablePrometheus),
 		},
 		RoomServerEvents: &RistrettoCachePartition[int64, *gomatrixserverlib.Event]{
-			cache: cache,
-			Name:  "room_events",
+			cache: MustCreateCache("room_events", 1*GB, enablePrometheus),
 		},
 		RoomInfos: &RistrettoCachePartition[string, types.RoomInfo]{
-			cache:   cache,
-			Name:    "room_infos",
+			cache:   MustCreateCache("room_infos", 16*MB, enablePrometheus),
 			Mutable: true,
 			MaxAge:  time.Minute * 5,
 		},
 		FederationPDUs: &RistrettoCachePartition[int64, *gomatrixserverlib.HeaderedEvent]{
-			cache:   cache,
-			Name:    "federation_events_pdu",
+			cache:   MustCreateCache("federation_pdus", 128*MB, enablePrometheus),
 			Mutable: true,
 		},
 		FederationEDUs: &RistrettoCachePartition[int64, *gomatrixserverlib.EDU]{
-			cache:   cache,
-			Name:    "federation_events_edu",
+			cache:   MustCreateCache("federation_edus", 128*MB, enablePrometheus),
 			Mutable: true,
 		},
 		SpaceSummaryRooms: &RistrettoCachePartition[string, gomatrixserverlib.MSC2946SpacesResponse]{
-			cache:   cache,
-			Name:    "space_summary_rooms",
+			cache:   MustCreateCache("space_summary_rooms", 128, enablePrometheus), // TODO: not costed
 			Mutable: true,
 		},
 		LazyLoading: &RistrettoCachePartition[string, any]{ // TODO: type
-			cache:   cache,
-			Name:    "lazy_loading",
+			cache:   MustCreateCache("lazy_loading", 256, enablePrometheus), // TODO: not costed
 			Mutable: true,
 		},
 	}, nil
@@ -86,16 +82,14 @@ func NewRistrettoCache(maxCost CacheSize, enablePrometheus bool) (*Caches, error
 
 type RistrettoCachePartition[K keyable, V any] struct {
 	cache   *ristretto.Cache
-	Name    string
 	Mutable bool
 	MaxAge  time.Duration
 }
 
 func (c *RistrettoCachePartition[K, V]) Set(key K, value V) {
-	strkey := fmt.Sprintf("%v\000%s", key, c.Name)
 	if !c.Mutable {
-		if v, ok := c.cache.Get(strkey); ok && v != nil && !reflect.DeepEqual(v, value) {
-			panic(fmt.Sprintf("invalid use of immutable cache tries to change value of %v from %v to %v", strkey, v, value))
+		if v, ok := c.cache.Get(key); ok && v != nil && !reflect.DeepEqual(v, value) {
+			panic(fmt.Sprintf("invalid use of immutable cache tries to change value of %v from %v to %v", key, v, value))
 		}
 	}
 	var cost int64
@@ -106,20 +100,18 @@ func (c *RistrettoCachePartition[K, V]) Set(key K, value V) {
 	} else {
 		cost = int64(unsafe.Sizeof(value))
 	}
-	c.cache.SetWithTTL(strkey, value, cost, c.MaxAge)
+	c.cache.SetWithTTL(key, value, cost, c.MaxAge)
 }
 
 func (c *RistrettoCachePartition[K, V]) Unset(key K) {
-	strkey := fmt.Sprintf("%s_%v", c.Name, key)
 	if !c.Mutable {
-		panic(fmt.Sprintf("invalid use of immutable cache tries to unset value of %v", strkey))
+		panic(fmt.Sprintf("invalid use of immutable cache tries to unset value of %v", key))
 	}
-	c.cache.Del(strkey)
+	c.cache.Del(key)
 }
 
 func (c *RistrettoCachePartition[K, V]) Get(key K) (value V, ok bool) {
-	strkey := fmt.Sprintf("%s_%v", c.Name, key)
-	v, ok := c.cache.Get(strkey)
+	v, ok := c.cache.Get(key)
 	if !ok || v == nil {
 		var empty V
 		return empty, false

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -35,8 +35,7 @@ func NewRistrettoCache(maxCost CacheSize, enablePrometheus bool) (*Caches, error
 		Subsystem: "caching_ristretto",
 		Name:      "cost",
 	}, func() float64 {
-		evicted := cache.Metrics.CostEvicted() + cache.Metrics.CostEvicted()
-		return float64(cache.Metrics.CostAdded() - evicted)
+		return float64(cache.Metrics.CostAdded() - cache.Metrics.CostEvicted())
 	})
 	return &Caches{
 		RoomVersions: &RistrettoCachePartition[string, gomatrixserverlib.RoomVersion]{

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -111,7 +111,7 @@ func NewRistrettoCache(maxCost config.DataUnit, maxAge time.Duration, enableProm
 			Mutable: true,
 			MaxAge:  maxAge,
 		},
-		LazyLoading: &RistrettoCachePartition[string, any]{ // TODO: type
+		LazyLoading: &RistrettoCachePartition[lazyLoadingCacheKey, string]{
 			cache:   cache,
 			Prefix:  lazyLoadingCache,
 			Mutable: true,

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -119,6 +119,15 @@ func NewRistrettoCache(maxCost CacheSize, enablePrometheus bool) (*Caches, error
 	}, nil
 }
 
+type RistrettoCostedCachePartition[k keyable, v costable] struct {
+	*RistrettoCachePartition[k, v]
+}
+
+func (c *RistrettoCostedCachePartition[K, V]) Set(key K, value V) {
+	cost := value.CacheCost()
+	c.setWithCost(key, value, int64(cost))
+}
+
 type RistrettoCachePartition[K keyable, V any] struct {
 	cache   *ristretto.Cache
 	Prefix  byte
@@ -163,13 +172,4 @@ func (c *RistrettoCachePartition[K, V]) Get(key K) (value V, ok bool) {
 	}
 	value, ok = v.(V)
 	return
-}
-
-type RistrettoCostedCachePartition[k keyable, v costable] struct {
-	*RistrettoCachePartition[k, v]
-}
-
-func (c *RistrettoCostedCachePartition[K, V]) Set(key K, value V) {
-	cost := value.CacheCost()
-	c.setWithCost(key, value, int64(cost))
 }

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -51,6 +51,10 @@ func NewRistrettoCache(maxCost CacheSize, enablePrometheus bool) (*Caches, error
 			cache: cache,
 			Name:  "room_ids",
 		},
+		RoomServerEvents: &RistrettoCachePartition[int64, *gomatrixserverlib.Event]{
+			cache: cache,
+			Name:  "room_events",
+		},
 		RoomInfos: &RistrettoCachePartition[string, types.RoomInfo]{
 			cache:   cache,
 			Name:    "room_infos",

--- a/internal/eventutil/events.go
+++ b/internal/eventutil/events.go
@@ -170,20 +170,18 @@ func truncateAuthAndPrevEvents(auth, prev []gomatrixserverlib.EventReference) (
 
 // RedactEvent redacts the given event and sets the unsigned field appropriately. This should be used by
 // downstream components to the roomserver when an OutputTypeRedactedEvent occurs.
-func RedactEvent(redactionEvent, redactedEvent *gomatrixserverlib.Event) (*gomatrixserverlib.Event, error) {
+func RedactEvent(redactionEvent, redactedEvent *gomatrixserverlib.Event) error {
 	// sanity check
 	if redactionEvent.Type() != gomatrixserverlib.MRoomRedaction {
-		return nil, fmt.Errorf("RedactEvent: redactionEvent isn't a redaction event, is '%s'", redactionEvent.Type())
+		return fmt.Errorf("RedactEvent: redactionEvent isn't a redaction event, is '%s'", redactionEvent.Type())
 	}
-	r := redactedEvent.Redact()
-	err := r.SetUnsignedField("redacted_because", redactionEvent)
-	if err != nil {
-		return nil, err
+	redactedEvent.Redact()
+	if err := redactedEvent.SetUnsignedField("redacted_because", redactionEvent); err != nil {
+		return err
 	}
 	// NOTSPEC: sytest relies on this unspecced field existing :(
-	err = r.SetUnsignedField("redacted_by", redactionEvent.EventID())
-	if err != nil {
-		return nil, err
+	if err := redactedEvent.SetUnsignedField("redacted_by", redactionEvent.EventID()); err != nil {
+		return err
 	}
-	return r, nil
+	return nil
 }

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -319,11 +319,9 @@ func (r *Inputer) processRoomEvent(
 
 	// if storing this event results in it being redacted then do so.
 	if !isRejected && redactedEventID == event.EventID() {
-		r, rerr := eventutil.RedactEvent(redactionEvent, event)
-		if rerr != nil {
+		if err = eventutil.RedactEvent(redactionEvent, event); err != nil {
 			return fmt.Errorf("eventutil.RedactEvent: %w", rerr)
 		}
-		event = r
 	}
 
 	// For outliers we can stop after we've stored the event itself as it

--- a/roomserver/internal/input/input_test.go
+++ b/roomserver/internal/input/input_test.go
@@ -48,7 +48,7 @@ func TestSingleTransactionOnInput(t *testing.T) {
 		Kind:  api.KindOutlier, // don't panic if we generate an output event
 		Event: event.Headered(gomatrixserverlib.RoomVersionV6),
 	}
-	cache, err := caching.NewRistrettoCache(8*1024*1024, false)
+	cache, err := caching.NewRistrettoCache(8*1024*1024, time.Hour, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/roomserver/internal/input/input_test.go
+++ b/roomserver/internal/input/input_test.go
@@ -48,7 +48,7 @@ func TestSingleTransactionOnInput(t *testing.T) {
 		Kind:  api.KindOutlier, // don't panic if we generate an output event
 		Event: event.Headered(gomatrixserverlib.RoomVersionV6),
 	}
-	cache, err := caching.NewRistrettoCache(8*caching.MB, false)
+	cache, err := caching.NewRistrettoCache(8*1024*1024, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/roomserver/internal/input/input_test.go
+++ b/roomserver/internal/input/input_test.go
@@ -48,10 +48,6 @@ func TestSingleTransactionOnInput(t *testing.T) {
 		Kind:  api.KindOutlier, // don't panic if we generate an output event
 		Event: event.Headered(gomatrixserverlib.RoomVersionV6),
 	}
-	cache, err := caching.NewRistrettoCache(8*1024*1024, time.Hour, false)
-	if err != nil {
-		t.Fatal(err)
-	}
 	db, err := storage.Open(
 		nil,
 		&config.DatabaseOptions{
@@ -59,7 +55,7 @@ func TestSingleTransactionOnInput(t *testing.T) {
 			MaxOpenConnections: 1,
 			MaxIdleConnections: 1,
 		},
-		cache,
+		caching.NewRistrettoCache(8*1024*1024, time.Hour, false),
 	)
 	if err != nil {
 		t.Logf("PostgreSQL not available (%s), skipping", err)

--- a/roomserver/internal/perform/perform_backfill.go
+++ b/roomserver/internal/perform/perform_backfill.go
@@ -593,12 +593,11 @@ func persistEvents(ctx context.Context, db storage.Database, events []*gomatrixs
 		// redacted, which we don't care about since we aren't returning it in this backfill.
 		if redactedEventID == ev.EventID() {
 			eventToRedact := ev.Unwrap()
-			redactedEvent, err := eventutil.RedactEvent(redactionEvent, eventToRedact)
-			if err != nil {
+			if err := eventutil.RedactEvent(redactionEvent, eventToRedact); err != nil {
 				logrus.WithError(err).WithField("event_id", ev.EventID()).Error("Failed to redact event")
 				continue
 			}
-			ev = redactedEvent.Headered(ev.RoomVersion)
+			ev = eventToRedact.Headered(ev.RoomVersion)
 			events[j] = ev
 		}
 		backfilledEventMap[ev.EventID()] = types.Event{

--- a/roomserver/state/state.go
+++ b/roomserver/state/state.go
@@ -1036,7 +1036,6 @@ func (v *StateResolution) loadStateEvents(
 			eventNIDs = append(eventNIDs, entry.EventNID)
 		}
 	}
-	sort.Sort(eventNIDs)
 	events, err := v.db.Events(ctx, eventNIDs)
 	if err != nil {
 		return nil, nil, err

--- a/roomserver/state/state.go
+++ b/roomserver/state/state.go
@@ -1027,7 +1027,7 @@ func (v *StateResolution) loadStateEvents(
 
 	result := make([]*gomatrixserverlib.Event, 0, len(entries))
 	eventEntries := make([]types.StateEntry, 0, len(entries))
-	eventNIDs := make([]types.EventNID, 0, len(entries))
+	eventNIDs := make(types.EventNIDs, 0, len(entries))
 	for _, entry := range entries {
 		if e, ok := v.events[entry.EventNID]; ok {
 			result = append(result, e)
@@ -1036,6 +1036,7 @@ func (v *StateResolution) loadStateEvents(
 			eventNIDs = append(eventNIDs, entry.EventNID)
 		}
 	}
+	sort.Sort(eventNIDs)
 	events, err := v.db.Events(ctx, eventNIDs)
 	if err != nil {
 		return nil, nil, err

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -438,7 +438,7 @@ func (d *Database) events(
 	results := make([]types.Event, len(inputEventNIDs))
 	eventNIDs := make([]types.EventNID, 0, len(results))
 	for _, nid := range inputEventNIDs {
-		if event, ok := d.Cache.GetRoomServerEvent(nid); ok {
+		if event, ok := d.Cache.GetRoomServerEvent(nid); ok && event != nil {
 			results = append(results, types.Event{
 				EventNID: nid,
 				Event:    event,

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -493,7 +493,7 @@ func (d *Database) events(
 		if err != nil {
 			return nil, err
 		}
-		if result.Event != nil {
+		if event != nil {
 			d.Cache.StoreRoomServerEvent(eventJSON.EventNID, event)
 		}
 		result.Event = event

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -875,7 +875,7 @@ func (d *Database) handleRedactions(
 
 	// mark the event as redacted
 	if redactionsArePermanent {
-		redactedEvent.Event = redactedEvent.Redact()
+		redactedEvent.Redact()
 	}
 
 	err = redactedEvent.SetUnsignedField("redacted_because", redactionEvent)
@@ -947,7 +947,7 @@ func (d *Database) loadRedactionPair(
 func (d *Database) applyRedactions(events []types.Event) {
 	for i := range events {
 		if result := gjson.GetBytes(events[i].Unsigned(), "redacted_because"); result.Exists() {
-			events[i].Event = events[i].Redact()
+			events[i].Redact()
 		}
 	}
 }

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -433,8 +433,9 @@ func (d *Database) Events(
 }
 
 func (d *Database) events(
-	ctx context.Context, txn *sql.Tx, inputEventNIDs []types.EventNID,
+	ctx context.Context, txn *sql.Tx, inputEventNIDs types.EventNIDs,
 ) ([]types.Event, error) {
+	sort.Sort(inputEventNIDs)
 	events := make(map[types.EventNID]*gomatrixserverlib.Event, len(inputEventNIDs))
 	eventNIDs := make([]types.EventNID, 0, len(inputEventNIDs))
 	for _, nid := range inputEventNIDs {
@@ -496,7 +497,7 @@ func (d *Database) events(
 	for _, nid := range inputEventNIDs {
 		event, ok := events[nid]
 		if !ok || event == nil {
-			panic("missing event")
+			return nil, fmt.Errorf("event %d missing", nid)
 		}
 		results = append(results, types.Event{
 			EventNID: nid,

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -501,10 +501,14 @@ func (d *Database) events(
 		if !ok {
 			panic("should have position")
 		}
+		delete(positions, result.EventNID)
 		results[pos] = result
 		if result.Event != nil {
 			d.Cache.StoreRoomServerEvent(result.EventNID, result.Event)
 		}
+	}
+	if len(positions) > 0 {
+		panic("unsatisfied events")
 	}
 	if !redactionsArePermanent {
 		d.applyRedactions(results)

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -493,7 +493,9 @@ func (d *Database) events(
 		if err != nil {
 			return nil, err
 		}
-		d.Cache.StoreRoomServerEvent(result.EventNID, result.Event)
+		if result.Event != nil {
+			d.Cache.StoreRoomServerEvent(result.EventNID, result.Event)
+		}
 	}
 	if !redactionsArePermanent {
 		d.applyRedactions(results)

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -437,7 +437,7 @@ func (d *Database) events(
 ) ([]types.Event, error) {
 	results := make([]types.Event, len(inputEventNIDs))
 	eventNIDs := make([]types.EventNID, 0, len(results))
-	for _, nid := range eventNIDs {
+	for _, nid := range inputEventNIDs {
 		if event, ok := d.Cache.GetRoomServerEvent(nid); ok {
 			results = append(results, types.Event{
 				EventNID: nid,
@@ -487,15 +487,16 @@ func (d *Database) events(
 		result.EventNID = eventJSON.EventNID
 		roomNID := roomNIDs[result.EventNID]
 		roomVersion := roomVersions[roomNID]
-		result.Event, err = gomatrixserverlib.NewEventFromTrustedJSONWithEventID(
+		event, err := gomatrixserverlib.NewEventFromTrustedJSONWithEventID(
 			eventIDs[eventJSON.EventNID], eventJSON.EventJSON, false, roomVersion,
 		)
 		if err != nil {
 			return nil, err
 		}
 		if result.Event != nil {
-			d.Cache.StoreRoomServerEvent(result.EventNID, result.Event)
+			d.Cache.StoreRoomServerEvent(eventJSON.EventNID, event)
 		}
+		result.Event = event
 	}
 	if !redactionsArePermanent {
 		d.applyRedactions(results)

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -495,7 +495,7 @@ func (d *Database) events(
 	results := make([]types.Event, 0, len(inputEventNIDs))
 	for _, nid := range inputEventNIDs {
 		event, ok := events[nid]
-		if !ok {
+		if !ok || event == nil {
 			panic("missing event")
 		}
 		results = append(results, types.Event{

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -487,16 +487,15 @@ func (d *Database) events(
 		result.EventNID = eventJSON.EventNID
 		roomNID := roomNIDs[result.EventNID]
 		roomVersion := roomVersions[roomNID]
-		event, err := gomatrixserverlib.NewEventFromTrustedJSONWithEventID(
+		result.Event, err = gomatrixserverlib.NewEventFromTrustedJSONWithEventID(
 			eventIDs[eventJSON.EventNID], eventJSON.EventJSON, false, roomVersion,
 		)
 		if err != nil {
 			return nil, err
 		}
-		if event != nil {
-			d.Cache.StoreRoomServerEvent(eventJSON.EventNID, event)
+		if result.Event != nil {
+			d.Cache.StoreRoomServerEvent(result.EventNID, result.Event)
 		}
-		result.Event = event
 	}
 	if !redactionsArePermanent {
 		d.applyRedactions(results)

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -997,10 +997,10 @@ func (d *Database) GetStateEvent(ctx context.Context, roomID, evType, stateKey s
 	if err != nil {
 		return nil, err
 	}
-	var inDatabase []types.EventNID
+	var eventNIDs []types.EventNID
 	for _, e := range entries {
 		if e.EventTypeNID == eventTypeNID && e.EventStateKeyNID == stateKeyNID {
-			inDatabase = append(inDatabase, e.EventNID)
+			eventNIDs = append(eventNIDs, e.EventNID)
 		}
 	}
 	eventIDs, _ := d.EventsTable.BulkSelectEventID(ctx, nil, eventNIDs)
@@ -1054,10 +1054,10 @@ func (d *Database) GetStateEventsWithEventType(ctx context.Context, roomID, evTy
 	if err != nil {
 		return nil, err
 	}
-	var inDatabase []types.EventNID
+	var eventNIDs []types.EventNID
 	for _, e := range entries {
 		if e.EventTypeNID == eventTypeNID {
-			inDatabase = append(inDatabase, e.EventNID)
+			eventNIDs = append(eventNIDs, e.EventNID)
 		}
 	}
 	eventIDs, _ := d.EventsTable.BulkSelectEventID(ctx, nil, eventNIDs)
@@ -1065,7 +1065,7 @@ func (d *Database) GetStateEventsWithEventType(ctx context.Context, roomID, evTy
 		eventIDs = map[types.EventNID]string{}
 	}
 	// return the events requested
-	eventPairs, err := d.EventJSONTable.BulkSelectEventJSON(ctx, nil, inDatabase)
+	eventPairs, err := d.EventJSONTable.BulkSelectEventJSON(ctx, nil, eventNIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -1158,7 +1158,7 @@ func (d *Database) GetBulkStateContent(ctx context.Context, roomIDs []string, tu
 		stateKeyNIDSet[nid] = true
 	}
 
-	var inDatabase []types.EventNID
+	var eventNIDs []types.EventNID
 	eventNIDToVer := make(map[types.EventNID]gomatrixserverlib.RoomVersion)
 	// TODO: This feels like this is going to be really slow...
 	for _, roomID := range roomIDs {
@@ -1177,7 +1177,7 @@ func (d *Database) GetBulkStateContent(ctx context.Context, roomIDs []string, tu
 		for _, entry := range entries {
 			if typeNIDSet[entry.EventTypeNID] {
 				if allowWildcard[entry.EventTypeNID] || stateKeyNIDSet[entry.EventStateKeyNID] {
-					inDatabase = append(inDatabase, entry.EventNID)
+					eventNIDs = append(eventNIDs, entry.EventNID)
 					eventNIDToVer[entry.EventNID] = roomInfo.RoomVersion
 				}
 			}
@@ -1187,7 +1187,7 @@ func (d *Database) GetBulkStateContent(ctx context.Context, roomIDs []string, tu
 	if err != nil {
 		eventIDs = map[types.EventNID]string{}
 	}
-	events, err := d.EventJSONTable.BulkSelectEventJSON(ctx, nil, inDatabase)
+	events, err := d.EventJSONTable.BulkSelectEventJSON(ctx, nil, eventNIDs)
 	if err != nil {
 		return nil, fmt.Errorf("GetBulkStateContent: failed to load event JSON for event nids: %w", err)
 	}

--- a/setup/base/base.go
+++ b/setup/base/base.go
@@ -161,7 +161,7 @@ func NewBaseDendrite(cfg *config.Dendrite, componentName string, options ...Base
 		}
 	}
 
-	cache, err := caching.NewRistrettoCache(caching.MB*64, enableMetrics)
+	cache, err := caching.NewRistrettoCache(1*caching.GB, enableMetrics)
 	if err != nil {
 		logrus.WithError(err).Warnf("Failed to create cache")
 	}

--- a/setup/base/base.go
+++ b/setup/base/base.go
@@ -161,7 +161,7 @@ func NewBaseDendrite(cfg *config.Dendrite, componentName string, options ...Base
 		}
 	}
 
-	cache, err := caching.NewRistrettoCache(1*caching.GB, enableMetrics)
+	cache, err := caching.NewRistrettoCache(caching.MB*64, enableMetrics)
 	if err != nil {
 		logrus.WithError(err).Warnf("Failed to create cache")
 	}

--- a/setup/base/base.go
+++ b/setup/base/base.go
@@ -161,7 +161,7 @@ func NewBaseDendrite(cfg *config.Dendrite, componentName string, options ...Base
 		}
 	}
 
-	cache, err := caching.NewRistrettoCache(cfg.Global.Cache.EstMaxSize, enableMetrics)
+	cache, err := caching.NewRistrettoCache(cfg.Global.Cache.EstMaxSize, cfg.Global.Cache.MaxAge, enableMetrics)
 	if err != nil {
 		logrus.WithError(err).Warnf("Failed to create cache")
 	}

--- a/setup/base/base.go
+++ b/setup/base/base.go
@@ -161,7 +161,7 @@ func NewBaseDendrite(cfg *config.Dendrite, componentName string, options ...Base
 		}
 	}
 
-	cache, err := caching.NewRistrettoCache(1*caching.GB, enableMetrics)
+	cache, err := caching.NewRistrettoCache(cfg.Global.Caches.EstMaxSize, enableMetrics)
 	if err != nil {
 		logrus.WithError(err).Warnf("Failed to create cache")
 	}

--- a/setup/base/base.go
+++ b/setup/base/base.go
@@ -161,11 +161,6 @@ func NewBaseDendrite(cfg *config.Dendrite, componentName string, options ...Base
 		}
 	}
 
-	cache, err := caching.NewRistrettoCache(cfg.Global.Cache.EstimatedMaxSize, cfg.Global.Cache.MaxAge, enableMetrics)
-	if err != nil {
-		logrus.WithError(err).Fatalf("Failed to create cache")
-	}
-
 	var dnsCache *gomatrixserverlib.DNSCache
 	if cfg.Global.DNSCache.Enabled {
 		dnsCache = gomatrixserverlib.NewDNSCache(
@@ -233,7 +228,7 @@ func NewBaseDendrite(cfg *config.Dendrite, componentName string, options ...Base
 		UseHTTPAPIs:            useHTTPAPIs,
 		tracerCloser:           closer,
 		Cfg:                    cfg,
-		Caches:                 cache,
+		Caches:                 caching.NewRistrettoCache(cfg.Global.Cache.EstimatedMaxSize, cfg.Global.Cache.MaxAge, enableMetrics),
 		DNSCache:               dnsCache,
 		PublicClientAPIMux:     mux.NewRouter().SkipClean(true).PathPrefix(httputil.PublicClientPathPrefix).Subrouter().UseEncodedPath(),
 		PublicFederationAPIMux: mux.NewRouter().SkipClean(true).PathPrefix(httputil.PublicFederationPathPrefix).Subrouter().UseEncodedPath(),

--- a/setup/base/base.go
+++ b/setup/base/base.go
@@ -161,9 +161,9 @@ func NewBaseDendrite(cfg *config.Dendrite, componentName string, options ...Base
 		}
 	}
 
-	cache, err := caching.NewRistrettoCache(cfg.Global.Cache.EstMaxSize, cfg.Global.Cache.MaxAge, enableMetrics)
+	cache, err := caching.NewRistrettoCache(cfg.Global.Cache.EstimatedMaxSize, cfg.Global.Cache.MaxAge, enableMetrics)
 	if err != nil {
-		logrus.WithError(err).Warnf("Failed to create cache")
+		logrus.WithError(err).Fatalf("Failed to create cache")
 	}
 
 	var dnsCache *gomatrixserverlib.DNSCache

--- a/setup/base/base.go
+++ b/setup/base/base.go
@@ -161,7 +161,7 @@ func NewBaseDendrite(cfg *config.Dendrite, componentName string, options ...Base
 		}
 	}
 
-	cache, err := caching.NewRistrettoCache(cfg.Global.Caches.EstMaxSize, enableMetrics)
+	cache, err := caching.NewRistrettoCache(cfg.Global.Cache.EstMaxSize, enableMetrics)
 	if err != nil {
 		logrus.WithError(err).Warnf("Failed to create cache")
 	}

--- a/setup/config/config_global.go
+++ b/setup/config/config_global.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"math/rand"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/matrix-org/gomatrixserverlib"
@@ -174,7 +176,7 @@ func (c *ServerNotices) Defaults(generate bool) {
 func (c *ServerNotices) Verify(errors *ConfigErrors, isMonolith bool) {}
 
 type Cache struct {
-	EstMaxSize int64 `yaml:"max_bytes_est"`
+	EstMaxSize DataUnit `yaml:"max_bytes_est"`
 }
 
 func (c *Cache) Defaults(generate bool) {
@@ -284,4 +286,29 @@ type PresenceOptions struct {
 	EnableInbound bool `yaml:"enable_inbound"`
 	// Whether outbound presence events are allowed
 	EnableOutbound bool `yaml:"enable_outbound"`
+}
+
+type DataUnit int64
+
+func (d *DataUnit) UnmarshalText(text []byte) error {
+	var magnitude float64
+	s := strings.ToLower(string(text))
+	switch {
+	case strings.HasSuffix(s, "tb"):
+		s, magnitude = s[:len(s)-2], 1024*1024*1024*1024
+	case strings.HasSuffix(s, "gb"):
+		s, magnitude = s[:len(s)-2], 1024*1024*1024
+	case strings.HasSuffix(s, "mb"):
+		s, magnitude = s[:len(s)-2], 1024*1024
+	case strings.HasSuffix(s, "kb"):
+		s, magnitude = s[:len(s)-2], 1024
+	default:
+		magnitude = 1
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return err
+	}
+	*d = DataUnit(v * magnitude)
+	return nil
 }

--- a/setup/config/config_global.go
+++ b/setup/config/config_global.go
@@ -176,7 +176,7 @@ func (c *ServerNotices) Defaults(generate bool) {
 func (c *ServerNotices) Verify(errors *ConfigErrors, isMonolith bool) {}
 
 type Cache struct {
-	EstMaxSize DataUnit      `yaml:"max_bytes_est"`
+	EstMaxSize DataUnit      `yaml:"max_size_est"`
 	MaxAge     time.Duration `yaml:"max_age"`
 }
 
@@ -186,7 +186,7 @@ func (c *Cache) Defaults(generate bool) {
 }
 
 func (c *Cache) Verify(errors *ConfigErrors, isMonolith bool) {
-	checkPositive(errors, "max_bytes_est", int64(c.EstMaxSize))
+	checkPositive(errors, "max_size_est", int64(c.EstMaxSize))
 }
 
 // ReportStats configures opt-in anonymous stats reporting.

--- a/setup/config/config_global.go
+++ b/setup/config/config_global.go
@@ -73,6 +73,9 @@ type Global struct {
 
 	// ReportStats configures opt-in anonymous stats reporting.
 	ReportStats ReportStats `yaml:"report_stats"`
+
+	// Configuration for the caches.
+	Caches Caches `yaml:"caches"`
 }
 
 func (c *Global) Defaults(generate bool) {
@@ -90,6 +93,7 @@ func (c *Global) Defaults(generate bool) {
 	c.Sentry.Defaults()
 	c.ServerNotices.Defaults(generate)
 	c.ReportStats.Defaults()
+	c.Caches.Defaults(generate)
 }
 
 func (c *Global) Verify(configErrs *ConfigErrors, isMonolith bool) {
@@ -102,6 +106,7 @@ func (c *Global) Verify(configErrs *ConfigErrors, isMonolith bool) {
 	c.DNSCache.Verify(configErrs, isMonolith)
 	c.ServerNotices.Verify(configErrs, isMonolith)
 	c.ReportStats.Verify(configErrs, isMonolith)
+	c.Caches.Verify(configErrs, isMonolith)
 }
 
 type OldVerifyKeys struct {
@@ -167,6 +172,20 @@ func (c *ServerNotices) Defaults(generate bool) {
 }
 
 func (c *ServerNotices) Verify(errors *ConfigErrors, isMonolith bool) {}
+
+type Caches struct {
+	Enabled    bool  `yaml:"enabled"`
+	EstMaxSize int64 `yaml:"max_bytes_est"`
+}
+
+func (c *Caches) Defaults(generate bool) {
+	c.Enabled = true
+	c.EstMaxSize = 1024 * 1024 * 1024 // 1GB
+}
+
+func (c *Caches) Verify(errors *ConfigErrors, isMonolith bool) {
+	checkPositive(errors, "max_bytes_est", int64(c.EstMaxSize))
+}
 
 // ReportStats configures opt-in anonymous stats reporting.
 type ReportStats struct {

--- a/setup/config/config_global.go
+++ b/setup/config/config_global.go
@@ -176,11 +176,13 @@ func (c *ServerNotices) Defaults(generate bool) {
 func (c *ServerNotices) Verify(errors *ConfigErrors, isMonolith bool) {}
 
 type Cache struct {
-	EstMaxSize DataUnit `yaml:"max_bytes_est"`
+	EstMaxSize DataUnit      `yaml:"max_bytes_est"`
+	MaxAge     time.Duration `yaml:"max_age"`
 }
 
 func (c *Cache) Defaults(generate bool) {
 	c.EstMaxSize = 1024 * 1024 * 1024 // 1GB
+	c.MaxAge = time.Hour
 }
 
 func (c *Cache) Verify(errors *ConfigErrors, isMonolith bool) {

--- a/setup/config/config_global.go
+++ b/setup/config/config_global.go
@@ -176,17 +176,17 @@ func (c *ServerNotices) Defaults(generate bool) {
 func (c *ServerNotices) Verify(errors *ConfigErrors, isMonolith bool) {}
 
 type Cache struct {
-	EstMaxSize DataUnit      `yaml:"max_size_est"`
-	MaxAge     time.Duration `yaml:"max_age"`
+	EstimatedMaxSize DataUnit      `yaml:"max_size_estimated"`
+	MaxAge           time.Duration `yaml:"max_age"`
 }
 
 func (c *Cache) Defaults(generate bool) {
-	c.EstMaxSize = 1024 * 1024 * 1024 // 1GB
+	c.EstimatedMaxSize = 1024 * 1024 * 1024 // 1GB
 	c.MaxAge = time.Hour
 }
 
 func (c *Cache) Verify(errors *ConfigErrors, isMonolith bool) {
-	checkPositive(errors, "max_size_est", int64(c.EstMaxSize))
+	checkPositive(errors, "max_size_estimated", int64(c.EstimatedMaxSize))
 }
 
 // ReportStats configures opt-in anonymous stats reporting.

--- a/setup/config/config_global.go
+++ b/setup/config/config_global.go
@@ -75,7 +75,7 @@ type Global struct {
 	ReportStats ReportStats `yaml:"report_stats"`
 
 	// Configuration for the caches.
-	Caches Caches `yaml:"caches"`
+	Cache Cache `yaml:"cache"`
 }
 
 func (c *Global) Defaults(generate bool) {
@@ -93,7 +93,7 @@ func (c *Global) Defaults(generate bool) {
 	c.Sentry.Defaults()
 	c.ServerNotices.Defaults(generate)
 	c.ReportStats.Defaults()
-	c.Caches.Defaults(generate)
+	c.Cache.Defaults(generate)
 }
 
 func (c *Global) Verify(configErrs *ConfigErrors, isMonolith bool) {
@@ -106,7 +106,7 @@ func (c *Global) Verify(configErrs *ConfigErrors, isMonolith bool) {
 	c.DNSCache.Verify(configErrs, isMonolith)
 	c.ServerNotices.Verify(configErrs, isMonolith)
 	c.ReportStats.Verify(configErrs, isMonolith)
-	c.Caches.Verify(configErrs, isMonolith)
+	c.Cache.Verify(configErrs, isMonolith)
 }
 
 type OldVerifyKeys struct {
@@ -173,17 +173,15 @@ func (c *ServerNotices) Defaults(generate bool) {
 
 func (c *ServerNotices) Verify(errors *ConfigErrors, isMonolith bool) {}
 
-type Caches struct {
-	Enabled    bool  `yaml:"enabled"`
+type Cache struct {
 	EstMaxSize int64 `yaml:"max_bytes_est"`
 }
 
-func (c *Caches) Defaults(generate bool) {
-	c.Enabled = true
+func (c *Cache) Defaults(generate bool) {
 	c.EstMaxSize = 1024 * 1024 * 1024 // 1GB
 }
 
-func (c *Caches) Verify(errors *ConfigErrors, isMonolith bool) {
+func (c *Cache) Verify(errors *ConfigErrors, isMonolith bool) {
 	checkPositive(errors, "max_bytes_est", int64(c.EstMaxSize))
 }
 

--- a/setup/config/config_test.go
+++ b/setup/config/config_test.go
@@ -17,6 +17,8 @@ package config
 import (
 	"fmt"
 	"testing"
+
+	"gopkg.in/yaml.v2"
 )
 
 func TestLoadConfigRelative(t *testing.T) {
@@ -268,3 +270,22 @@ n0Xq64k7fc42HXJpF8CGBkSaIhtlzcruO+vqR80B9r62+D0V7VmHOnP135MT6noU
 ANAf5kxmMsM0zlN2hkxl0H6o7wKlBSw3RI3cjfilXiMWRPJrzlc4
 -----END CERTIFICATE-----
 `
+
+func TestUnmarshalDataUnit(t *testing.T) {
+	target := struct {
+		Got DataUnit `yaml:"value"`
+	}{}
+	for input, expect := range map[string]DataUnit{
+		"value: 0.6tb": 659706976665,
+		"value: 1.2gb": 1288490188,
+		"value: 256mb": 268435456,
+		"value: 128kb": 131072,
+		"value: 128":   128,
+	} {
+		if err := yaml.Unmarshal([]byte(input), &target); err != nil {
+			t.Fatal(err)
+		} else if target.Got != expect {
+			t.Fatalf("expected value %d but got %d", expect, target.Got)
+		}
+	}
+}

--- a/syncapi/storage/shared/syncserver.go
+++ b/syncapi/storage/shared/syncserver.go
@@ -545,12 +545,11 @@ func (d *Database) RedactEvent(ctx context.Context, redactedEventID string, reda
 	}
 	eventToRedact := redactedEvents[0].Unwrap()
 	redactionEvent := redactedBecause.Unwrap()
-	ev, err := eventutil.RedactEvent(redactionEvent, eventToRedact)
-	if err != nil {
+	if err = eventutil.RedactEvent(redactionEvent, eventToRedact); err != nil {
 		return err
 	}
 
-	newEvent := ev.Headered(redactedBecause.RoomVersion)
+	newEvent := eventToRedact.Headered(redactedBecause.RoomVersion)
 	err = d.Writer.Do(nil, nil, func(txn *sql.Tx) error {
 		return d.OutputEvents.UpdateEventJSON(ctx, newEvent)
 	})


### PR DESCRIPTION
This places the built-in LRU caches with a new [Ristretto](https://github.com/dgraph-io/ristretto) cache. 

The discipline of this cache is rather different to before. Whereas the LRU cache would have admitted any new entry and evicted the least used one, Ristretto is much more conservative — it won't admit a cache entry on the first try and will only admit new entries if they are actually an improvement on the ones that are already in the cache. On the whole, this means that the cache quality should overall be much better and maintain items that are more useful to us over time.

In addition to this, because the entries are now costed (based on an in-memory estimate of their size), we can now *reasonably* cap the size of the cache. It's not a hard limit but it should be good enough to prevent unbounded cache growth on systems with limited memory.

Age is bounded too (although configurable) because this gives the cache a better opportunity to refresh itself over time. A much bigger cache will benefit from a longer age but a smaller cache may benefit from refreshing more often.

Finally, the other notable change is the use of generics here, so this effectively lifts our baseline supported Go version from 1.16 to 1.18. The upside is that managing the different cache partitions is now considerably simpler as they don't require runtime type assertions anymore.

A future piece of work could be to remove some of the outward-facing interfaces but there's very little overhead there to worry about for now.