### PR TITLE
Tweak cache counters

### DIFF
--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -44,9 +44,9 @@ const (
 
 func NewRistrettoCache(maxCost config.DataUnit, maxAge time.Duration, enablePrometheus bool) *Caches {
 	cache, err := ristretto.NewCache(&ristretto.Config{
-		NumCounters: 1e5, // 10x number of expected cache items, affects bloom filter size, gives us room for 10,000 currently
-		BufferItems: 64,  // recommended by the ristretto godocs as a sane buffer size value
-		MaxCost:     int64(maxCost),
+		NumCounters: int64((maxCost / 1024) * 10), // 10 counters per 1KB data, affects bloom filter size
+		BufferItems: 64,                           // recommended by the ristretto godocs as a sane buffer size value
+		MaxCost:     int64(maxCost),               // max cost is in bytes, as per the Dendrite config
 		Metrics:     true,
 		KeyToHash: func(key interface{}) (uint64, uint64) {
 			return z.KeyToHash(key)
@@ -70,6 +70,7 @@ func NewRistrettoCache(maxCost config.DataUnit, maxAge time.Duration, enableProm
 		}, func() float64 {
 			return float64(cache.Metrics.CostAdded() - cache.Metrics.CostEvicted())
 		})
+		cache.Metrics.GetsKept()
 	}
 	return &Caches{
 		RoomVersions: &RistrettoCachePartition[string, gomatrixserverlib.RoomVersion]{ // room ID -> room version


### PR DESCRIPTION
This makes the number of counters relative to the maximum cache size, rather than a fixed value. Since the counters effectively manage the size of the bloom filter, larger caches need more counters and smaller caches need less.

10 counters per 1KB data means that the default cache size of 1GB should result in an estimated 16MB for the bloom filter and TinyLRU admission set. It seems to work well on dendrite.matrix.org but we can always tweak it again in future if needs be.