### PR TITLE
Fix issue with membership event_nid being 0

### DIFF
--- a/roomserver/storage/shared/membership_updater.go
+++ b/roomserver/storage/shared/membership_updater.go
@@ -105,8 +105,15 @@ func (u *MembershipUpdater) SetToInvite(event *gomatrixserverlib.Event) (bool, e
 		if err != nil {
 			return fmt.Errorf("u.d.InvitesTable.InsertInviteEvent: %w", err)
 		}
+
+		// Look up the NID of the invite event
+		nIDs, err := u.d.eventNIDs(u.ctx, u.txn, []string{event.EventID()}, false)
+		if err != nil {
+			return fmt.Errorf("u.d.EventNIDs: %w", err)
+		}
+
 		if u.membership != tables.MembershipStateInvite {
-			if inserted, err = u.d.MembershipTable.UpdateMembership(u.ctx, u.txn, u.roomNID, u.targetUserNID, senderUserNID, tables.MembershipStateInvite, 0, false); err != nil {
+			if inserted, err = u.d.MembershipTable.UpdateMembership(u.ctx, u.txn, u.roomNID, u.targetUserNID, senderUserNID, tables.MembershipStateInvite, nIDs[event.EventID()], false); err != nil {
 				return fmt.Errorf("u.d.MembershipTable.UpdateMembership: %w", err)
 			}
 		}


### PR DESCRIPTION
Fixes an issue with membership event_nid being 0 when querying `/members`.
Not sure if we rely on the nid being 0 anywhere, couldn't find anything.

```
ERRO[2022-07-20T09:47:14.028210863Z] rsAPI.QueryMembershipsForRoom failed          error="event 0 missing" req.id=oa7J3zUrY0tm req.method=GET req.path="/_matrix/client/r0/rooms/!rlGcoH8QQTakCJIn:localhost/members"
```