### PR TITLE
Optimise checking other servers allowed to see events

### DIFF
--- a/roomserver/internal/helpers/helpers.go
+++ b/roomserver/internal/helpers/helpers.go
@@ -233,57 +233,6 @@ func LoadStateEvents(
 func CheckServerAllowedToSeeEvent(
 	ctx context.Context, db storage.Database, info *types.RoomInfo, eventID string, serverName gomatrixserverlib.ServerName, isServerInRoom bool,
 ) (bool, error) {
-	/*
-		roomState := state.NewStateResolution(db, info)
-		stateEntries, err := roomState.LoadStateAtEvent(ctx, eventID)
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return false, nil
-			}
-			return false, fmt.Errorf("roomState.LoadStateAtEvent: %w", err)
-		}
-
-		// Extract all of the event state key NIDs from the room state.
-		var stateKeyNIDs []types.EventStateKeyNID
-		for _, entry := range stateEntries {
-			stateKeyNIDs = append(stateKeyNIDs, entry.EventStateKeyNID)
-		}
-
-		// Then request those state key NIDs from the database.
-		stateKeys, err := db.EventStateKeys(ctx, stateKeyNIDs)
-		if err != nil {
-			return false, fmt.Errorf("db.EventStateKeys: %w", err)
-		}
-
-		// If the event state key doesn't match the given servername
-		// then we'll filter it out. This does preserve state keys that
-		// are "" since these will contain history visibility etc.
-		for nid, key := range stateKeys {
-			if key != "" && !strings.HasSuffix(key, ":"+string(serverName)) {
-				delete(stateKeys, nid)
-			}
-		}
-
-		// Now filter through all of the state events for the room.
-		// If the state key NID appears in the list of valid state
-		// keys then we'll add it to the list of filtered entries.
-		var filteredEntries []types.StateEntry
-		for _, entry := range stateEntries {
-			if _, ok := stateKeys[entry.EventStateKeyNID]; ok {
-				filteredEntries = append(filteredEntries, entry)
-			}
-		}
-
-		if len(filteredEntries) == 0 {
-			return false, nil
-		}
-
-		stateAtEvent, err := LoadStateEvents(ctx, db, filteredEntries)
-		if err != nil {
-			return false, err
-		}
-	*/
-
 	stateAtEvent, err := db.GetHistoryVisibilityState(ctx, info, eventID, string(serverName))
 	if err != nil {
 		return false, err

--- a/roomserver/state/state.go
+++ b/roomserver/state/state.go
@@ -124,6 +124,29 @@ func (v *StateResolution) LoadStateAtEvent(
 	return stateEntries, nil
 }
 
+// LoadStateAtEvent loads the full state of a room before a particular event.
+func (v *StateResolution) LoadStateAtEventForHistoryVisibility(
+	ctx context.Context, eventID string,
+) ([]types.StateEntry, error) {
+	span, ctx := opentracing.StartSpanFromContext(ctx, "StateResolution.LoadStateAtEvent")
+	defer span.Finish()
+
+	snapshotNID, err := v.db.SnapshotNIDFromEventID(ctx, eventID)
+	if err != nil {
+		return nil, fmt.Errorf("LoadStateAtEvent.SnapshotNIDFromEventID failed for event %s : %w", eventID, err)
+	}
+	if snapshotNID == 0 {
+		return nil, fmt.Errorf("LoadStateAtEvent.SnapshotNIDFromEventID(%s) returned 0 NID, was this event stored?", eventID)
+	}
+
+	stateEntries, err := v.LoadStateAtSnapshot(ctx, snapshotNID)
+	if err != nil {
+		return nil, err
+	}
+
+	return stateEntries, nil
+}
+
 // LoadCombinedStateAfterEvents loads a snapshot of the state after each of the events
 // and combines those snapshots together into a single list. At this point it is
 // possible to run into duplicate (type, state key) tuples.

--- a/roomserver/storage/interface.go
+++ b/roomserver/storage/interface.go
@@ -167,5 +167,5 @@ type Database interface {
 	// ForgetRoom sets a flag in the membership table, that the user wishes to forget a specific room
 	ForgetRoom(ctx context.Context, userID, roomID string, forget bool) error
 
-	lityState(ctx context.Context, roomInfo *types.RoomInfo, eventID string, domain string) ([]*gomatrixserverlib.Event, error)
+	GetHistoryVisibilityState(ctx context.Context, roomInfo *types.RoomInfo, eventID string, domain string) ([]*gomatrixserverlib.Event, error)
 }

--- a/roomserver/storage/interface.go
+++ b/roomserver/storage/interface.go
@@ -166,4 +166,6 @@ type Database interface {
 	GetKnownRooms(ctx context.Context) ([]string, error)
 	// ForgetRoom sets a flag in the membership table, that the user wishes to forget a specific room
 	ForgetRoom(ctx context.Context, userID, roomID string, forget bool) error
+
+	lityState(ctx context.Context, roomInfo *types.RoomInfo, eventID string, domain string) ([]*gomatrixserverlib.Event, error)
 }

--- a/roomserver/storage/postgres/state_snapshot_table.go
+++ b/roomserver/storage/postgres/state_snapshot_table.go
@@ -72,9 +72,32 @@ const bulkSelectStateBlockNIDsSQL = "" +
 	"SELECT state_snapshot_nid, state_block_nids FROM roomserver_state_snapshots" +
 	" WHERE state_snapshot_nid = ANY($1) ORDER BY state_snapshot_nid ASC"
 
+// Looks up both the history visibility event and relevant membership events from
+// a given domain name from a given state snapshot. This is used to optimise the
+// helpers.CheckServerAllowedToSeeEvent function.
+// TODO: There's a sequence scan here because of the hash join strategy, which is
+// probably O(n) on state key entries, so there must be a way to avoid that somehow.
+const bulkSelectStateForHistoryVisibilitySQL = `
+SELECT event_nid FROM (
+	SELECT event_nid, event_type_nid, event_state_key_nid FROM roomserver_events
+	WHERE (event_type_nid = 5 OR event_type_nid = 7)
+	AND event_nid = ANY(
+		SELECT UNNEST(event_nids) FROM roomserver_state_block
+		WHERE state_block_nid = ANY(
+			SELECT UNNEST(state_block_nids) FROM roomserver_state_snapshots
+			WHERE state_snapshot_nid = $1
+		)
+	)
+) AS roomserver_events
+INNER JOIN roomserver_event_state_keys
+	ON roomserver_events.event_state_key_nid = roomserver_event_state_keys.event_state_key_nid
+	AND (event_type_nid = 7 OR event_state_key LIKE '%:$2');
+`
+
 type stateSnapshotStatements struct {
-	insertStateStmt              *sql.Stmt
-	bulkSelectStateBlockNIDsStmt *sql.Stmt
+	insertStateStmt                         *sql.Stmt
+	bulkSelectStateBlockNIDsStmt            *sql.Stmt
+	bulkSelectStateForHistoryVisibilityStmt *sql.Stmt
 }
 
 func CreateStateSnapshotTable(db *sql.DB) error {
@@ -88,6 +111,7 @@ func PrepareStateSnapshotTable(db *sql.DB) (tables.StateSnapshot, error) {
 	return s, sqlutil.StatementList{
 		{&s.insertStateStmt, insertStateSQL},
 		{&s.bulkSelectStateBlockNIDsStmt, bulkSelectStateBlockNIDsSQL},
+		{&s.bulkSelectStateForHistoryVisibilityStmt, bulkSelectStateForHistoryVisibilitySQL},
 	}.Prepare(db)
 }
 
@@ -133,6 +157,29 @@ func (s *stateSnapshotStatements) BulkSelectStateBlockNIDs(
 	}
 	if i != len(stateNIDs) {
 		return nil, types.MissingStateError(fmt.Sprintf("storage: state NIDs missing from the database (%d != %d)", i, len(stateNIDs)))
+	}
+	return results, nil
+}
+
+func (s *stateSnapshotStatements) BulkSelectStateForHistoryVisibility(
+	ctx context.Context, txn *sql.Tx, stateSnapshotNID types.StateSnapshotNID, domain string,
+) ([]types.EventNID, error) {
+	stmt := sqlutil.TxStmt(txn, s.bulkSelectStateForHistoryVisibilityStmt)
+	rows, err := stmt.QueryContext(ctx, stateSnapshotNID, domain)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() // nolint: errcheck
+	results := make([]types.EventNID, 0, 16)
+	for i := 0; rows.Next(); i++ {
+		var eventNID types.EventNID
+		if err = rows.Scan(&eventNID); err != nil {
+			return nil, err
+		}
+		results = append(results, eventNID)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
 	}
 	return results, nil
 }

--- a/roomserver/storage/postgres/state_snapshot_table.go
+++ b/roomserver/storage/postgres/state_snapshot_table.go
@@ -91,7 +91,7 @@ SELECT event_nid FROM (
 ) AS roomserver_events
 INNER JOIN roomserver_event_state_keys
 	ON roomserver_events.event_state_key_nid = roomserver_event_state_keys.event_state_key_nid
-	AND (event_type_nid = 7 OR event_state_key LIKE '%:$2');
+	AND (event_type_nid = 7 OR event_state_key LIKE '%:' || $2);
 `
 
 type stateSnapshotStatements struct {

--- a/roomserver/storage/postgres/state_snapshot_table.go
+++ b/roomserver/storage/postgres/state_snapshot_table.go
@@ -77,22 +77,21 @@ const bulkSelectStateBlockNIDsSQL = "" +
 // helpers.CheckServerAllowedToSeeEvent function.
 // TODO: There's a sequence scan here because of the hash join strategy, which is
 // probably O(n) on state key entries, so there must be a way to avoid that somehow.
-const bulkSelectStateForHistoryVisibilitySQL = `
-SELECT event_nid FROM (
-	SELECT event_nid, event_type_nid, event_state_key_nid FROM roomserver_events
-	WHERE (event_type_nid = 5 OR event_type_nid = 7)
-	AND event_nid = ANY(
-		SELECT UNNEST(event_nids) FROM roomserver_state_block
-		WHERE state_block_nid = ANY(
-			SELECT UNNEST(state_block_nids) FROM roomserver_state_snapshots
-			WHERE state_snapshot_nid = $1
-		)
-	)
-) AS roomserver_events
-INNER JOIN roomserver_event_state_keys
-	ON roomserver_events.event_state_key_nid = roomserver_event_state_keys.event_state_key_nid
-	AND (event_type_nid = 7 OR event_state_key LIKE '%:' || $2);
-`
+const bulkSelectStateForHistoryVisibilitySQL = "" +
+	"SELECT event_nid FROM (" +
+	" SELECT event_nid, event_type_nid, event_state_key_nid FROM roomserver_events" +
+	" WHERE (event_type_nid = 5 OR event_type_nid = 7)" +
+	" AND event_nid = ANY(" +
+	"  SELECT UNNEST(event_nids) FROM roomserver_state_block" +
+	"  WHERE state_block_nid = ANY(" +
+	"   SELECT UNNEST(state_block_nids) FROM roomserver_state_snapshots" +
+	"   WHERE state_snapshot_nid = $1" +
+	"  )" +
+	" )" +
+	") AS roomserver_events" +
+	" INNER JOIN roomserver_event_state_keys" +
+	"  ON roomserver_events.event_state_key_nid = roomserver_event_state_keys.event_state_key_nid" +
+	"  AND (event_type_nid = 7 OR event_state_key LIKE '%:' || $2);"
 
 type stateSnapshotStatements struct {
 	insertStateStmt                         *sql.Stmt

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -993,7 +993,11 @@ func (d *Database) GetHistoryVisibilityState(ctx context.Context, roomInfo *type
 	if err != nil {
 		return nil, err
 	}
-	eventNIDs, err := d.StateSnapshotTable.BulkSelectStateForHistoryVisibility(ctx, nil, eventStates[0].BeforeStateSnapshotNID, domain)
+	stateSnapshotNID := eventStates[0].BeforeStateSnapshotNID
+	if stateSnapshotNID == 0 {
+		return nil, nil
+	}
+	eventNIDs, err := d.StateSnapshotTable.BulkSelectStateForHistoryVisibility(ctx, nil, stateSnapshotNID, domain)
 	if err != nil {
 		return nil, err
 	}

--- a/roomserver/storage/sqlite3/state_snapshot_table.go
+++ b/roomserver/storage/sqlite3/state_snapshot_table.go
@@ -140,3 +140,9 @@ func (s *stateSnapshotStatements) BulkSelectStateBlockNIDs(
 	}
 	return results, nil
 }
+
+func (s *stateSnapshotStatements) BulkSelectStateForHistoryVisibility(
+	ctx context.Context, txn *sql.Tx, stateSnapshotNID types.StateSnapshotNID, domain string,
+) ([]types.EventNID, error) {
+	return nil, nil
+}

--- a/roomserver/storage/sqlite3/state_snapshot_table.go
+++ b/roomserver/storage/sqlite3/state_snapshot_table.go
@@ -62,10 +62,32 @@ const bulkSelectStateBlockNIDsSQL = "" +
 	"SELECT state_snapshot_nid, state_block_nids FROM roomserver_state_snapshots" +
 	" WHERE state_snapshot_nid IN ($1) ORDER BY state_snapshot_nid ASC"
 
+// Looks up both the history visibility event and relevant membership events from
+// a given domain name from a given state snapshot. This is used to optimise the
+// helpers.CheckServerAllowedToSeeEvent function.
+// TODO: There's a sequence scan here because of the hash join strategy, which is
+// probably O(n) on state key entries, so there must be a way to avoid that somehow.
+const bulkSelectStateForHistoryVisibilitySQL = "" +
+	"SELECT event_nid FROM (" +
+	" SELECT event_nid, event_type_nid, event_state_key_nid FROM roomserver_events" +
+	" WHERE (event_type_nid = 5 OR event_type_nid = 7)" +
+	" AND event_nid = ANY(" +
+	"  SELECT UNNEST(event_nids) FROM roomserver_state_block" +
+	"  WHERE state_block_nid = ANY(" +
+	"   SELECT UNNEST(state_block_nids) FROM roomserver_state_snapshots" +
+	"   WHERE state_snapshot_nid = $1" +
+	"  )" +
+	" )" +
+	") AS roomserver_events" +
+	" INNER JOIN roomserver_event_state_keys" +
+	"  ON roomserver_events.event_state_key_nid = roomserver_event_state_keys.event_state_key_nid" +
+	"  AND (event_type_nid = 7 OR event_state_key LIKE '%:' || $2);"
+
 type stateSnapshotStatements struct {
-	db                           *sql.DB
-	insertStateStmt              *sql.Stmt
-	bulkSelectStateBlockNIDsStmt *sql.Stmt
+	db                                      *sql.DB
+	insertStateStmt                         *sql.Stmt
+	bulkSelectStateBlockNIDsStmt            *sql.Stmt
+	bulkSelectStateForHistoryVisibilityStmt *sql.Stmt
 }
 
 func CreateStateSnapshotTable(db *sql.DB) error {
@@ -81,6 +103,7 @@ func PrepareStateSnapshotTable(db *sql.DB) (tables.StateSnapshot, error) {
 	return s, sqlutil.StatementList{
 		{&s.insertStateStmt, insertStateSQL},
 		{&s.bulkSelectStateBlockNIDsStmt, bulkSelectStateBlockNIDsSQL},
+		{&s.bulkSelectStateForHistoryVisibilityStmt, bulkSelectStateForHistoryVisibilitySQL},
 	}.Prepare(db)
 }
 
@@ -144,5 +167,22 @@ func (s *stateSnapshotStatements) BulkSelectStateBlockNIDs(
 func (s *stateSnapshotStatements) BulkSelectStateForHistoryVisibility(
 	ctx context.Context, txn *sql.Tx, stateSnapshotNID types.StateSnapshotNID, domain string,
 ) ([]types.EventNID, error) {
-	return nil, nil
+	stmt := sqlutil.TxStmt(txn, s.bulkSelectStateForHistoryVisibilityStmt)
+	rows, err := stmt.QueryContext(ctx, stateSnapshotNID, domain)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close() // nolint: errcheck
+	results := make([]types.EventNID, 0, 16)
+	for i := 0; rows.Next(); i++ {
+		var eventNID types.EventNID
+		if err = rows.Scan(&eventNID); err != nil {
+			return nil, err
+		}
+		results = append(results, eventNID)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+	return results, nil
 }

--- a/roomserver/storage/tables/interface.go
+++ b/roomserver/storage/tables/interface.go
@@ -80,6 +80,7 @@ type Rooms interface {
 type StateSnapshot interface {
 	InsertState(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, stateBlockNIDs types.StateBlockNIDs) (stateNID types.StateSnapshotNID, err error)
 	BulkSelectStateBlockNIDs(ctx context.Context, txn *sql.Tx, stateNIDs []types.StateSnapshotNID) ([]types.StateBlockNIDList, error)
+	BulkSelectStateForHistoryVisibility(ctx context.Context, txn *sql.Tx, stateSnapshotNID types.StateSnapshotNID, domain string) ([]types.EventNID, error)
 }
 
 type StateBlock interface {

--- a/roomserver/storage/tables/interface.go
+++ b/roomserver/storage/tables/interface.go
@@ -3,11 +3,14 @@ package tables
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/tidwall/gjson"
 )
+
+var OptimisationNotSupportedError = errors.New("optimisation not supported")
 
 type EventJSONPair struct {
 	EventNID  types.EventNID

--- a/roomserver/storage/tables/interface.go
+++ b/roomserver/storage/tables/interface.go
@@ -83,6 +83,9 @@ type Rooms interface {
 type StateSnapshot interface {
 	InsertState(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, stateBlockNIDs types.StateBlockNIDs) (stateNID types.StateSnapshotNID, err error)
 	BulkSelectStateBlockNIDs(ctx context.Context, txn *sql.Tx, stateNIDs []types.StateSnapshotNID) ([]types.StateBlockNIDList, error)
+	// BulkSelectStateForHistoryVisibility is a PostgreSQL-only optimisation for finding
+	// which users are in a room faster than having to load the entire room state. In the
+	// case of SQLite, this will return tables.OptimisationNotSupportedError.
 	BulkSelectStateForHistoryVisibility(ctx context.Context, txn *sql.Tx, stateSnapshotNID types.StateSnapshotNID, domain string) ([]types.EventNID, error)
 }
 

--- a/roomserver/storage/tables/state_snapshot_table_test.go
+++ b/roomserver/storage/tables/state_snapshot_table_test.go
@@ -23,6 +23,15 @@ func mustCreateStateSnapshotTable(t *testing.T, dbType test.DBType) (tab tables.
 	assert.NoError(t, err)
 	switch dbType {
 	case test.DBTypePostgres:
+		// for the PostgreSQL history visibility optimisation to work,
+		// we also need some other tables to exist
+		err = postgres.CreateEventStateKeysTable(db)
+		assert.NoError(t, err)
+		err = postgres.CreateEventsTable(db)
+		assert.NoError(t, err)
+		err = postgres.CreateStateBlockTable(db)
+		assert.NoError(t, err)
+		// ... and then the snapshot table itself
 		err = postgres.CreateStateSnapshotTable(db)
 		assert.NoError(t, err)
 		tab, err = postgres.PrepareStateSnapshotTable(db)


### PR DESCRIPTION
This is done quite a lot for federation requests, i.e. `/event`, and it's expensive enough today to warrant its own optimised query.

The query filters out all events from the state snapshots that aren't relevant, leaving only the history visibility event and the membership events for the domain name in question.