### PR TITLE
Set CORS headers for HTTP 404 and 405 errors

### DIFF
--- a/setup/base/base.go
+++ b/setup/base/base.go
@@ -451,6 +451,10 @@ func (b *BaseDendrite) SetupAndServeHTTP(
 	externalRouter.PathPrefix(httputil.PublicMediaPathPrefix).Handler(b.PublicMediaAPIMux)
 	externalRouter.PathPrefix(httputil.PublicWellKnownPrefix).Handler(b.PublicWellKnownAPIMux)
 
+	notFoundHandler := httputil.WrapHandlerInCORS(http.NotFoundHandler())
+	internalRouter.NotFoundHandler = notFoundHandler
+	externalRouter.NotFoundHandler = notFoundHandler
+
 	if internalAddr != NoListener && internalAddr != externalAddr {
 		go func() {
 			var internalShutdown atomic.Bool // RegisterOnShutdown can be called more than once

--- a/setup/base/base.go
+++ b/setup/base/base.go
@@ -369,7 +369,7 @@ func (b *BaseDendrite) CreateFederationClient() *gomatrixserverlib.FederationCli
 	return client
 }
 
-func (b *BaseDendrite) configureHTTPErrors(internalRouter, externalRouter *mux.Router) {
+func (b *BaseDendrite) configureHTTPErrors() {
 	notAllowedHandler := func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		_, _ = w.Write([]byte(fmt.Sprintf("405 %s not allowed on this endpoint", r.Method)))
@@ -379,11 +379,9 @@ func (b *BaseDendrite) configureHTTPErrors(internalRouter, externalRouter *mux.R
 	notAllowedCORSHandler := httputil.WrapHandlerInCORS(http.HandlerFunc(notAllowedHandler))
 
 	for _, router := range []*mux.Router{
-		internalRouter, externalRouter,
+		b.PublicClientAPIMux, b.PublicMediaAPIMux,
 		b.DendriteAdminMux, b.SynapseAdminMux,
-		b.InternalAPIMux, b.PublicWellKnownAPIMux,
-		b.PublicClientAPIMux, b.PublicFederationAPIMux,
-		b.PublicKeyAPIMux, b.PublicMediaAPIMux,
+		b.PublicWellKnownAPIMux,
 	} {
 		router.NotFoundHandler = notFoundCORSHandler
 		router.MethodNotAllowedHandler = notAllowedCORSHandler
@@ -430,7 +428,7 @@ func (b *BaseDendrite) SetupAndServeHTTP(
 		}
 	}
 
-	b.configureHTTPErrors(internalRouter, externalRouter)
+	b.configureHTTPErrors()
 
 	internalRouter.PathPrefix(httputil.InternalPathPrefix).Handler(b.InternalAPIMux)
 	if b.Cfg.Global.Metrics.Enabled {

--- a/setup/base/base.go
+++ b/setup/base/base.go
@@ -370,16 +370,12 @@ func (b *BaseDendrite) CreateFederationClient() *gomatrixserverlib.FederationCli
 }
 
 func (b *BaseDendrite) configureHTTPErrors(internalRouter, externalRouter *mux.Router) {
-	notFoundHandler := func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte("HTTP 404: endpoint not found"))
-	}
 	notAllowedHandler := func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusMethodNotAllowed)
-		_, _ = w.Write([]byte(fmt.Sprintf("HTTP 405: %s not allowed on this endpoint", r.Method)))
+		_, _ = w.Write([]byte(fmt.Sprintf("405 %s not allowed on this endpoint", r.Method)))
 	}
 
-	notFoundCORSHandler := httputil.WrapHandlerInCORS(http.HandlerFunc(notFoundHandler))
+	notFoundCORSHandler := httputil.WrapHandlerInCORS(http.NotFoundHandler())
 	notAllowedCORSHandler := httputil.WrapHandlerInCORS(http.HandlerFunc(notAllowedHandler))
 
 	for _, router := range []*mux.Router{


### PR DESCRIPTION
This should mean that Element Web etc will surface actual HTTP errors instead of just reporting CORS errors for missing endpoints or incorrect methods, since this seems to throw a lot of people off leading them to believe there's a problem with their configs.