### PR TITLE
Only create a new destinationQueue if we don't have one

### DIFF
--- a/federationapi/queue/queue.go
+++ b/federationapi/queue/queue.go
@@ -158,7 +158,7 @@ func (oqs *OutgoingQueues) getQueue(destination gomatrixserverlib.ServerName) *d
 	oqs.queuesMutex.Lock()
 	defer oqs.queuesMutex.Unlock()
 	oq, ok := oqs.queues[destination]
-	if !ok || oq != nil {
+	if !ok || oq == nil {
 		destinationQueueTotal.Inc()
 		oq = &destinationQueue{
 			queues:           oqs,


### PR DESCRIPTION
From the looks of it, the federationapi seems a bit more calm with this change.
