### PR TITLE
Use `is_direct` flag from `/createRoom`, update stripped state

### DIFF
--- a/clientapi/routing/createroom.go
+++ b/clientapi/routing/createroom.go
@@ -49,6 +49,7 @@ type createRoomRequest struct {
 	GuestCanJoin              bool                          `json:"guest_can_join"`
 	RoomVersion               gomatrixserverlib.RoomVersion `json:"room_version"`
 	PowerLevelContentOverride json.RawMessage               `json:"power_level_content_override"`
+	IsDirect                  bool                          `json:"is_direct"`
 }
 
 const (
@@ -500,7 +501,13 @@ func createRoom(
 		var globalStrippedState []gomatrixserverlib.InviteV2StrippedState
 		for _, event := range builtEvents {
 			switch event.Type() {
+			case gomatrixserverlib.MRoomCreate:
+				fallthrough
 			case gomatrixserverlib.MRoomName:
+				fallthrough
+			case gomatrixserverlib.MRoomAvatar:
+				fallthrough
+			case gomatrixserverlib.MRoomTopic:
 				fallthrough
 			case gomatrixserverlib.MRoomCanonicalAlias:
 				fallthrough
@@ -522,7 +529,7 @@ func createRoom(
 			// Build the invite event.
 			inviteEvent, err := buildMembershipEvent(
 				ctx, invitee, "", profileAPI, device, gomatrixserverlib.Invite,
-				roomID, true, cfg, evTime, rsAPI, asAPI,
+				roomID, r.IsDirect, cfg, evTime, rsAPI, asAPI,
 			)
 			if err != nil {
 				util.GetLogger(ctx).WithError(err).Error("buildMembershipEvent failed")

--- a/clientapi/routing/createroom.go
+++ b/clientapi/routing/createroom.go
@@ -500,6 +500,8 @@ func createRoom(
 		// Build some stripped state for the invite.
 		var globalStrippedState []gomatrixserverlib.InviteV2StrippedState
 		for _, event := range builtEvents {
+			// Chosen events from the spec:
+			// https://spec.matrix.org/v1.3/client-server-api/#stripped-state
 			switch event.Type() {
 			case gomatrixserverlib.MRoomCreate:
 				fallthrough


### PR DESCRIPTION
This PR does two things:

* Checks if `is_direct` was specified in the `/createRoom` request and uses that to populate the `is_direct` key of the invited users
* Updates the stripped state to include the create event, avatar and topic as per the [spec](https://spec.matrix.org/v1.3/client-server-api/#stripped-state)