### PR TITLE
Reprocess rejected input events

### DIFF
--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -119,11 +119,12 @@ func (r *Inputer) processRoomEvent(
 		return fmt.Errorf("room %s does not exist for event %s", event.RoomID(), event.EventID())
 	}
 
-	// If we already know about this event and it hasn't been rejected
-	// then we won't attempt to reprocess it. If it was rejected then we
-	// can attempt to reprocess, in case we have learned something new
-	// that will allow us to accept the event this time.
-	if roomInfo != nil {
+	// If we already know about this outlier and it hasn't been rejected
+	// then we won't attempt to reprocess it. If it was rejected or has now
+	// arrived as a different kind of event, then we can attempt to reprocess,
+	// in case we have learned something new or need to weave the event into
+	// the DAG now.
+	if input.Kind == api.KindOutlier && roomInfo != nil {
 		wasRejected, werr := r.DB.IsEventRejected(ctx, roomInfo.RoomNID, event.EventID())
 		switch {
 		case werr == sql.ErrNoRows:

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -114,8 +114,7 @@ func (r *Inputer) processRoomEvent(
 	wasRejected, werr := r.DB.IsEventRejected(ctx, event.EventID())
 	if werr != nil && werr != sql.ErrNoRows {
 		return werr
-	}
-	if !wasRejected {
+	} else if werr == nil && !wasRejected {
 		logger.Debugf("Already processed event %q, ignoring", event.EventID())
 		return nil
 	}

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -95,6 +95,9 @@ func (r *Queryer) QueryStateAfterEvents(
 		if _, ok := err.(types.MissingEventError); ok {
 			return nil
 		}
+		if _, ok := err.(types.MissingStateError); ok {
+			return nil
+		}
 		return err
 	}
 

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -77,7 +77,7 @@ func (r *Queryer) QueryStateAfterEvents(
 			util.GetLogger(ctx).Errorf("QueryStateAfterEvents: MissingEventError: %s", err)
 			return nil
 		default:
-			return err
+			return fmt.Errorf("r.DB.StateAtEventIDs: %w", err)
 		}
 	}
 	response.PrevEventsExist = true
@@ -88,19 +88,22 @@ func (r *Queryer) QueryStateAfterEvents(
 		stateEntries, err = roomState.LoadCombinedStateAfterEvents(
 			ctx, prevStates,
 		)
+		if err != nil {
+			return fmt.Errorf("roomState.LoadCombinedStateAfterEvents: %w", err)
+		}
 	} else {
 		// Look up the current state for the requested tuples.
 		stateEntries, err = roomState.LoadStateAfterEventsForStringTuples(
 			ctx, prevStates, request.StateToFetch,
 		)
-	}
-	if err != nil {
-		return err
+		if err != nil {
+			return fmt.Errorf("roomState.LoadStateAfterEventsForStringTuples: %w", err)
+		}
 	}
 
 	stateEvents, err := helpers.LoadStateEvents(ctx, r.DB, stateEntries)
 	if err != nil {
-		return err
+		return fmt.Errorf("helpers.LoadStateEvents: %w", err)
 	}
 
 	if len(request.PrevEventIDs) > 1 && len(request.StateToFetch) == 0 {

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -88,17 +88,14 @@ func (r *Queryer) QueryStateAfterEvents(
 		stateEntries, err = roomState.LoadCombinedStateAfterEvents(
 			ctx, prevStates,
 		)
-		if err != nil {
-			return fmt.Errorf("roomState.LoadCombinedStateAfterEvents: %w", err)
-		}
 	} else {
 		// Look up the current state for the requested tuples.
 		stateEntries, err = roomState.LoadStateAfterEventsForStringTuples(
 			ctx, prevStates, request.StateToFetch,
 		)
-		if err != nil {
-			return fmt.Errorf("roomState.LoadStateAfterEventsForStringTuples: %w", err)
-		}
+	}
+	if err != nil {
+		return err
 	}
 
 	stateEvents, err := helpers.LoadStateEvents(ctx, r.DB, stateEntries)

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -842,7 +842,7 @@ func (r *Queryer) QueryRestrictedJoinAllowed(ctx context.Context, req *api.Query
 	}
 	var joinRules gomatrixserverlib.JoinRuleContent
 	if err = json.Unmarshal(joinRulesEvent.Content(), &joinRules); err != nil {
-		return nil
+		return fmt.Errorf("json.Unmarshal: %w (JSON content: %s)", err, joinRulesEvent.Content())
 	}
 	// If the join rule isn't "restricted" then there's nothing more to do.
 	res.Restricted = joinRules.JoinRule == gomatrixserverlib.Restricted

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -72,13 +72,7 @@ func (r *Queryer) QueryStateAfterEvents(
 
 	prevStates, err := r.DB.StateAtEventIDs(ctx, request.PrevEventIDs)
 	if err != nil {
-		switch err.(type) {
-		case types.MissingEventError:
-			util.GetLogger(ctx).Errorf("QueryStateAfterEvents: MissingEventError: %s", err)
-			return nil
-		default:
-			return fmt.Errorf("r.DB.StateAtEventIDs: %w", err)
-		}
+		return nil
 	}
 	response.PrevEventsExist = true
 

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -842,7 +842,7 @@ func (r *Queryer) QueryRestrictedJoinAllowed(ctx context.Context, req *api.Query
 	}
 	var joinRules gomatrixserverlib.JoinRuleContent
 	if err = json.Unmarshal(joinRulesEvent.Content(), &joinRules); err != nil {
-		return fmt.Errorf("json.Unmarshal: %w", err)
+		return fmt.Errorf("json.Unmarshal: %w (JSON content: %s)", err, joinRulesEvent.Content())
 	}
 	// If the join rule isn't "restricted" then there's nothing more to do.
 	res.Restricted = joinRules.JoinRule == gomatrixserverlib.Restricted

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -842,7 +842,7 @@ func (r *Queryer) QueryRestrictedJoinAllowed(ctx context.Context, req *api.Query
 	}
 	var joinRules gomatrixserverlib.JoinRuleContent
 	if err = json.Unmarshal(joinRulesEvent.Content(), &joinRules); err != nil {
-		return fmt.Errorf("json.Unmarshal: %w (JSON content: %s)", err, joinRulesEvent.Content())
+		return nil
 	}
 	// If the join rule isn't "restricted" then there's nothing more to do.
 	res.Restricted = joinRules.JoinRule == gomatrixserverlib.Restricted

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -103,7 +103,7 @@ func (r *Queryer) QueryStateAfterEvents(
 
 	stateEvents, err := helpers.LoadStateEvents(ctx, r.DB, stateEntries)
 	if err != nil {
-		return fmt.Errorf("helpers.LoadStateEvents: %w", err)
+		return err
 	}
 
 	if len(request.PrevEventIDs) > 1 && len(request.StateToFetch) == 0 {
@@ -851,7 +851,7 @@ func (r *Queryer) QueryRestrictedJoinAllowed(ctx context.Context, req *api.Query
 	}
 	var joinRules gomatrixserverlib.JoinRuleContent
 	if err = json.Unmarshal(joinRulesEvent.Content(), &joinRules); err != nil {
-		return fmt.Errorf("json.Unmarshal: %w (JSON content: %s)", err, joinRulesEvent.Content())
+		return fmt.Errorf("json.Unmarshal: %w", err)
 	}
 	// If the join rule isn't "restricted" then there's nothing more to do.
 	res.Restricted = joinRules.JoinRule == gomatrixserverlib.Restricted

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -72,6 +72,9 @@ func (r *Queryer) QueryStateAfterEvents(
 
 	prevStates, err := r.DB.StateAtEventIDs(ctx, request.PrevEventIDs)
 	if err != nil {
+		if _, ok := err.(types.MissingEventError); ok {
+			return nil
+		}
 		return nil
 	}
 	response.PrevEventsExist = true
@@ -89,6 +92,9 @@ func (r *Queryer) QueryStateAfterEvents(
 		)
 	}
 	if err != nil {
+		if _, ok := err.(types.MissingEventError); ok {
+			return nil
+		}
 		return err
 	}
 

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -75,7 +75,7 @@ func (r *Queryer) QueryStateAfterEvents(
 		if _, ok := err.(types.MissingEventError); ok {
 			return nil
 		}
-		return nil
+		return err
 	}
 	response.PrevEventsExist = true
 

--- a/roomserver/storage/interface.go
+++ b/roomserver/storage/interface.go
@@ -95,7 +95,7 @@ type Database interface {
 	// The GetRoomUpdater must have Commit or Rollback called on it if this doesn't return an error.
 	// If this returns an error then no further action is required.
 	// IsEventRejected returns true if the event is known and rejected.
-	IsEventRejected(ctx context.Context, eventID string) (rejected bool, err error)
+	IsEventRejected(ctx context.Context, roomNID types.RoomNID, eventID string) (rejected bool, err error)
 	GetRoomUpdater(ctx context.Context, roomInfo *types.RoomInfo) (*shared.RoomUpdater, error)
 	// Look up event references for the latest events in the room and the current state snapshot.
 	// Returns the latest events, the current state and the maximum depth of the latest events plus 1.

--- a/roomserver/storage/interface.go
+++ b/roomserver/storage/interface.go
@@ -94,6 +94,8 @@ type Database interface {
 	// Opens and returns a room updater, which locks the room and opens a transaction.
 	// The GetRoomUpdater must have Commit or Rollback called on it if this doesn't return an error.
 	// If this returns an error then no further action is required.
+	// IsEventRejected returns true if the event is known and rejected.
+	IsEventRejected(ctx context.Context, eventID string) (rejected bool, err error)
 	GetRoomUpdater(ctx context.Context, roomInfo *types.RoomInfo) (*shared.RoomUpdater, error)
 	// Look up event references for the latest events in the room and the current state snapshot.
 	// Returns the latest events, the current state and the maximum depth of the latest events plus 1.

--- a/roomserver/storage/postgres/events_table.go
+++ b/roomserver/storage/postgres/events_table.go
@@ -137,7 +137,7 @@ const selectRoomNIDsForEventNIDsSQL = "" +
 	"SELECT event_nid, room_nid FROM roomserver_events WHERE event_nid = ANY($1)"
 
 const selectEventRejectedSQL = "" +
-	"SELECT is_rejected FROM roomserver_Events WHERE event_id = $1"
+	"SELECT is_rejected FROM roomserver_events WHERE event_id = $1"
 
 type eventStatements struct {
 	insertEventStmt                        *sql.Stmt

--- a/roomserver/storage/postgres/events_table.go
+++ b/roomserver/storage/postgres/events_table.go
@@ -136,6 +136,9 @@ const selectMaxEventDepthSQL = "" +
 const selectRoomNIDsForEventNIDsSQL = "" +
 	"SELECT event_nid, room_nid FROM roomserver_events WHERE event_nid = ANY($1)"
 
+const selectEventRejectedSQL = "" +
+	"SELECT is_rejected FROM roomserver_Events WHERE event_id = $1"
+
 type eventStatements struct {
 	insertEventStmt                        *sql.Stmt
 	selectEventStmt                        *sql.Stmt
@@ -153,6 +156,7 @@ type eventStatements struct {
 	bulkSelectUnsentEventNIDStmt           *sql.Stmt
 	selectMaxEventDepthStmt                *sql.Stmt
 	selectRoomNIDsForEventNIDsStmt         *sql.Stmt
+	selectEventRejectedStmt                *sql.Stmt
 }
 
 func CreateEventsTable(db *sql.DB) error {
@@ -180,6 +184,7 @@ func PrepareEventsTable(db *sql.DB) (tables.Events, error) {
 		{&s.bulkSelectUnsentEventNIDStmt, bulkSelectUnsentEventNIDSQL},
 		{&s.selectMaxEventDepthStmt, selectMaxEventDepthSQL},
 		{&s.selectRoomNIDsForEventNIDsStmt, selectRoomNIDsForEventNIDsSQL},
+		{&s.selectEventRejectedStmt, selectEventRejectedSQL},
 	}.Prepare(db)
 }
 
@@ -539,4 +544,12 @@ func eventNIDsAsArray(eventNIDs []types.EventNID) pq.Int64Array {
 		nids[i] = int64(eventNIDs[i])
 	}
 	return nids
+}
+
+func (s *eventStatements) SelectEventRejected(
+	ctx context.Context, txn *sql.Tx, eventID string,
+) (rejected bool, err error) {
+	stmt := sqlutil.TxStmt(txn, s.selectEventRejectedStmt)
+	err = stmt.QueryRowContext(ctx, eventID).Scan(&rejected)
+	return
 }

--- a/roomserver/storage/postgres/events_table.go
+++ b/roomserver/storage/postgres/events_table.go
@@ -137,7 +137,7 @@ const selectRoomNIDsForEventNIDsSQL = "" +
 	"SELECT event_nid, room_nid FROM roomserver_events WHERE event_nid = ANY($1)"
 
 const selectEventRejectedSQL = "" +
-	"SELECT is_rejected FROM roomserver_events WHERE event_id = $1"
+	"SELECT is_rejected FROM roomserver_events WHERE room_nid = $1 AND event_id = $2"
 
 type eventStatements struct {
 	insertEventStmt                        *sql.Stmt
@@ -547,9 +547,9 @@ func eventNIDsAsArray(eventNIDs []types.EventNID) pq.Int64Array {
 }
 
 func (s *eventStatements) SelectEventRejected(
-	ctx context.Context, txn *sql.Tx, eventID string,
+	ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, eventID string,
 ) (rejected bool, err error) {
 	stmt := sqlutil.TxStmt(txn, s.selectEventRejectedStmt)
-	err = stmt.QueryRowContext(ctx, eventID).Scan(&rejected)
+	err = stmt.QueryRowContext(ctx, roomNID, eventID).Scan(&rejected)
 	return
 }

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -567,6 +567,10 @@ func (d *Database) GetRoomUpdater(
 	return updater, err
 }
 
+func (d *Database) IsEventRejected(ctx context.Context, eventID string) (bool, error) {
+	return d.EventsTable.SelectEventRejected(ctx, nil, eventID)
+}
+
 func (d *Database) StoreEvent(
 	ctx context.Context, event *gomatrixserverlib.Event,
 	authEventNIDs []types.EventNID, isRejected bool,

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -567,8 +567,8 @@ func (d *Database) GetRoomUpdater(
 	return updater, err
 }
 
-func (d *Database) IsEventRejected(ctx context.Context, eventID string) (bool, error) {
-	return d.EventsTable.SelectEventRejected(ctx, nil, eventID)
+func (d *Database) IsEventRejected(ctx context.Context, roomNID types.RoomNID, eventID string) (bool, error) {
+	return d.EventsTable.SelectEventRejected(ctx, nil, roomNID, eventID)
 }
 
 func (d *Database) StoreEvent(

--- a/roomserver/storage/sqlite3/events_table.go
+++ b/roomserver/storage/sqlite3/events_table.go
@@ -110,7 +110,7 @@ const selectRoomNIDsForEventNIDsSQL = "" +
 	"SELECT event_nid, room_nid FROM roomserver_events WHERE event_nid IN ($1)"
 
 const selectEventRejectedSQL = "" +
-	"SELECT is_rejected FROM roomserver_Events WHERE event_id = $1"
+	"SELECT is_rejected FROM roomserver_events WHERE event_id = $1"
 
 type eventStatements struct {
 	db                                     *sql.DB

--- a/roomserver/storage/sqlite3/events_table.go
+++ b/roomserver/storage/sqlite3/events_table.go
@@ -110,7 +110,7 @@ const selectRoomNIDsForEventNIDsSQL = "" +
 	"SELECT event_nid, room_nid FROM roomserver_events WHERE event_nid IN ($1)"
 
 const selectEventRejectedSQL = "" +
-	"SELECT is_rejected FROM roomserver_events WHERE event_id = $1"
+	"SELECT is_rejected FROM roomserver_events WHERE room_nid = $1 AND event_id = $2"
 
 type eventStatements struct {
 	db                                     *sql.DB
@@ -621,9 +621,9 @@ func eventNIDsAsArray(eventNIDs []types.EventNID) string {
 }
 
 func (s *eventStatements) SelectEventRejected(
-	ctx context.Context, txn *sql.Tx, eventID string,
+	ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, eventID string,
 ) (rejected bool, err error) {
 	stmt := sqlutil.TxStmt(txn, s.selectEventRejectedStmt)
-	err = stmt.QueryRowContext(ctx, eventID).Scan(&rejected)
+	err = stmt.QueryRowContext(ctx, roomNID, eventID).Scan(&rejected)
 	return
 }

--- a/roomserver/storage/tables/interface.go
+++ b/roomserver/storage/tables/interface.go
@@ -66,6 +66,7 @@ type Events interface {
 	BulkSelectUnsentEventNID(ctx context.Context, txn *sql.Tx, eventIDs []string) (map[string]types.EventNID, error)
 	SelectMaxEventDepth(ctx context.Context, txn *sql.Tx, eventNIDs []types.EventNID) (int64, error)
 	SelectRoomNIDsForEventNIDs(ctx context.Context, txn *sql.Tx, eventNIDs []types.EventNID) (roomNIDs map[types.EventNID]types.RoomNID, err error)
+	SelectEventRejected(ctx context.Context, txn *sql.Tx, eventID string) (rejected bool, err error)
 }
 
 type Rooms interface {

--- a/roomserver/storage/tables/interface.go
+++ b/roomserver/storage/tables/interface.go
@@ -66,7 +66,7 @@ type Events interface {
 	BulkSelectUnsentEventNID(ctx context.Context, txn *sql.Tx, eventIDs []string) (map[string]types.EventNID, error)
 	SelectMaxEventDepth(ctx context.Context, txn *sql.Tx, eventNIDs []types.EventNID) (int64, error)
 	SelectRoomNIDsForEventNIDs(ctx context.Context, txn *sql.Tx, eventNIDs []types.EventNID) (roomNIDs map[types.EventNID]types.RoomNID, err error)
-	SelectEventRejected(ctx context.Context, txn *sql.Tx, eventID string) (rejected bool, err error)
+	SelectEventRejected(ctx context.Context, txn *sql.Tx, roomNID types.RoomNID, eventID string) (rejected bool, err error)
 }
 
 type Rooms interface {


### PR DESCRIPTION
... otherwise they stay perma-rejected, even if we've since learned about something that might allow us to reprocess it successfully later.