### PR TITLE
Fetch more data for newly joined rooms in an incremental sync

### DIFF
--- a/syncapi/streams/stream_pdu.go
+++ b/syncapi/streams/stream_pdu.go
@@ -231,7 +231,7 @@ func (p *PDUStreamProvider) IncrementalSync(
 			delete(req.Response.Rooms.Join, x)
 		}
 		r = types.Range{
-			From:      p.latest,
+			From:      to,
 			To:        0,
 			Backwards: true,
 		}

--- a/syncapi/streams/stream_presence.go
+++ b/syncapi/streams/stream_presence.go
@@ -19,9 +19,11 @@ import (
 	"encoding/json"
 	"sync"
 
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/tidwall/gjson"
+
 	"github.com/matrix-org/dendrite/syncapi/notifier"
 	"github.com/matrix-org/dendrite/syncapi/types"
-	"github.com/matrix-org/gomatrixserverlib"
 )
 
 type PresenceStreamProvider struct {
@@ -175,6 +177,10 @@ func membershipEventPresent(events []gomatrixserverlib.ClientEvent, userID strin
 		// it's enough to know that we have our member event here, don't need to check membership content
 		// as it's implied by being in the respective section of the sync response.
 		if ev.Type == gomatrixserverlib.MRoomMember && ev.StateKey != nil && *ev.StateKey == userID {
+			// ignore e.g. join -> join changes
+			if gjson.GetBytes(ev.Unsigned, "prev_content.membership").Str == gjson.GetBytes(ev.Content, "membership").Str {
+				continue
+			}
 			return true
 		}
 	}

--- a/syncapi/syncapi_test.go
+++ b/syncapi/syncapi_test.go
@@ -190,12 +190,12 @@ func testSyncAccessTokens(t *testing.T, dbType test.DBType) {
 // been sent to the syncapi
 func TestSyncAPICreateRoomSyncEarly(t *testing.T) {
 	test.WithAllDatabases(t, func(t *testing.T, dbType test.DBType) {
-		t.SkipNow() // Temporary?
 		testSyncAPICreateRoomSyncEarly(t, dbType)
 	})
 }
 
 func testSyncAPICreateRoomSyncEarly(t *testing.T, dbType test.DBType) {
+	t.SkipNow() // Temporary?
 	user := test.NewUser(t)
 	room := test.NewRoom(t, user)
 	alice := userapi.Device{

--- a/syncapi/syncapi_test.go
+++ b/syncapi/syncapi_test.go
@@ -190,6 +190,7 @@ func testSyncAccessTokens(t *testing.T, dbType test.DBType) {
 // been sent to the syncapi
 func TestSyncAPICreateRoomSyncEarly(t *testing.T) {
 	test.WithAllDatabases(t, func(t *testing.T, dbType test.DBType) {
+		t.SkipNow() // Temporary?
 		testSyncAPICreateRoomSyncEarly(t, dbType)
 	})
 }


### PR DESCRIPTION
If we've joined a new room in an incremental sync, try fetching more data.
This deflakes the complement server notices test (at least in my tests).