### PR TITLE
Change detection of already executed migrations

### DIFF
--- a/internal/sqlutil/migrate.go
+++ b/internal/sqlutil/migrate.go
@@ -142,7 +142,8 @@ func (m *Migrator) ExecutedMigrations(ctx context.Context) (map[string]struct{},
 	return result, rows.Err()
 }
 
-// InsertMigration inserts a migration given there name to the database.
+// InsertMigration creates the migrations table if it doesn't exist and
+// inserts a migration given their name to the database.
 // This should only be used when manually inserting migrations.
 func InsertMigration(ctx context.Context, db *sql.DB, migrationName string) error {
 	_, err := db.ExecContext(ctx, createDBMigrationsSQL)

--- a/internal/sqlutil/migrate.go
+++ b/internal/sqlutil/migrate.go
@@ -145,7 +145,11 @@ func (m *Migrator) ExecutedMigrations(ctx context.Context) (map[string]struct{},
 // InsertMigration inserts a migration given there name to the database.
 // This should only be used when manually inserting migrations.
 func InsertMigration(ctx context.Context, db *sql.DB, migrationName string) error {
-	_, err := db.ExecContext(ctx, insertVersionSQL,
+	_, err := db.ExecContext(ctx, createDBMigrationsSQL)
+	if err != nil {
+		return fmt.Errorf("unable to create db_migrations: %w", err)
+	}
+	_, err = db.ExecContext(ctx, insertVersionSQL,
 		migrationName,
 		time.Now().Format(time.RFC3339),
 		internal.VersionString(),

--- a/keyserver/storage/postgres/key_changes_table.go
+++ b/keyserver/storage/postgres/key_changes_table.go
@@ -75,17 +75,8 @@ func executeMigration(ctx context.Context, db *sql.DB) error {
 	// This forces an error, which indicates the migration is already applied, since the
 	// column partition was removed from the table
 	migrationName := "keyserver: refactor key changes"
-	var migrationCount int
 
-	err := db.QueryRowContext(ctx, "SELECT count(*) FROM db_migrations WHERE version = $1", migrationName).Scan(&migrationCount)
-	if err != nil {
-		return err
-	}
-	if migrationCount > 0 {
-		return nil
-	}
-
-	err = db.QueryRowContext(ctx, "select column_name from information_schema.columns where table_name = 'keyserver_key_changes' AND column_name = 'partition'").Err()
+	err := db.QueryRowContext(ctx, "select column_name from information_schema.columns where table_name = 'keyserver_key_changes' AND column_name = 'partition'").Err()
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) { // migration was already executed, as the column was removed
 			if err = sqlutil.InsertMigration(ctx, db, migrationName); err != nil {

--- a/keyserver/storage/postgres/key_changes_table.go
+++ b/keyserver/storage/postgres/key_changes_table.go
@@ -19,6 +19,7 @@ import (
 	"database/sql"
 
 	"github.com/lib/pq"
+	"github.com/sirupsen/logrus"
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
@@ -63,30 +64,54 @@ func NewPostgresKeyChangesTable(db *sql.DB) (tables.KeyChanges, error) {
 		return s, err
 	}
 
+	if err = executeMigration(context.Background(), db); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func executeMigration(ctx context.Context, db *sql.DB) error {
 	// TODO: Remove when we are sure we are not having goose artefacts in the db
 	// This forces an error, which indicates the migration is already applied, since the
 	// column partition was removed from the table
-	var count int
-	err = db.QueryRow("SELECT partition FROM keyserver_key_changes LIMIT 1;").Scan(&count)
+	migrationName := "keyserver: refactor key changes"
+	var migrationCount int
+
+	err := db.QueryRowContext(ctx, "SELECT count(*) FROM db_migrations WHERE version = $1", migrationName).Scan(&migrationCount)
+	if err != nil {
+		return err
+	}
+	if migrationCount > 0 {
+		return nil
+	}
+
+	var partition int
+	err = db.QueryRowContext(ctx, "SELECT partition FROM keyserver_key_changes LIMIT 1;").Scan(&partition)
 	if err == nil {
 		m := sqlutil.NewMigrator(db)
 		m.AddMigrations(sqlutil.Migration{
-			Version: "keyserver: refactor key changes",
+			Version: migrationName,
 			Up:      deltas.UpRefactorKeyChanges,
 		})
-		return s, m.Up(context.Background())
+		if err = m.Up(ctx); err != nil {
+			return err
+		}
 	} else {
 		switch e := err.(type) {
 		case *pq.Error:
 			// ignore undefined_column (42703) errors, as this is expected at this point
 			if e.Code != "42703" {
-				return nil, err
+				return err
+			}
+			if err = sqlutil.InsertMigration(ctx, db, migrationName); err != nil {
+				// not a fatal error, log and continue
+				logrus.WithError(err).Warnf("unable to manually insert migration '%s'", migrationName)
 			}
 		default:
-			return nil, err
+			return err
 		}
 	}
-	return s, nil
+	return nil
 }
 
 func (s *keyChangesStatements) Prepare() (err error) {

--- a/keyserver/storage/postgres/key_changes_table.go
+++ b/keyserver/storage/postgres/key_changes_table.go
@@ -76,7 +76,8 @@ func executeMigration(ctx context.Context, db *sql.DB) error {
 	// column partition was removed from the table
 	migrationName := "keyserver: refactor key changes"
 
-	err := db.QueryRowContext(ctx, "select column_name from information_schema.columns where table_name = 'keyserver_key_changes' AND column_name = 'partition'").Err()
+	var cName string
+	err := db.QueryRowContext(ctx, "select column_name from information_schema.columns where table_name = 'keyserver_key_changes' AND column_name = 'partition'").Scan(&cName)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) { // migration was already executed, as the column was removed
 			if err = sqlutil.InsertMigration(ctx, db, migrationName); err != nil {

--- a/keyserver/storage/postgres/key_changes_table.go
+++ b/keyserver/storage/postgres/key_changes_table.go
@@ -101,11 +101,8 @@ func executeMigration(ctx context.Context, db *sql.DB) error {
 		Version: migrationName,
 		Up:      deltas.UpRefactorKeyChanges,
 	})
-	if err = m.Up(ctx); err != nil {
-		return err
-	}
 
-	return nil
+	return m.Up(ctx)
 }
 
 func (s *keyChangesStatements) Prepare() (err error) {

--- a/keyserver/storage/sqlite3/key_changes_table.go
+++ b/keyserver/storage/sqlite3/key_changes_table.go
@@ -75,7 +75,8 @@ func executeMigration(ctx context.Context, db *sql.DB) error {
 	// column partition was removed from the table
 	migrationName := "keyserver: refactor key changes"
 
-	err := db.QueryRowContext(ctx, `SELECT p.name FROM sqlite_master AS m JOIN pragma_table_info(m.name) AS p WHERE m.name = 'keyserver_key_changes' AND p.name = 'partition'`).Err()
+	var cName string
+	err := db.QueryRowContext(ctx, `SELECT p.name FROM sqlite_master AS m JOIN pragma_table_info(m.name) AS p WHERE m.name = 'keyserver_key_changes' AND p.name = 'partition'`).Scan(&cName)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) { // migration was already executed, as the column was removed
 			if err = sqlutil.InsertMigration(ctx, db, migrationName); err != nil {

--- a/keyserver/storage/sqlite3/key_changes_table.go
+++ b/keyserver/storage/sqlite3/key_changes_table.go
@@ -74,17 +74,8 @@ func executeMigration(ctx context.Context, db *sql.DB) error {
 	// This forces an error, which indicates the migration is already applied, since the
 	// column partition was removed from the table
 	migrationName := "keyserver: refactor key changes"
-	var migrationCount int
 
-	err := db.QueryRowContext(ctx, "SELECT count(*) FROM db_migrations WHERE version = $1", migrationName).Scan(&migrationCount)
-	if err != nil {
-		return err
-	}
-	if migrationCount > 0 {
-		return nil
-	}
-
-	err = db.QueryRowContext(ctx, `SELECT p.name FROM sqlite_master AS m JOIN pragma_table_info(m.name) AS p WHERE m.name = 'keyserver_key_changes' AND p.name = 'partition'`).Err()
+	err := db.QueryRowContext(ctx, `SELECT p.name FROM sqlite_master AS m JOIN pragma_table_info(m.name) AS p WHERE m.name = 'keyserver_key_changes' AND p.name = 'partition'`).Err()
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) { // migration was already executed, as the column was removed
 			if err = sqlutil.InsertMigration(ctx, db, migrationName); err != nil {

--- a/roomserver/storage/postgres/storage.go
+++ b/roomserver/storage/postgres/storage.go
@@ -16,10 +16,13 @@
 package postgres
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 
 	"github.com/lib/pq"
+	"github.com/sirupsen/logrus"
+
 	// Import the postgres database driver.
 	_ "github.com/lib/pq"
 
@@ -52,30 +55,8 @@ func Open(base *base.BaseDendrite, dbProperties *config.DatabaseOptions, cache c
 
 	// Special case, since this migration uses several tables, so it needs to
 	// be sure that all tables are created first.
-	// TODO: Remove when we are sure we are not having goose artefacts in the db
-	// This forces an error, which indicates the migration is already applied, since the
-	// column event_nid was removed from the table
-	var eventNID int
-	err = db.QueryRow("SELECT event_nid FROM roomserver_state_block LIMIT 1;").Scan(&eventNID)
-	if err == nil {
-		m := sqlutil.NewMigrator(db)
-		m.AddMigrations(sqlutil.Migration{
-			Version: "roomserver: state blocks refactor",
-			Up:      deltas.UpStateBlocksRefactor,
-		})
-		if err = m.Up(base.Context()); err != nil {
-			return nil, err
-		}
-	} else {
-		switch e := err.(type) {
-		case *pq.Error:
-			// ignore undefined_column (42703) errors, as this is expected at this point
-			if e.Code != "42703" {
-				return nil, err
-			}
-		default:
-			return nil, err
-		}
+	if err = executeMigration(base.Context(), db); err != nil {
+		return nil, err
 	}
 
 	// Then prepare the statements. Now that the migrations have run, any columns referred
@@ -85,6 +66,50 @@ func Open(base *base.BaseDendrite, dbProperties *config.DatabaseOptions, cache c
 	}
 
 	return &d, nil
+}
+
+func executeMigration(ctx context.Context, db *sql.DB) error {
+	// TODO: Remove when we are sure we are not having goose artefacts in the db
+	// This forces an error, which indicates the migration is already applied, since the
+	// column event_nid was removed from the table
+	migrationName := "roomserver: state blocks refactor"
+	var migrationCount int
+
+	err := db.QueryRowContext(ctx, "SELECT count(*) FROM db_migrations WHERE version = $1", migrationName).Scan(&migrationCount)
+	if err != nil {
+		return err
+	}
+	if migrationCount > 0 {
+		return nil
+	}
+
+	var eventNID int
+	err = db.QueryRowContext(ctx, "SELECT event_nid FROM roomserver_state_block LIMIT 1;").Scan(&eventNID)
+	if err == nil {
+		m := sqlutil.NewMigrator(db)
+		m.AddMigrations(sqlutil.Migration{
+			Version: migrationName,
+			Up:      deltas.UpStateBlocksRefactor,
+		})
+		if err = m.Up(ctx); err != nil {
+			return err
+		}
+	} else {
+		switch e := err.(type) {
+		case *pq.Error:
+			// ignore undefined_column (42703) errors, as this is expected at this point
+			if e.Code != "42703" {
+				return err
+			}
+			if err = sqlutil.InsertMigration(ctx, db, migrationName); err != nil {
+				// not a fatal error, log and continue
+				logrus.WithError(err).Warnf("unable to manually insert migration '%s'", migrationName)
+			}
+		default:
+			return err
+		}
+	}
+	return nil
 }
 
 func (d *Database) create(db *sql.DB) error {

--- a/roomserver/storage/postgres/storage.go
+++ b/roomserver/storage/postgres/storage.go
@@ -99,10 +99,8 @@ func executeMigration(ctx context.Context, db *sql.DB) error {
 		Version: migrationName,
 		Up:      deltas.UpStateBlocksRefactor,
 	})
-	if err = m.Up(ctx); err != nil {
-		return err
-	}
-	return nil
+
+	return m.Up(ctx)
 }
 
 func (d *Database) create(db *sql.DB) error {

--- a/roomserver/storage/postgres/storage.go
+++ b/roomserver/storage/postgres/storage.go
@@ -74,7 +74,8 @@ func executeMigration(ctx context.Context, db *sql.DB) error {
 	// column event_nid was removed from the table
 	migrationName := "roomserver: state blocks refactor"
 
-	err := db.QueryRowContext(ctx, "select column_name from information_schema.columns where table_name = 'roomserver_state_block' AND column_name = 'event_nid'").Err()
+	var cName string
+	err := db.QueryRowContext(ctx, "select column_name from information_schema.columns where table_name = 'roomserver_state_block' AND column_name = 'event_nid'").Scan(&cName)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) { // migration was already executed, as the column was removed
 			if err = sqlutil.InsertMigration(ctx, db, migrationName); err != nil {

--- a/roomserver/storage/postgres/storage.go
+++ b/roomserver/storage/postgres/storage.go
@@ -73,17 +73,8 @@ func executeMigration(ctx context.Context, db *sql.DB) error {
 	// This forces an error, which indicates the migration is already applied, since the
 	// column event_nid was removed from the table
 	migrationName := "roomserver: state blocks refactor"
-	var migrationCount int
 
-	err := db.QueryRowContext(ctx, "SELECT count(*) FROM db_migrations WHERE version = $1", migrationName).Scan(&migrationCount)
-	if err != nil {
-		return err
-	}
-	if migrationCount > 0 {
-		return nil
-	}
-
-	err = db.QueryRowContext(ctx, "select column_name from information_schema.columns where table_name = 'roomserver_state_block' AND column_name = 'event_nid'").Err()
+	err := db.QueryRowContext(ctx, "select column_name from information_schema.columns where table_name = 'roomserver_state_block' AND column_name = 'event_nid'").Err()
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) { // migration was already executed, as the column was removed
 			if err = sqlutil.InsertMigration(ctx, db, migrationName); err != nil {

--- a/roomserver/storage/sqlite3/storage.go
+++ b/roomserver/storage/sqlite3/storage.go
@@ -82,7 +82,8 @@ func executeMigration(ctx context.Context, db *sql.DB) error {
 	// column event_nid was removed from the table
 	migrationName := "roomserver: state blocks refactor"
 
-	err := db.QueryRowContext(ctx, `SELECT p.name FROM sqlite_master AS m JOIN pragma_table_info(m.name) AS p WHERE m.name = 'roomserver_state_block' AND p.name = 'event_nid'`).Err()
+	var cName string
+	err := db.QueryRowContext(ctx, `SELECT p.name FROM sqlite_master AS m JOIN pragma_table_info(m.name) AS p WHERE m.name = 'roomserver_state_block' AND p.name = 'event_nid'`).Scan(&cName)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) { // migration was already executed, as the column was removed
 			if err = sqlutil.InsertMigration(ctx, db, migrationName); err != nil {

--- a/roomserver/storage/sqlite3/storage.go
+++ b/roomserver/storage/sqlite3/storage.go
@@ -81,17 +81,8 @@ func executeMigration(ctx context.Context, db *sql.DB) error {
 	// This forces an error, which indicates the migration is already applied, since the
 	// column event_nid was removed from the table
 	migrationName := "roomserver: state blocks refactor"
-	var migrationCount int
 
-	err := db.QueryRowContext(ctx, "SELECT count(*) FROM db_migrations WHERE version = $1", migrationName).Scan(&migrationCount)
-	if err != nil {
-		return err
-	}
-	if migrationCount > 0 {
-		return nil
-	}
-
-	err = db.QueryRowContext(ctx, `SELECT p.name FROM sqlite_master AS m JOIN pragma_table_info(m.name) AS p WHERE m.name = 'roomserver_state_block' AND p.name = 'event_nid'`).Err()
+	err := db.QueryRowContext(ctx, `SELECT p.name FROM sqlite_master AS m JOIN pragma_table_info(m.name) AS p WHERE m.name = 'roomserver_state_block' AND p.name = 'event_nid'`).Err()
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) { // migration was already executed, as the column was removed
 			if err = sqlutil.InsertMigration(ctx, db, migrationName); err != nil {


### PR DESCRIPTION
This changes the detection of already executed migrations for the roomserver state block and keychange refactor. It now uses schema tables provided by the database engine to check if the column was already removed. We now also store the migration in the migrations table.

This should stop e.g. Postgres from logging errors like `ERROR:  column "event_nid" does not exist at character 8`.