### PR TITLE
Only set backOffStarted to false if until is not zero

### DIFF
--- a/federationapi/statistics/statistics.go
+++ b/federationapi/statistics/statistics.go
@@ -5,10 +5,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/matrix-org/dendrite/federationapi/storage"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/atomic"
+
+	"github.com/matrix-org/dendrite/federationapi/storage"
 )
 
 // Statistics contains information about all of the remote federated
@@ -126,13 +127,13 @@ func (s *ServerStatistics) Failure() (time.Time, bool) {
 
 		go func() {
 			until, ok := s.backoffUntil.Load().(time.Time)
-			if ok {
+			if ok && !until.IsZero() {
 				select {
 				case <-time.After(time.Until(until)):
 				case <-s.interrupt:
 				}
+				s.backoffStarted.Store(false)
 			}
-			s.backoffStarted.Store(false)
 		}()
 	}
 


### PR DESCRIPTION
Fixes `TestBackoff` failing when run with e.g. `go test -count=1000`
```
--- FAIL: TestBackoff (0.00s)
    statistics_test.go:27: Backoff counter: 1
    statistics_test.go:59: Backoff 1 is for 2s
    statistics_test.go:59: Backoff 2 is for 8s
    statistics_test.go:61: Backoff 2 should have been 4s but was 8s
FAIL
FAIL    github.com/matrix-org/dendrite/federationapi/statistics 0.039s
```