### PR TITLE
Fix race condition on startup

### DIFF
--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -18,6 +18,8 @@ import (
 	"flag"
 	"os"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/matrix-org/dendrite/appservice"
 	"github.com/matrix-org/dendrite/federationapi"
 	"github.com/matrix-org/dendrite/keyserver"
@@ -29,7 +31,6 @@ import (
 	"github.com/matrix-org/dendrite/setup/mscs"
 	"github.com/matrix-org/dendrite/userapi"
 	uapi "github.com/matrix-org/dendrite/userapi/api"
-	"github.com/sirupsen/logrus"
 
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -155,14 +156,6 @@ func main() {
 		}
 	}
 
-	// Expose the matrix APIs directly rather than putting them under a /api path.
-	go func() {
-		base.SetupAndServeHTTP(
-			httpAPIAddr, // internal API
-			httpAddr,    // external API
-			nil, nil,    // TLS settings
-		)
-	}()
 	// Handle HTTPS if certificate and key are provided
 	if *certFile != "" && *keyFile != "" {
 		go func() {
@@ -170,6 +163,15 @@ func main() {
 				basepkg.NoListener, // internal API
 				httpsAddr,          // external API
 				certFile, keyFile,  // TLS settings
+			)
+		}()
+	} else {
+		// Expose the matrix APIs directly rather than putting them under a /api path.
+		go func() {
+			base.SetupAndServeHTTP(
+				httpAPIAddr, // internal API
+				httpAddr,    // external API
+				nil, nil,    // TLS settings
 			)
 		}()
 	}

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -18,8 +18,6 @@ import (
 	"flag"
 	"os"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/matrix-org/dendrite/appservice"
 	"github.com/matrix-org/dendrite/federationapi"
 	"github.com/matrix-org/dendrite/keyserver"
@@ -31,6 +29,7 @@ import (
 	"github.com/matrix-org/dendrite/setup/mscs"
 	"github.com/matrix-org/dendrite/userapi"
 	uapi "github.com/matrix-org/dendrite/userapi/api"
+	"github.com/sirupsen/logrus"
 
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -156,6 +155,14 @@ func main() {
 		}
 	}
 
+	// Expose the matrix APIs directly rather than putting them under a /api path.
+	go func() {
+		base.SetupAndServeHTTP(
+			httpAPIAddr, // internal API
+			httpAddr,    // external API
+			nil, nil,    // TLS settings
+		)
+	}()
 	// Handle HTTPS if certificate and key are provided
 	if *certFile != "" && *keyFile != "" {
 		go func() {
@@ -163,15 +170,6 @@ func main() {
 				basepkg.NoListener, // internal API
 				httpsAddr,          // external API
 				certFile, keyFile,  // TLS settings
-			)
-		}()
-	} else {
-		// Expose the matrix APIs directly rather than putting them under a /api path.
-		go func() {
-			base.SetupAndServeHTTP(
-				httpAPIAddr, // internal API
-				httpAddr,    // external API
-				nil, nil,    // TLS settings
 			)
 		}()
 	}

--- a/setup/base/base.go
+++ b/setup/base/base.go
@@ -25,20 +25,22 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
 	"github.com/getsentry/sentry-go"
 	sentryhttp "github.com/getsentry/sentry-go/http"
-	"github.com/matrix-org/dendrite/internal/caching"
-	"github.com/matrix-org/dendrite/internal/httputil"
-	"github.com/matrix-org/dendrite/internal/pushgateway"
-	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/atomic"
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
+
+	"github.com/matrix-org/dendrite/internal/caching"
+	"github.com/matrix-org/dendrite/internal/httputil"
+	"github.com/matrix-org/dendrite/internal/pushgateway"
+	"github.com/matrix-org/dendrite/internal/sqlutil"
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/setup/jetstream"
@@ -46,6 +48,8 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/kardianos/minwinsvc"
+
+	"github.com/sirupsen/logrus"
 
 	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"
 	asinthttp "github.com/matrix-org/dendrite/appservice/inthttp"
@@ -58,7 +62,6 @@ import (
 	"github.com/matrix-org/dendrite/setup/config"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 	userapiinthttp "github.com/matrix-org/dendrite/userapi/inthttp"
-	"github.com/sirupsen/logrus"
 )
 
 // BaseDendrite is a base for creating new instances of dendrite. It parses
@@ -87,6 +90,7 @@ type BaseDendrite struct {
 	Database               *sql.DB
 	DatabaseWriter         sqlutil.Writer
 	EnableMetrics          bool
+	startupLock            sync.Mutex
 }
 
 const NoListener = ""
@@ -394,6 +398,9 @@ func (b *BaseDendrite) SetupAndServeHTTP(
 	internalHTTPAddr, externalHTTPAddr config.HTTPAddress,
 	certFile, keyFile *string,
 ) {
+	// Manually unlocked right before actually serving requests,
+	// as we don't return from this method (defer doesn't work).
+	b.startupLock.Lock()
 	internalAddr, _ := internalHTTPAddr.Address()
 	externalAddr, _ := externalHTTPAddr.Address()
 
@@ -472,6 +479,7 @@ func (b *BaseDendrite) SetupAndServeHTTP(
 	externalRouter.PathPrefix(httputil.PublicMediaPathPrefix).Handler(b.PublicMediaAPIMux)
 	externalRouter.PathPrefix(httputil.PublicWellKnownPrefix).Handler(b.PublicWellKnownAPIMux)
 
+	b.startupLock.Unlock()
 	if internalAddr != NoListener && internalAddr != externalAddr {
 		go func() {
 			var internalShutdown atomic.Bool // RegisterOnShutdown can be called more than once


### PR DESCRIPTION
`SetupAndServeHTTP` would race in `configureHTTPErrors` and while configuring routes.
This is probably the same error @brianathere observed in #2678 