### PR TITLE
Fix issue with stale device lists

### DIFF
--- a/federationapi/inthttp/server.go
+++ b/federationapi/inthttp/server.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/matrix-org/gomatrix"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
+	"github.com/sirupsen/logrus"
 
 	"github.com/matrix-org/dendrite/federationapi/api"
 	"github.com/matrix-org/dendrite/internal/httputil"
@@ -235,7 +237,13 @@ func federationClientError(err error) error {
 		return &api.FederationClientError{
 			Code: ferr.Code,
 		}
+	case *url.Error: // e.g. certificate error, unable to connect
+		return &api.FederationClientError{
+			Err:  ferr.Error(),
+			Code: 400,
+		}
 	default:
+		logrus.Debugf("Unknown error: %T", ferr)
 		return &api.FederationClientError{
 			Err: err.Error(),
 		}

--- a/federationapi/inthttp/server.go
+++ b/federationapi/inthttp/server.go
@@ -10,7 +10,6 @@ import (
 	"github.com/matrix-org/gomatrix"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
-	"github.com/sirupsen/logrus"
 
 	"github.com/matrix-org/dendrite/federationapi/api"
 	"github.com/matrix-org/dendrite/internal/httputil"
@@ -243,9 +242,11 @@ func federationClientError(err error) error {
 			Code: 400,
 		}
 	default:
-		logrus.Debugf("Unknown error: %T", ferr)
+		// We don't know what exactly failed, but we probably don't
+		// want to retry the request immediately in the device list updater
 		return &api.FederationClientError{
-			Err: err.Error(),
+			Err:  err.Error(),
+			Code: 400,
 		}
 	}
 }

--- a/keyserver/internal/device_list_update.go
+++ b/keyserver/internal/device_list_update.go
@@ -428,7 +428,7 @@ userLoop:
 				// It probably doesn't make sense to try further users.
 				if !e.Timeout() {
 					waitTime = time.Minute * 10
-					logrus.WithError(e).Error("GetUserDevices returned net.Error")
+					logger.WithError(e).Error("GetUserDevices returned net.Error")
 					break userLoop
 				}
 			case gomatrix.HTTPError:

--- a/keyserver/internal/device_list_update.go
+++ b/keyserver/internal/device_list_update.go
@@ -167,6 +167,7 @@ func (u *DeviceListUpdater) Start() error {
 		step = (time.Second * 120) / time.Duration(max)
 	}
 	for _, userID := range staleLists {
+		userID := userID // otherwise we are only sending the last entry
 		time.AfterFunc(offset, func() {
 			u.notifyWorkers(userID)
 		})


### PR DESCRIPTION
We were only sending the last entry to the worker, so most likely missed updates.