### PR TITLE
Update getting pushrules, add tests, tweak pushrules

### DIFF
--- a/internal/pushrules/default_content.go
+++ b/internal/pushrules/default_content.go
@@ -16,6 +16,12 @@ func mRuleContainsUserNameDefinition(localpart string) *Rule {
 		Default: true,
 		Enabled: true,
 		Pattern: localpart,
+		Conditions: []*Condition{
+			{
+				Kind: EventMatchCondition,
+				Key:  "content.body",
+			},
+		},
 		Actions: []*Action{
 			{Kind: NotifyAction},
 			{

--- a/internal/pushrules/default_override.go
+++ b/internal/pushrules/default_override.go
@@ -7,8 +7,9 @@ func defaultOverrideRules(userID string) []*Rule {
 		mRuleInviteForMeDefinition(userID),
 		&mRuleMemberEventDefinition,
 		&mRuleContainsDisplayNameDefinition,
-		&mRuleTombstoneDefinition,
 		&mRuleRoomNotifDefinition,
+		&mRuleTombstoneDefinition,
+		&mRuleReactionDefinition,
 	}
 }
 
@@ -20,6 +21,7 @@ const (
 	MRuleContainsDisplayName = ".m.rule.contains_display_name"
 	MRuleTombstone           = ".m.rule.tombstone"
 	MRuleRoomNotif           = ".m.rule.roomnotif"
+	MRuleReaction            = ".m.rule.reaction"
 )
 
 var (
@@ -96,7 +98,7 @@ var (
 			{
 				Kind:  SetTweakAction,
 				Tweak: HighlightTweak,
-				Value: false,
+				Value: true,
 			},
 		},
 	}
@@ -120,8 +122,23 @@ var (
 			{
 				Kind:  SetTweakAction,
 				Tweak: HighlightTweak,
-				Value: false,
+				Value: true,
 			},
+		},
+	}
+	mRuleReactionDefinition = Rule{
+		RuleID:  MRuleReaction,
+		Default: true,
+		Enabled: true,
+		Conditions: []*Condition{
+			{
+				Kind:    EventMatchCondition,
+				Key:     "type",
+				Pattern: "m.reaction",
+			},
+		},
+		Actions: []*Action{
+			{Kind: DontNotifyAction},
 		},
 	}
 )

--- a/internal/pushrules/default_underride.go
+++ b/internal/pushrules/default_underride.go
@@ -10,8 +10,8 @@ const (
 
 var defaultUnderrideRules = []*Rule{
 	&mRuleCallDefinition,
-	&mRuleEncryptedRoomOneToOneDefinition,
 	&mRuleRoomOneToOneDefinition,
+	&mRuleEncryptedRoomOneToOneDefinition,
 	&mRuleMessageDefinition,
 	&mRuleEncryptedDefinition,
 }
@@ -61,6 +61,11 @@ var (
 			{Kind: NotifyAction},
 			{
 				Kind:  SetTweakAction,
+				Tweak: SoundTweak,
+				Value: "default",
+			},
+			{
+				Kind:  SetTweakAction,
 				Tweak: HighlightTweak,
 				Value: false,
 			},
@@ -88,6 +93,11 @@ var (
 				Tweak: HighlightTweak,
 				Value: false,
 			},
+			{
+				Kind:  SetTweakAction,
+				Tweak: HighlightTweak,
+				Value: false,
+			},
 		},
 	}
 	mRuleMessageDefinition = Rule{
@@ -101,7 +111,14 @@ var (
 				Pattern: "m.room.message",
 			},
 		},
-		Actions: []*Action{{Kind: NotifyAction}},
+		Actions: []*Action{
+			{Kind: NotifyAction},
+			{
+				Kind:  SetTweakAction,
+				Tweak: HighlightTweak,
+				Value: false,
+			},
+		},
 	}
 	mRuleEncryptedDefinition = Rule{
 		RuleID:  MRuleEncrypted,
@@ -114,6 +131,13 @@ var (
 				Pattern: "m.room.encrypted",
 			},
 		},
-		Actions: []*Action{{Kind: NotifyAction}},
+		Actions: []*Action{
+			{Kind: NotifyAction},
+			{
+				Kind:  SetTweakAction,
+				Tweak: HighlightTweak,
+				Value: false,
+			},
+		},
 	}
 )

--- a/internal/pushrules/util.go
+++ b/internal/pushrules/util.go
@@ -11,7 +11,7 @@ import (
 // kind and a tweaks map. Returns a nil map if it would have been
 // empty.
 func ActionsToTweaks(as []*Action) (ActionKind, map[string]interface{}, error) {
-	var kind ActionKind
+	kind := UnknownAction
 	tweaks := map[string]interface{}{}
 
 	for _, a := range as {

--- a/userapi/consumers/syncapi_streamevent_test.go
+++ b/userapi/consumers/syncapi_streamevent_test.go
@@ -1,0 +1,129 @@
+package consumers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/matrix-org/dendrite/internal/pushrules"
+	"github.com/matrix-org/dendrite/setup/config"
+	"github.com/matrix-org/dendrite/test"
+	"github.com/matrix-org/dendrite/userapi/storage"
+)
+
+func mustCreateDatabase(t *testing.T, dbType test.DBType) (storage.Database, func()) {
+	t.Helper()
+	connStr, close := test.PrepareDBConnectionString(t, dbType)
+	db, err := storage.NewUserAPIDatabase(nil, &config.DatabaseOptions{
+		ConnectionString: config.DataSource(connStr),
+	}, "", 4, 0, 0, "")
+	if err != nil {
+		t.Fatalf("failed to create new user db: %v", err)
+	}
+	return db, close
+}
+
+func mustCreateEvent(t *testing.T, content string) *gomatrixserverlib.HeaderedEvent {
+	t.Helper()
+	ev, err := gomatrixserverlib.NewEventFromTrustedJSON([]byte(content), false, gomatrixserverlib.RoomVersionV10)
+	if err != nil {
+		t.Fatalf("failed to create event: %v", err)
+	}
+	return ev.Headered(gomatrixserverlib.RoomVersionV10)
+}
+
+func Test_evaluatePushRules(t *testing.T) {
+	ctx := context.Background()
+
+	test.WithAllDatabases(t, func(t *testing.T, dbType test.DBType) {
+		db, close := mustCreateDatabase(t, dbType)
+		defer close()
+		consumer := OutputStreamEventConsumer{db: db}
+
+		testCases := []struct {
+			name         string
+			eventContent string
+			wantAction   pushrules.ActionKind
+			wantActions  []*pushrules.Action
+			wantNotify   bool
+		}{
+			{
+				name:         "m.receipt doesn't notify",
+				eventContent: `{"type":"m.receipt"}`,
+				wantAction:   pushrules.UnknownAction,
+				wantActions:  nil,
+			},
+			{
+				name:         "m.reaction doesn't notify",
+				eventContent: `{"type":"m.reaction"}`,
+				wantAction:   pushrules.DontNotifyAction,
+				wantActions: []*pushrules.Action{
+					{
+						Kind: pushrules.DontNotifyAction,
+					},
+				},
+			},
+			{
+				name:         "m.room.message notifies",
+				eventContent: `{"type":"m.room.message"}`,
+				wantNotify:   true,
+				wantAction:   pushrules.NotifyAction,
+				wantActions: []*pushrules.Action{
+					{Kind: pushrules.NotifyAction},
+					{
+						Kind:  pushrules.SetTweakAction,
+						Tweak: pushrules.HighlightTweak,
+						Value: false,
+					},
+				},
+			},
+			{
+				name:         "m.room.message highlights",
+				eventContent: `{"type":"m.room.message", "content": {"body": "test"} }`,
+				wantNotify:   true,
+				wantAction:   pushrules.NotifyAction,
+				wantActions: []*pushrules.Action{
+					{Kind: pushrules.NotifyAction},
+					{
+						Kind:  pushrules.SetTweakAction,
+						Tweak: pushrules.SoundTweak,
+						Value: "default",
+					},
+					{
+						Kind:  pushrules.SetTweakAction,
+						Tweak: pushrules.HighlightTweak,
+						Value: true,
+					},
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				actions, err := consumer.evaluatePushRules(ctx, mustCreateEvent(t, tc.eventContent), &localMembership{
+					UserID:    "@test:localhost",
+					Localpart: "test",
+					Domain:    "localhost",
+				}, 10)
+				if err != nil {
+					t.Fatalf("failed to evaluate push rules: %v", err)
+				}
+				assert.Equal(t, tc.wantActions, actions)
+				gotAction, _, err := pushrules.ActionsToTweaks(actions)
+				if err != nil {
+					t.Fatalf("failed to get actions: %v", err)
+				}
+				if gotAction != tc.wantAction {
+					t.Fatalf("expected action to be '%s', got '%s'", tc.wantAction, gotAction)
+				}
+				// this is taken from `notifyLocal`
+				if tc.wantNotify && gotAction != pushrules.NotifyAction && gotAction != pushrules.CoalesceAction {
+					t.Fatalf("expected to notify but didn't")
+				}
+			})
+
+		}
+	})
+}

--- a/userapi/storage/interface.go
+++ b/userapi/storage/interface.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
+	"github.com/matrix-org/dendrite/internal/pushrules"
 	"github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/dendrite/userapi/storage/tables"
 	"github.com/matrix-org/dendrite/userapi/types"
@@ -53,6 +54,7 @@ type AccountData interface {
 	// If no account data could be found, returns nil
 	// Returns an error if there was an issue with the retrieval
 	GetAccountDataByType(ctx context.Context, localpart, roomID, dataType string) (data json.RawMessage, err error)
+	QueryPushRules(ctx context.Context, localpart string) (*pushrules.AccountRuleSets, error)
 }
 
 type Device interface {

--- a/userapi/userapi.go
+++ b/userapi/userapi.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+
 	"github.com/matrix-org/dendrite/internal/pushgateway"
 	keyapi "github.com/matrix-org/dendrite/keyserver/api"
 	rsapi "github.com/matrix-org/dendrite/roomserver/api"
@@ -31,7 +33,6 @@ import (
 	"github.com/matrix-org/dendrite/userapi/producers"
 	"github.com/matrix-org/dendrite/userapi/storage"
 	"github.com/matrix-org/dendrite/userapi/util"
-	"github.com/sirupsen/logrus"
 )
 
 // AddInternalRoutes registers HTTP handlers for the internal API. Invokes functions
@@ -90,7 +91,7 @@ func NewInternalAPI(
 	}
 
 	eventConsumer := consumers.NewOutputStreamEventConsumer(
-		base.ProcessContext, cfg, js, db, pgClient, userAPI, rsAPI, syncProducer,
+		base.ProcessContext, cfg, js, db, pgClient, rsAPI, syncProducer,
 	)
 	if err := eventConsumer.Start(); err != nil {
 		logrus.WithError(err).Panic("failed to start user API streamed event consumer")


### PR DESCRIPTION
This PR
- adds tests for `evaluatePushrules`
- removes the need for the UserAPI on the `OutputStreamEventConsumer` (for easier testing)
- adds a method to get the pushrules from the database
- adds a new default pushrule for `m.reaction` events (and some other tweaks)