### PR TITLE
Exclude `KindOld` from sync

### DIFF
--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -278,20 +278,14 @@ func (s *OutputRoomEventConsumer) onOldRoomEvent(
 ) error {
 	ev := msg.Event
 
-	// TODO: The state key check when excluding from sync is designed
-	// to stop us from lying to clients with old state, whilst still
-	// allowing normal timeline events through. This is an absolute
-	// hack but until we have some better strategy for dealing with
-	// old events in the sync API, this should at least prevent us
-	// from confusing clients into thinking they've joined/left rooms.
 	pduPos, err := s.db.WriteEvent(
 		ctx,
 		ev,
 		[]*gomatrixserverlib.HeaderedEvent{},
-		[]string{},           // adds no state
-		[]string{},           // removes no state
-		nil,                  // no transaction
-		ev.StateKey() != nil, // exclude from sync?,
+		[]string{}, // adds no state
+		[]string{}, // removes no state
+		nil,        // no transaction
+		true,       // exclude from sync
 		msg.HistoryVisibility,
 	)
 	if err != nil {


### PR DESCRIPTION
Otherwise one user who is backfilling can potentially poison the timeline of another user who will suddenly see lots of out-of-order messages.