### PR TITLE
Bug fix #2718 appservice txnid should be different for each batch of events

### DIFF
--- a/appservice/consumers/roomserver.go
+++ b/appservice/consumers/roomserver.go
@@ -174,9 +174,9 @@ func (s *OutputRoomEventConsumer) sendEvents(
 	}
 
 	// If the number of items in the array is different,
-	// then this should be a different transaction. Incorporate the length
+	// then this should be treated as a different transaction. Incorporate the length
 	// of events into the transaction ID.
-	txnID := events[0].Event.OriginServerTS().Time().Add(time.Duration(len(events)))
+	txnID := events[0].Event.OriginServerTS().Time().Nanosecond() + len(transaction)
 
 	// Send the transaction to the appservice.
 	// https://matrix.org/docs/spec/application_service/r0.1.2#put-matrix-app-v1-transactions-txnid

--- a/appservice/consumers/roomserver.go
+++ b/appservice/consumers/roomserver.go
@@ -154,25 +154,23 @@ func (s *OutputRoomEventConsumer) onMessage(
 
 	txnID := ""
 	// Try to get the message metadata, if we're able to, use the timestamp as the txnID
-	if len(msgs) > 0 {
-		metadata, err := msgs[0].Metadata()
-		if err == nil {
-			txnID = strconv.Itoa(int(metadata.Timestamp.UnixNano()))
-		}
+	metadata, err := msgs[0].Metadata()
+	if err == nil {
+		txnID = strconv.Itoa(int(metadata.Timestamp.UnixNano()))
 	}
 
 	// Send event to any relevant application services. If we hit
 	// an error here, return false, so that we negatively ack.
 	log.WithField("appservice", state.ID).Debugf("Appservice worker sending %d events(s) from roomserver", len(events))
-	return s.sendEvents(txnID, ctx, state, events) == nil
+	return s.sendEvents(ctx, state, events, txnID) == nil
 }
 
 // sendEvents passes events to the appservice by using the transactions
 // endpoint. It will block for the backoff period if necessary.
 func (s *OutputRoomEventConsumer) sendEvents(
-	txnID string,
 	ctx context.Context, state *appserviceState,
 	events []*gomatrixserverlib.HeaderedEvent,
+	txnID string,
 ) error {
 	// Create the transaction body.
 	transaction, err := json.Marshal(

--- a/appservice/consumers/roomserver.go
+++ b/appservice/consumers/roomserver.go
@@ -173,9 +173,10 @@ func (s *OutputRoomEventConsumer) sendEvents(
 		return err
 	}
 
-	// TODO: We should probably be more intelligent and pick something not
-	// in the control of the event. A NATS timestamp header or something maybe.
-	txnID := events[0].Event.OriginServerTS()
+	// If the number of items in the array is different,
+	// then this should be a different transaction. Incorporate the length
+	// of events into the transaction ID.
+	txnID := events[0].Event.OriginServerTS().Time().Add(time.Duration(len(events)))
 
 	// Send the transaction to the appservice.
 	// https://matrix.org/docs/spec/application_service/r0.1.2#put-matrix-app-v1-transactions-txnid

--- a/appservice/consumers/roomserver.go
+++ b/appservice/consumers/roomserver.go
@@ -176,11 +176,11 @@ func (s *OutputRoomEventConsumer) sendEvents(
 	// If the number of items in the array is different,
 	// then this should be treated as a different transaction. Incorporate the length
 	// of events into the transaction ID.
-	txnID := events[0].Event.OriginServerTS().Time().Nanosecond() + len(transaction)
+	txnID := fmt.Sprintf("%d_%d", events[0].Event.OriginServerTS(), len(transaction))
 
 	// Send the transaction to the appservice.
 	// https://matrix.org/docs/spec/application_service/r0.1.2#put-matrix-app-v1-transactions-txnid
-	address := fmt.Sprintf("%s/transactions/%d?access_token=%s", state.URL, txnID, url.QueryEscape(state.HSToken))
+	address := fmt.Sprintf("%s/transactions/%s?access_token=%s", state.URL, txnID, url.QueryEscape(state.HSToken))
 	req, err := http.NewRequestWithContext(ctx, "PUT", address, bytes.NewBuffer(transaction))
 	if err != nil {
 		return err


### PR DESCRIPTION
See issue: [#2718](https://github.com/matrix-org/dendrite/issues/2718) for more details.

The fix assumes that if the number of transaction items are different, then the txnid should be different. 

txnid := OriginalServerTS()_len(transactions) 

The case that it doesn't address is if the txnid generated this way is the same for 2 different batches of events which have the same OriginalServerTS and the same array length.

Another option:

txnid := OriginalServerTS()_hash(transactions)

Would love to hear other ideas and ways to fix this.

### Pull Request Checklist

* [x ] I have added added tests for PR _or_ I have justified why this PR doesn't need tests.
* [x ] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/main/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `Tak Wai Wong <tak@hntlabs.com>`
