### PR TITLE
Verify `msgtype` is set on `m.room.message` events

### DIFF
--- a/clientapi/routing/sendevent.go
+++ b/clientapi/routing/sendevent.go
@@ -120,6 +120,16 @@ func SendEvent(
 		delete(r, "join_authorised_via_users_server")
 	}
 
+	// As per the spec, m.room.message events require a msgtype, verify it is set
+	if eventType == "m.room.message" {
+		if _, ok := r["msgtype"]; !ok {
+			return util.JSONResponse{
+				Code: http.StatusBadRequest,
+				JSON: jsonerror.Unknown("'msgtype' not in content"),
+			}
+		}
+	}
+
 	evTime, err := httputil.ParseTSParam(req)
 	if err != nil {
 		return util.JSONResponse{


### PR DESCRIPTION
https://spec.matrix.org/v1.3/client-server-api/#mroommessage
"Discovered" because I forgot to set the `msgtype` in Complement, Dendrite was happy, Synapse failed the tests because of the missing `msgtype`