### PR TITLE
Mark device list as stale, if we don't have the requesting device

### DIFF
--- a/keyserver/api/api.go
+++ b/keyserver/api/api.go
@@ -340,5 +340,6 @@ type QuerySignaturesResponse struct {
 
 type PerformMarkAsStaleRequest struct {
 	UserID   string
+	Domain   gomatrixserverlib.ServerName
 	DeviceID string
 }

--- a/keyserver/api/api.go
+++ b/keyserver/api/api.go
@@ -21,9 +21,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/matrix-org/gomatrixserverlib"
+
 	"github.com/matrix-org/dendrite/keyserver/types"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
-	"github.com/matrix-org/gomatrixserverlib"
 )
 
 type KeyInternalAPI interface {
@@ -56,6 +57,7 @@ type UserKeyAPI interface {
 type SyncKeyAPI interface {
 	QueryKeyChanges(ctx context.Context, req *QueryKeyChangesRequest, res *QueryKeyChangesResponse) error
 	QueryOneTimeKeys(ctx context.Context, req *QueryOneTimeKeysRequest, res *QueryOneTimeKeysResponse) error
+	PerformMarkAsStaleIfNeeded(ctx context.Context, req *PerformMarkAsStaleRequest, res *struct{}) error
 }
 
 type FederationKeyAPI interface {
@@ -334,4 +336,9 @@ type QuerySignaturesResponse struct {
 	UserSigningKeys map[string]gomatrixserverlib.CrossSigningKey
 	// The request error, if any
 	Error *KeyError
+}
+
+type PerformMarkAsStaleRequest struct {
+	UserID   string
+	DeviceID string
 }

--- a/keyserver/internal/internal.go
+++ b/keyserver/internal/internal.go
@@ -233,11 +233,7 @@ func (a *KeyInternalAPI) PerformMarkAsStaleIfNeeded(ctx context.Context, req *ap
 		return err
 	}
 	if len(knownDevices) == 0 {
-		_, remoteServer, err := gomatrixserverlib.SplitID('@', req.UserID)
-		if err != nil {
-			return err
-		}
-		return a.Updater.ManualUpdate(ctx, remoteServer, req.UserID)
+		return a.Updater.ManualUpdate(ctx, req.Domain, req.UserID)
 	}
 	return nil
 }

--- a/keyserver/internal/internal.go
+++ b/keyserver/internal/internal.go
@@ -228,7 +228,7 @@ func (a *KeyInternalAPI) QueryDeviceMessages(ctx context.Context, req *api.Query
 // PerformMarkAsStaleIfNeeded marks the users device list as stale, if the given deviceID is not present
 // in our database.
 func (a *KeyInternalAPI) PerformMarkAsStaleIfNeeded(ctx context.Context, req *api.PerformMarkAsStaleRequest, res *struct{}) error {
-	knownDevices, err := a.DB.DeviceKeysForUser(ctx, req.UserID, []string{}, true)
+	knownDevices, err := a.DB.DeviceKeysForUser(ctx, req.UserID, []string{req.DeviceID}, true)
 	if err != nil {
 		return err
 	}

--- a/keyserver/internal/internal.go
+++ b/keyserver/internal/internal.go
@@ -23,16 +23,17 @@ import (
 	"sync"
 	"time"
 
-	fedsenderapi "github.com/matrix-org/dendrite/federationapi/api"
-	"github.com/matrix-org/dendrite/keyserver/api"
-	"github.com/matrix-org/dendrite/keyserver/producers"
-	"github.com/matrix-org/dendrite/keyserver/storage"
-	userapi "github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 	"github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+
+	fedsenderapi "github.com/matrix-org/dendrite/federationapi/api"
+	"github.com/matrix-org/dendrite/keyserver/api"
+	"github.com/matrix-org/dendrite/keyserver/producers"
+	"github.com/matrix-org/dendrite/keyserver/storage"
+	userapi "github.com/matrix-org/dendrite/userapi/api"
 )
 
 type KeyInternalAPI struct {
@@ -221,6 +222,23 @@ func (a *KeyInternalAPI) QueryDeviceMessages(ctx context.Context, req *api.Query
 	}
 	res.Devices = result
 	res.StreamID = maxStreamID
+	return nil
+}
+
+// PerformMarkAsStaleIfNeeded marks the users device list as stale, if the given deviceID is not present
+// in our database.
+func (a *KeyInternalAPI) PerformMarkAsStaleIfNeeded(ctx context.Context, req *api.PerformMarkAsStaleRequest, res *struct{}) error {
+	knownDevices, err := a.DB.DeviceKeysForUser(ctx, req.UserID, []string{}, true)
+	if err != nil {
+		return err
+	}
+	if len(knownDevices) == 0 {
+		_, remoteServer, err := gomatrixserverlib.SplitID('@', req.UserID)
+		if err != nil {
+			return err
+		}
+		return a.Updater.ManualUpdate(ctx, remoteServer, req.UserID)
+	}
 	return nil
 }
 

--- a/keyserver/inthttp/client.go
+++ b/keyserver/inthttp/client.go
@@ -37,6 +37,7 @@ const (
 	QueryOneTimeKeysPath              = "/keyserver/queryOneTimeKeys"
 	QueryDeviceMessagesPath           = "/keyserver/queryDeviceMessages"
 	QuerySignaturesPath               = "/keyserver/querySignatures"
+	PerformMarkAsStalePath            = "/keyserver/markAsStale"
 )
 
 // NewKeyServerClient creates a KeyInternalAPI implemented by talking to a HTTP POST API.
@@ -169,6 +170,17 @@ func (h *httpKeyInternalAPI) QuerySignatures(
 ) error {
 	return httputil.CallInternalRPCAPI(
 		"QuerySignatures", h.apiURL+QuerySignaturesPath,
+		h.httpClient, ctx, request, response,
+	)
+}
+
+func (h *httpKeyInternalAPI) PerformMarkAsStaleIfNeeded(
+	ctx context.Context,
+	request *api.PerformMarkAsStaleRequest,
+	response *struct{},
+) error {
+	return httputil.CallInternalRPCAPI(
+		"MarkAsStale", h.apiURL+PerformMarkAsStalePath,
 		h.httpClient, ctx, request, response,
 	)
 }

--- a/keyserver/inthttp/server.go
+++ b/keyserver/inthttp/server.go
@@ -16,6 +16,7 @@ package inthttp
 
 import (
 	"github.com/gorilla/mux"
+
 	"github.com/matrix-org/dendrite/internal/httputil"
 	"github.com/matrix-org/dendrite/keyserver/api"
 )
@@ -69,5 +70,10 @@ func AddRoutes(internalAPIMux *mux.Router, s api.KeyInternalAPI) {
 	internalAPIMux.Handle(
 		QuerySignaturesPath,
 		httputil.MakeInternalRPCAPI("KeyserverQuerySignatures", s.QuerySignatures),
+	)
+
+	internalAPIMux.Handle(
+		PerformMarkAsStalePath,
+		httputil.MakeInternalRPCAPI("KeyserverMarkAsStale", s.PerformMarkAsStaleIfNeeded),
 	)
 }

--- a/syncapi/consumers/sendtodevice.go
+++ b/syncapi/consumers/sendtodevice.go
@@ -115,7 +115,7 @@ func (s *OutputSendToDeviceEventConsumer) onMessage(ctx context.Context, msgs []
 		_, senderDomain, _ := gomatrixserverlib.SplitID('@', output.Sender)
 		if requestingDeviceID != "" && senderDomain != s.serverName {
 			// Mark the requesting device as stale, if we don't know about it.
-			if err := s.keyAPI.PerformMarkAsStaleIfNeeded(ctx, &keyapi.PerformMarkAsStaleRequest{
+			if err = s.keyAPI.PerformMarkAsStaleIfNeeded(ctx, &keyapi.PerformMarkAsStaleRequest{
 				UserID: output.Sender, Domain: senderDomain, DeviceID: requestingDeviceID,
 			}, &struct{}{}); err != nil {
 				logger.WithError(err).Errorf("failed to mark as stale if needed")

--- a/syncapi/internal/keychange_test.go
+++ b/syncapi/internal/keychange_test.go
@@ -22,6 +22,10 @@ var (
 
 type mockKeyAPI struct{}
 
+func (k *mockKeyAPI) PerformMarkAsStaleIfNeeded(ctx context.Context, req *keyapi.PerformMarkAsStaleRequest, res *struct{}) error {
+	return nil
+}
+
 func (k *mockKeyAPI) PerformUploadKeys(ctx context.Context, req *keyapi.PerformUploadKeysRequest, res *keyapi.PerformUploadKeysResponse) error {
 	return nil
 }

--- a/syncapi/syncapi.go
+++ b/syncapi/syncapi.go
@@ -17,8 +17,9 @@ package syncapi
 import (
 	"context"
 
-	"github.com/matrix-org/dendrite/internal/caching"
 	"github.com/sirupsen/logrus"
+
+	"github.com/matrix-org/dendrite/internal/caching"
 
 	keyapi "github.com/matrix-org/dendrite/keyserver/api"
 	"github.com/matrix-org/dendrite/roomserver/api"
@@ -126,7 +127,7 @@ func AddPublicRoutes(
 	}
 
 	sendToDeviceConsumer := consumers.NewOutputSendToDeviceEventConsumer(
-		base.ProcessContext, cfg, js, syncDB, notifier, streams.SendToDeviceStreamProvider,
+		base.ProcessContext, cfg, js, syncDB, keyAPI, notifier, streams.SendToDeviceStreamProvider,
 	)
 	if err = sendToDeviceConsumer.Start(); err != nil {
 		logrus.WithError(err).Panicf("failed to start send-to-device consumer")


### PR DESCRIPTION
This hopefully makes E2EE chats a little bit more reliable by re-syncing devices if we don't have the `requesting_device_id` in our database. (As seen in [Synapse](https://github.com/matrix-org/synapse/blob/c52abc1cfdd9e5480cdb4a03d626fe61cacc6573/synapse/handlers/devicemessage.py#L157-L201))