### PR TITLE
Use /usr/bin/env bash in shebangs to make them universal

### DIFF
--- a/build/docker/images-build.sh
+++ b/build/docker/images-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd $(git rev-parse --show-toplevel)
 

--- a/build/docker/images-pull.sh
+++ b/build/docker/images-pull.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TAG=${1:-latest}
 

--- a/build/docker/images-push.sh
+++ b/build/docker/images-push.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TAG=${1:-latest}
 

--- a/run-sytest.sh
+++ b/run-sytest.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Runs SyTest either from Docker Hub, or from ../sytest. If it's run
 # locally, the Docker image is rebuilt first.

--- a/show-expected-fail-tests.sh
+++ b/show-expected-fail-tests.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 #
 # Parses a results.tap file from SyTest output and a file containing test names (a test whitelist)
 # and checks whether a test name that exists in the whitelist (that should pass), failed or not.


### PR DESCRIPTION
Some systems (like nixos) don't have bash living at `/bin/bash` so using `/usr/bin/env bash` we can make these scripts universal.

### Pull Request Checklist

<!-- Please read docs/CONTRIBUTING.md before submitting your pull request -->

* [X] I have added added tests for PR _or_ I have justified why this PR doesn't need tests.
* [x] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/main/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: `Dov Alperin <git@dov.dev>`
