### PR TITLE
Fix for `sql: converting argument $1 type: unsupported type []interfa…

### DIFF
--- a/syncapi/storage/sqlite3/notification_data_table.go
+++ b/syncapi/storage/sqlite3/notification_data_table.go
@@ -90,8 +90,8 @@ func (r *notificationDataStatements) SelectUserUnreadCountsForRooms(
 	for i := range roomIDs {
 		params[i+1] = roomIDs[i]
 	}
-	sql := strings.Replace(selectUserUnreadNotificationsForRooms, "($1)", sqlutil.QueryVariadic(len(params)), 1)
-	rows, err := r.db.QueryContext(ctx, sql, params)
+	sql := strings.Replace(selectUserUnreadNotificationsForRooms, "($2)", sqlutil.QueryVariadicOffset(len(roomIDs), 1), 1)
+	rows, err := r.db.QueryContext(ctx, sql, params...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
…ce {}, a slice of interface` in new notifications select

The sqlite3 version was just not working, original pr here: https://github.com/matrix-org/dendrite/pull/2688

signed off by: austin ellis <austin@hntlabs.com>

This doesn't fix the notification counts, they still only work about 1 out of every 5 times in my tests. I will stick with my other fix locally for reliable notification delivery: https://github.com/matrix-org/dendrite/pull/2701