### PR TITLE
Allow specifying old signing keys with the public key and key ID only

### DIFF
--- a/dendrite-sample.monolith.yaml
+++ b/dendrite-sample.monolith.yaml
@@ -25,7 +25,7 @@ global:
   #  If the old private key file is available:
   #  - private_key: old_matrix_key.pem
   #    expired_at: 1601024554498
-  #  If only the public key (in base64 format) and key ID is known:
+  #  If only the public key (in base64 format) and key ID are known:
   #  - public_key: mn59Kxfdq9VziYHSBzI7+EDPDcBS2Xl7jeUdiiQcOnM=
   #    key_id: ed25519:mykeyid
   #    expired_at: 1601024554498

--- a/dendrite-sample.monolith.yaml
+++ b/dendrite-sample.monolith.yaml
@@ -25,7 +25,7 @@ global:
   #  If the old private key file is available:
   #  - private_key: old_matrix_key.pem
   #    expired_at: 1601024554498
-  #  If only the public key and key ID is known:
+  #  If only the public key (in base64 format) and key ID is known:
   #  - public_key: mn59Kxfdq9VziYHSBzI7+EDPDcBS2Xl7jeUdiiQcOnM=
   #    key_id: ed25519:mykeyid
   #    expired_at: 1601024554498

--- a/dendrite-sample.monolith.yaml
+++ b/dendrite-sample.monolith.yaml
@@ -18,11 +18,16 @@ global:
   private_key: matrix_key.pem
 
   # The paths and expiry timestamps (as a UNIX timestamp in millisecond precision)
-  # to old signing private keys that were formerly in use on this domain. These
+  # to old signing keys that were formerly in use on this domain name. These
   # keys will not be used for federation request or event signing, but will be
   # provided to any other homeserver that asks when trying to verify old events.
   old_private_keys:
+  #  If the old private key file is available:
   #  - private_key: old_matrix_key.pem
+  #    expired_at: 1601024554498
+  #  If only the public key and key ID is known:
+  #  - public_key: mn59Kxfdq9VziYHSBzI7+EDPDcBS2Xl7jeUdiiQcOnM=
+  #    key_id: ed25519:mykeyid
   #    expired_at: 1601024554498
 
   # How long a remote server can cache our server signing key before requesting it

--- a/dendrite-sample.polylith.yaml
+++ b/dendrite-sample.polylith.yaml
@@ -25,7 +25,7 @@ global:
   #  If the old private key file is available:
   #  - private_key: old_matrix_key.pem
   #    expired_at: 1601024554498
-  #  If only the public key (in base64 format) and key ID is known:
+  #  If only the public key (in base64 format) and key ID are known:
   #  - public_key: mn59Kxfdq9VziYHSBzI7+EDPDcBS2Xl7jeUdiiQcOnM=
   #    key_id: ed25519:mykeyid
   #    expired_at: 1601024554498

--- a/dendrite-sample.polylith.yaml
+++ b/dendrite-sample.polylith.yaml
@@ -25,7 +25,7 @@ global:
   #  If the old private key file is available:
   #  - private_key: old_matrix_key.pem
   #    expired_at: 1601024554498
-  #  If only the public key and key ID is known:
+  #  If only the public key (in base64 format) and key ID is known:
   #  - public_key: mn59Kxfdq9VziYHSBzI7+EDPDcBS2Xl7jeUdiiQcOnM=
   #    key_id: ed25519:mykeyid
   #    expired_at: 1601024554498

--- a/dendrite-sample.polylith.yaml
+++ b/dendrite-sample.polylith.yaml
@@ -18,11 +18,16 @@ global:
   private_key: matrix_key.pem
 
   # The paths and expiry timestamps (as a UNIX timestamp in millisecond precision)
-  # to old signing private keys that were formerly in use on this domain. These
+  # to old signing keys that were formerly in use on this domain name. These
   # keys will not be used for federation request or event signing, but will be
   # provided to any other homeserver that asks when trying to verify old events.
   old_private_keys:
+  #  If the old private key file is available:
   #  - private_key: old_matrix_key.pem
+  #    expired_at: 1601024554498
+  #  If only the public key and key ID is known:
+  #  - public_key: mn59Kxfdq9VziYHSBzI7+EDPDcBS2Xl7jeUdiiQcOnM=
+  #    key_id: ed25519:mykeyid
   #    expired_at: 1601024554498
 
   # How long a remote server can cache our server signing key before requesting it

--- a/federationapi/routing/keys.go
+++ b/federationapi/routing/keys.go
@@ -160,7 +160,7 @@ func localKeys(cfg *config.FederationAPI, validUntil time.Time) (*gomatrixserver
 	for _, oldVerifyKey := range cfg.Matrix.OldVerifyKeys {
 		keys.OldVerifyKeys[oldVerifyKey.KeyID] = gomatrixserverlib.OldVerifyKey{
 			VerifyKey: gomatrixserverlib.VerifyKey{
-				Key: gomatrixserverlib.Base64Bytes(oldVerifyKey.PrivateKey.Public().(ed25519.PublicKey)),
+				Key: gomatrixserverlib.Base64Bytes(oldVerifyKey.PublicKey),
 			},
 			ExpiredTS: oldVerifyKey.ExpiredAt,
 		}

--- a/federationapi/routing/keys.go
+++ b/federationapi/routing/keys.go
@@ -160,7 +160,7 @@ func localKeys(cfg *config.FederationAPI, validUntil time.Time) (*gomatrixserver
 	for _, oldVerifyKey := range cfg.Matrix.OldVerifyKeys {
 		keys.OldVerifyKeys[oldVerifyKey.KeyID] = gomatrixserverlib.OldVerifyKey{
 			VerifyKey: gomatrixserverlib.VerifyKey{
-				Key: gomatrixserverlib.Base64Bytes(oldVerifyKey.PublicKey),
+				Key: oldVerifyKey.PublicKey,
 			},
 			ExpiredTS: oldVerifyKey.ExpiredAt,
 		}

--- a/setup/config/config.go
+++ b/setup/config/config.go
@@ -251,7 +251,7 @@ func loadConfig(
 
 			key.KeyID = keyID
 			key.PrivateKey = privateKey
-			key.PublicKey = privateKey.Public().(gomatrixserverlib.Base64Bytes)
+			key.PublicKey = gomatrixserverlib.Base64Bytes(privateKey.Public().(ed25519.PublicKey))
 
 		case len(key.PublicKey) == ed25519.PublicKeySize:
 			continue

--- a/setup/config/config.go
+++ b/setup/config/config.go
@@ -253,14 +253,14 @@ func loadConfig(
 			key.PrivateKey = privateKey
 			key.PublicKey = gomatrixserverlib.Base64Bytes(privateKey.Public().(ed25519.PublicKey))
 
+		case key.KeyID == "":
+			return nil, fmt.Errorf("'key_id' must be specified if 'public_key' is specified")
+
 		case len(key.PublicKey) == ed25519.PublicKeySize:
 			continue
 
 		case len(key.PublicKey) > 0:
 			return nil, fmt.Errorf("the supplied 'public_key' is the wrong length")
-
-		case key.KeyID == "":
-			return nil, fmt.Errorf("'key_id' must be specified if 'public_key' is specified")
 
 		default:
 			return nil, fmt.Errorf("either specify a 'private_key' path or supply both 'public_key' and 'key_id'")

--- a/setup/config/config.go
+++ b/setup/config/config.go
@@ -263,7 +263,7 @@ func loadConfig(
 
 			key.KeyID = keyID
 			key.PrivateKey = privateKey
-			key.PublicKey = privateKey.Public().(ed25519.PublicKey)
+			key.PublicKey = privateKey.Public().(gomatrixserverlib.Base64Bytes)
 		}
 	}
 

--- a/setup/config/config.go
+++ b/setup/config/config.go
@@ -233,19 +233,7 @@ func loadConfig(
 
 	for _, key := range c.Global.OldVerifyKeys {
 		switch {
-		case key.KeyID == "":
-			return nil, fmt.Errorf("key ID must be specified if public_key is specified")
-
-		case len(key.PublicKey) == ed25519.PublicKeySize:
-			continue
-
-		case len(key.PublicKey) > 0:
-			return nil, fmt.Errorf("the public_key is the wrong length")
-
-		case key.PrivateKeyPath == "":
-			return nil, fmt.Errorf("a private_key path must be specified if public_key isn't")
-
-		default:
+		case key.PrivateKeyPath != "":
 			var oldPrivateKeyData []byte
 			oldPrivateKeyPath := absPath(basePath, key.PrivateKeyPath)
 			oldPrivateKeyData, err = readFile(oldPrivateKeyPath)
@@ -264,6 +252,18 @@ func loadConfig(
 			key.KeyID = keyID
 			key.PrivateKey = privateKey
 			key.PublicKey = privateKey.Public().(gomatrixserverlib.Base64Bytes)
+
+		case len(key.PublicKey) == ed25519.PublicKeySize:
+			continue
+
+		case len(key.PublicKey) > 0:
+			return nil, fmt.Errorf("the supplied 'public_key' is the wrong length")
+
+		case key.KeyID == "":
+			return nil, fmt.Errorf("'key_id' must be specified if 'public_key' is specified")
+
+		default:
+			return nil, fmt.Errorf("either specify a 'private_key' path or supply both 'public_key' and 'key_id'")
 		}
 	}
 

--- a/setup/config/config.go
+++ b/setup/config/config.go
@@ -234,7 +234,7 @@ func loadConfig(
 	for _, key := range c.Global.OldVerifyKeys {
 		switch {
 		case key.KeyID == "":
-			return nil, fmt.Errorf("key ID must be specified for old_verify_keys")
+			return nil, fmt.Errorf("key ID must be specified if public_key is specified")
 
 		case len(key.PublicKey) == ed25519.PublicKeySize:
 			continue

--- a/setup/config/config_global.go
+++ b/setup/config/config_global.go
@@ -27,7 +27,7 @@ type Global struct {
 	// Information about old private keys that used to be used to sign requests and
 	// events on this domain. They will not be used but will be advertised to other
 	// servers that ask for them to help verify old events.
-	OldVerifyKeys []OldVerifyKeys `yaml:"old_private_keys"`
+	OldVerifyKeys []*OldVerifyKeys `yaml:"old_private_keys"`
 
 	// How long a remote server can cache our server key for before requesting it again.
 	// Increasing this number will reduce the number of requests made by remote servers
@@ -126,6 +126,9 @@ type OldVerifyKeys struct {
 
 	// The private key itself.
 	PrivateKey ed25519.PrivateKey `yaml:"-"`
+
+	// The public key, in case only that part is known.
+	PublicKey ed25519.PublicKey `yaml:"public_key"`
 
 	// The key ID of the private key.
 	KeyID gomatrixserverlib.KeyID `yaml:"-"`

--- a/setup/config/config_global.go
+++ b/setup/config/config_global.go
@@ -128,7 +128,7 @@ type OldVerifyKeys struct {
 	PrivateKey ed25519.PrivateKey `yaml:"-"`
 
 	// The public key, in case only that part is known.
-	PublicKey ed25519.PublicKey `yaml:"public_key"`
+	PublicKey gomatrixserverlib.Base64Bytes `yaml:"public_key"`
 
 	// The key ID of the private key.
 	KeyID gomatrixserverlib.KeyID `yaml:"-"`

--- a/setup/config/config_global.go
+++ b/setup/config/config_global.go
@@ -131,7 +131,7 @@ type OldVerifyKeys struct {
 	PublicKey gomatrixserverlib.Base64Bytes `yaml:"public_key"`
 
 	// The key ID of the private key.
-	KeyID gomatrixserverlib.KeyID `yaml:"-"`
+	KeyID gomatrixserverlib.KeyID `yaml:"key_id"`
 
 	// When the private key was designed as "expired", as a UNIX timestamp
 	// in millisecond precision.


### PR DESCRIPTION
If the private key file is lost, it's often possible to retrieve the public key from another server elsewhere, so we should make it possible to configure it in that way.