### PR TITLE
Add Monolith config options for HTTP(s) Bind Addresses

### DIFF
--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -46,6 +46,9 @@ func main() {
 	cfg := setup.ParseFlags(true)
 	httpAddr := cfg.Global.Monolith.HTTPBindAddr
 	httpsAddr := cfg.Global.Monolith.HTTPBindAddr
+	certPath := string(cfg.Global.Monolith.TlsCertificatePath)
+	keyPath := string(cfg.Global.Monolith.TlsPrivateKeyPath)
+
 	if *httpBindAddr != "" {
 		httpAddr = config.HTTPAddress("http://" + *httpBindAddr)
 	}
@@ -53,6 +56,14 @@ func main() {
 		httpsAddr = config.HTTPAddress("https://" + *httpsBindAddr)
 	}
 	httpAPIAddr := httpAddr
+
+	if *certFile != "" {
+		certPath = *certFile
+	}
+	if *keyFile != "" {
+		keyPath = *keyFile
+	}
+
 	options := []basepkg.BaseDendriteOptions{}
 	if *enableHTTPAPIs {
 		logrus.Warnf("DANGER! The -api option is enabled, exposing internal APIs on %q!", *apiBindAddr)
@@ -168,12 +179,12 @@ func main() {
 		)
 	}()
 	// Handle HTTPS if certificate and key are provided
-	if *certFile != "" && *keyFile != "" {
+	if certPath != "" && keyPath != "" {
 		go func() {
 			base.SetupAndServeHTTP(
 				basepkg.NoListener, // internal API
 				httpsAddr,          // external API
-				certFile, keyFile,  // TLS settings
+				&certPath, &keyPath,// TLS settings
 			)
 		}()
 	}

--- a/cmd/dendrite-monolith-server/main.go
+++ b/cmd/dendrite-monolith-server/main.go
@@ -33,8 +33,8 @@ import (
 )
 
 var (
-	httpBindAddr   = flag.String("http-bind-address", ":8008", "The HTTP listening port for the server")
-	httpsBindAddr  = flag.String("https-bind-address", ":8448", "The HTTPS listening port for the server")
+	httpBindAddr   = flag.String("http-bind-address", "", "The HTTP listening port for the server")
+	httpsBindAddr  = flag.String("https-bind-address", "", "The HTTPS listening port for the server")
 	apiBindAddr    = flag.String("api-bind-address", "localhost:18008", "The HTTP listening port for the internal HTTP APIs (if -api is enabled)")
 	certFile       = flag.String("tls-cert", "", "The PEM formatted X509 certificate to use for TLS")
 	keyFile        = flag.String("tls-key", "", "The PEM private key to use for TLS")
@@ -44,8 +44,14 @@ var (
 
 func main() {
 	cfg := setup.ParseFlags(true)
-	httpAddr := config.HTTPAddress("http://" + *httpBindAddr)
-	httpsAddr := config.HTTPAddress("https://" + *httpsBindAddr)
+	httpAddr := cfg.Global.Monolith.HTTPBindAddr
+	httpsAddr := cfg.Global.Monolith.HTTPBindAddr
+	if *httpBindAddr != "" {
+		httpAddr = config.HTTPAddress("http://" + *httpBindAddr)
+	}
+	if *httpsBindAddr != "" {
+		httpsAddr = config.HTTPAddress("https://" + *httpsBindAddr)
+	}
 	httpAPIAddr := httpAddr
 	options := []basepkg.BaseDendriteOptions{}
 	if *enableHTTPAPIs {

--- a/dendrite-sample.monolith.yaml
+++ b/dendrite-sample.monolith.yaml
@@ -11,9 +11,16 @@ version: 2
 global:
   # Monolith specific configuration
   monolith:
-    # HTTP and HTTPS bind address
+    # HTTP listener bind address
     http_bind_address: http://:8008
+
+    # HTTPS listener bind address.
+    # Only used when a valid cert and key are provided.
     https_bind_address: https://:8448
+
+    # Path to PEM formated X509 certificate and private key
+    tls_cert_path: ""
+    tls_key_path: ""
 
   # The domain name of this homeserver.
   server_name: localhost

--- a/dendrite-sample.monolith.yaml
+++ b/dendrite-sample.monolith.yaml
@@ -9,6 +9,12 @@ version: 2
 
 # Global Matrix configuration. This configuration applies to all components.
 global:
+  # Monolith specific configuration
+  monolith:
+    # HTTP and HTTPS bind address
+    http_bind_address: http://:8008
+    https_bind_address: https://:8448
+
   # The domain name of this homeserver.
   server_name: localhost
 

--- a/setup/config/config_global.go
+++ b/setup/config/config_global.go
@@ -12,6 +12,9 @@ import (
 )
 
 type Global struct {
+	// Monolith specific configuration options, like bind address.
+	Monolith Monolith `yaml:"monolith,omitempty"`
+
 	// Signing identity contains the server name, private key and key ID of
 	// the deployment.
 	gomatrixserverlib.SigningIdentity `yaml:",inline"`
@@ -96,6 +99,7 @@ func (c *Global) Defaults(opts DefaultOpts) {
 	if opts.Monolithic {
 		c.DatabaseOptions.Defaults(90)
 	}
+	c.Monolith.Defaults(opts)
 	c.JetStream.Defaults(opts)
 	c.Metrics.Defaults(opts)
 	c.DNSCache.Defaults()
@@ -113,6 +117,7 @@ func (c *Global) Verify(configErrs *ConfigErrors, isMonolith bool) {
 		v.Verify(configErrs)
 	}
 
+	c.Monolith.Verify(configErrs, isMonolith)
 	c.JetStream.Verify(configErrs, isMonolith)
 	c.Metrics.Verify(configErrs, isMonolith)
 	c.Sentry.Verify(configErrs, isMonolith)

--- a/setup/config/config_monolith.go
+++ b/setup/config/config_monolith.go
@@ -1,0 +1,22 @@
+package config
+
+type Monolith struct {
+	HTTPBindAddr  HTTPAddress `yaml:"http_bind_address"`
+	HTTPSBindAddr HTTPAddress `yaml:"https_bind_address"`
+}
+
+func (c *Monolith) Defaults(opts DefaultOpts) {
+	if !opts.Monolithic {
+		return
+	}
+	c.HTTPBindAddr = "http://:8008"
+	c.HTTPSBindAddr = "https://:8448"
+}
+
+func (c *Monolith) Verify(configErrs *ConfigErrors, isMonolith bool) {
+	if !isMonolith {
+		return
+	}
+	checkURL(configErrs, "monolith.http_bind_address", string(c.HTTPBindAddr))
+	checkURL(configErrs, "monolith.https_bind_address", string(c.HTTPSBindAddr))
+}

--- a/setup/config/config_monolith.go
+++ b/setup/config/config_monolith.go
@@ -3,6 +3,9 @@ package config
 type Monolith struct {
 	HTTPBindAddr  HTTPAddress `yaml:"http_bind_address"`
 	HTTPSBindAddr HTTPAddress `yaml:"https_bind_address"`
+
+	TlsCertificatePath Path `yaml:"tls_cert_path"`
+	TlsPrivateKeyPath  Path `yaml:"tls_key_path"`
 }
 
 func (c *Monolith) Defaults(opts DefaultOpts) {


### PR DESCRIPTION
It so far wasn't possible to specify the monoliths bind address(es) via the config file, only via command line options.
Pretty straight forward implementation. If the CLI option is set, it takes precedence over the config one in all cases.
Behaviour should be unchanged, even if the options are unset, given that the defaults match up with the old cli option defaults.