### PR TITLE
Change Default Room version to 10

### DIFF
--- a/roomserver/version/version.go
+++ b/roomserver/version/version.go
@@ -23,7 +23,7 @@ import (
 // DefaultRoomVersion contains the room version that will, by
 // default, be used to create new rooms on this server.
 func DefaultRoomVersion() gomatrixserverlib.RoomVersion {
-	return gomatrixserverlib.RoomVersionV9
+	return gomatrixserverlib.RoomVersionV10
 }
 
 // RoomVersions returns a map of all known room versions to this


### PR DESCRIPTION
This PR implements MSC3904. This PR is expected to sit and wait until MSC3904 passes FCP and that is accepted by the author of this PR. 

Also as for the lack of tests i belive that this simple change does not need to pass new tests due to that these tests are expected to already have been passed by the successful use of Dendrite with Room version 10 already. 

### Pull Request Checklist

* [X] I have added tests for PR _or_ I have justified why this PR doesn't need tests.
* [X] Pull request includes a [sign off](https://github.com/matrix-org/dendrite/blob/main/docs/CONTRIBUTING.md#sign-off)

Signed-off-by: Catalan Lover <catalanlover@protonmail.com>
