### PR TITLE
Repeatable reads for `/sync`

### DIFF
--- a/syncapi/storage/shared/storage_consumer.go
+++ b/syncapi/storage/shared/storage_consumer.go
@@ -56,31 +56,23 @@ type Database struct {
 }
 
 func (d *Database) NewDatabaseSnapshot(ctx context.Context) (*DatabaseTransaction, error) {
-	return d.NewDatabaseTransaction(ctx)
-
-	/*
-		TODO: Repeatable read is probably the right thing to do here,
-		but it seems to cause some problems with the invite tests, so
-		need to investigate that further.
-
-		txn, err := d.DB.BeginTx(ctx, &sql.TxOptions{
-			// Set the isolation level so that we see a snapshot of the database.
-			// In PostgreSQL repeatable read transactions will see a snapshot taken
-			// at the first query, and since the transaction is read-only it can't
-			// run into any serialisation errors.
-			// https://www.postgresql.org/docs/9.5/static/transaction-iso.html#XACT-REPEATABLE-READ
-			Isolation: sql.LevelRepeatableRead,
-			ReadOnly:  true,
-		})
-		if err != nil {
-			return nil, err
-		}
-		return &DatabaseTransaction{
-			Database: d,
-			ctx:      ctx,
-			txn:      txn,
-		}, nil
-	*/
+	txn, err := d.DB.BeginTx(ctx, &sql.TxOptions{
+		// Set the isolation level so that we see a snapshot of the database.
+		// In PostgreSQL repeatable read transactions will see a snapshot taken
+		// at the first query, and since the transaction is read-only it can't
+		// run into any serialisation errors.
+		// https://www.postgresql.org/docs/9.5/static/transaction-iso.html#XACT-REPEATABLE-READ
+		Isolation: sql.LevelRepeatableRead,
+		ReadOnly:  true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &DatabaseTransaction{
+		Database: d,
+		ctx:      ctx,
+		txn:      txn,
+	}, nil
 }
 
 func (d *Database) NewDatabaseTransaction(ctx context.Context) (*DatabaseTransaction, error) {


### PR DESCRIPTION
This puts repeatable reads into all sync streams.