### PR TITLE
Fix joined hosts with `RewritesState`

### DIFF
--- a/federationapi/storage/shared/storage.go
+++ b/federationapi/storage/shared/storage.go
@@ -69,7 +69,6 @@ func (d *Database) UpdateRoom(
 	purgeRoomFirst bool,
 ) (joinedHosts []types.JoinedHost, err error) {
 	err = d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
-		var joinedHosts []types.JoinedHost
 		if purgeRoomFirst {
 			// If the event is a create event then we'll delete all of the existing
 			// data for the room. The only reason that a create event would be replayed

--- a/federationapi/storage/shared/storage.go
+++ b/federationapi/storage/shared/storage.go
@@ -82,16 +82,15 @@ func (d *Database) UpdateRoom(
 				return err
 			}
 		}
-
+		if err = d.FederationJoinedHosts.DeleteJoinedHosts(ctx, txn, removeHosts); err != nil {
+			return err
+		}
 		for _, add := range addHosts {
 			err = d.FederationJoinedHosts.InsertJoinedHosts(ctx, txn, roomID, add.MemberEventID, add.ServerName)
 			if err != nil {
 				return err
 			}
 			joinedHosts = append(joinedHosts, add)
-		}
-		if err = d.FederationJoinedHosts.DeleteJoinedHosts(ctx, txn, removeHosts); err != nil {
-			return err
 		}
 		return nil
 	})

--- a/federationapi/storage/shared/storage.go
+++ b/federationapi/storage/shared/storage.go
@@ -88,6 +88,7 @@ func (d *Database) UpdateRoom(
 			if err != nil {
 				return err
 			}
+			joinedHosts = append(joinedHosts, add)
 		}
 		if err = d.FederationJoinedHosts.DeleteJoinedHosts(ctx, txn, removeHosts); err != nil {
 			return err


### PR DESCRIPTION
This ensures that the joined hosts in the federation API are correct after the state is rewritten. This might fix some races around the time of joining federated rooms.