### PR TITLE
Event relations

### DIFF
--- a/docs/caddy/polylith/Caddyfile
+++ b/docs/caddy/polylith/Caddyfile
@@ -1,66 +1,85 @@
-# Sample Caddyfile for using Caddy in front of Dendrite.
-#
-# Customize email address and domain names.
-# Optional settings commented out.
-#
-# BE SURE YOUR DOMAINS ARE POINTED AT YOUR SERVER FIRST.
-# Documentation: https://caddyserver.com/docs/
-#
-# Bonus tip: If your IP address changes, use Caddy's
-# dynamic DNS plugin to update your DNS records to
-# point to your new IP automatically:
-# https://github.com/mholt/caddy-dynamicdns
+# Sample Caddyfile for using Caddy in front of Dendrite
+
 #
 
+# Customize email address and domain names
+
+# Optional settings commented out
+
+#
+
+# BE SURE YOUR DOMAINS ARE POINTED AT YOUR SERVER FIRST
+
+# Documentation: <https://caddyserver.com/docs/>
+
+#
+
+# Bonus tip: If your IP address changes, use Caddy's
+
+# dynamic DNS plugin to update your DNS records to
+
+# point to your new IP automatically
+
+# <https://github.com/mholt/caddy-dynamicdns>
+
+#
 
 # Global options block
+
 {
-	# In case there is a problem with your certificates.
-	# email example@example.com
+ # In case there is a problem with your certificates.
+ # email example@example.com
 
-	# Turn off the admin endpoint if you don't need graceful config
-	# changes and/or are running untrusted code on your machine.
-	# admin off
+ # Turn off the admin endpoint if you don't need graceful config
+ # changes and/or are running untrusted code on your machine.
+ # admin off
 
-	# Enable this if your clients don't send ServerName in TLS handshakes.
-	# default_sni example.com
+ # Enable this if your clients don't send ServerName in TLS handshakes.
+ # default_sni example.com
 
-	# Enable debug mode for verbose logging.
-	# debug
+ # Enable debug mode for verbose logging.
+ # debug
 
-	# Use Let's Encrypt's staging endpoint for testing.
-	# acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
+ # Use Let's Encrypt's staging endpoint for testing.
+ # acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
 
-	# If you're port-forwarding HTTP/HTTPS ports from 80/443 to something
-	# else, enable these and put the alternate port numbers here.
-	# http_port  8080
-	# https_port 8443
+ # If you're port-forwarding HTTP/HTTPS ports from 80/443 to something
+ # else, enable these and put the alternate port numbers here.
+ # http_port  8080
+ # https_port 8443
 }
 
 # The server name of your matrix homeserver. This example shows
-# "well-known delegation" from the registered domain to a subdomain,
+
+# "well-known delegation" from the registered domain to a subdomain
+
 # which is only needed if your server_name doesn't match your Matrix
+
 # homeserver URL (i.e. you can show users a vanity domain that looks
+
 # nice and is easy to remember but still have your Matrix server on
-# its own subdomain or hosted service).
+
+# its own subdomain or hosted service)
+
 example.com {
-	header /.well-known/matrix/* Content-Type application/json
-	header /.well-known/matrix/* Access-Control-Allow-Origin *
-	respond /.well-known/matrix/server `{"m.server": "matrix.example.com:443"}`
-	respond /.well-known/matrix/client `{"m.homeserver": {"base_url": "https://matrix.example.com"}}`
+ header /.well-known/matrix/*Content-Type application/json
+ header /.well-known/matrix/* Access-Control-Allow-Origin *
+ respond /.well-known/matrix/server `{"m.server": "matrix.example.com:443"}`
+ respond /.well-known/matrix/client `{"m.homeserver": {"base_url": "https://matrix.example.com"}}`
 }
 
-# The actual domain name whereby your Matrix server is accessed.
-matrix.example.com {
-	# Change the end of each reverse_proxy line to the correct
-	# address for your various services.
-	@sync_api {
-		path_regexp /_matrix/client/.*?/(sync|user/.*?/filter/?.*|keys/changes|rooms/.*?/(messages|context/.*?|event/.*?))$
-	}
-	reverse_proxy @sync_api sync_api:8073
+# The actual domain name whereby your Matrix server is accessed
 
-	reverse_proxy /_matrix/client* client_api:8071
-	reverse_proxy /_matrix/federation* federation_api:8071
-	reverse_proxy /_matrix/key* federation_api:8071
-	reverse_proxy /_matrix/media* media_api:8071
+matrix.example.com {
+ # Change the end of each reverse_proxy line to the correct
+ # address for your various services.
+ @sync_api {
+  path_regexp /_matrix/client/.*?/(sync|user/.*?/filter/?.*|keys/changes|rooms/.*?/(messages|context/.*?|relations/.*?|event/.*?))$
+ }
+ reverse_proxy @sync_api sync_api:8073
+
+ reverse_proxy /_matrix/client* client_api:8071
+ reverse_proxy /_matrix/federation* federation_api:8071
+ reverse_proxy /_matrix/key* federation_api:8071
+ reverse_proxy /_matrix/media* media_api:8071
 }

--- a/docs/hiawatha/polylith-sample.conf
+++ b/docs/hiawatha/polylith-sample.conf
@@ -20,8 +20,11 @@ VirtualHost {
         # /_matrix/client/.*/rooms/{roomId}/messages
         # /_matrix/client/.*/rooms/{roomId}/context/{eventID}
         # /_matrix/client/.*/rooms/{roomId}/event/{eventID}
+        # /_matrix/client/.*/rooms/{roomId}/relations/{eventID}
+        # /_matrix/client/.*/rooms/{roomId}/relations/{eventID}/{relType}
+        # /_matrix/client/.*/rooms/{roomId}/relations/{eventID}/{relType}/{eventType}
         # to sync_api
-        ReverseProxy = /_matrix/client/.*?/(sync|user/.*?/filter/?.*|keys/changes|rooms/.*?/(messages|context/.*?|event/.*?))$ http://localhost:8073 600
+        ReverseProxy = /_matrix/client/.*?/(sync|user/.*?/filter/?.*|keys/changes|rooms/.*?/(messages|context/.*?|relations/.*?|event/.*?))$ http://localhost:8073 600
         ReverseProxy = /_matrix/client http://localhost:8071 600
         ReverseProxy = /_matrix/federation http://localhost:8072 600
         ReverseProxy = /_matrix/key http://localhost:8072 600

--- a/docs/nginx/polylith-sample.conf
+++ b/docs/nginx/polylith-sample.conf
@@ -30,8 +30,11 @@ server {
     # /_matrix/client/.*/rooms/{roomId}/messages
     # /_matrix/client/.*/rooms/{roomId}/context/{eventID}
     # /_matrix/client/.*/rooms/{roomId}/event/{eventID}
+    # /_matrix/client/.*/rooms/{roomId}/relations/{eventID}
+    # /_matrix/client/.*/rooms/{roomId}/relations/{eventID}/{relType}
+    # /_matrix/client/.*/rooms/{roomId}/relations/{eventID}/{relType}/{eventType}
     # to sync_api
-    location ~ /_matrix/client/.*?/(sync|user/.*?/filter/?.*|keys/changes|rooms/.*?/(messages|context/.*?|event/.*?))$  {
+    location ~ /_matrix/client/.*?/(sync|user/.*?/filter/?.*|keys/changes|rooms/.*?/(messages|context/.*?|relations/.*?|event/.*?))$  {
         proxy_pass http://sync_api:8073;
     }
 

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/matrix-org/dugong v0.0.0-20210921133753-66e6b1c67e2e
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91
 	github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20220929190355-91d455cd3621
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20221011115330-49fa704b9a64
 	github.com/matrix-org/pinecone v0.0.0-20220929155234-2ce51dd4a42c
 	github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4
 	github.com/mattn/go-sqlite3 v1.14.15

--- a/go.sum
+++ b/go.sum
@@ -384,8 +384,8 @@ github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91 h1:s7fexw
 github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91/go.mod h1:e+cg2q7C7yE5QnAXgzo512tgFh1RbQLC0+jozuegKgo=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16 h1:ZtO5uywdd5dLDCud4r0r55eP4j9FuUNpl60Gmntcop4=
 github.com/matrix-org/gomatrix v0.0.0-20210324163249-be2af5ef2e16/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20220929190355-91d455cd3621 h1:a8IaoSPDxevkgXnOUrtIW9AqVNvXBJAG0gtnX687S7g=
-github.com/matrix-org/gomatrixserverlib v0.0.0-20220929190355-91d455cd3621/go.mod h1:Mtifyr8q8htcBeugvlDnkBcNUy5LO8OzUoplAf1+mb4=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20221011115330-49fa704b9a64 h1:QJmfAPC3P0ZHJzYD/QtbNc5EztKlK1ipRWP5SO/m4jw=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20221011115330-49fa704b9a64/go.mod h1:Mtifyr8q8htcBeugvlDnkBcNUy5LO8OzUoplAf1+mb4=
 github.com/matrix-org/pinecone v0.0.0-20220929155234-2ce51dd4a42c h1:iCHLYwwlPsf4TYFrvhKdhQoAM2lXzcmDZYqwBNWcnVk=
 github.com/matrix-org/pinecone v0.0.0-20220929155234-2ce51dd4a42c/go.mod h1:K0N1ixHQxXoCyqolDqVxPM3ArrDtcMs8yegOx2Lfv9k=
 github.com/matrix-org/util v0.0.0-20200807132607-55161520e1d4 h1:eCEHXWDv9Rm335MSuB49mFUK44bwZPFSDde3ORE3syk=

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -271,6 +271,13 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 		return err
 	}
 
+	if err = s.db.UpdateRelations(ctx, ev); err != nil {
+		log.WithFields(log.Fields{
+			"event_id": ev.EventID(),
+			"type":     ev.Type(),
+		}).WithError(err).Warn("Failed to update relations")
+	}
+
 	s.pduStream.Advance(pduPos)
 	s.notifier.OnNewEvent(ev, ev.RoomID(), nil, types.StreamingToken{PDUPosition: pduPos})
 

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -155,6 +155,7 @@ func (s *OutputRoomEventConsumer) onRedactEvent(
 			"event_id":          msg.RedactedBecause.EventID(),
 			"redacted_event_id": msg.RedactedEventID,
 		}).WithError(err).Warn("Failed to redact relations")
+		return err
 	}
 
 	// fake a room event so we notify clients about the redaction, as if it were
@@ -285,6 +286,7 @@ func (s *OutputRoomEventConsumer) onNewRoomEvent(
 			"event_id": ev.EventID(),
 			"type":     ev.Type(),
 		}).WithError(err).Warn("Failed to update relations")
+		return err
 	}
 
 	s.pduStream.Advance(pduPos)
@@ -337,6 +339,7 @@ func (s *OutputRoomEventConsumer) onOldRoomEvent(
 			"event_id": ev.EventID(),
 			"type":     ev.Type(),
 		}).WithError(err).Warn("Failed to update relations")
+		return err
 	}
 
 	if pduPos, err = s.notifyJoinedPeeks(ctx, ev, pduPos); err != nil {

--- a/syncapi/routing/relations.go
+++ b/syncapi/routing/relations.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
+	"github.com/sirupsen/logrus"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
@@ -70,6 +71,7 @@ func Relations(req *http.Request, device *api.Device, syncDB storage.Database, r
 
 	snapshot, err := syncDB.NewDatabaseSnapshot(req.Context())
 	if err != nil {
+		logrus.WithError(err).Error("Failed to get snapshot for relations")
 		return jsonerror.InternalServerError()
 	}
 	var succeeded bool

--- a/syncapi/routing/relations.go
+++ b/syncapi/routing/relations.go
@@ -75,15 +75,9 @@ func Relations(req *http.Request, device *api.Device, syncDB storage.Database, r
 	var succeeded bool
 	defer sqlutil.EndTransactionWithCheck(snapshot, &succeeded, &err)
 
-	if to == 0 {
-		if to, err = snapshot.MaxStreamPositionForRelations(req.Context()); err != nil {
-			return util.ErrorResponse(err)
-		}
-	}
-
 	res := &RelationsResponse{}
 	res.Chunk, res.PrevBatch, res.NextBatch, err = snapshot.RelationsFor(
-		req.Context(), roomID, eventID, relType, eventType, from, to, limit,
+		req.Context(), roomID, eventID, relType, eventType, from, to, dir == "b", limit,
 	)
 	if err != nil {
 		return util.ErrorResponse(err)

--- a/syncapi/routing/relations.go
+++ b/syncapi/routing/relations.go
@@ -68,8 +68,6 @@ func Relations(req *http.Request, device *api.Device, syncDB storage.Database, r
 		}
 	}
 
-	res := &RelationsResponse{}
-
 	snapshot, err := syncDB.NewDatabaseSnapshot(req.Context())
 	if err != nil {
 		return jsonerror.InternalServerError()
@@ -83,6 +81,7 @@ func Relations(req *http.Request, device *api.Device, syncDB storage.Database, r
 		}
 	}
 
+	res := &RelationsResponse{}
 	res.Chunk, res.PrevBatch, res.NextBatch, err = snapshot.RelationsFor(
 		req.Context(), roomID, eventID, relType, eventType, from, to, limit,
 	)

--- a/syncapi/routing/relations.go
+++ b/syncapi/routing/relations.go
@@ -1,0 +1,68 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"net/http"
+
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/util"
+
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"github.com/matrix-org/dendrite/internal/sqlutil"
+	"github.com/matrix-org/dendrite/syncapi/storage"
+	"github.com/matrix-org/dendrite/userapi/api"
+)
+
+type RelationsResponse struct {
+	Chunk     []gomatrixserverlib.ClientEvent `json:"chunk"`
+	NextBatch string                          `json:"next_batch,omitempty"`
+	PrevBatch string                          `json:"prev_batch,omitempty"`
+}
+
+// nolint:gocyclo
+func Relations(req *http.Request, device *api.Device, syncDB storage.Database, roomID, eventID, relType, eventType string) util.JSONResponse {
+	dir := req.URL.Query().Get("dir")
+	from := req.URL.Query().Get("from")
+	to := req.URL.Query().Get("to")
+	limit := req.URL.Query().Get("limit")
+
+	if dir != "b" && dir != "f" {
+		return util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.MissingArgument("Bad or missing dir query parameter (should be either 'b' or 'f')"),
+		}
+	}
+	if dir == "" {
+		dir = "b"
+	}
+
+	res := &RelationsResponse{}
+
+	snapshot, err := syncDB.NewDatabaseSnapshot(req.Context())
+	if err != nil {
+		return jsonerror.InternalServerError()
+	}
+	var succeeded bool
+	defer sqlutil.EndTransactionWithCheck(snapshot, &succeeded, &err)
+
+	_, _, _, _ = from, to, limit, dir
+
+	succeeded = true
+	return util.JSONResponse{
+		Code: http.StatusOK,
+		JSON: res,
+	}
+}

--- a/syncapi/routing/routing.go
+++ b/syncapi/routing/routing.go
@@ -110,6 +110,48 @@ func Setup(
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
+	v3mux.Handle("/rooms/{roomId}/relations/{eventId}",
+		httputil.MakeAuthAPI(gomatrixserverlib.Join, userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
+			if err != nil {
+				return util.ErrorResponse(err)
+			}
+
+			return Relations(
+				req, device, syncDB,
+				vars["roomId"], vars["eventId"], "", "",
+			)
+		}),
+	).Methods(http.MethodGet, http.MethodOptions)
+
+	v3mux.Handle("/rooms/{roomId}/relations/{eventId}/{relType}",
+		httputil.MakeAuthAPI(gomatrixserverlib.Join, userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
+			if err != nil {
+				return util.ErrorResponse(err)
+			}
+
+			return Relations(
+				req, device, syncDB,
+				vars["roomId"], vars["eventId"], vars["relType"], "",
+			)
+		}),
+	).Methods(http.MethodGet, http.MethodOptions)
+
+	v3mux.Handle("/rooms/{roomId}/relations/{eventId}/{relType}/{eventType}",
+		httputil.MakeAuthAPI(gomatrixserverlib.Join, userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
+			if err != nil {
+				return util.ErrorResponse(err)
+			}
+
+			return Relations(
+				req, device, syncDB,
+				vars["roomId"], vars["eventId"], vars["relType"], vars["eventType"],
+			)
+		}),
+	).Methods(http.MethodGet, http.MethodOptions)
+
 	v3mux.Handle("/search",
 		httputil.MakeAuthAPI("search", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
 			if !cfg.Fulltext.Enabled {

--- a/syncapi/routing/routing.go
+++ b/syncapi/routing/routing.go
@@ -45,6 +45,7 @@ func Setup(
 	lazyLoadCache caching.LazyLoadCache,
 	fts *fulltext.Search,
 ) {
+	v1mux := csMux.PathPrefix("/v1/").Subrouter()
 	v3mux := csMux.PathPrefix("/{apiversion:(?:r0|v3)}/").Subrouter()
 
 	// TODO: Add AS support for all handlers below.
@@ -110,7 +111,7 @@ func Setup(
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
-	v3mux.Handle("/rooms/{roomId}/relations/{eventId}",
+	v1mux.Handle("/rooms/{roomId}/relations/{eventId}",
 		httputil.MakeAuthAPI(gomatrixserverlib.Join, userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
 			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
 			if err != nil {
@@ -124,7 +125,7 @@ func Setup(
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
-	v3mux.Handle("/rooms/{roomId}/relations/{eventId}/{relType}",
+	v1mux.Handle("/rooms/{roomId}/relations/{eventId}/{relType}",
 		httputil.MakeAuthAPI(gomatrixserverlib.Join, userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
 			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
 			if err != nil {
@@ -138,7 +139,7 @@ func Setup(
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
-	v3mux.Handle("/rooms/{roomId}/relations/{eventId}/{relType}/{eventType}",
+	v1mux.Handle("/rooms/{roomId}/relations/{eventId}/{relType}/{eventType}",
 		httputil.MakeAuthAPI(gomatrixserverlib.Join, userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
 			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
 			if err != nil {

--- a/syncapi/routing/routing.go
+++ b/syncapi/routing/routing.go
@@ -119,7 +119,7 @@ func Setup(
 			}
 
 			return Relations(
-				req, device, syncDB,
+				req, device, syncDB, rsAPI,
 				vars["roomId"], vars["eventId"], "", "",
 			)
 		}),
@@ -133,7 +133,7 @@ func Setup(
 			}
 
 			return Relations(
-				req, device, syncDB,
+				req, device, syncDB, rsAPI,
 				vars["roomId"], vars["eventId"], vars["relType"], "",
 			)
 		}),
@@ -147,7 +147,7 @@ func Setup(
 			}
 
 			return Relations(
-				req, device, syncDB,
+				req, device, syncDB, rsAPI,
 				vars["roomId"], vars["eventId"], vars["relType"], vars["eventType"],
 			)
 		}),

--- a/syncapi/routing/routing.go
+++ b/syncapi/routing/routing.go
@@ -45,7 +45,7 @@ func Setup(
 	lazyLoadCache caching.LazyLoadCache,
 	fts *fulltext.Search,
 ) {
-	v1mux := csMux.PathPrefix("/v1/").Subrouter()
+	v1unstablemux := csMux.PathPrefix("/{apiversion:(?:v1|unstable)}/").Subrouter()
 	v3mux := csMux.PathPrefix("/{apiversion:(?:r0|v3)}/").Subrouter()
 
 	// TODO: Add AS support for all handlers below.
@@ -111,7 +111,7 @@ func Setup(
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
-	v1mux.Handle("/rooms/{roomId}/relations/{eventId}",
+	v1unstablemux.Handle("/rooms/{roomId}/relations/{eventId}",
 		httputil.MakeAuthAPI(gomatrixserverlib.Join, userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
 			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
 			if err != nil {
@@ -125,7 +125,7 @@ func Setup(
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
-	v1mux.Handle("/rooms/{roomId}/relations/{eventId}/{relType}",
+	v1unstablemux.Handle("/rooms/{roomId}/relations/{eventId}/{relType}",
 		httputil.MakeAuthAPI(gomatrixserverlib.Join, userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
 			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
 			if err != nil {
@@ -139,7 +139,7 @@ func Setup(
 		}),
 	).Methods(http.MethodGet, http.MethodOptions)
 
-	v1mux.Handle("/rooms/{roomId}/relations/{eventId}/{relType}/{eventType}",
+	v1unstablemux.Handle("/rooms/{roomId}/relations/{eventId}/{relType}/{eventType}",
 		httputil.MakeAuthAPI(gomatrixserverlib.Join, userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
 			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
 			if err != nil {

--- a/syncapi/storage/interface.go
+++ b/syncapi/storage/interface.go
@@ -38,6 +38,7 @@ type DatabaseTransaction interface {
 	MaxStreamPositionForSendToDeviceMessages(ctx context.Context) (types.StreamPosition, error)
 	MaxStreamPositionForNotificationData(ctx context.Context) (types.StreamPosition, error)
 	MaxStreamPositionForPresence(ctx context.Context) (types.StreamPosition, error)
+	MaxStreamPositionForRelations(ctx context.Context) (types.StreamPosition, error)
 
 	CurrentState(ctx context.Context, roomID string, stateFilterPart *gomatrixserverlib.StateFilter, excludeEventIDs []string) ([]*gomatrixserverlib.HeaderedEvent, error)
 	GetStateDeltasForFullStateSync(ctx context.Context, device *userapi.Device, r types.Range, userID string, stateFilter *gomatrixserverlib.StateFilter) ([]types.StateDelta, []string, error)
@@ -107,6 +108,7 @@ type DatabaseTransaction interface {
 	GetUserUnreadNotificationCountsForRooms(ctx context.Context, userID string, roomIDs map[string]string) (map[string]*eventutil.NotificationData, error)
 	GetPresence(ctx context.Context, userID string) (*types.PresenceInternal, error)
 	PresenceAfter(ctx context.Context, after types.StreamPosition, filter gomatrixserverlib.EventFilter) (map[string]*types.PresenceInternal, error)
+	RelationsFor(ctx context.Context, roomID, eventID, relType, eventType string, from, to types.StreamPosition, limit int) (clientEvents []gomatrixserverlib.ClientEvent, prevBatch, nextBatch string, err error)
 }
 
 type Database interface {

--- a/syncapi/storage/interface.go
+++ b/syncapi/storage/interface.go
@@ -108,7 +108,7 @@ type DatabaseTransaction interface {
 	GetUserUnreadNotificationCountsForRooms(ctx context.Context, userID string, roomIDs map[string]string) (map[string]*eventutil.NotificationData, error)
 	GetPresence(ctx context.Context, userID string) (*types.PresenceInternal, error)
 	PresenceAfter(ctx context.Context, after types.StreamPosition, filter gomatrixserverlib.EventFilter) (map[string]*types.PresenceInternal, error)
-	RelationsFor(ctx context.Context, roomID, eventID, relType, eventType string, from, to types.StreamPosition, limit int) (clientEvents []gomatrixserverlib.ClientEvent, prevBatch, nextBatch string, err error)
+	RelationsFor(ctx context.Context, roomID, eventID, relType, eventType string, from, to types.StreamPosition, backwards bool, limit int) (clientEvents []gomatrixserverlib.ClientEvent, prevBatch, nextBatch string, err error)
 }
 
 type Database interface {

--- a/syncapi/storage/interface.go
+++ b/syncapi/storage/interface.go
@@ -108,7 +108,7 @@ type DatabaseTransaction interface {
 	GetUserUnreadNotificationCountsForRooms(ctx context.Context, userID string, roomIDs map[string]string) (map[string]*eventutil.NotificationData, error)
 	GetPresence(ctx context.Context, userID string) (*types.PresenceInternal, error)
 	PresenceAfter(ctx context.Context, after types.StreamPosition, filter gomatrixserverlib.EventFilter) (map[string]*types.PresenceInternal, error)
-	RelationsFor(ctx context.Context, roomID, eventID, relType, eventType string, from, to types.StreamPosition, backwards bool, limit int) (clientEvents []gomatrixserverlib.ClientEvent, prevBatch, nextBatch string, err error)
+	RelationsFor(ctx context.Context, roomID, eventID, relType, eventType string, from, to types.StreamPosition, backwards bool, limit int) (events []types.StreamEvent, prevBatch, nextBatch string, err error)
 }
 
 type Database interface {

--- a/syncapi/storage/interface.go
+++ b/syncapi/storage/interface.go
@@ -175,6 +175,7 @@ type Database interface {
 	UpdateIgnoresForUser(ctx context.Context, userID string, ignores *types.IgnoredUsers) error
 	ReIndex(ctx context.Context, limit, afterID int64) (map[int64]gomatrixserverlib.HeaderedEvent, error)
 	UpdateRelations(ctx context.Context, event *gomatrixserverlib.HeaderedEvent) error
+	RedactRelations(ctx context.Context, roomID, redactedEventID string) error
 }
 
 type Presence interface {

--- a/syncapi/storage/interface.go
+++ b/syncapi/storage/interface.go
@@ -174,6 +174,7 @@ type Database interface {
 	StoreReceipt(ctx context.Context, roomId, receiptType, userId, eventId string, timestamp gomatrixserverlib.Timestamp) (pos types.StreamPosition, err error)
 	UpdateIgnoresForUser(ctx context.Context, userID string, ignores *types.IgnoredUsers) error
 	ReIndex(ctx context.Context, limit, afterID int64) (map[int64]gomatrixserverlib.HeaderedEvent, error)
+	UpdateRelations(ctx context.Context, event *gomatrixserverlib.HeaderedEvent) error
 }
 
 type Presence interface {

--- a/syncapi/storage/postgres/relations_table.go
+++ b/syncapi/storage/postgres/relations_table.go
@@ -50,12 +50,12 @@ const deleteRelationSQL = "" +
 
 const selectRelationsInRangeSQL = "" +
 	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
-	" WHERE room_id = $1 AND event_id = $2 AND id > $3 AND id <= $4" +
+	" WHERE room_id = $1 AND event_id = $2 AND id >= $3 AND id <= $4" +
 	" ORDER BY id DESC LIMIT $5"
 
 const selectRelationsByTypeInRangeSQL = "" +
 	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
-	" WHERE room_id = $1 AND event_id = $2 AND rel_type = $3 AND id > $4 AND id <= $5" +
+	" WHERE room_id = $1 AND event_id = $2 AND rel_type = $3 AND id >= $4 AND id <= $5" +
 	" ORDER BY id DESC LIMIT $6"
 
 const selectMaxRelationIDSQL = "" +

--- a/syncapi/storage/postgres/relations_table.go
+++ b/syncapi/storage/postgres/relations_table.go
@@ -26,6 +26,8 @@ import (
 )
 
 const relationsSchema = `
+CREATE SEQUENCE IF NOT EXISTS syncapi_relation_id;
+
 CREATE TABLE IF NOT EXISTS syncapi_relations (
 	id BIGINT PRIMARY KEY DEFAULT nextval('syncapi_relation_id'),
 	room_id TEXT NOT NULL,

--- a/syncapi/storage/postgres/relations_table.go
+++ b/syncapi/storage/postgres/relations_table.go
@@ -119,7 +119,7 @@ func (s *relationsStatements) DeleteRelation(
 func (s *relationsStatements) SelectRelationsInRange(
 	ctx context.Context, txn *sql.Tx, roomID, eventID, relType string,
 	r types.Range, limit int,
-) (map[string][]string, types.StreamPosition, error) {
+) (map[string][]types.RelationEntry, types.StreamPosition, error) {
 	var lastPos types.StreamPosition
 	var rows *sql.Rows
 	var err error
@@ -134,7 +134,7 @@ func (s *relationsStatements) SelectRelationsInRange(
 		return nil, lastPos, err
 	}
 	defer internal.CloseAndLogIfError(ctx, rows, "selectRelationsInRange: rows.close() failed")
-	result := map[string][]string{}
+	result := map[string][]types.RelationEntry{}
 	for rows.Next() {
 		var (
 			id           types.StreamPosition
@@ -148,7 +148,10 @@ func (s *relationsStatements) SelectRelationsInRange(
 		if id > lastPos {
 			lastPos = id
 		}
-		result[relType] = append(result[relType], childEventID)
+		result[relType] = append(result[relType], types.RelationEntry{
+			Position: id,
+			EventID:  childEventID,
+		})
 	}
 	if lastPos == 0 {
 		lastPos = r.To

--- a/syncapi/storage/postgres/relations_table.go
+++ b/syncapi/storage/postgres/relations_table.go
@@ -109,6 +109,9 @@ func (s *relationsStatements) DeleteRelation(
 	_, err := stmt.ExecContext(
 		ctx, roomID, childEventID,
 	)
+	if err == sql.ErrNoRows {
+		return nil
+	}
 	return err
 }
 

--- a/syncapi/storage/postgres/relations_table.go
+++ b/syncapi/storage/postgres/relations_table.go
@@ -42,7 +42,7 @@ const insertRelationSQL = "" +
 	"INSERT INTO syncapi_relations (" +
 	"  room_id, event_id, child_event_id, rel_type" +
 	") VALUES ($1, $2, $3, $4) " +
-	" ON CONFLICT syncapi_relations_unique DO UPDATE SET event_id=EXCLUDED.event_id" +
+	" ON CONFLICT ON CONSTRAINT syncapi_relations_unique DO UPDATE SET event_id=EXCLUDED.event_id" +
 	" RETURNING id"
 
 const deleteRelationSQL = "" +

--- a/syncapi/storage/postgres/relations_table.go
+++ b/syncapi/storage/postgres/relations_table.go
@@ -1,5 +1,4 @@
-// Copyright 2017-2018 New Vector Ltd
-// Copyright 2019-2020 The Matrix.org Foundation C.I.C.
+// Copyright 2022 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,34 +41,33 @@ const insertRelationSQL = "" +
 	"INSERT INTO syncapi_relations (" +
 	"  room_id, event_id, child_event_id, rel_type" +
 	") VALUES ($1, $2, $3, $4) " +
-	" ON CONFLICT ON CONSTRAINT syncapi_relations_unique DO UPDATE SET event_id=EXCLUDED.event_id" +
-	" RETURNING id"
+	" ON CONFLICT DO NOTHING"
 
 const deleteRelationSQL = "" +
 	"DELETE FROM syncapi_relations WHERE room_id = $1 AND child_event_id = $2"
 
 const selectRelationsInRangeAscSQL = "" +
-	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
+	"SELECT id, child_event_id, rel_type FROM syncapi_relations" +
 	" WHERE room_id = $1 AND event_id = $2 AND id > $3 AND id <= $4" +
 	" ORDER BY id ASC LIMIT $5"
 
 const selectRelationsInRangeDescSQL = "" +
-	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
+	"SELECT id, child_event_id, rel_type FROM syncapi_relations" +
 	" WHERE room_id = $1 AND event_id = $2 AND id >= $3 AND id < $4" +
 	" ORDER BY id DESC LIMIT $5"
 
 const selectRelationsByTypeInRangeAscSQL = "" +
-	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
+	"SELECT id, child_event_id, rel_type FROM syncapi_relations" +
 	" WHERE room_id = $1 AND event_id = $2 AND rel_type = $3 AND id > $4 AND id <= $5" +
 	" ORDER BY id ASC LIMIT $6"
 
 const selectRelationsByTypeInRangeDescSQL = "" +
-	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
+	"SELECT id, child_event_id, rel_type FROM syncapi_relations" +
 	" WHERE room_id = $1 AND event_id = $2 AND rel_type = $3 AND id >= $4 AND id < $5" +
 	" ORDER BY id DESC LIMIT $6"
 
 const selectMaxRelationIDSQL = "" +
-	"SELECT MAX(id) FROM syncapi_relations"
+	"SELECT COALESCE(MAX(id), 0) FROM syncapi_relations"
 
 type relationsStatements struct {
 	insertRelationStmt                   *sql.Stmt
@@ -87,36 +85,23 @@ func NewPostgresRelationsTable(db *sql.DB) (tables.Relations, error) {
 	if err != nil {
 		return nil, err
 	}
-	if s.insertRelationStmt, err = db.Prepare(insertRelationSQL); err != nil {
-		return nil, err
-	}
-	if s.selectRelationsInRangeAscStmt, err = db.Prepare(selectRelationsInRangeAscSQL); err != nil {
-		return nil, err
-	}
-	if s.selectRelationsInRangeDescStmt, err = db.Prepare(selectRelationsInRangeDescSQL); err != nil {
-		return nil, err
-	}
-	if s.selectRelationsByTypeInRangeAscStmt, err = db.Prepare(selectRelationsByTypeInRangeAscSQL); err != nil {
-		return nil, err
-	}
-	if s.selectRelationsByTypeInRangeDescStmt, err = db.Prepare(selectRelationsByTypeInRangeDescSQL); err != nil {
-		return nil, err
-	}
-	if s.deleteRelationStmt, err = db.Prepare(deleteRelationSQL); err != nil {
-		return nil, err
-	}
-	if s.selectMaxRelationIDStmt, err = db.Prepare(selectMaxRelationIDSQL); err != nil {
-		return nil, err
-	}
-	return s, nil
+	return s, sqlutil.StatementList{
+		{&s.insertRelationStmt, insertRelationSQL},
+		{&s.selectRelationsInRangeAscStmt, selectRelationsInRangeAscSQL},
+		{&s.selectRelationsInRangeDescStmt, selectRelationsInRangeDescSQL},
+		{&s.selectRelationsByTypeInRangeAscStmt, selectRelationsByTypeInRangeAscSQL},
+		{&s.selectRelationsByTypeInRangeDescStmt, selectRelationsByTypeInRangeDescSQL},
+		{&s.deleteRelationStmt, deleteRelationSQL},
+		{&s.selectMaxRelationIDStmt, selectMaxRelationIDSQL},
+	}.Prepare(db)
 }
 
 func (s *relationsStatements) InsertRelation(
 	ctx context.Context, txn *sql.Tx, roomID, eventID, childEventID, relType string,
-) (streamPos types.StreamPosition, err error) {
-	err = sqlutil.TxStmt(txn, s.insertRelationStmt).QueryRowContext(
+) (err error) {
+	_, err = sqlutil.TxStmt(txn, s.insertRelationStmt).ExecContext(
 		ctx, roomID, eventID, childEventID, relType,
-	).Scan(&streamPos)
+	)
 	return
 }
 
@@ -127,9 +112,6 @@ func (s *relationsStatements) DeleteRelation(
 	_, err := stmt.ExecContext(
 		ctx, roomID, childEventID,
 	)
-	if err == sql.ErrNoRows {
-		return nil
-	}
 	return err
 }
 
@@ -162,20 +144,19 @@ func (s *relationsStatements) SelectRelationsInRange(
 	}
 	defer internal.CloseAndLogIfError(ctx, rows, "selectRelationsInRange: rows.close() failed")
 	result := map[string][]types.RelationEntry{}
+	var (
+		id           types.StreamPosition
+		childEventID string
+		relationType string
+	)
 	for rows.Next() {
-		var (
-			id           types.StreamPosition
-			roomID       string
-			childEventID string
-			relType      string
-		)
-		if err = rows.Scan(&id, &roomID, &childEventID, &relType); err != nil {
+		if err = rows.Scan(&id, &childEventID, &relationType); err != nil {
 			return nil, lastPos, err
 		}
 		if id > lastPos {
 			lastPos = id
 		}
-		result[relType] = append(result[relType], types.RelationEntry{
+		result[relationType] = append(result[relationType], types.RelationEntry{
 			Position: id,
 			EventID:  childEventID,
 		})
@@ -189,11 +170,7 @@ func (s *relationsStatements) SelectRelationsInRange(
 func (s *relationsStatements) SelectMaxRelationID(
 	ctx context.Context, txn *sql.Tx,
 ) (id int64, err error) {
-	var nullableID sql.NullInt64
 	stmt := sqlutil.TxStmt(txn, s.selectMaxRelationIDStmt)
-	err = stmt.QueryRowContext(ctx).Scan(&nullableID)
-	if nullableID.Valid {
-		id = nullableID.Int64
-	}
+	err = stmt.QueryRowContext(ctx).Scan(&id)
 	return
 }

--- a/syncapi/storage/postgres/relations_table.go
+++ b/syncapi/storage/postgres/relations_table.go
@@ -46,7 +46,7 @@ const insertRelationSQL = "" +
 	" RETURNING id"
 
 const deleteRelationSQL = "" +
-	"DELETE FROM syncapi_relations WHERE event_id = $1"
+	"DELETE FROM syncapi_relations WHERE room_id = $1 AND child_event_id = $2"
 
 const selectRelationsInRangeSQL = "" +
 	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
@@ -103,11 +103,11 @@ func (s *relationsStatements) InsertRelation(
 }
 
 func (s *relationsStatements) DeleteRelation(
-	ctx context.Context, txn *sql.Tx, roomID, eventID, childEventID, relType string,
+	ctx context.Context, txn *sql.Tx, roomID, childEventID string,
 ) error {
 	stmt := sqlutil.TxStmt(txn, s.deleteRelationStmt)
 	_, err := stmt.ExecContext(
-		ctx, roomID, eventID, childEventID, relType,
+		ctx, roomID, childEventID,
 	)
 	return err
 }

--- a/syncapi/storage/postgres/relations_table.go
+++ b/syncapi/storage/postgres/relations_table.go
@@ -39,7 +39,9 @@ CREATE TABLE IF NOT EXISTS syncapi_relations (
 const insertRelationSQL = "" +
 	"INSERT INTO syncapi_relations (" +
 	"  room_id, event_id, child_event_id, rel_type" +
-	") VALUES ($1, $2, $3, $4) RETURNING id"
+	") VALUES ($1, $2, $3, $4) " +
+	" ON CONFLICT syncapi_relations_unique DO UPDATE SET event_id=EXCLUDED.event_id" +
+	" RETURNING id"
 
 const deleteRelationSQL = "" +
 	"DELETE FROM syncapi_relations WHERE event_id = $1"

--- a/syncapi/storage/postgres/relations_table.go
+++ b/syncapi/storage/postgres/relations_table.go
@@ -50,12 +50,12 @@ const deleteRelationSQL = "" +
 
 const selectRelationsInRangeSQL = "" +
 	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
-	" WHERE room_id = $1 AND event_id = $2 AND id >= $3 AND id <= $4" +
+	" WHERE room_id = $1 AND event_id = $2 AND id > $3 AND id <= $4" +
 	" ORDER BY id DESC LIMIT $5"
 
 const selectRelationsByTypeInRangeSQL = "" +
 	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
-	" WHERE room_id = $1 AND event_id = $2 AND rel_type = $3 AND id >= $4 AND id <= $5" +
+	" WHERE room_id = $1 AND event_id = $2 AND rel_type = $3 AND id > $4 AND id <= $5" +
 	" ORDER BY id DESC LIMIT $6"
 
 const selectMaxRelationIDSQL = "" +

--- a/syncapi/storage/postgres/relations_table.go
+++ b/syncapi/storage/postgres/relations_table.go
@@ -1,0 +1,161 @@
+// Copyright 2017-2018 New Vector Ltd
+// Copyright 2019-2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/matrix-org/dendrite/internal"
+	"github.com/matrix-org/dendrite/internal/sqlutil"
+	"github.com/matrix-org/dendrite/syncapi/storage/tables"
+	"github.com/matrix-org/dendrite/syncapi/types"
+)
+
+const relationsSchema = `
+CREATE TABLE IF NOT EXISTS syncapi_relations (
+	id BIGINT PRIMARY KEY DEFAULT nextval('syncapi_relation_id'),
+	room_id TEXT NOT NULL,
+	event_id TEXT NOT NULL,
+	child_event_id TEXT NOT NULL,
+	rel_type TEXT NOT NULL,
+	CONSTRAINT syncapi_relations_unique UNIQUE (room_id, event_id, child_event_id, rel_type)
+);
+`
+
+const insertRelationSQL = "" +
+	"INSERT INTO syncapi_relations (" +
+	"  room_id, event_id, child_event_id, rel_type" +
+	") VALUES ($1, $2, $3, $4) RETURNING id"
+
+const deleteRelationSQL = "" +
+	"DELETE FROM syncapi_relations WHERE event_id = $1"
+
+const selectRelationsInRangeSQL = "" +
+	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
+	" WHERE room_id = $1 AND event_id = $2 AND id > $3 AND id <= $4" +
+	" ORDER BY id DESC"
+
+const selectRelationsByTypeInRangeSQL = "" +
+	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
+	" WHERE room_id = $1 AND event_id = $2 AND rel_type = $3 AND id > $4 AND id <= $5" +
+	" ORDER BY id DESC"
+
+const selectMaxRelationIDSQL = "" +
+	"SELECT MAX(id) FROM syncapi_relations"
+
+type relationsStatements struct {
+	insertRelationStmt               *sql.Stmt
+	selectRelationsInRangeStmt       *sql.Stmt
+	selectRelationsByTypeInRangeStmt *sql.Stmt
+	deleteRelationStmt               *sql.Stmt
+	selectMaxRelationIDStmt          *sql.Stmt
+}
+
+func NewPostgresRelationsTable(db *sql.DB) (tables.Relations, error) {
+	s := &relationsStatements{}
+	_, err := db.Exec(relationsSchema)
+	if err != nil {
+		return nil, err
+	}
+	if s.insertRelationStmt, err = db.Prepare(insertRelationSQL); err != nil {
+		return nil, err
+	}
+	if s.selectRelationsInRangeStmt, err = db.Prepare(selectRelationsInRangeSQL); err != nil {
+		return nil, err
+	}
+	if s.selectRelationsByTypeInRangeStmt, err = db.Prepare(selectRelationsByTypeInRangeSQL); err != nil {
+		return nil, err
+	}
+	if s.deleteRelationStmt, err = db.Prepare(deleteRelationSQL); err != nil {
+		return nil, err
+	}
+	if s.selectMaxRelationIDStmt, err = db.Prepare(selectMaxRelationIDSQL); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *relationsStatements) InsertRelation(
+	ctx context.Context, txn *sql.Tx, roomID, eventID, childEventID, relType string,
+) (streamPos types.StreamPosition, err error) {
+	err = sqlutil.TxStmt(txn, s.insertRelationStmt).QueryRowContext(
+		ctx, roomID, eventID, childEventID, relType,
+	).Scan(&streamPos)
+	return
+}
+
+func (s *relationsStatements) DeleteRelation(
+	ctx context.Context, txn *sql.Tx, roomID, eventID, childEventID, relType string,
+) error {
+	stmt := sqlutil.TxStmt(txn, s.deleteRelationStmt)
+	_, err := stmt.ExecContext(
+		ctx, roomID, eventID, childEventID, relType,
+	)
+	return err
+}
+
+// SelectRelationsInRange returns a map rel_type -> []child_event_id
+func (s *relationsStatements) SelectRelationsInRange(
+	ctx context.Context, txn *sql.Tx, roomID, eventID, relType string, r types.Range,
+) (map[string][]string, types.StreamPosition, error) {
+	var lastPos types.StreamPosition
+	var rows *sql.Rows
+	var err error
+	if relType != "" {
+		stmt := sqlutil.TxStmt(txn, s.selectRelationsByTypeInRangeStmt)
+		rows, err = stmt.QueryContext(ctx, roomID, eventID, relType, r.Low(), r.High())
+	} else {
+		stmt := sqlutil.TxStmt(txn, s.selectRelationsInRangeStmt)
+		rows, err = stmt.QueryContext(ctx, roomID, eventID, r.Low(), r.High())
+	}
+	if err != nil {
+		return nil, lastPos, err
+	}
+	defer internal.CloseAndLogIfError(ctx, rows, "selectRelationsInRange: rows.close() failed")
+	result := map[string][]string{}
+	for rows.Next() {
+		var (
+			id           types.StreamPosition
+			roomID       string
+			childEventID string
+			relType      string
+		)
+		if err = rows.Scan(&id, &roomID, &childEventID, &relType); err != nil {
+			return nil, lastPos, err
+		}
+		if id > lastPos {
+			lastPos = id
+		}
+		result[relType] = append(result[relType], childEventID)
+	}
+	if lastPos == 0 {
+		lastPos = r.To
+	}
+	return result, lastPos, rows.Err()
+}
+
+func (s *relationsStatements) SelectMaxRelationID(
+	ctx context.Context, txn *sql.Tx,
+) (id int64, err error) {
+	var nullableID sql.NullInt64
+	stmt := sqlutil.TxStmt(txn, s.selectMaxRelationIDStmt)
+	err = stmt.QueryRowContext(ctx).Scan(&nullableID)
+	if nullableID.Valid {
+		id = nullableID.Int64
+	}
+	return
+}

--- a/syncapi/storage/postgres/syncserver.go
+++ b/syncapi/storage/postgres/syncserver.go
@@ -98,6 +98,10 @@ func NewDatabase(base *base.BaseDendrite, dbProperties *config.DatabaseOptions) 
 	if err != nil {
 		return nil, err
 	}
+	relations, err := NewPostgresRelationsTable(d.db)
+	if err != nil {
+		return nil, err
+	}
 
 	// apply migrations which need multiple tables
 	m := sqlutil.NewMigrator(d.db)
@@ -129,6 +133,7 @@ func NewDatabase(base *base.BaseDendrite, dbProperties *config.DatabaseOptions) 
 		NotificationData:    notificationData,
 		Ignores:             ignores,
 		Presence:            presence,
+		Relations:           relations,
 	}
 	return &d, nil
 }

--- a/syncapi/storage/shared/storage_consumer.go
+++ b/syncapi/storage/shared/storage_consumer.go
@@ -604,14 +604,10 @@ func (d *Database) UpdateRelations(ctx context.Context, event *gomatrixserverlib
 		return nil
 	default:
 		return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
-			var err error
-			_, err = d.Relations.InsertRelation(
+			_, err := d.Relations.InsertRelation(
 				ctx, txn, event.RoomID(), content.Relations.EventID,
 				event.EventID(), content.Relations.RelationType,
 			)
-			if err != nil {
-				logrus.WithError(err).Errorf("Failed to update relations for room %s when processing event %s", event.RoomID(), event.EventID())
-			}
 			return err
 		})
 	}

--- a/syncapi/storage/shared/storage_consumer.go
+++ b/syncapi/storage/shared/storage_consumer.go
@@ -606,7 +606,7 @@ func (d *Database) UpdateRelations(ctx context.Context, event *gomatrixserverlib
 		return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
 			return d.Relations.InsertRelation(
 				ctx, txn, event.RoomID(), content.Relations.EventID,
-				event.EventID(), content.Relations.RelationType,
+				event.EventID(), event.Type(), content.Relations.RelationType,
 			)
 		})
 	}

--- a/syncapi/storage/shared/storage_consumer.go
+++ b/syncapi/storage/shared/storage_consumer.go
@@ -601,9 +601,7 @@ func (d *Database) UpdateRelations(ctx context.Context, event *gomatrixserverlib
 	case content.Relations.RelationType == "":
 		return nil
 	case event.Type() == gomatrixserverlib.MRoomRedaction:
-		return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
-			return d.Relations.DeleteRelation(ctx, txn, event.RoomID(), event.Redacts())
-		})
+		return nil
 	default:
 		return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
 			var err error
@@ -617,4 +615,10 @@ func (d *Database) UpdateRelations(ctx context.Context, event *gomatrixserverlib
 			return err
 		})
 	}
+}
+
+func (d *Database) RedactRelations(ctx context.Context, roomID, redactedEventID string) error {
+	return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
+		return d.Relations.DeleteRelation(ctx, txn, roomID, redactedEventID)
+	})
 }

--- a/syncapi/storage/shared/storage_consumer.go
+++ b/syncapi/storage/shared/storage_consumer.go
@@ -598,10 +598,9 @@ func (d *Database) UpdateRelations(ctx context.Context, event *gomatrixserverlib
 	}
 	return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
 		var err error
-		if event.Redacted() {
+		if event.Type() == gomatrixserverlib.MRoomRedaction {
 			err = d.Relations.DeleteRelation(
-				ctx, txn, event.RoomID(), content.Relations.EventID,
-				event.EventID(), content.Relations.RelationType,
+				ctx, txn, event.RoomID(), event.Redacts(),
 			)
 		} else {
 			_, err = d.Relations.InsertRelation(

--- a/syncapi/storage/shared/storage_consumer.go
+++ b/syncapi/storage/shared/storage_consumer.go
@@ -53,6 +53,7 @@ type Database struct {
 	NotificationData    tables.NotificationData
 	Ignores             tables.Ignores
 	Presence            tables.Presence
+	Relations           tables.Relations
 }
 
 func (d *Database) NewDatabaseSnapshot(ctx context.Context) (*DatabaseTransaction, error) {
@@ -579,10 +580,27 @@ func (d *Database) SelectMembershipForUser(ctx context.Context, roomID, userID s
 	return d.Memberships.SelectMembershipForUser(ctx, nil, roomID, userID, pos)
 }
 
-func (s *Database) ReIndex(ctx context.Context, limit, afterID int64) (map[int64]gomatrixserverlib.HeaderedEvent, error) {
-	return s.OutputEvents.ReIndex(ctx, nil, limit, afterID, []string{
+func (d *Database) ReIndex(ctx context.Context, limit, afterID int64) (map[int64]gomatrixserverlib.HeaderedEvent, error) {
+	return d.OutputEvents.ReIndex(ctx, nil, limit, afterID, []string{
 		gomatrixserverlib.MRoomName,
 		gomatrixserverlib.MRoomTopic,
 		"m.room.message",
+	})
+}
+
+func (d *Database) UpdateRelations(ctx context.Context, event *gomatrixserverlib.HeaderedEvent) error {
+	var content gomatrixserverlib.RelationContent
+	if err := json.Unmarshal(event.Content(), &content); err != nil {
+		return fmt.Errorf("json.Unmarshal: %w", err)
+	}
+	if content.Relations == nil {
+		return nil
+	}
+	return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
+		_, err := d.Relations.InsertRelation(
+			ctx, txn, event.RoomID(), event.EventID(),
+			content.Relations.EventID, content.Relations.RelationType,
+		)
+		return err
 	})
 }

--- a/syncapi/storage/shared/storage_consumer.go
+++ b/syncapi/storage/shared/storage_consumer.go
@@ -608,6 +608,9 @@ func (d *Database) UpdateRelations(ctx context.Context, event *gomatrixserverlib
 				event.EventID(), content.Relations.RelationType,
 			)
 		}
+		if err != nil {
+			logrus.WithError(err).Errorf("Failed to update relations for room %s when processing event %s", event.RoomID(), event.EventID())
+		}
 		return err
 	})
 }

--- a/syncapi/storage/shared/storage_consumer.go
+++ b/syncapi/storage/shared/storage_consumer.go
@@ -598,8 +598,8 @@ func (d *Database) UpdateRelations(ctx context.Context, event *gomatrixserverlib
 	}
 	return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
 		_, err := d.Relations.InsertRelation(
-			ctx, txn, event.RoomID(), event.EventID(),
-			content.Relations.EventID, content.Relations.RelationType,
+			ctx, txn, event.RoomID(), content.Relations.EventID,
+			event.EventID(), content.Relations.RelationType,
 		)
 		return err
 	})

--- a/syncapi/storage/shared/storage_consumer.go
+++ b/syncapi/storage/shared/storage_consumer.go
@@ -604,11 +604,10 @@ func (d *Database) UpdateRelations(ctx context.Context, event *gomatrixserverlib
 		return nil
 	default:
 		return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
-			_, err := d.Relations.InsertRelation(
+			return d.Relations.InsertRelation(
 				ctx, txn, event.RoomID(), content.Relations.EventID,
 				event.EventID(), content.Relations.RelationType,
 			)
-			return err
 		})
 	}
 }

--- a/syncapi/storage/shared/storage_consumer.go
+++ b/syncapi/storage/shared/storage_consumer.go
@@ -597,10 +597,18 @@ func (d *Database) UpdateRelations(ctx context.Context, event *gomatrixserverlib
 		return nil
 	}
 	return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
-		_, err := d.Relations.InsertRelation(
-			ctx, txn, event.RoomID(), content.Relations.EventID,
-			event.EventID(), content.Relations.RelationType,
-		)
+		var err error
+		if event.Redacted() {
+			err = d.Relations.DeleteRelation(
+				ctx, txn, event.RoomID(), content.Relations.EventID,
+				event.EventID(), content.Relations.RelationType,
+			)
+		} else {
+			_, err = d.Relations.InsertRelation(
+				ctx, txn, event.RoomID(), content.Relations.EventID,
+				event.EventID(), content.Relations.RelationType,
+			)
+		}
 		return err
 	})
 }

--- a/syncapi/storage/shared/storage_sync.go
+++ b/syncapi/storage/shared/storage_sync.go
@@ -626,7 +626,7 @@ func (d *DatabaseTransaction) RelationsFor(ctx context.Context, roomID, eventID,
 	// First look up any relations from the database. We add one to the limit here
 	// so that we can tell if we're overflowing, as we will only set the "next_batch"
 	// in the response if we are.
-	relations, _, err := d.Relations.SelectRelationsInRange(ctx, d.txn, roomID, eventID, relType, r, limit+1)
+	relations, _, err := d.Relations.SelectRelationsInRange(ctx, d.txn, roomID, eventID, relType, eventType, r, limit+1)
 	if err != nil {
 		return nil, "", "", fmt.Errorf("d.Relations.SelectRelationsInRange: %w", err)
 	}
@@ -672,9 +672,6 @@ func (d *DatabaseTransaction) RelationsFor(ctx context.Context, roomID, eventID,
 	// type if it was specified.
 	clientEvents = make([]gomatrixserverlib.ClientEvent, 0, len(events))
 	for _, event := range events {
-		if eventType != "" && event.Type() != eventType {
-			continue
-		}
 		clientEvents = append(
 			clientEvents,
 			gomatrixserverlib.ToClientEvent(event.Event, gomatrixserverlib.FormatAll),

--- a/syncapi/storage/shared/storage_sync.go
+++ b/syncapi/storage/shared/storage_sync.go
@@ -636,7 +636,7 @@ func (d *DatabaseTransaction) RelationsFor(ctx context.Context, roomID, eventID,
 
 	// If there were no entries returned, there were no relations, so stop at this point.
 	if len(entries) == 0 {
-		return nil, "", "", nil
+		return clientEvents, "", "", nil
 	}
 
 	// Otherwise, let's try and work out what sensible prev_batch and next_batch values

--- a/syncapi/storage/shared/storage_sync.go
+++ b/syncapi/storage/shared/storage_sync.go
@@ -598,17 +598,24 @@ func (d *DatabaseTransaction) MaxStreamPositionForRelations(ctx context.Context)
 func (d *DatabaseTransaction) RelationsFor(ctx context.Context, roomID, eventID, relType, eventType string, from, to types.StreamPosition, limit int) (
 	clientEvents []gomatrixserverlib.ClientEvent, prevBatch, nextBatch string, err error,
 ) {
-	var eventIDs []string
+	clientEvents = []gomatrixserverlib.ClientEvent{}
+	eventIDs := []string{}
 	r := types.Range{
 		From:      from,
 		To:        to,
 		Backwards: from > to,
 	}
+
+	// First up look up any relations from the database. We add one to the limit here
+	// so that we can tell if we're overflowing, as we will only set the "next_batch"
+	// in the response if we are.
 	relations, _, err := d.Relations.SelectRelationsInRange(ctx, d.txn, roomID, eventID, relType, r, limit+1)
 	if err != nil {
 		return nil, "", "", fmt.Errorf("d.Relations.SelectRelationsInRange: %w", err)
 	}
 
+	// If we specified a relation type then just get those results, otherwise collate
+	// them from all of the returned relation types.
 	entries := []types.RelationEntry{}
 	if relType != "" {
 		entries = relations[relType]
@@ -618,10 +625,13 @@ func (d *DatabaseTransaction) RelationsFor(ctx context.Context, roomID, eventID,
 		}
 	}
 
+	// If there were no entries returned, there were no relations, so stop at this point.
 	if len(entries) == 0 {
 		return nil, "", "", nil
 	}
 
+	// Otherwise, let's try and work out what sensible prev_batch and next_batch values
+	// could be.
 	if from > 0 {
 		prevBatch = fmt.Sprintf("%d", entries[0].Position-1)
 	}
@@ -630,15 +640,18 @@ func (d *DatabaseTransaction) RelationsFor(ctx context.Context, roomID, eventID,
 		entries = entries[:len(entries)-1]
 	}
 
+	// Extract all of the event IDs from the relation entries so that we can pull the
+	// events out of the database.
 	for _, entry := range entries {
 		eventIDs = append(eventIDs, entry.EventID)
 	}
-
 	events, err := d.OutputEvents.SelectEvents(ctx, d.txn, eventIDs, nil, true)
 	if err != nil {
 		return nil, "", "", fmt.Errorf("d.OutputEvents.SelectEvents: %w", err)
 	}
 
+	// Convert the events into client events, and optionally filter based on the event
+	// type if it was specified.
 	for _, event := range events {
 		if eventType != "" && event.Type() != eventType {
 			continue

--- a/syncapi/storage/shared/storage_sync.go
+++ b/syncapi/storage/shared/storage_sync.go
@@ -590,6 +590,11 @@ func (d *DatabaseTransaction) MaxStreamPositionForPresence(ctx context.Context) 
 	return d.Presence.GetMaxPresenceID(ctx, d.txn)
 }
 
+func (d *DatabaseTransaction) MaxStreamPositionForRelations(ctx context.Context) (types.StreamPosition, error) {
+	id, err := d.Relations.SelectMaxRelationID(ctx, d.txn)
+	return types.StreamPosition(id), err
+}
+
 func (d *DatabaseTransaction) RelationsFor(ctx context.Context, roomID, eventID, relType, eventType string, from, to types.StreamPosition, limit int) (
 	clientEvents []gomatrixserverlib.ClientEvent, prevBatch, nextBatch string, err error,
 ) {

--- a/syncapi/storage/sqlite3/relations_table.go
+++ b/syncapi/storage/sqlite3/relations_table.go
@@ -48,12 +48,12 @@ const deleteRelationSQL = "" +
 
 const selectRelationsInRangeSQL = "" +
 	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
-	" WHERE room_id = $1 AND event_id = $2 AND id > $3 AND id <= $4" +
+	" WHERE room_id = $1 AND event_id = $2 AND id >= $3 AND id <= $4" +
 	" ORDER BY id DESC LIMIT $5"
 
 const selectRelationsByTypeInRangeSQL = "" +
 	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
-	" WHERE room_id = $1 AND event_id = $2 AND rel_type = $3 AND id > $4 AND id <= $5" +
+	" WHERE room_id = $1 AND event_id = $2 AND rel_type = $3 AND id >= $4 AND id <= $5" +
 	" ORDER BY id DESC LIMIT $6"
 
 const selectMaxRelationIDSQL = "" +

--- a/syncapi/storage/sqlite3/relations_table.go
+++ b/syncapi/storage/sqlite3/relations_table.go
@@ -48,12 +48,12 @@ const deleteRelationSQL = "" +
 
 const selectRelationsInRangeSQL = "" +
 	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
-	" WHERE room_id = $1 AND event_id = $2 AND id >= $3 AND id <= $4" +
+	" WHERE room_id = $1 AND event_id = $2 AND id > $3 AND id <= $4" +
 	" ORDER BY id DESC LIMIT $5"
 
 const selectRelationsByTypeInRangeSQL = "" +
 	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
-	" WHERE room_id = $1 AND event_id = $2 AND rel_type = $3 AND id >= $4 AND id <= $5" +
+	" WHERE room_id = $1 AND event_id = $2 AND rel_type = $3 AND id > $4 AND id <= $5" +
 	" ORDER BY id DESC LIMIT $6"
 
 const selectMaxRelationIDSQL = "" +

--- a/syncapi/storage/sqlite3/relations_table.go
+++ b/syncapi/storage/sqlite3/relations_table.go
@@ -49,12 +49,12 @@ const deleteRelationSQL = "" +
 const selectRelationsInRangeSQL = "" +
 	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
 	" WHERE room_id = $1 AND event_id = $2 AND id > $3 AND id <= $4" +
-	" ORDER BY id DESC"
+	" ORDER BY id DESC LIMIT $5"
 
 const selectRelationsByTypeInRangeSQL = "" +
 	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
 	" WHERE room_id = $1 AND event_id = $2 AND rel_type = $3 AND id > $4 AND id <= $5" +
-	" ORDER BY id DESC"
+	" ORDER BY id DESC LIMIT $6"
 
 const selectMaxRelationIDSQL = "" +
 	"SELECT MAX(id) FROM syncapi_relations"
@@ -121,17 +121,18 @@ func (s *relationsStatements) DeleteRelation(
 
 // SelectRelationsInRange returns a map rel_type -> []child_event_id
 func (s *relationsStatements) SelectRelationsInRange(
-	ctx context.Context, txn *sql.Tx, roomID, eventID, relType string, r types.Range,
+	ctx context.Context, txn *sql.Tx, roomID, eventID, relType string,
+	r types.Range, limit int,
 ) (map[string][]string, types.StreamPosition, error) {
 	var lastPos types.StreamPosition
 	var rows *sql.Rows
 	var err error
 	if relType != "" {
 		stmt := sqlutil.TxStmt(txn, s.selectRelationsByTypeInRangeStmt)
-		rows, err = stmt.QueryContext(ctx, roomID, eventID, relType, r.Low(), r.High())
+		rows, err = stmt.QueryContext(ctx, roomID, eventID, relType, r.Low(), r.High(), limit)
 	} else {
 		stmt := sqlutil.TxStmt(txn, s.selectRelationsInRangeStmt)
-		rows, err = stmt.QueryContext(ctx, roomID, eventID, r.Low(), r.High())
+		rows, err = stmt.QueryContext(ctx, roomID, eventID, r.Low(), r.High(), limit)
 	}
 	if err != nil {
 		return nil, lastPos, err

--- a/syncapi/storage/sqlite3/relations_table.go
+++ b/syncapi/storage/sqlite3/relations_table.go
@@ -97,14 +97,13 @@ func NewSqliteRelationsTable(db *sql.DB, streamID *StreamIDStatements) (tables.R
 func (s *relationsStatements) InsertRelation(
 	ctx context.Context, txn *sql.Tx, roomID, eventID, childEventID, relType string,
 ) (streamPos types.StreamPosition, err error) {
-	pos, err := s.streamIDStatements.nextRelationID(ctx, txn)
-	if err != nil {
+	if streamPos, err = s.streamIDStatements.nextRelationID(ctx, txn); err != nil {
 		return
 	}
-	_, err = sqlutil.TxStmt(txn, s.insertRelationStmt).ExecContext(
-		ctx, pos, roomID, eventID, childEventID, relType,
-	)
-	return pos, err
+	err = sqlutil.TxStmt(txn, s.insertRelationStmt).QueryRowContext(
+		ctx, streamPos, roomID, eventID, childEventID, relType,
+	).Scan(&streamPos)
+	return
 }
 
 func (s *relationsStatements) DeleteRelation(

--- a/syncapi/storage/sqlite3/relations_table.go
+++ b/syncapi/storage/sqlite3/relations_table.go
@@ -1,0 +1,171 @@
+// Copyright 2017-2018 New Vector Ltd
+// Copyright 2019-2020 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sqlite3
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/matrix-org/dendrite/internal"
+	"github.com/matrix-org/dendrite/internal/sqlutil"
+	"github.com/matrix-org/dendrite/syncapi/storage/tables"
+	"github.com/matrix-org/dendrite/syncapi/types"
+)
+
+const relationsSchema = `
+CREATE TABLE IF NOT EXISTS syncapi_relations (
+	id BIGINT PRIMARY KEY,
+	room_id TEXT NOT NULL,
+	event_id TEXT NOT NULL,
+	child_event_id TEXT NOT NULL,
+	rel_type TEXT NOT NULL,
+	UNIQUE (room_id, event_id, child_event_id, rel_type)
+);
+`
+
+const insertRelationSQL = "" +
+	"INSERT INTO syncapi_relations (" +
+	"  id, room_id, event_id, child_event_id, rel_type" +
+	") VALUES ($1, $2, $3, $4, $5) " +
+	" ON CONFLICT (room_id, event_id, child_event_id, rel_type) DO UPDATE SET event_id=EXCLUDED.event_id" +
+	" RETURNING id"
+
+const deleteRelationSQL = "" +
+	"DELETE FROM syncapi_relations WHERE room_id = $1 AND child_event_id = $2"
+
+const selectRelationsInRangeSQL = "" +
+	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
+	" WHERE room_id = $1 AND event_id = $2 AND id > $3 AND id <= $4" +
+	" ORDER BY id DESC"
+
+const selectRelationsByTypeInRangeSQL = "" +
+	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
+	" WHERE room_id = $1 AND event_id = $2 AND rel_type = $3 AND id > $4 AND id <= $5" +
+	" ORDER BY id DESC"
+
+const selectMaxRelationIDSQL = "" +
+	"SELECT MAX(id) FROM syncapi_relations"
+
+type relationsStatements struct {
+	streamIDStatements               *StreamIDStatements
+	insertRelationStmt               *sql.Stmt
+	selectRelationsInRangeStmt       *sql.Stmt
+	selectRelationsByTypeInRangeStmt *sql.Stmt
+	deleteRelationStmt               *sql.Stmt
+	selectMaxRelationIDStmt          *sql.Stmt
+}
+
+func NewSqliteRelationsTable(db *sql.DB) (tables.Relations, error) {
+	s := &relationsStatements{}
+	_, err := db.Exec(relationsSchema)
+	if err != nil {
+		return nil, err
+	}
+	if s.insertRelationStmt, err = db.Prepare(insertRelationSQL); err != nil {
+		return nil, err
+	}
+	if s.selectRelationsInRangeStmt, err = db.Prepare(selectRelationsInRangeSQL); err != nil {
+		return nil, err
+	}
+	if s.selectRelationsByTypeInRangeStmt, err = db.Prepare(selectRelationsByTypeInRangeSQL); err != nil {
+		return nil, err
+	}
+	if s.deleteRelationStmt, err = db.Prepare(deleteRelationSQL); err != nil {
+		return nil, err
+	}
+	if s.selectMaxRelationIDStmt, err = db.Prepare(selectMaxRelationIDSQL); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *relationsStatements) InsertRelation(
+	ctx context.Context, txn *sql.Tx, roomID, eventID, childEventID, relType string,
+) (streamPos types.StreamPosition, err error) {
+	pos, err := s.streamIDStatements.nextRelationID(ctx, txn)
+	if err != nil {
+		return
+	}
+	_, err = sqlutil.TxStmt(txn, s.insertRelationStmt).ExecContext(
+		ctx, pos, roomID, eventID, childEventID, relType,
+	)
+	return pos, err
+}
+
+func (s *relationsStatements) DeleteRelation(
+	ctx context.Context, txn *sql.Tx, roomID, childEventID string,
+) error {
+	stmt := sqlutil.TxStmt(txn, s.deleteRelationStmt)
+	_, err := stmt.ExecContext(
+		ctx, roomID, childEventID,
+	)
+	if err == sql.ErrNoRows {
+		return nil
+	}
+	return err
+}
+
+// SelectRelationsInRange returns a map rel_type -> []child_event_id
+func (s *relationsStatements) SelectRelationsInRange(
+	ctx context.Context, txn *sql.Tx, roomID, eventID, relType string, r types.Range,
+) (map[string][]string, types.StreamPosition, error) {
+	var lastPos types.StreamPosition
+	var rows *sql.Rows
+	var err error
+	if relType != "" {
+		stmt := sqlutil.TxStmt(txn, s.selectRelationsByTypeInRangeStmt)
+		rows, err = stmt.QueryContext(ctx, roomID, eventID, relType, r.Low(), r.High())
+	} else {
+		stmt := sqlutil.TxStmt(txn, s.selectRelationsInRangeStmt)
+		rows, err = stmt.QueryContext(ctx, roomID, eventID, r.Low(), r.High())
+	}
+	if err != nil {
+		return nil, lastPos, err
+	}
+	defer internal.CloseAndLogIfError(ctx, rows, "selectRelationsInRange: rows.close() failed")
+	result := map[string][]string{}
+	for rows.Next() {
+		var (
+			id           types.StreamPosition
+			roomID       string
+			childEventID string
+			relType      string
+		)
+		if err = rows.Scan(&id, &roomID, &childEventID, &relType); err != nil {
+			return nil, lastPos, err
+		}
+		if id > lastPos {
+			lastPos = id
+		}
+		result[relType] = append(result[relType], childEventID)
+	}
+	if lastPos == 0 {
+		lastPos = r.To
+	}
+	return result, lastPos, rows.Err()
+}
+
+func (s *relationsStatements) SelectMaxRelationID(
+	ctx context.Context, txn *sql.Tx,
+) (id int64, err error) {
+	var nullableID sql.NullInt64
+	stmt := sqlutil.TxStmt(txn, s.selectMaxRelationIDStmt)
+	err = stmt.QueryRowContext(ctx).Scan(&nullableID)
+	if nullableID.Valid {
+		id = nullableID.Int64
+	}
+	return
+}

--- a/syncapi/storage/sqlite3/relations_table.go
+++ b/syncapi/storage/sqlite3/relations_table.go
@@ -46,26 +46,38 @@ const insertRelationSQL = "" +
 const deleteRelationSQL = "" +
 	"DELETE FROM syncapi_relations WHERE room_id = $1 AND child_event_id = $2"
 
-const selectRelationsInRangeSQL = "" +
+const selectRelationsInRangeAscSQL = "" +
 	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
 	" WHERE room_id = $1 AND event_id = $2 AND id > $3 AND id <= $4" +
+	" ORDER BY id ASC LIMIT $5"
+
+const selectRelationsInRangeDescSQL = "" +
+	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
+	" WHERE room_id = $1 AND event_id = $2 AND id >= $3 AND id < $4" +
 	" ORDER BY id DESC LIMIT $5"
 
-const selectRelationsByTypeInRangeSQL = "" +
+const selectRelationsByTypeInRangeAscSQL = "" +
 	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
 	" WHERE room_id = $1 AND event_id = $2 AND rel_type = $3 AND id > $4 AND id <= $5" +
+	" ORDER BY id ASC LIMIT $6"
+
+const selectRelationsByTypeInRangeDescSQL = "" +
+	"SELECT id, room_id, child_event_id, rel_type FROM syncapi_relations" +
+	" WHERE room_id = $1 AND event_id = $2 AND rel_type = $3 AND id >= $4 AND id < $5" +
 	" ORDER BY id DESC LIMIT $6"
 
 const selectMaxRelationIDSQL = "" +
 	"SELECT MAX(id) FROM syncapi_relations"
 
 type relationsStatements struct {
-	streamIDStatements               *StreamIDStatements
-	insertRelationStmt               *sql.Stmt
-	selectRelationsInRangeStmt       *sql.Stmt
-	selectRelationsByTypeInRangeStmt *sql.Stmt
-	deleteRelationStmt               *sql.Stmt
-	selectMaxRelationIDStmt          *sql.Stmt
+	streamIDStatements                   *StreamIDStatements
+	insertRelationStmt                   *sql.Stmt
+	selectRelationsInRangeAscStmt        *sql.Stmt
+	selectRelationsInRangeDescStmt       *sql.Stmt
+	selectRelationsByTypeInRangeAscStmt  *sql.Stmt
+	selectRelationsByTypeInRangeDescStmt *sql.Stmt
+	deleteRelationStmt                   *sql.Stmt
+	selectMaxRelationIDStmt              *sql.Stmt
 }
 
 func NewSqliteRelationsTable(db *sql.DB, streamID *StreamIDStatements) (tables.Relations, error) {
@@ -79,10 +91,16 @@ func NewSqliteRelationsTable(db *sql.DB, streamID *StreamIDStatements) (tables.R
 	if s.insertRelationStmt, err = db.Prepare(insertRelationSQL); err != nil {
 		return nil, err
 	}
-	if s.selectRelationsInRangeStmt, err = db.Prepare(selectRelationsInRangeSQL); err != nil {
+	if s.selectRelationsInRangeAscStmt, err = db.Prepare(selectRelationsInRangeAscSQL); err != nil {
 		return nil, err
 	}
-	if s.selectRelationsByTypeInRangeStmt, err = db.Prepare(selectRelationsByTypeInRangeSQL); err != nil {
+	if s.selectRelationsInRangeDescStmt, err = db.Prepare(selectRelationsInRangeDescSQL); err != nil {
+		return nil, err
+	}
+	if s.selectRelationsByTypeInRangeAscStmt, err = db.Prepare(selectRelationsByTypeInRangeAscSQL); err != nil {
+		return nil, err
+	}
+	if s.selectRelationsByTypeInRangeDescStmt, err = db.Prepare(selectRelationsByTypeInRangeDescSQL); err != nil {
 		return nil, err
 	}
 	if s.deleteRelationStmt, err = db.Prepare(deleteRelationSQL); err != nil {
@@ -125,13 +143,22 @@ func (s *relationsStatements) SelectRelationsInRange(
 	r types.Range, limit int,
 ) (map[string][]types.RelationEntry, types.StreamPosition, error) {
 	var lastPos types.StreamPosition
+	var stmt *sql.Stmt
 	var rows *sql.Rows
 	var err error
 	if relType != "" {
-		stmt := sqlutil.TxStmt(txn, s.selectRelationsByTypeInRangeStmt)
+		if r.Backwards {
+			stmt = sqlutil.TxStmt(txn, s.selectRelationsByTypeInRangeDescStmt)
+		} else {
+			stmt = sqlutil.TxStmt(txn, s.selectRelationsByTypeInRangeAscStmt)
+		}
 		rows, err = stmt.QueryContext(ctx, roomID, eventID, relType, r.Low(), r.High(), limit)
 	} else {
-		stmt := sqlutil.TxStmt(txn, s.selectRelationsInRangeStmt)
+		if r.Backwards {
+			stmt = sqlutil.TxStmt(txn, s.selectRelationsInRangeDescStmt)
+		} else {
+			stmt = sqlutil.TxStmt(txn, s.selectRelationsInRangeAscStmt)
+		}
 		rows, err = stmt.QueryContext(ctx, roomID, eventID, r.Low(), r.High(), limit)
 	}
 	if err != nil {

--- a/syncapi/storage/sqlite3/relations_table.go
+++ b/syncapi/storage/sqlite3/relations_table.go
@@ -123,7 +123,7 @@ func (s *relationsStatements) DeleteRelation(
 func (s *relationsStatements) SelectRelationsInRange(
 	ctx context.Context, txn *sql.Tx, roomID, eventID, relType string,
 	r types.Range, limit int,
-) (map[string][]string, types.StreamPosition, error) {
+) (map[string][]types.RelationEntry, types.StreamPosition, error) {
 	var lastPos types.StreamPosition
 	var rows *sql.Rows
 	var err error
@@ -138,7 +138,7 @@ func (s *relationsStatements) SelectRelationsInRange(
 		return nil, lastPos, err
 	}
 	defer internal.CloseAndLogIfError(ctx, rows, "selectRelationsInRange: rows.close() failed")
-	result := map[string][]string{}
+	result := map[string][]types.RelationEntry{}
 	for rows.Next() {
 		var (
 			id           types.StreamPosition
@@ -152,7 +152,10 @@ func (s *relationsStatements) SelectRelationsInRange(
 		if id > lastPos {
 			lastPos = id
 		}
-		result[relType] = append(result[relType], childEventID)
+		result[relType] = append(result[relType], types.RelationEntry{
+			Position: id,
+			EventID:  childEventID,
+		})
 	}
 	if lastPos == 0 {
 		lastPos = r.To

--- a/syncapi/storage/sqlite3/relations_table.go
+++ b/syncapi/storage/sqlite3/relations_table.go
@@ -68,8 +68,10 @@ type relationsStatements struct {
 	selectMaxRelationIDStmt          *sql.Stmt
 }
 
-func NewSqliteRelationsTable(db *sql.DB) (tables.Relations, error) {
-	s := &relationsStatements{}
+func NewSqliteRelationsTable(db *sql.DB, streamID *StreamIDStatements) (tables.Relations, error) {
+	s := &relationsStatements{
+		streamIDStatements: streamID,
+	}
 	_, err := db.Exec(relationsSchema)
 	if err != nil {
 		return nil, err

--- a/syncapi/storage/sqlite3/stream_id_table.go
+++ b/syncapi/storage/sqlite3/stream_id_table.go
@@ -28,6 +28,8 @@ INSERT INTO syncapi_stream_id (stream_name, stream_id) VALUES ("presence", 0)
   ON CONFLICT DO NOTHING;
 INSERT INTO syncapi_stream_id (stream_name, stream_id) VALUES ("notification", 0)
   ON CONFLICT DO NOTHING;
+INSERT INTO syncapi_stream_id (stream_name, stream_id) VALUES ("relation", 0)
+  ON CONFLICT DO NOTHING;
 `
 
 const increaseStreamIDStmt = "" +
@@ -84,5 +86,11 @@ func (s *StreamIDStatements) nextPresenceID(ctx context.Context, txn *sql.Tx) (p
 func (s *StreamIDStatements) nextNotificationID(ctx context.Context, txn *sql.Tx) (pos types.StreamPosition, err error) {
 	increaseStmt := sqlutil.TxStmt(txn, s.increaseStreamIDStmt)
 	err = increaseStmt.QueryRowContext(ctx, "notification").Scan(&pos)
+	return
+}
+
+func (s *StreamIDStatements) nextRelationID(ctx context.Context, txn *sql.Tx) (pos types.StreamPosition, err error) {
+	increaseStmt := sqlutil.TxStmt(txn, s.increaseStreamIDStmt)
+	err = increaseStmt.QueryRowContext(ctx, "relation").Scan(&pos)
 	return
 }

--- a/syncapi/storage/sqlite3/syncserver.go
+++ b/syncapi/storage/sqlite3/syncserver.go
@@ -123,7 +123,7 @@ func (d *SyncServerDatasource) prepare(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
-	relations, err := NewSqliteRelationsTable(d.db)
+	relations, err := NewSqliteRelationsTable(d.db, &d.streamID)
 	if err != nil {
 		return err
 	}

--- a/syncapi/storage/sqlite3/syncserver.go
+++ b/syncapi/storage/sqlite3/syncserver.go
@@ -123,6 +123,10 @@ func (d *SyncServerDatasource) prepare(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
+	relations, err := NewSqliteRelationsTable(d.db)
+	if err != nil {
+		return err
+	}
 
 	// apply migrations which need multiple tables
 	m := sqlutil.NewMigrator(d.db)
@@ -153,6 +157,7 @@ func (d *SyncServerDatasource) prepare(ctx context.Context) (err error) {
 		NotificationData:    notificationData,
 		Ignores:             ignores,
 		Presence:            presence,
+		Relations:           relations,
 	}
 	return nil
 }

--- a/syncapi/storage/tables/interface.go
+++ b/syncapi/storage/tables/interface.go
@@ -206,3 +206,10 @@ type Presence interface {
 	GetMaxPresenceID(ctx context.Context, txn *sql.Tx) (pos types.StreamPosition, err error)
 	GetPresenceAfter(ctx context.Context, txn *sql.Tx, after types.StreamPosition, filter gomatrixserverlib.EventFilter) (presences map[string]*types.PresenceInternal, err error)
 }
+
+type Relations interface {
+	InsertRelation(ctx context.Context, txn *sql.Tx, roomID, eventID, childEventID, relType string) (streamPos types.StreamPosition, err error)
+	DeleteRelation(ctx context.Context, txn *sql.Tx, roomID, eventID, childEventID, relType string) error
+	SelectRelationsInRange(ctx context.Context, txn *sql.Tx, roomID, eventID, relType string, r types.Range) (map[string][]string, types.StreamPosition, error)
+	SelectMaxRelationID(ctx context.Context, txn *sql.Tx) (id int64, err error)
+}

--- a/syncapi/storage/tables/interface.go
+++ b/syncapi/storage/tables/interface.go
@@ -210,7 +210,7 @@ type Presence interface {
 type Relations interface {
 	// Inserts a relation which refers from the child event ID to the event ID in the given room.
 	// If the relation already exists then this function will do nothing and return no error.
-	InsertRelation(ctx context.Context, txn *sql.Tx, roomID, eventID, childEventID, relType string) (err error)
+	InsertRelation(ctx context.Context, txn *sql.Tx, roomID, eventID, childEventID, childEventType, relType string) (err error)
 	// Deletes a relation which already exists as the result of an event redaction. If the relation
 	// does not exist then this function will do nothing and return no error.
 	DeleteRelation(ctx context.Context, txn *sql.Tx, roomID, childEventID string) error
@@ -219,7 +219,7 @@ type Relations interface {
 	// contain relations of that type, otherwise if "" is specified then all relations in the range
 	// will be returned, inclusive of the "to" position but excluding the "from" position. The stream
 	// position returned is the maximum position of the returned results.
-	SelectRelationsInRange(ctx context.Context, txn *sql.Tx, roomID, eventID, relType string, r types.Range, limit int) (map[string][]types.RelationEntry, types.StreamPosition, error)
+	SelectRelationsInRange(ctx context.Context, txn *sql.Tx, roomID, eventID, relType, eventType string, r types.Range, limit int) (map[string][]types.RelationEntry, types.StreamPosition, error)
 	// SelectMaxRelationID returns the maximum ID of all relations, used to determine what the boundaries
 	// should be if there are no boundaries supplied (i.e. we want to work backwards but don't have a
 	// "from" or want to work forwards and don't have a "to").

--- a/syncapi/storage/tables/interface.go
+++ b/syncapi/storage/tables/interface.go
@@ -210,6 +210,6 @@ type Presence interface {
 type Relations interface {
 	InsertRelation(ctx context.Context, txn *sql.Tx, roomID, eventID, childEventID, relType string) (streamPos types.StreamPosition, err error)
 	DeleteRelation(ctx context.Context, txn *sql.Tx, roomID, childEventID string) error
-	SelectRelationsInRange(ctx context.Context, txn *sql.Tx, roomID, eventID, relType string, r types.Range) (map[string][]string, types.StreamPosition, error)
+	SelectRelationsInRange(ctx context.Context, txn *sql.Tx, roomID, eventID, relType string, r types.Range, limit int) (map[string][]string, types.StreamPosition, error)
 	SelectMaxRelationID(ctx context.Context, txn *sql.Tx) (id int64, err error)
 }

--- a/syncapi/storage/tables/interface.go
+++ b/syncapi/storage/tables/interface.go
@@ -208,7 +208,7 @@ type Presence interface {
 }
 
 type Relations interface {
-	InsertRelation(ctx context.Context, txn *sql.Tx, roomID, eventID, childEventID, relType string) (streamPos types.StreamPosition, err error)
+	InsertRelation(ctx context.Context, txn *sql.Tx, roomID, eventID, childEventID, relType string) (err error)
 	DeleteRelation(ctx context.Context, txn *sql.Tx, roomID, childEventID string) error
 	SelectRelationsInRange(ctx context.Context, txn *sql.Tx, roomID, eventID, relType string, r types.Range, limit int) (map[string][]types.RelationEntry, types.StreamPosition, error)
 	SelectMaxRelationID(ctx context.Context, txn *sql.Tx) (id int64, err error)

--- a/syncapi/storage/tables/interface.go
+++ b/syncapi/storage/tables/interface.go
@@ -209,7 +209,7 @@ type Presence interface {
 
 type Relations interface {
 	InsertRelation(ctx context.Context, txn *sql.Tx, roomID, eventID, childEventID, relType string) (streamPos types.StreamPosition, err error)
-	DeleteRelation(ctx context.Context, txn *sql.Tx, roomID, eventID, childEventID, relType string) error
+	DeleteRelation(ctx context.Context, txn *sql.Tx, roomID, childEventID string) error
 	SelectRelationsInRange(ctx context.Context, txn *sql.Tx, roomID, eventID, relType string, r types.Range) (map[string][]string, types.StreamPosition, error)
 	SelectMaxRelationID(ctx context.Context, txn *sql.Tx) (id int64, err error)
 }

--- a/syncapi/storage/tables/interface.go
+++ b/syncapi/storage/tables/interface.go
@@ -208,8 +208,19 @@ type Presence interface {
 }
 
 type Relations interface {
+	// Inserts a relation which refers from the child event ID to the event ID in the given room.
+	// If the relation already exists then this function will do nothing and return no error.
 	InsertRelation(ctx context.Context, txn *sql.Tx, roomID, eventID, childEventID, relType string) (err error)
+	// Deletes a relation which already exists as the result of an event redaction. If the relation
+	// does not exist then this function will do nothing and return no error.
 	DeleteRelation(ctx context.Context, txn *sql.Tx, roomID, childEventID string) error
+	// SelectRelationsInRange will return relations grouped by relation type within the given range.
+	// The map is relType -> []entry. If a relType parameter is specified then the results will only
+	// contain relations of that type, otherwise if "" is specified then all relations in the range
+	// will be returned. The stream position returned is the maximum position of the returned results.
 	SelectRelationsInRange(ctx context.Context, txn *sql.Tx, roomID, eventID, relType string, r types.Range, limit int) (map[string][]types.RelationEntry, types.StreamPosition, error)
+	// SelectMaxRelationID returns the maximum ID of all relations, used to determine what the boundaries
+	// should be if there are no boundaries supplied (i.e. we want to work backwards but don't have a
+	// "from" or want to work forwards and don't have a "to").
 	SelectMaxRelationID(ctx context.Context, txn *sql.Tx) (id int64, err error)
 }

--- a/syncapi/storage/tables/interface.go
+++ b/syncapi/storage/tables/interface.go
@@ -210,6 +210,6 @@ type Presence interface {
 type Relations interface {
 	InsertRelation(ctx context.Context, txn *sql.Tx, roomID, eventID, childEventID, relType string) (streamPos types.StreamPosition, err error)
 	DeleteRelation(ctx context.Context, txn *sql.Tx, roomID, childEventID string) error
-	SelectRelationsInRange(ctx context.Context, txn *sql.Tx, roomID, eventID, relType string, r types.Range, limit int) (map[string][]string, types.StreamPosition, error)
+	SelectRelationsInRange(ctx context.Context, txn *sql.Tx, roomID, eventID, relType string, r types.Range, limit int) (map[string][]types.RelationEntry, types.StreamPosition, error)
 	SelectMaxRelationID(ctx context.Context, txn *sql.Tx) (id int64, err error)
 }

--- a/syncapi/storage/tables/interface.go
+++ b/syncapi/storage/tables/interface.go
@@ -217,7 +217,8 @@ type Relations interface {
 	// SelectRelationsInRange will return relations grouped by relation type within the given range.
 	// The map is relType -> []entry. If a relType parameter is specified then the results will only
 	// contain relations of that type, otherwise if "" is specified then all relations in the range
-	// will be returned. The stream position returned is the maximum position of the returned results.
+	// will be returned, inclusive of the "to" position but excluding the "from" position. The stream
+	// position returned is the maximum position of the returned results.
 	SelectRelationsInRange(ctx context.Context, txn *sql.Tx, roomID, eventID, relType string, r types.Range, limit int) (map[string][]types.RelationEntry, types.StreamPosition, error)
 	// SelectMaxRelationID returns the maximum ID of all relations, used to determine what the boundaries
 	// should be if there are no boundaries supplied (i.e. we want to work backwards but don't have a

--- a/syncapi/storage/tables/relations_test.go
+++ b/syncapi/storage/tables/relations_test.go
@@ -43,7 +43,7 @@ func newRelationsTable(t *testing.T, dbType test.DBType) (tables.Relations, *sql
 
 func compareRelationsToExpected(t *testing.T, tab tables.Relations, r types.Range, expected []types.RelationEntry) {
 	ctx := context.Background()
-	relations, _, err := tab.SelectRelationsInRange(ctx, nil, roomID, "a", "", r, 50)
+	relations, _, err := tab.SelectRelationsInRange(ctx, nil, roomID, "a", "", "", r, 50)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -60,6 +60,7 @@ func compareRelationsToExpected(t *testing.T, tab tables.Relations, r types.Rang
 }
 
 const roomID = "!roomid:server"
+const childType = "m.room.something"
 const relType = "m.reaction"
 
 func TestRelationsTable(t *testing.T) {
@@ -70,7 +71,7 @@ func TestRelationsTable(t *testing.T) {
 
 		// Insert some relations
 		for _, child := range []string{"b", "c", "d"} {
-			if err := tab.InsertRelation(ctx, nil, roomID, "a", child, relType); err != nil {
+			if err := tab.InsertRelation(ctx, nil, roomID, "a", child, childType, relType); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -138,7 +139,7 @@ func TestRelationsTable(t *testing.T) {
 
 		// Insert some new relations
 		for _, child := range []string{"e", "f", "g", "h"} {
-			if err := tab.InsertRelation(ctx, nil, roomID, "a", child, relType); err != nil {
+			if err := tab.InsertRelation(ctx, nil, roomID, "a", child, childType, relType); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/syncapi/storage/tables/relations_test.go
+++ b/syncapi/storage/tables/relations_test.go
@@ -1,0 +1,185 @@
+package tables_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/matrix-org/dendrite/internal/sqlutil"
+	"github.com/matrix-org/dendrite/setup/config"
+	"github.com/matrix-org/dendrite/syncapi/storage/postgres"
+	"github.com/matrix-org/dendrite/syncapi/storage/sqlite3"
+	"github.com/matrix-org/dendrite/syncapi/storage/tables"
+	"github.com/matrix-org/dendrite/syncapi/types"
+	"github.com/matrix-org/dendrite/test"
+)
+
+func newRelationsTable(t *testing.T, dbType test.DBType) (tables.Relations, *sql.DB, func()) {
+	t.Helper()
+	connStr, close := test.PrepareDBConnectionString(t, dbType)
+	db, err := sqlutil.Open(&config.DatabaseOptions{
+		ConnectionString: config.DataSource(connStr),
+	}, sqlutil.NewExclusiveWriter())
+	if err != nil {
+		t.Fatalf("failed to open db: %s", err)
+	}
+
+	var tab tables.Relations
+	switch dbType {
+	case test.DBTypePostgres:
+		tab, err = postgres.NewPostgresRelationsTable(db)
+	case test.DBTypeSQLite:
+		var stream sqlite3.StreamIDStatements
+		if err = stream.Prepare(db); err != nil {
+			t.Fatalf("failed to prepare stream stmts: %s", err)
+		}
+		tab, err = sqlite3.NewSqliteRelationsTable(db, &stream)
+	}
+	if err != nil {
+		t.Fatalf("failed to make new table: %s", err)
+	}
+	return tab, db, close
+}
+
+func compareRelationsToExpected(t *testing.T, tab tables.Relations, r types.Range, expected []types.RelationEntry) {
+	ctx := context.Background()
+	relations, _, err := tab.SelectRelationsInRange(ctx, nil, roomID, "a", "", r, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(relations[relType]) != len(expected) {
+		t.Fatalf("incorrect number of values returned for range %v (got %d, want %d)", r, len(relations[relType]), len(expected))
+	}
+	for i := 0; i < len(relations[relType]); i++ {
+		got := relations[relType][i]
+		want := expected[i]
+		if got != want {
+			t.Fatalf("range %v position %d should have been %q but got %q", r, i, got, want)
+		}
+	}
+}
+
+const roomID = "!roomid:server"
+const relType = "m.reaction"
+
+func TestRelationsTable(t *testing.T) {
+	ctx := context.Background()
+	test.WithAllDatabases(t, func(t *testing.T, dbType test.DBType) {
+		tab, _, close := newRelationsTable(t, dbType)
+		defer close()
+
+		// Insert some relations
+		for _, child := range []string{"b", "c", "d"} {
+			if err := tab.InsertRelation(ctx, nil, roomID, "a", child, relType); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Check the max position, we've inserted three things so it
+		// should be 3
+		if max, err := tab.SelectMaxRelationID(ctx, nil); err != nil {
+			t.Fatal(err)
+		} else if max != 3 {
+			t.Fatalf("max position should have been 3 but got %d", max)
+		}
+
+		// Query some ranges for "a"
+		for r, expected := range map[types.Range][]types.RelationEntry{
+			{From: 0, To: 10, Backwards: false}: {
+				{Position: 1, EventID: "b"},
+				{Position: 2, EventID: "c"},
+				{Position: 3, EventID: "d"},
+			},
+			{From: 1, To: 2, Backwards: false}: {
+				{Position: 2, EventID: "c"},
+			},
+			{From: 1, To: 3, Backwards: false}: {
+				{Position: 2, EventID: "c"},
+				{Position: 3, EventID: "d"},
+			},
+			{From: 10, To: 0, Backwards: true}: {
+				{Position: 3, EventID: "d"},
+				{Position: 2, EventID: "c"},
+				{Position: 1, EventID: "b"},
+			},
+			{From: 3, To: 1, Backwards: true}: {
+				{Position: 2, EventID: "c"},
+				{Position: 1, EventID: "b"},
+			},
+		} {
+			compareRelationsToExpected(t, tab, r, expected)
+		}
+
+		// Now delete one of the relations
+		if err := tab.DeleteRelation(ctx, nil, roomID, "c"); err != nil {
+			t.Fatal(err)
+		}
+
+		// Query some more ranges for "a"
+		for r, expected := range map[types.Range][]types.RelationEntry{
+			{From: 0, To: 10, Backwards: false}: {
+				{Position: 1, EventID: "b"},
+				{Position: 3, EventID: "d"},
+			},
+			{From: 1, To: 2, Backwards: false}: {},
+			{From: 1, To: 3, Backwards: false}: {
+				{Position: 3, EventID: "d"},
+			},
+			{From: 10, To: 0, Backwards: true}: {
+				{Position: 3, EventID: "d"},
+				{Position: 1, EventID: "b"},
+			},
+			{From: 3, To: 1, Backwards: true}: {
+				{Position: 1, EventID: "b"},
+			},
+		} {
+			compareRelationsToExpected(t, tab, r, expected)
+		}
+
+		// Insert some new relations
+		for _, child := range []string{"e", "f", "g", "h"} {
+			if err := tab.InsertRelation(ctx, nil, roomID, "a", child, relType); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Check the max position, we've inserted four things so it
+		// should now be 7
+		if max, err := tab.SelectMaxRelationID(ctx, nil); err != nil {
+			t.Fatal(err)
+		} else if max != 7 {
+			t.Fatalf("max position should have been 3 but got %d", max)
+		}
+
+		// Query last set of ranges for "a"
+		for r, expected := range map[types.Range][]types.RelationEntry{
+			{From: 0, To: 10, Backwards: false}: {
+				{Position: 1, EventID: "b"},
+				{Position: 3, EventID: "d"},
+				{Position: 4, EventID: "e"},
+				{Position: 5, EventID: "f"},
+				{Position: 6, EventID: "g"},
+				{Position: 7, EventID: "h"},
+			},
+			{From: 1, To: 2, Backwards: false}: {},
+			{From: 1, To: 3, Backwards: false}: {
+				{Position: 3, EventID: "d"},
+			},
+			{From: 10, To: 0, Backwards: true}: {
+				{Position: 7, EventID: "h"},
+				{Position: 6, EventID: "g"},
+				{Position: 5, EventID: "f"},
+				{Position: 4, EventID: "e"},
+				{Position: 3, EventID: "d"},
+				{Position: 1, EventID: "b"},
+			},
+			{From: 6, To: 3, Backwards: true}: {
+				{Position: 5, EventID: "f"},
+				{Position: 4, EventID: "e"},
+				{Position: 3, EventID: "d"},
+			},
+		} {
+			compareRelationsToExpected(t, tab, r, expected)
+		}
+	})
+}

--- a/syncapi/types/types.go
+++ b/syncapi/types/types.go
@@ -47,6 +47,14 @@ type StateDelta struct {
 // StreamPosition represents the offset in the sync stream a client is at.
 type StreamPosition int64
 
+func NewStreamPositionFromString(s string) (StreamPosition, error) {
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, err
+	}
+	return StreamPosition(n), nil
+}
+
 // StreamEvent is the same as gomatrixserverlib.Event but also has the PDU stream position for this event.
 type StreamEvent struct {
 	*gomatrixserverlib.HeaderedEvent

--- a/syncapi/types/types.go
+++ b/syncapi/types/types.go
@@ -607,3 +607,8 @@ type OutputSendToDeviceEvent struct {
 type IgnoredUsers struct {
 	List map[string]interface{} `json:"ignored_users"`
 }
+
+type RelationEntry struct {
+	Position StreamPosition
+	EventID  string
+}


### PR DESCRIPTION
This adds support for tracking `m.relates_to`, as well as adding support for the various `/room/{roomID}/relations/...` endpoints to the CS API.