### PR TITLE
Always add `UnreadNotifications` to joined room reponses

### DIFF
--- a/syncapi/streams/stream_notificationdata.go
+++ b/syncapi/streams/stream_notificationdata.go
@@ -3,6 +3,7 @@ package streams
 import (
 	"context"
 
+	"github.com/matrix-org/dendrite/internal/eventutil"
 	"github.com/matrix-org/dendrite/syncapi/storage"
 	"github.com/matrix-org/dendrite/syncapi/types"
 )
@@ -53,7 +54,7 @@ func (p *NotificationDataStreamProvider) IncrementalSync(
 	for roomID, jr := range req.Response.Rooms.Join {
 		counts := countsByRoom[roomID]
 		if counts == nil {
-			continue
+			counts = &eventutil.NotificationData{}
 		}
 		jr.UnreadNotifications = &types.UnreadNotifications{
 			HighlightCount:    counts.UnreadHighlightCount,

--- a/syncapi/types/types.go
+++ b/syncapi/types/types.go
@@ -492,9 +492,11 @@ func (jr JoinResponse) MarshalJSON() ([]byte, error) {
 		}
 
 	}
-	if jr.UnreadNotifications != nil &&
-		jr.UnreadNotifications.NotificationCount == 0 && jr.UnreadNotifications.HighlightCount == 0 {
-		a.UnreadNotifications = nil
+	if jr.UnreadNotifications != nil {
+		// if everything else is nil, also remove UnreadNotifications
+		if a.State == nil && a.Ephemeral == nil && a.AccountData == nil && a.Timeline == nil && a.Summary == nil {
+			a.UnreadNotifications = nil
+		}
 	}
 	return json.Marshal(a)
 }

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -745,3 +745,5 @@ User in shared private room does appear in user directory until leave
 Existing members see new member's presence
 Inbound federation can return missing events for joined visibility
 outliers whose auth_events are in a different room are correctly rejected
+Messages that notify from another user increment notification_count
+Messages that highlight from another user increment unread highlight count


### PR DESCRIPTION
Fixes a minor bug, where we failed to add `UnreadNotifications` to the join response, if it wasn't in `GetUserUnreadNotificationCountsForRooms`.