### PR TITLE
Set inactivity threshold on durable consumers in the roomserver input API

### DIFF
--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -94,7 +94,7 @@ type Inputer struct {
 // indefinitely for rooms that might no longer be active, since they do
 // have an interest overhead in the NATS Server. If the room becomes
 // active again then we'll recreate the consumer anyway.
-const inactiveThreshold = time.Minute
+const inactiveThreshold = time.Hour * 24
 
 type worker struct {
 	phony.Inbox

--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -130,6 +130,13 @@ func (r *Inputer) startWorkerForRoom(roomID string) {
 				DeliverPolicy: nats.DeliverAllPolicy,
 				FilterSubject: subject,
 				AckWait:       MaximumMissingProcessingTime + (time.Second * 10),
+
+				// If the consumer is inactive for a while then we will allow NATS
+				// to clean it up. This prevents us from holding onto durable
+				// consumers indefinitely for rooms that might no longer be active,
+				// since they do have a small overhead. If the room becomes active
+				// again then we'll recreate the consumer anyway.
+				InactiveThreshold: time.Hour,
 			},
 		); err != nil {
 			logrus.WithError(err).Errorf("Failed to create consumer for room %q", w.roomID)

--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -152,6 +152,7 @@ func (r *Inputer) startWorkerForRoom(roomID string) {
 			nats.DeliverAll(),
 			nats.AckWait(MaximumMissingProcessingTime+(time.Second*10)),
 			nats.Bind(r.InputRoomEventTopic, consumer),
+			nats.InactiveThreshold(time.Hour),
 		)
 		if err != nil {
 			logrus.WithError(err).Errorf("Failed to subscribe to stream for room %q", w.roomID)


### PR DESCRIPTION
This prevents us from holding onto durable consumers indefinitely for rooms that have long since turned inactive, since they do have a bit of a processing overhead in the NATS Server. If we clear up a consumer and then a room becomes active again, the consumer gets recreated as needed.

The threshold is set to 24 hours for now, we can tweak it later if needs be.