### PR TITLE
Allow `m.read.private` to clear notifications

### DIFF
--- a/userapi/consumers/clientapi.go
+++ b/userapi/consumers/clientapi.go
@@ -81,7 +81,12 @@ func (s *OutputReceiptEventConsumer) onMessage(ctx context.Context, msgs []*nats
 	readPos := msg.Header.Get(jetstream.EventID)
 	evType := msg.Header.Get("type")
 
-	if readPos == "" || evType != "m.read" {
+	switch {
+	case readPos == "":
+		return true
+	case evType == "m.read": // allowed
+	case evType == "m.read.private": // allowed
+	default:
 		return true
 	}
 

--- a/userapi/consumers/clientapi.go
+++ b/userapi/consumers/clientapi.go
@@ -81,12 +81,7 @@ func (s *OutputReceiptEventConsumer) onMessage(ctx context.Context, msgs []*nats
 	readPos := msg.Header.Get(jetstream.EventID)
 	evType := msg.Header.Get("type")
 
-	switch {
-	case readPos == "":
-		return true
-	case evType == "m.read": // allowed
-	case evType == "m.read.private": // allowed
-	default:
+	if readPos == "" || (evType != "m.read" && evType != "m.read.private") {
 		return true
 	}
 


### PR DESCRIPTION
Otherwise if a user switches to private read receipts, they may not be able to clear notification counts.