### PR TITLE
Get messages from before user left the room

### DIFF
--- a/syncapi/routing/messages.go
+++ b/syncapi/routing/messages.go
@@ -206,11 +206,6 @@ func OnIncomingMessagesRequest(
 		}
 		if backwardOrdering {
 			from = token
-		} else {
-			// Increment, so we would get events the user isn't allowed to see anymore
-			token.Depth++
-			token.PDUPosition++
-			to = token
 		}
 	}
 

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -753,3 +753,5 @@ When user joins a room the state is included in a gapped sync
 Messages that notify from another user increment notification_count
 Messages that highlight from another user increment unread highlight count
 Notifications can be viewed with GET /notifications
+Can get rooms/{roomId}/messages for a departed room (SPEC-216)
+Local device key changes appear in /keys/changes


### PR DESCRIPTION
This is going to make `Can get rooms/{roomId}/messages for a departed room (SPEC-216)` pass, since we now only grep events from before the user left the room.