### PR TITLE
Filter `/members`, return members at given point

### DIFF
--- a/clientapi/routing/joined_rooms.go
+++ b/clientapi/routing/joined_rooms.go
@@ -1,0 +1,52 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routing
+
+import (
+	"net/http"
+
+	"github.com/matrix-org/util"
+
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"github.com/matrix-org/dendrite/roomserver/api"
+	userapi "github.com/matrix-org/dendrite/userapi/api"
+)
+
+type getJoinedRoomsResponse struct {
+	JoinedRooms []string `json:"joined_rooms"`
+}
+
+func GetJoinedRooms(
+	req *http.Request,
+	device *userapi.Device,
+	rsAPI api.ClientRoomserverAPI,
+) util.JSONResponse {
+	var res api.QueryRoomsForUserResponse
+	err := rsAPI.QueryRoomsForUser(req.Context(), &api.QueryRoomsForUserRequest{
+		UserID:         device.UserID,
+		WantMembership: "join",
+	}, &res)
+	if err != nil {
+		util.GetLogger(req.Context()).WithError(err).Error("QueryRoomsForUser failed")
+		return jsonerror.InternalServerError()
+	}
+	if res.RoomIDs == nil {
+		res.RoomIDs = []string{}
+	}
+	return util.JSONResponse{
+		Code: http.StatusOK,
+		JSON: getJoinedRoomsResponse{res.RoomIDs},
+	}
+}

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -950,26 +950,6 @@ func Setup(
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
 
-	v3mux.Handle("/rooms/{roomID}/members",
-		httputil.MakeAuthAPI("rooms_members", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
-			if err != nil {
-				return util.ErrorResponse(err)
-			}
-			return GetMemberships(req, device, vars["roomID"], false, cfg, rsAPI)
-		}),
-	).Methods(http.MethodGet, http.MethodOptions)
-
-	v3mux.Handle("/rooms/{roomID}/joined_members",
-		httputil.MakeAuthAPI("rooms_members", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
-			if err != nil {
-				return util.ErrorResponse(err)
-			}
-			return GetMemberships(req, device, vars["roomID"], true, cfg, rsAPI)
-		}),
-	).Methods(http.MethodGet, http.MethodOptions)
-
 	v3mux.Handle("/rooms/{roomID}/read_markers",
 		httputil.MakeAuthAPI("rooms_read_markers", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
 			if r := rateLimits.Limit(req, device); r != nil {

--- a/docs/caddy/polylith/Caddyfile
+++ b/docs/caddy/polylith/Caddyfile
@@ -74,7 +74,7 @@ matrix.example.com {
  # Change the end of each reverse_proxy line to the correct
  # address for your various services.
  @sync_api {
-  path_regexp /_matrix/client/.*?/(sync|user/.*?/filter/?.*|keys/changes|rooms/.*?/(messages|context/.*?|relations/.*?|event/.*?))$
+  path_regexp /_matrix/client/.*?/(sync|user/.*?/filter/?.*|keys/changes|rooms/.*?/(messages|.*?_?members|context/.*?|relations/.*?|event/.*?))$
  }
  reverse_proxy @sync_api sync_api:8073
 

--- a/docs/hiawatha/polylith-sample.conf
+++ b/docs/hiawatha/polylith-sample.conf
@@ -23,8 +23,10 @@ VirtualHost {
         # /_matrix/client/.*/rooms/{roomId}/relations/{eventID}
         # /_matrix/client/.*/rooms/{roomId}/relations/{eventID}/{relType}
         # /_matrix/client/.*/rooms/{roomId}/relations/{eventID}/{relType}/{eventType}
+        # /_matrix/client/.*/rooms/{roomId}/members
+        # /_matrix/client/.*/rooms/{roomId}/joined_members
         # to sync_api
-        ReverseProxy = /_matrix/client/.*?/(sync|user/.*?/filter/?.*|keys/changes|rooms/.*?/(messages|context/.*?|relations/.*?|event/.*?))$ http://localhost:8073 600
+        ReverseProxy = /_matrix/client/.*?/(sync|user/.*?/filter/?.*|keys/changes|rooms/.*?/(messages|.*?_?members|context/.*?|relations/.*?|event/.*?))$ http://localhost:8073 600
         ReverseProxy = /_matrix/client http://localhost:8071 600
         ReverseProxy = /_matrix/federation http://localhost:8072 600
         ReverseProxy = /_matrix/key http://localhost:8072 600

--- a/docs/nginx/polylith-sample.conf
+++ b/docs/nginx/polylith-sample.conf
@@ -33,8 +33,10 @@ server {
     # /_matrix/client/.*/rooms/{roomId}/relations/{eventID}
     # /_matrix/client/.*/rooms/{roomId}/relations/{eventID}/{relType}
     # /_matrix/client/.*/rooms/{roomId}/relations/{eventID}/{relType}/{eventType}
+    # /_matrix/client/.*/rooms/{roomId}/members
+    # /_matrix/client/.*/rooms/{roomId}/joined_members
     # to sync_api
-    location ~ /_matrix/client/.*?/(sync|user/.*?/filter/?.*|keys/changes|rooms/.*?/(messages|context/.*?|relations/.*?|event/.*?))$  {
+    location ~ /_matrix/client/.*?/(sync|user/.*?/filter/?.*|keys/changes|rooms/.*?/(messages|.*?_?members|context/.*?|relations/.*?|event/.*?))$  {
         proxy_pass http://sync_api:8073;
     }
 

--- a/syncapi/routing/routing.go
+++ b/syncapi/routing/routing.go
@@ -172,4 +172,37 @@ func Setup(
 			return Search(req, device, syncDB, fts, nextBatch)
 		}),
 	).Methods(http.MethodPost, http.MethodOptions)
+
+	v3mux.Handle("/rooms/{roomID}/members",
+		httputil.MakeAuthAPI("rooms_members", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
+			if err != nil {
+				return util.ErrorResponse(err)
+			}
+			var membership, notMembership *string
+			if req.URL.Query().Has("membership") {
+				m := req.URL.Query().Get("membership")
+				membership = &m
+			}
+			if req.URL.Query().Has("not_membership") {
+				m := req.URL.Query().Get("not_membership")
+				notMembership = &m
+			}
+
+			at := req.URL.Query().Get("at")
+			return GetMemberships(req, device, vars["roomID"], syncDB, rsAPI, false, membership, notMembership, at)
+		}),
+	).Methods(http.MethodGet, http.MethodOptions)
+
+	v3mux.Handle("/rooms/{roomID}/joined_members",
+		httputil.MakeAuthAPI("rooms_members", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
+			vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
+			if err != nil {
+				return util.ErrorResponse(err)
+			}
+			at := req.URL.Query().Get("at")
+			membership := gomatrixserverlib.Join
+			return GetMemberships(req, device, vars["roomID"], syncDB, rsAPI, true, &membership, nil, at)
+		}),
+	).Methods(http.MethodGet, http.MethodOptions)
 }

--- a/syncapi/storage/interface.go
+++ b/syncapi/storage/interface.go
@@ -178,6 +178,11 @@ type Database interface {
 	ReIndex(ctx context.Context, limit, afterID int64) (map[int64]gomatrixserverlib.HeaderedEvent, error)
 	UpdateRelations(ctx context.Context, event *gomatrixserverlib.HeaderedEvent) error
 	RedactRelations(ctx context.Context, roomID, redactedEventID string) error
+	SelectMemberships(
+		ctx context.Context,
+		roomID string, pos types.TopologyToken,
+		membership, notMembership *string,
+	) (eventIDs []string, err error)
 }
 
 type Presence interface {

--- a/syncapi/storage/postgres/memberships_table.go
+++ b/syncapi/storage/postgres/memberships_table.go
@@ -20,11 +20,13 @@ import (
 	"fmt"
 
 	"github.com/lib/pq"
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/sirupsen/logrus"
+
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/syncapi/storage/tables"
 	"github.com/matrix-org/dendrite/syncapi/types"
-	"github.com/matrix-org/gomatrixserverlib"
 )
 
 // The memberships table is designed to track the last time that
@@ -69,11 +71,20 @@ const selectHeroesSQL = "" +
 const selectMembershipBeforeSQL = "" +
 	"SELECT membership, topological_pos FROM syncapi_memberships WHERE room_id = $1 and user_id = $2 AND topological_pos <= $3 ORDER BY topological_pos DESC LIMIT 1"
 
+const selectMembersSQL = `
+SELECT event_id FROM (
+	SELECT DISTINCT ON (room_id, user_id) room_id, user_id, event_id, membership FROM syncapi_memberships WHERE room_id = $1 AND topological_pos <= $2 ORDER BY room_id, user_id, stream_pos DESC  
+) t 
+WHERE ($3::text IS NULL OR t.membership = $3)
+	AND ($4::text IS NULL OR t.membership <> $4)
+`
+
 type membershipsStatements struct {
 	upsertMembershipStmt        *sql.Stmt
 	selectMembershipCountStmt   *sql.Stmt
 	selectHeroesStmt            *sql.Stmt
 	selectMembershipForUserStmt *sql.Stmt
+	selectMembersStmt           *sql.Stmt
 }
 
 func NewPostgresMembershipsTable(db *sql.DB) (tables.Memberships, error) {
@@ -87,6 +98,7 @@ func NewPostgresMembershipsTable(db *sql.DB) (tables.Memberships, error) {
 		{&s.selectMembershipCountStmt, selectMembershipCountSQL},
 		{&s.selectHeroesStmt, selectHeroesSQL},
 		{&s.selectMembershipForUserStmt, selectMembershipBeforeSQL},
+		{&s.selectMembersStmt, selectMembersSQL},
 	}.Prepare(db)
 }
 
@@ -107,6 +119,7 @@ func (s *membershipsStatements) UpsertMembership(
 		streamPos,
 		topologicalPos,
 	)
+	logrus.Debugf("XXX: upserMembership: %d %d %s", streamPos, topologicalPos, *event.StateKey())
 	return err
 }
 
@@ -153,4 +166,27 @@ func (s *membershipsStatements) SelectMembershipForUser(
 		return "", 0, err
 	}
 	return membership, topologyPos, nil
+}
+
+func (s *membershipsStatements) SelectMemberships(
+	ctx context.Context, txn *sql.Tx,
+	roomID string, pos types.TopologyToken,
+	membership, notMembership *string,
+) (eventIDs []string, err error) {
+	stmt := sqlutil.TxStmt(txn, s.selectMembersStmt)
+	rows, err := stmt.QueryContext(ctx, roomID, pos.Depth, membership, notMembership)
+	if err != nil {
+		return
+	}
+	var (
+		eventID string
+	)
+	for rows.Next() {
+		if err = rows.Scan(&eventID); err != nil {
+			return
+		}
+		logrus.Debugf("XXX: eventID: %s", eventID)
+		eventIDs = append(eventIDs, eventID)
+	}
+	return eventIDs, rows.Err()
 }

--- a/syncapi/storage/postgres/memberships_table.go
+++ b/syncapi/storage/postgres/memberships_table.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/matrix-org/gomatrixserverlib"
-	"github.com/sirupsen/logrus"
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
@@ -119,7 +118,6 @@ func (s *membershipsStatements) UpsertMembership(
 		streamPos,
 		topologicalPos,
 	)
-	logrus.Debugf("XXX: upserMembership: %d %d %s", streamPos, topologicalPos, *event.StateKey())
 	return err
 }
 
@@ -185,7 +183,6 @@ func (s *membershipsStatements) SelectMemberships(
 		if err = rows.Scan(&eventID); err != nil {
 			return
 		}
-		logrus.Debugf("XXX: eventID: %s", eventID)
 		eventIDs = append(eventIDs, eventID)
 	}
 	return eventIDs, rows.Err()

--- a/syncapi/storage/shared/storage_consumer.go
+++ b/syncapi/storage/shared/storage_consumer.go
@@ -617,3 +617,11 @@ func (d *Database) RedactRelations(ctx context.Context, roomID, redactedEventID 
 		return d.Relations.DeleteRelation(ctx, txn, roomID, redactedEventID)
 	})
 }
+
+func (d *Database) SelectMemberships(
+	ctx context.Context,
+	roomID string, pos types.TopologyToken,
+	membership, notMembership *string,
+) (eventIDs []string, err error) {
+	return d.Memberships.SelectMemberships(ctx, nil, roomID, pos, membership, notMembership)
+}

--- a/syncapi/storage/tables/interface.go
+++ b/syncapi/storage/tables/interface.go
@@ -187,6 +187,11 @@ type Memberships interface {
 	SelectMembershipCount(ctx context.Context, txn *sql.Tx, roomID, membership string, pos types.StreamPosition) (count int, err error)
 	SelectHeroes(ctx context.Context, txn *sql.Tx, roomID, userID string, memberships []string) (heroes []string, err error)
 	SelectMembershipForUser(ctx context.Context, txn *sql.Tx, roomID, userID string, pos int64) (membership string, topologicalPos int, err error)
+	SelectMemberships(
+		ctx context.Context, txn *sql.Tx,
+		roomID string, pos types.TopologyToken,
+		membership, notMembership *string,
+	) (eventIDs []string, err error)
 }
 
 type NotificationData interface {

--- a/syncapi/types/types.go
+++ b/syncapi/types/types.go
@@ -234,6 +234,9 @@ func (t *TopologyToken) StreamToken() StreamingToken {
 }
 
 func (t TopologyToken) String() string {
+	if t.Depth <= 0 && t.PDUPosition <= 0 {
+		return ""
+	}
 	return fmt.Sprintf("t%d_%d", t.Depth, t.PDUPosition)
 }
 

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -755,3 +755,5 @@ Messages that highlight from another user increment unread highlight count
 Notifications can be viewed with GET /notifications
 Can get rooms/{roomId}/messages for a departed room (SPEC-216)
 Local device key changes appear in /keys/changes
+Can get rooms/{roomId}/members at a given point
+Can filter rooms/{roomId}/members


### PR DESCRIPTION
Makes the tests
```
Can get rooms/{roomId}/members at a given point
Can filter rooms/{roomId}/members
```
pass, by moving `/members` and `/joined_members` to the SyncAPI.

Query:
```sql
EXPLAIN ANALYSE
SELECT
    event_id
FROM
    (                          SELECT
                                   DISTINCT
                                       ON (room_id,
                                       user_id) room_id,
                                                user_id,
                                                event_id,
                                                membership
                               FROM
                                   syncapi_memberships
                               WHERE
                                       room_id = '!RcWPWcZrMeBxOGaalX:matrix.org'
                                 AND topological_pos <= 10000000
                               ORDER BY
                                   room_id,
                                   user_id,
                                   stream_pos DESC) t
WHERE
    (
            'join'::text IS NULL
            OR t.membership = 'join'
        )
  AND (
        NULL::text IS NULL
        OR t.membership <> NULL
    )
```
Result:

```sql
Subquery Scan on t  (cost=313.82..348.37 rows=9 width=45) (actual time=2.954..3.459 rows=1443 loops=1)
  Filter: (t.membership = 'join'::text)
  Rows Removed by Filter: 417
  ->  Unique  (cost=313.82..324.73 rows=1891 width=111) (actual time=2.950..3.274 rows=1860 loops=1)
        ->  Sort  (cost=313.82..319.27 rows=2183 width=111) (actual time=2.950..3.033 rows=2203 loops=1)
"              Sort Key: syncapi_memberships.user_id, syncapi_memberships.stream_pos DESC"
              Sort Method: quicksort  Memory: 524kB
              ->  Seq Scan on syncapi_memberships  (cost=0.00..192.75 rows=2183 width=111) (actual time=0.008..0.845 rows=2203 loops=1)
                    Filter: ((topological_pos <= 10000000) AND (room_id = '!RcWPWcZrMeBxOGaalX:matrix.org'::text))
                    Rows Removed by Filter: 2414
Planning Time: 0.097 ms
Execution Time: 3.562 ms
```