### PR TITLE
Fix #2842 - room state incorrectly filtered away for newly joined member

### DIFF
--- a/syncapi/streams/stream_pdu.go
+++ b/syncapi/streams/stream_pdu.go
@@ -257,7 +257,7 @@ func (p *PDUStreamProvider) addRoomDeltaToResponse(
 	// or not, it needs the m.room.create event which may be chronologically outside
 	// the filter limit.
 	if !delta.NewlyJoined {
-		delta.StateEvents = removeDuplicates(delta.StateEvents, recentEvents) // roll back
+		delta.StateEvents = removeDuplicates(delta.StateEvents, recentEvents)
 	}
 	prevBatch, err := snapshot.GetBackwardTopologyPos(ctx, recentStreamEvents)
 	if err != nil {


### PR DESCRIPTION
Issue: #2842 

repro:
- alice creates a space and a child room
- alice sends 20 messages in the space
- alice invites bob to the room
- bob joins the room, but unable to get proper room states

In stream_pdu.go in the func addRoomDeltaToResponse:55 the stateEvents are removed.

`delta.StateEvents = removeDuplicates(delta.StateEvents, recentEvents) `

This is normally fine, but because recentEvents contains many other events (> 20), when historyVisibility filtering is applied, the original room events (like m.room.create) is filtered out because the filter limit is set.

This is a problem for newly joined members like bob who needs the room state such as the m.room.create event to determine room vs space types among other states.





Signed-off-by: `Tak Wai Wong <tak@hntlabs.com>`
