### PR TITLE
Fix workdir in Dockerfile (and make it a volume)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ LABEL org.opencontainers.image.documentation="https://matrix-org.github.io/dendr
 LABEL org.opencontainers.image.vendor="The Matrix.org Foundation C.I.C."
 RUN addgroup dendrite && adduser dendrite -G dendrite -u 1337 -D
 USER dendrite
-WORKDIR /home/dendrite
 
 #
 # Builds the polylith image and only contains the polylith binary
@@ -42,6 +41,9 @@ FROM dendrite-base AS polylith
 LABEL org.opencontainers.image.title="Dendrite (Polylith)"
 
 COPY --from=build /out/dendrite-polylith-multi /usr/bin/
+
+VOLUME /etc/dendrite
+WORKDIR /etc/dendrite
 
 ENTRYPOINT ["/usr/bin/dendrite-polylith-multi"]
 
@@ -55,6 +57,9 @@ COPY --from=build /out/create-account /usr/bin/create-account
 COPY --from=build /out/generate-config /usr/bin/generate-config
 COPY --from=build /out/generate-keys /usr/bin/generate-keys
 COPY --from=build /out/dendrite-monolith-server /usr/bin/dendrite-monolith-server
+
+VOLUME /etc/dendrite
+WORKDIR /etc/dendrite
 
 ENTRYPOINT ["/usr/bin/dendrite-monolith-server"]
 EXPOSE 8008 8448


### PR DESCRIPTION
This is a regression after #2850 was merged. The container currently defaults to `/home/dendrite` as the workdir and so, cannot find configs and data previously stored in the volume at `/etc/dendrite`. This PR restores the previous behaviour of using `/etc/dendrite` as the workdir (both in monolith and polylith images) and also marks this path as a volume once again.

Storing the dendrite data and configs in `/home/dendrite` does make sense now that dendrite is running under the `dendrite` user, but it's probably an unnecessary compatibility break. In either case though, the path should still be marked as a volume.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [x] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately
