### PR TITLE
Send presence to joined hosts only

### DIFF
--- a/federationapi/consumers/presence.go
+++ b/federationapi/consumers/presence.go
@@ -34,14 +34,13 @@ import (
 
 // OutputReceiptConsumer consumes events that originate in the clientapi.
 type OutputPresenceConsumer struct {
-	ctx               context.Context
-	jetstream         nats.JetStreamContext
-	durable           string
-	db                storage.Database
-	queues            *queue.OutgoingQueues
-	isLocalServerName func(gomatrixserverlib.ServerName) bool
-	rsAPI             roomserverAPI.FederationRoomserverAPI
-	roomserverAPI.FederationRoomserverAPI
+	ctx                     context.Context
+	jetstream               nats.JetStreamContext
+	durable                 string
+	db                      storage.Database
+	queues                  *queue.OutgoingQueues
+	isLocalServerName       func(gomatrixserverlib.ServerName) bool
+	rsAPI                   roomserverAPI.FederationRoomserverAPI
 	topic                   string
 	outboundPresenceEnabled bool
 }

--- a/federationapi/consumers/presence.go
+++ b/federationapi/consumers/presence.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"strconv"
 
-	"github.com/getsentry/sentry-go"
 	"github.com/matrix-org/dendrite/federationapi/queue"
 	"github.com/matrix-org/dendrite/federationapi/storage"
 	fedTypes "github.com/matrix-org/dendrite/federationapi/types"
@@ -112,10 +111,10 @@ func (t *OutputPresenceConsumer) onMessage(ctx context.Context, msgs []*nats.Msg
 		return true
 	}
 
-	// send this key change to all servers who share rooms with this user.
+	// send this presence to all servers who share rooms with this user.
 	joined, err := t.db.GetJoinedHostsForRooms(t.ctx, queryRes.RoomIDs, true)
 	if err != nil {
-		sentry.CaptureException(err)
+		log.WithError(err).Error("failed to get joined hosts")
 		return true
 	}
 

--- a/federationapi/federationapi.go
+++ b/federationapi/federationapi.go
@@ -164,7 +164,7 @@ func NewInternalAPI(
 	}
 
 	presenceConsumer := consumers.NewOutputPresenceConsumer(
-		base.ProcessContext, cfg, js, queues, federationDB,
+		base.ProcessContext, cfg, js, queues, federationDB, rsAPI,
 	)
 	if err = presenceConsumer.Start(); err != nil {
 		logrus.WithError(err).Panic("failed to start presence consumer")

--- a/sytest-blacklist
+++ b/sytest-blacklist
@@ -46,3 +46,6 @@ If a device list update goes missing, the server resyncs on the next one
 # Might be a bug in the test because leaves do appear :-(
 
 Leaves are present in non-gapped incremental syncs
+
+# Below test was passing for the wrong reason, failing correctly since #2858
+New federated private chats get full presence information (SYN-115)

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -682,7 +682,6 @@ Presence changes are reported to local room members
 Presence changes are also reported to remote room members
 Presence changes to UNAVAILABLE are reported to local room members
 Presence changes to UNAVAILABLE are reported to remote room members
-New federated private chats get full presence information (SYN-115)
 /upgrade copies >100 power levels to the new room
 Room state after a rejected message event is the same as before
 Room state after a rejected state event is the same as before


### PR DESCRIPTION
Send presence events only to rooms the user is participating, not all servers we know about.
Should fix #2752