### PR TITLE
Update `latestPosition` when getting reversed room delta

### DIFF
--- a/syncapi/streams/stream_pdu.go
+++ b/syncapi/streams/stream_pdu.go
@@ -264,6 +264,9 @@ func (p *PDUStreamProvider) addRoomDeltaToResponse(
 	// Work out what the highest stream position is for all of the events in this
 	// room that were returned.
 	latestPosition := r.To
+	if r.Backwards {
+		latestPosition = r.From
+	}
 	updateLatestPosition := func(mostRecentEventID string) {
 		var pos types.StreamPosition
 		if _, pos, err = snapshot.PositionInTopology(ctx, mostRecentEventID); err == nil {


### PR DESCRIPTION
Regression test added in https://github.com/matrix-org/complement/pull/551
Should fix https://github.com/matrix-org/dendrite/issues/2514?