### PR TITLE
Handle `m.room.tombstone` events in the UserAPI

### DIFF
--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -759,3 +759,4 @@ Can filter rooms/{roomId}/members
 Current state appears in timeline in private history with many messages after
 AS can publish rooms in their own list
 AS and main public room lists are separate
+/upgrade preserves direct room state

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -760,3 +760,5 @@ Current state appears in timeline in private history with many messages after
 AS can publish rooms in their own list
 AS and main public room lists are separate
 /upgrade preserves direct room state
+local user has tags copied to the new room
+remote user has tags copied to the new room


### PR DESCRIPTION
Fixes #2863 and makes 
```
/upgrade preserves direct room state
local user has tags copied to the new room
remote user has tags copied to the new room
```
pass.