### PR TITLE
Handle remote room upgrades

### DIFF
--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -414,7 +414,7 @@ func (r *Inputer) processRoomEvent(
 	// Handle remote room upgrades, e.g. remove published room
 	if event.Type() == "m.room.tombstone" && event.StateKeyEquals("") && !r.Cfg.Matrix.IsLocalServerName(senderDomain) {
 		if err = r.handleRemoteRoomUpgrade(ctx, event); err != nil {
-			return fmt.Errorf("failed to handle remote room upgrade: %w")
+			return fmt.Errorf("failed to handle remote room upgrade: %w", err)
 		}
 	}
 

--- a/roomserver/storage/interface.go
+++ b/roomserver/storage/interface.go
@@ -172,4 +172,5 @@ type Database interface {
 	ForgetRoom(ctx context.Context, userID, roomID string, forget bool) error
 
 	GetHistoryVisibilityState(ctx context.Context, roomInfo *types.RoomInfo, eventID string, domain string) ([]*gomatrixserverlib.Event, error)
+	UpgradeRoom(ctx context.Context, oldRoomID, newRoomID, eventSender string) error
 }

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -1406,7 +1406,7 @@ func (d *Database) UpgradeRoom(ctx context.Context, oldRoomID, newRoomID, eventS
 
 		for _, alias := range aliases {
 			if err = d.RoomAliasesTable.DeleteRoomAlias(ctx, txn, alias); err != nil {
-				fmt.Errorf("failed to remove room alias: %w", err)
+				return fmt.Errorf("failed to remove room alias: %w", err)
 			}
 			if err = d.RoomAliasesTable.InsertRoomAlias(ctx, txn, alias, newRoomID, eventSender); err != nil {
 				return fmt.Errorf("failed to set room alias: %w", err)

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -1386,6 +1386,36 @@ func (d *Database) ForgetRoom(ctx context.Context, userID, roomID string, forget
 	})
 }
 
+func (d *Database) UpgradeRoom(ctx context.Context, oldRoomID, newRoomID, eventSender string) error {
+
+	return d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
+		// un-publish old room
+		if err := d.PublishedTable.UpsertRoomPublished(ctx, txn, oldRoomID, "", "", false); err != nil {
+			return fmt.Errorf("failed to unpublish room: %w", err)
+		}
+		// publish new room
+		if err := d.PublishedTable.UpsertRoomPublished(ctx, txn, newRoomID, "", "", true); err != nil {
+			return fmt.Errorf("failed to publish room: %w", err)
+		}
+
+		// Migrate any existing room aliases
+		aliases, err := d.RoomAliasesTable.SelectAliasesFromRoomID(ctx, txn, oldRoomID)
+		if err != nil {
+			return fmt.Errorf("failed to get room aliases: %w", err)
+		}
+
+		for _, alias := range aliases {
+			if err = d.RoomAliasesTable.DeleteRoomAlias(ctx, txn, alias); err != nil {
+				fmt.Errorf("failed to remove room alias: %w", err)
+			}
+			if err = d.RoomAliasesTable.InsertRoomAlias(ctx, txn, alias, newRoomID, eventSender); err != nil {
+				return fmt.Errorf("failed to set room alias: %w", err)
+			}
+		}
+		return nil
+	})
+}
+
 // FIXME TODO: Remove all this - horrible dupe with roomserver/state. Can't use the original impl because of circular loops
 // it should live in this package!
 

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -762,3 +762,5 @@ AS and main public room lists are separate
 /upgrade preserves direct room state
 local user has tags copied to the new room
 remote user has tags copied to the new room
+/upgrade moves remote aliases to the new room
+Local and remote users' homeservers remove a room from their public directory on upgrade


### PR DESCRIPTION
Makes the following tests pass
```
/upgrade moves remote aliases to the new room
Local and remote users' homeservers remove a room from their public directory on upgrade
```