### PR TITLE
Never filter out a user's own membership when using LL

### DIFF
--- a/syncapi/streams/stream_pdu.go
+++ b/syncapi/streams/stream_pdu.go
@@ -588,7 +588,7 @@ func (p *PDUStreamProvider) lazyLoadMembers(
 			isGappedIncremental := limited && incremental
 			// We want this users membership event, keep it in the list
 			stateKey := *event.StateKey()
-			if _, ok := timelineUsers[stateKey]; ok || isGappedIncremental {
+			if _, ok := timelineUsers[stateKey]; ok || isGappedIncremental || stateKey == device.UserID {
 				newStateEvents = append(newStateEvents, event)
 				if !stateFilter.IncludeRedundantMembers {
 					p.lazyLoadCache.StoreLazyLoadedUser(device, roomID, stateKey, event.EventID())


### PR DESCRIPTION
This isn't normally a problem as generally the user will have just joined the room and so will get included.

However, if rooms are being imported then we might send down the "new" room without including the user's join event, confusing clients.
