### PR TITLE
Don't omit `pattern` key if empty.

### DIFF
--- a/internal/pushrules/condition.go
+++ b/internal/pushrules/condition.go
@@ -14,7 +14,7 @@ type Condition struct {
 
 	// Pattern indicates the value pattern that must match. Required
 	// for EventMatchCondition.
-	Pattern string `json:"pattern,omitempty"`
+	Pattern string `json:"pattern"`
 
 	// Is indicates the condition that must be fulfilled. Required for
 	// RoomMemberCountCondition.


### PR DESCRIPTION
This is needed to match state events with an empty string value. Fixes #2882

Feel free to dismiss this PR in case you think that clients should interpret a missing pattern key in state event conditions as if the pattern would be `*`. However, for a lot of state events, this would also match events that have an arbitrary value, not only those that have `pattern: ''`` (empty string). So maybe clients should interpret a missing pattern key as if `pattern: ''` was given.