### PR TITLE
Return empty JSON if we don't have any protocols to return

### DIFF
--- a/clientapi/routing/thirdparty.go
+++ b/clientapi/routing/thirdparty.go
@@ -36,9 +36,15 @@ func Protocols(req *http.Request, asAPI appserviceAPI.AppServiceInternalAPI, dev
 		return jsonerror.InternalServerError()
 	}
 	if !resp.Exists {
+		if protocol != "" {
+			return util.JSONResponse{
+				Code: http.StatusNotFound,
+				JSON: jsonerror.NotFound("The protocol is unknown."),
+			}
+		}
 		return util.JSONResponse{
-			Code: http.StatusNotFound,
-			JSON: jsonerror.NotFound("The protocol is unknown."),
+			Code: http.StatusOK,
+			JSON: struct{}{},
 		}
 	}
 	if protocol != "" {


### PR DESCRIPTION
This should help with Element reporting `The homeserver may be too old to support third party networks.`