### PR TITLE
Add clientapi tests

### DIFF
--- a/.github/workflows/dendrite.yml
+++ b/.github/workflows/dendrite.yml
@@ -331,8 +331,7 @@ jobs:
             postgres: postgres
             api: full-http
     container:
-      # Temporary for debugging to see if this image is working better.
-      image: matrixdotorg/sytest-dendrite@sha256:434ad464a9f4ed3f8c3cc47200275b6ccb5c5031a8063daf4acea62be5a23c73
+      image: matrixdotorg/sytest-dendrite
       volumes:
         - ${{ github.workspace }}:/src
         - /root/.cache/go-build:/github/home/.cache/go-build

--- a/clientapi/routing/admin.go
+++ b/clientapi/routing/admin.go
@@ -137,7 +137,7 @@ func AdminResetPassword(req *http.Request, cfg *config.ClientAPI, device *userap
 	request := struct {
 		Password string `json:"password"`
 	}{}
-	if err := json.NewDecoder(req.Body).Decode(&request); err != nil {
+	if err = json.NewDecoder(req.Body).Decode(&request); err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.Unknown("Failed to decode request body: " + err.Error()),
@@ -150,8 +150,8 @@ func AdminResetPassword(req *http.Request, cfg *config.ClientAPI, device *userap
 		}
 	}
 
-	if resErr := internal.ValidatePassword(request.Password); resErr != nil {
-		return *resErr
+	if err = internal.ValidatePassword(request.Password); err != nil {
+		return *internal.PasswordResponse(err)
 	}
 
 	updateReq := &userapi.PerformPasswordUpdateRequest{

--- a/clientapi/routing/auth_fallback.go
+++ b/clientapi/routing/auth_fallback.go
@@ -162,6 +162,8 @@ func AuthFallback(
 		response := req.Form.Get(cfg.RecaptchaFormField)
 		if err := validateRecaptcha(cfg, response, clientIP); err != nil {
 			util.GetLogger(req.Context()).Error(err)
+			w.WriteHeader(http.StatusUnauthorized)
+			serveRecaptcha() // serve the initial page again, instead of nothing
 			return err
 		}
 

--- a/clientapi/routing/auth_fallback_test.go
+++ b/clientapi/routing/auth_fallback_test.go
@@ -1,0 +1,105 @@
+package routing
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
+	"github.com/matrix-org/dendrite/setup/config"
+	"github.com/matrix-org/dendrite/test/testrig"
+)
+
+func Test_AuthFallback(t *testing.T) {
+	base, _, _ := testrig.Base(nil)
+	defer base.Close()
+
+	for _, useHCaptcha := range []bool{false, true} {
+		for _, recaptchaEnabled := range []bool{false, true} {
+			for _, wantErr := range []bool{false, true} {
+				t.Run(fmt.Sprintf("useHCaptcha(%v) - recaptchaEnabled(%v) - wantErr(%v)", useHCaptcha, recaptchaEnabled, wantErr), func(t *testing.T) {
+					// Set the defaults for each test
+					base.Cfg.ClientAPI.Defaults(config.DefaultOpts{Generate: true, Monolithic: true})
+					base.Cfg.ClientAPI.RecaptchaEnabled = recaptchaEnabled
+					base.Cfg.ClientAPI.RecaptchaPublicKey = "pub"
+					base.Cfg.ClientAPI.RecaptchaPrivateKey = "priv"
+					if useHCaptcha {
+						base.Cfg.ClientAPI.RecaptchaSiteVerifyAPI = "https://hcaptcha.com/siteverify"
+						base.Cfg.ClientAPI.RecaptchaApiJsUrl = "https://js.hcaptcha.com/1/api.js"
+						base.Cfg.ClientAPI.RecaptchaFormField = "h-captcha-response"
+						base.Cfg.ClientAPI.RecaptchaSitekeyClass = "h-captcha"
+					}
+					cfgErrs := &config.ConfigErrors{}
+					base.Cfg.ClientAPI.Verify(cfgErrs, true)
+					if len(*cfgErrs) > 0 {
+						t.Fatalf("(hCaptcha=%v) unexpected config errors: %s", useHCaptcha, cfgErrs.Error())
+					}
+
+					req := httptest.NewRequest(http.MethodGet, "/?session=1337", nil)
+					rec := httptest.NewRecorder()
+
+					AuthFallback(rec, req, authtypes.LoginTypeRecaptcha, &base.Cfg.ClientAPI)
+					if !recaptchaEnabled {
+						if rec.Code != http.StatusBadRequest {
+							t.Fatalf("unexpected response code: %d, want %d", rec.Code, http.StatusBadRequest)
+						}
+						if rec.Body.String() != "Recaptcha login is disabled on this Homeserver" {
+							t.Fatalf("unexpected response body: %s", rec.Body.String())
+						}
+					} else {
+						if !strings.Contains(rec.Body.String(), base.Cfg.ClientAPI.RecaptchaSitekeyClass) {
+							t.Fatalf("body does not contain %s: %s", base.Cfg.ClientAPI.RecaptchaSitekeyClass, rec.Body.String())
+						}
+					}
+
+					srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						if wantErr {
+							_, _ = w.Write([]byte(`{"success":false}`))
+							return
+						}
+						_, _ = w.Write([]byte(`{"success":true}`))
+					}))
+					defer srv.Close() // nolint: errcheck
+
+					base.Cfg.ClientAPI.RecaptchaSiteVerifyAPI = srv.URL
+
+					req = httptest.NewRequest(http.MethodPost, "/?session=1337", nil)
+					req.Form = url.Values{}
+					req.Form.Add(base.Cfg.ClientAPI.RecaptchaFormField, "someRandomValue")
+					rec = httptest.NewRecorder()
+					AuthFallback(rec, req, authtypes.LoginTypeRecaptcha, &base.Cfg.ClientAPI)
+				})
+			}
+		}
+	}
+
+	t.Run("unknown fallbacks are handled correctly", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/?session=1337", nil)
+		rec := httptest.NewRecorder()
+		AuthFallback(rec, req, "DoesNotExist", &base.Cfg.ClientAPI)
+		if rec.Code != http.StatusNotImplemented {
+			t.Fatalf("unexpected http status: %d, want %d", rec.Code, http.StatusNotImplemented)
+		}
+	})
+
+	t.Run("unknown methods are handled correctly", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodDelete, "/?session=1337", nil)
+		rec := httptest.NewRecorder()
+		AuthFallback(rec, req, authtypes.LoginTypeRecaptcha, &base.Cfg.ClientAPI)
+		if rec.Code != http.StatusMethodNotAllowed {
+			t.Fatalf("unexpected http status: %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+		}
+	})
+
+	t.Run("missing session parameter is handled correctly", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		AuthFallback(rec, req, authtypes.LoginTypeRecaptcha, &base.Cfg.ClientAPI)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("unexpected http status: %d, want %d", rec.Code, http.StatusBadRequest)
+		}
+	})
+}

--- a/clientapi/routing/auth_fallback_test.go
+++ b/clientapi/routing/auth_fallback_test.go
@@ -128,4 +128,22 @@ func Test_AuthFallback(t *testing.T) {
 			t.Fatalf("unexpected http status: %d, want %d", rec.Code, http.StatusBadRequest)
 		}
 	})
+
+	t.Run("missing session parameter is handled correctly", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		AuthFallback(rec, req, authtypes.LoginTypeRecaptcha, &base.Cfg.ClientAPI)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("unexpected http status: %d, want %d", rec.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("missing 'response' is handled correctly", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/?session=1337", nil)
+		rec := httptest.NewRecorder()
+		AuthFallback(rec, req, authtypes.LoginTypeRecaptcha, &base.Cfg.ClientAPI)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("unexpected http status: %d, want %d", rec.Code, http.StatusBadRequest)
+		}
+	})
 }

--- a/clientapi/routing/login.go
+++ b/clientapi/routing/login.go
@@ -23,15 +23,13 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/userutil"
 	"github.com/matrix-org/dendrite/setup/config"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
-	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 )
 
 type loginResponse struct {
-	UserID      string                       `json:"user_id"`
-	AccessToken string                       `json:"access_token"`
-	HomeServer  gomatrixserverlib.ServerName `json:"home_server"`
-	DeviceID    string                       `json:"device_id"`
+	UserID      string `json:"user_id"`
+	AccessToken string `json:"access_token"`
+	DeviceID    string `json:"device_id"`
 }
 
 type flows struct {
@@ -116,7 +114,6 @@ func completeAuth(
 		JSON: loginResponse{
 			UserID:      performRes.Device.UserID,
 			AccessToken: performRes.Device.AccessToken,
-			HomeServer:  serverName,
 			DeviceID:    performRes.Device.ID,
 		},
 	}

--- a/clientapi/routing/password.go
+++ b/clientapi/routing/password.go
@@ -82,8 +82,8 @@ func Password(
 	sessions.addCompletedSessionStage(sessionID, authtypes.LoginTypePassword)
 
 	// Check the new password strength.
-	if resErr = internal.ValidatePassword(r.NewPassword); resErr != nil {
-		return *resErr
+	if err := internal.ValidatePassword(r.NewPassword); err != nil {
+		return *internal.PasswordResponse(err)
 	}
 
 	// Get the local part.

--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -292,7 +292,7 @@ func validateRecaptcha(
 		return ErrMissingResponse
 	}
 
-	// Make a POST request to Google's API to check the captcha response
+	// Make a POST request to the captcha provider API to check the captcha response
 	resp, err := http.PostForm(cfg.RecaptchaSiteVerifyAPI,
 		url.Values{
 			"secret":   {cfg.RecaptchaPrivateKey},
@@ -508,11 +508,6 @@ func Register(
 	}
 	if resErr := httputil.UnmarshalJSON(reqBody, &r); resErr != nil {
 		return *resErr
-	}
-	var l string
-	var d gomatrixserverlib.ServerName
-	if l, d, err = cfg.Matrix.SplitLocalID('@', r.Username); err == nil {
-		r.Username, r.ServerName = l, d
 	}
 	if req.URL.Query().Get("kind") == "guest" {
 		return handleGuestRegistration(req, r, cfg, userAPI)

--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -323,7 +323,7 @@ func validatePassword(password string) *util.JSONResponse {
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.BadJSON(fmt.Sprintf("'password' >%d characters", maxPasswordLength)),
 		}
-	} else if len(password) > 0 && len(password) < minPasswordLength {
+	} else if len(password) < minPasswordLength {
 		return &util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.WeakPassword(fmt.Sprintf("password too weak: min %d chars", minPasswordLength)),

--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -263,10 +263,9 @@ func newUserInteractiveResponse(
 
 // http://matrix.org/speculator/spec/HEAD/client_server/unstable.html#post-matrix-client-unstable-register
 type registerResponse struct {
-	UserID      string                       `json:"user_id"`
-	AccessToken string                       `json:"access_token,omitempty"`
-	HomeServer  gomatrixserverlib.ServerName `json:"home_server"`
-	DeviceID    string                       `json:"device_id,omitempty"`
+	UserID      string `json:"user_id"`
+	AccessToken string `json:"access_token,omitempty"`
+	DeviceID    string `json:"device_id,omitempty"`
 }
 
 // recaptchaResponse represents the HTTP response from a Google Recaptcha server
@@ -715,7 +714,6 @@ func handleGuestRegistration(
 		JSON: registerResponse{
 			UserID:      devRes.Device.UserID,
 			AccessToken: devRes.Device.AccessToken,
-			HomeServer:  res.Account.ServerName,
 			DeviceID:    devRes.Device.ID,
 		},
 	}
@@ -942,8 +940,7 @@ func completeRegistration(
 		return util.JSONResponse{
 			Code: http.StatusOK,
 			JSON: registerResponse{
-				UserID:     userutil.MakeUserID(username, accRes.Account.ServerName),
-				HomeServer: accRes.Account.ServerName,
+				UserID: userutil.MakeUserID(username, accRes.Account.ServerName),
 			},
 		}
 	}
@@ -976,7 +973,6 @@ func completeRegistration(
 	result := registerResponse{
 		UserID:      devRes.Device.UserID,
 		AccessToken: devRes.Device.AccessToken,
-		HomeServer:  accRes.Account.ServerName,
 		DeviceID:    devRes.Device.ID,
 	}
 	sessions.addCompletedRegistration(sessionID, result)

--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -322,7 +322,7 @@ func validatePassword(password string) *util.JSONResponse {
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.BadJSON(fmt.Sprintf("'password' >%d characters", maxPasswordLength)),
 		}
-	} else if len(password) < minPasswordLength {
+	} else if len(password) > 0 && len(password) < minPasswordLength {
 		return &util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.WeakPassword(fmt.Sprintf("password too weak: min %d chars", minPasswordLength)),

--- a/clientapi/routing/register_test.go
+++ b/clientapi/routing/register_test.go
@@ -15,8 +15,11 @@
 package routing
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"regexp"
 	"strings"
@@ -25,7 +28,12 @@ import (
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"github.com/matrix-org/dendrite/keyserver"
+	"github.com/matrix-org/dendrite/roomserver"
 	"github.com/matrix-org/dendrite/setup/config"
+	"github.com/matrix-org/dendrite/test"
+	"github.com/matrix-org/dendrite/test/testrig"
+	"github.com/matrix-org/dendrite/userapi"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 )
@@ -373,4 +381,233 @@ func Test_validatePassword(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_register(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		kind                 string
+		password             string
+		username             string
+		loginType            string
+		forceEmpty           bool
+		registrationDisabled bool
+		guestsDisabled       bool
+		wantResponse         util.JSONResponse
+	}{
+		{
+			name:           "disallow guests",
+			kind:           "guest",
+			guestsDisabled: true,
+			wantResponse: util.JSONResponse{
+				Code: http.StatusForbidden,
+				JSON: jsonerror.Forbidden(`Guest registration is disabled on "test"`),
+			},
+		},
+		{
+			name: "allow guests",
+			kind: "guest",
+		},
+		{
+			name:      "unknown login type",
+			loginType: "im.not.known",
+			wantResponse: util.JSONResponse{
+				Code: http.StatusNotImplemented,
+				JSON: jsonerror.Unknown("unknown/unimplemented auth type"),
+			},
+		},
+		{
+			name:                 "disabled registration",
+			registrationDisabled: true,
+			wantResponse: util.JSONResponse{
+				Code: http.StatusForbidden,
+				JSON: jsonerror.Forbidden(`Registration is disabled on "test"`),
+			},
+		},
+		{
+			name:       "successful registration, numeric ID",
+			username:   "",
+			password:   "someRandomPassword",
+			forceEmpty: true,
+		},
+		{
+			name:     "successful registration",
+			username: "success",
+		},
+		{
+			name:     "failing registration - user already exists",
+			username: "success",
+			wantResponse: util.JSONResponse{
+				Code: http.StatusBadRequest,
+				JSON: jsonerror.UserInUse("Desired user ID is already taken."),
+			},
+		},
+		{
+			name:     "successful registration",
+			username: "LOWERCASED", // this is going to be lower-cased
+		},
+		{
+			name:     "invalid username",
+			username: "#totalyNotValid",
+			wantResponse: util.JSONResponse{
+				Code: http.StatusBadRequest,
+				JSON: jsonerror.InvalidUsername("Username can only contain characters a-z, 0-9, or '_-./='"),
+			},
+		},
+		{
+			name:     "numeric username is forbidden",
+			username: "1337",
+			wantResponse: util.JSONResponse{
+				Code: http.StatusBadRequest,
+				JSON: jsonerror.InvalidUsername("Numeric user IDs are reserved"),
+			},
+		},
+		{
+			name:       "can't register without password",
+			username:   "helloworld",
+			password:   "",
+			forceEmpty: true,
+			wantResponse: util.JSONResponse{
+				Code: http.StatusBadRequest,
+				JSON: jsonerror.WeakPassword(fmt.Sprintf("password too weak: min %d chars", minPasswordLength)),
+			},
+		},
+	}
+
+	test.WithAllDatabases(t, func(t *testing.T, dbType test.DBType) {
+		base, baseClose := testrig.CreateBaseDendrite(t, dbType)
+		defer baseClose()
+
+		rsAPI := roomserver.NewInternalAPI(base)
+		keyAPI := keyserver.NewInternalAPI(base, &base.Cfg.KeyServer, nil, rsAPI)
+		userAPI := userapi.NewInternalAPI(base, &base.Cfg.UserAPI, nil, keyAPI, rsAPI, nil)
+		keyAPI.SetUserAPI(userAPI)
+
+		if err := base.Cfg.Derive(); err != nil {
+			t.Fatalf("failed to derive config: %s", err)
+		}
+
+		for _, tc := range testCases {
+			if tc.kind == "" {
+				tc.kind = "user"
+			}
+			if tc.password == "" && !tc.forceEmpty {
+				tc.password = "someRandomPassword"
+			}
+			if tc.username == "" && !tc.forceEmpty {
+				tc.username = "valid"
+			}
+			if tc.loginType == "" {
+				tc.loginType = "m.login.dummy"
+			}
+
+			reg := registerRequest{
+				Password: tc.password,
+				Username: tc.username,
+			}
+
+			body := &bytes.Buffer{}
+
+			base.Cfg.ClientAPI.RegistrationDisabled = tc.registrationDisabled
+			base.Cfg.ClientAPI.GuestsDisabled = tc.guestsDisabled
+
+			err := json.NewEncoder(body).Encode(reg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			req := httptest.NewRequest(http.MethodPost, fmt.Sprintf("/?kind=%s", tc.kind), body)
+
+			resp := Register(req, userAPI, &base.Cfg.ClientAPI)
+			t.Logf("Resp: %+v", resp)
+
+			// The first request should return a userInteractiveResponse
+			switch r := resp.JSON.(type) {
+			case userInteractiveResponse:
+				// Check that the flows are the ones we configured
+				if !reflect.DeepEqual(r.Flows, base.Cfg.Derived.Registration.Flows) {
+					t.Fatalf("unexpected registration flows: %+v, want %+v", r.Flows, base.Cfg.Derived.Registration.Flows)
+				}
+			case *jsonerror.MatrixError:
+				if !reflect.DeepEqual(tc.wantResponse, resp) {
+					t.Fatalf("(%s), unexpected response: %+v, want: %+v", tc.name, resp, tc.wantResponse)
+				}
+				continue
+			case registerResponse:
+				// this should only be possible on guest user registration, never for normal users
+				if tc.kind != "guest" {
+					t.Fatalf("got register response on first request: %+v", r)
+				}
+				// assert we've got a UserID, AccessToken and DeviceID
+				if r.UserID == "" {
+					t.Fatalf("missing userID in response")
+				}
+				if r.AccessToken == "" {
+					t.Fatalf("missing accessToken in response")
+				}
+				if r.DeviceID == "" {
+					t.Fatalf("missing deviceID in response")
+				}
+				continue
+			default:
+				t.Logf("Got response: %T", resp.JSON)
+			}
+
+			// If we reached this, we should have received a UIA response
+			uia, ok := resp.JSON.(userInteractiveResponse)
+			if !ok {
+				t.Fatalf("did not receive a userInteractiveResponse: %T", resp.JSON)
+			}
+			t.Logf("%+v", uia)
+
+			// Register the user
+			reg.Auth = authDict{
+				Type:    authtypes.LoginType(tc.loginType),
+				Session: uia.Session,
+			}
+			dummy := "dummy"
+			reg.DeviceID = &dummy
+			reg.InitialDisplayName = &dummy
+			reg.Type = authtypes.LoginType(tc.loginType)
+
+			err = json.NewEncoder(body).Encode(reg)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			req = httptest.NewRequest(http.MethodPost, "/", body)
+
+			resp = Register(req, userAPI, &base.Cfg.ClientAPI)
+
+			switch resp.JSON.(type) {
+			case *jsonerror.MatrixError:
+				if !reflect.DeepEqual(tc.wantResponse, resp) {
+					t.Fatalf("unexpected response: %+v, want: %+v", resp, tc.wantResponse)
+				}
+				continue
+			}
+
+			rr, ok := resp.JSON.(registerResponse)
+			if !ok {
+				t.Fatalf("expected a registerresponse, got %T", resp.JSON)
+			}
+
+			// validate the response
+			if tc.forceEmpty {
+				// when not supplying a username, one will be generated. Given this _SHOULD_ be
+				// the second user, set the username accordingly
+				reg.Username = "2"
+			}
+			wantUserID := strings.ToLower(fmt.Sprintf("@%s:%s", reg.Username, "test"))
+			if wantUserID != rr.UserID {
+				t.Fatalf("unexpected userID: %s, want %s", rr.UserID, wantUserID)
+			}
+			if rr.DeviceID != *reg.DeviceID {
+				t.Fatalf("unexpected deviceID: %s, want %s", rr.DeviceID, *reg.DeviceID)
+			}
+			if rr.AccessToken == "" {
+				t.Fatalf("missing accessToken in response")
+			}
+		}
+	})
 }

--- a/clientapi/routing/register_test.go
+++ b/clientapi/routing/register_test.go
@@ -351,13 +351,6 @@ func Test_validatePassword(t *testing.T) {
 		want     *util.JSONResponse
 	}{
 		{
-			name: "no password supplied",
-			want: &util.JSONResponse{
-				Code: http.StatusBadRequest,
-				JSON: jsonerror.WeakPassword(fmt.Sprintf("password too weak: min %d chars", minPasswordLength)),
-			},
-		},
-		{
 			name:     "password too short",
 			password: "shortpw",
 			want: &util.JSONResponse{
@@ -460,16 +453,6 @@ func Test_register(t *testing.T) {
 			wantResponse: util.JSONResponse{
 				Code: http.StatusBadRequest,
 				JSON: jsonerror.InvalidUsername("Numeric user IDs are reserved"),
-			},
-		},
-		{
-			name:       "can't register without password",
-			username:   "helloworld",
-			password:   "",
-			forceEmpty: true,
-			wantResponse: util.JSONResponse{
-				Code: http.StatusBadRequest,
-				JSON: jsonerror.WeakPassword(fmt.Sprintf("password too weak: min %d chars", minPasswordLength)),
 			},
 		},
 	}

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -631,9 +631,9 @@ func Setup(
 	).Methods(http.MethodGet, http.MethodPost, http.MethodOptions)
 
 	v3mux.Handle("/auth/{authType}/fallback/web",
-		httputil.MakeHTMLAPI("auth_fallback", func(w http.ResponseWriter, req *http.Request) *util.JSONResponse {
+		httputil.MakeHTMLAPI("auth_fallback", func(w http.ResponseWriter, req *http.Request) {
 			vars := mux.Vars(req)
-			return AuthFallback(w, req, vars["authType"], cfg)
+			AuthFallback(w, req, vars["authType"], cfg)
 		}),
 	).Methods(http.MethodGet, http.MethodPost, http.MethodOptions)
 

--- a/internal/httputil/httpapi.go
+++ b/internal/httputil/httpapi.go
@@ -198,17 +198,12 @@ func MakeExternalAPI(metricsName string, f func(*http.Request) util.JSONResponse
 
 // MakeHTMLAPI adds Span metrics to the HTML Handler function
 // This is used to serve HTML alongside JSON error messages
-func MakeHTMLAPI(metricsName string, f func(http.ResponseWriter, *http.Request) *util.JSONResponse) http.Handler {
+func MakeHTMLAPI(metricsName string, f func(http.ResponseWriter, *http.Request)) http.Handler {
 	withSpan := func(w http.ResponseWriter, req *http.Request) {
 		span := opentracing.StartSpan(metricsName)
 		defer span.Finish()
 		req = req.WithContext(opentracing.ContextWithSpan(req.Context(), span))
-		if err := f(w, req); err != nil {
-			h := util.MakeJSONAPI(util.NewJSONRequestHandler(func(req *http.Request) util.JSONResponse {
-				return *err
-			}))
-			h.ServeHTTP(w, req)
-		}
+		f(w, req)
 	}
 
 	return promhttp.InstrumentHandlerCounter(

--- a/internal/validate.go
+++ b/internal/validate.go
@@ -41,7 +41,7 @@ var (
 	validUsernameRegex    = regexp.MustCompile(`^[0-9a-z_\-=./]+$`)
 )
 
-// ValidatePassword returns an error response if the password is invalid
+// ValidatePassword returns an error if the password is invalid
 func ValidatePassword(password string) error {
 	// https://github.com/matrix-org/synapse/blob/v0.20.0/synapse/rest/client/v2_alpha/register.py#L161
 	if len(password) > maxPasswordLength {

--- a/internal/validate.go
+++ b/internal/validate.go
@@ -15,30 +15,96 @@
 package internal
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 )
 
-const minPasswordLength = 8 // http://matrix.org/docs/spec/client_server/r0.2.0.html#password-based
+const (
+	maxUsernameLength = 254 // http://matrix.org/speculator/spec/HEAD/intro.html#user-identifiers TODO account for domain
 
-const maxPasswordLength = 512 // https://github.com/matrix-org/synapse/blob/v0.20.0/synapse/rest/client/v2_alpha/register.py#L161
+	minPasswordLength = 8   // http://matrix.org/docs/spec/client_server/r0.2.0.html#password-based
+	maxPasswordLength = 512 // https://github.com/matrix-org/synapse/blob/v0.20.0/synapse/rest/client/v2_alpha/register.py#L161
+)
+
+var (
+	ErrPasswordTooLong    = fmt.Errorf("password too long: max %d characters", maxPasswordLength)
+	ErrPasswordWeak       = fmt.Errorf("password too weak: min %d characters", minPasswordLength)
+	ErrUsernameTooLong    = fmt.Errorf("username exceeds the maximum length of %d characters", maxUsernameLength)
+	ErrUsernameInvalid    = errors.New("username can only contain characters a-z, 0-9, or '_-./='")
+	ErrUsernameUnderscore = errors.New("username cannot start with a '_'")
+	validUsernameRegex    = regexp.MustCompile(`^[0-9a-z_\-=./]+$`)
+)
 
 // ValidatePassword returns an error response if the password is invalid
-func ValidatePassword(password string) *util.JSONResponse {
+func ValidatePassword(password string) error {
 	// https://github.com/matrix-org/synapse/blob/v0.20.0/synapse/rest/client/v2_alpha/register.py#L161
 	if len(password) > maxPasswordLength {
-		return &util.JSONResponse{
-			Code: http.StatusBadRequest,
-			JSON: jsonerror.BadJSON(fmt.Sprintf("password too long: max %d characters", maxPasswordLength)),
-		}
+		return ErrPasswordTooLong
 	} else if len(password) > 0 && len(password) < minPasswordLength {
+		return ErrPasswordWeak
+	}
+	return nil
+}
+
+// PasswordResponse returns a util.JSONResponse for a given error, if any.
+func PasswordResponse(err error) *util.JSONResponse {
+	switch err {
+	case ErrPasswordWeak:
 		return &util.JSONResponse{
 			Code: http.StatusBadRequest,
-			JSON: jsonerror.WeakPassword(fmt.Sprintf("password too weak: min %d chars", minPasswordLength)),
+			JSON: jsonerror.WeakPassword(ErrPasswordWeak.Error()),
 		}
+	case ErrPasswordTooLong:
+		return &util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.BadJSON(ErrPasswordTooLong.Error()),
+		}
+	}
+	return nil
+}
+
+// ValidateUsername returns an error if the username is invalid
+func ValidateUsername(localpart string, domain gomatrixserverlib.ServerName) error {
+	// https://github.com/matrix-org/synapse/blob/v0.20.0/synapse/rest/client/v2_alpha/register.py#L161
+	if id := fmt.Sprintf("@%s:%s", localpart, domain); len(id) > maxUsernameLength {
+		return ErrUsernameTooLong
+	} else if !validUsernameRegex.MatchString(localpart) {
+		return ErrUsernameInvalid
+	} else if localpart[0] == '_' { // Regex checks its not a zero length string
+		return ErrUsernameUnderscore
+	}
+	return nil
+}
+
+// UsernameResponse returns a util.JSONResponse for the given error, if any.
+func UsernameResponse(err error) *util.JSONResponse {
+	switch err {
+	case ErrUsernameTooLong:
+		return &util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.BadJSON(err.Error()),
+		}
+	case ErrUsernameInvalid, ErrUsernameUnderscore:
+		return &util.JSONResponse{
+			Code: http.StatusBadRequest,
+			JSON: jsonerror.InvalidUsername(err.Error()),
+		}
+	}
+	return nil
+}
+
+// ValidateApplicationServiceUsername returns an error if the username is invalid for an application service
+func ValidateApplicationServiceUsername(localpart string, domain gomatrixserverlib.ServerName) error {
+	if id := fmt.Sprintf("@%s:%s", localpart, domain); len(id) > maxUsernameLength {
+		return ErrUsernameTooLong
+	} else if !validUsernameRegex.MatchString(localpart) {
+		return ErrUsernameInvalid
 	}
 	return nil
 }

--- a/internal/validate_test.go
+++ b/internal/validate_test.go
@@ -1,0 +1,170 @@
+package internal
+
+import (
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/util"
+)
+
+func Test_validatePassword(t *testing.T) {
+	tests := []struct {
+		name      string
+		password  string
+		wantError error
+		wantJSON  *util.JSONResponse
+	}{
+		{
+			name:      "password too short",
+			password:  "shortpw",
+			wantError: ErrPasswordWeak,
+			wantJSON:  &util.JSONResponse{Code: http.StatusBadRequest, JSON: jsonerror.WeakPassword(ErrPasswordWeak.Error())},
+		},
+		{
+			name:      "password too long",
+			password:  strings.Repeat("a", maxPasswordLength+1),
+			wantError: ErrPasswordTooLong,
+			wantJSON:  &util.JSONResponse{Code: http.StatusBadRequest, JSON: jsonerror.BadJSON(ErrPasswordTooLong.Error())},
+		},
+		{
+			name:     "password OK",
+			password: util.RandomString(10),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotErr := ValidatePassword(tt.password)
+			if !reflect.DeepEqual(gotErr, tt.wantError) {
+				t.Errorf("validatePassword() = %v, wantJSON %v", gotErr, tt.wantError)
+			}
+
+			if got := PasswordResponse(gotErr); !reflect.DeepEqual(got, tt.wantJSON) {
+				t.Errorf("validatePassword() = %v, wantJSON %v", got, tt.wantJSON)
+			}
+		})
+	}
+}
+
+func Test_validateUsername(t *testing.T) {
+	tooLongUsername := strings.Repeat("a", maxUsernameLength)
+	tests := []struct {
+		name      string
+		localpart string
+		domain    gomatrixserverlib.ServerName
+		wantErr   error
+		wantJSON  *util.JSONResponse
+	}{
+		{
+			name:      "empty username",
+			localpart: "",
+			domain:    "localhost",
+			wantErr:   ErrUsernameInvalid,
+			wantJSON: &util.JSONResponse{
+				Code: http.StatusBadRequest,
+				JSON: jsonerror.InvalidUsername(ErrUsernameInvalid.Error()),
+			},
+		},
+		{
+			name:      "invalid username",
+			localpart: "INVALIDUSERNAME",
+			domain:    "localhost",
+			wantErr:   ErrUsernameInvalid,
+			wantJSON: &util.JSONResponse{
+				Code: http.StatusBadRequest,
+				JSON: jsonerror.InvalidUsername(ErrUsernameInvalid.Error()),
+			},
+		},
+		{
+			name:      "username too long",
+			localpart: tooLongUsername,
+			domain:    "localhost",
+			wantErr:   ErrUsernameTooLong,
+			wantJSON: &util.JSONResponse{
+				Code: http.StatusBadRequest,
+				JSON: jsonerror.BadJSON(ErrUsernameTooLong.Error()),
+			},
+		},
+		{
+			name:      "localpart starting with an underscore",
+			localpart: "_notvalid",
+			domain:    "localhost",
+			wantErr:   ErrUsernameUnderscore,
+			wantJSON: &util.JSONResponse{
+				Code: http.StatusBadRequest,
+				JSON: jsonerror.InvalidUsername(ErrUsernameUnderscore.Error()),
+			},
+		},
+		{
+			name:      "valid username",
+			localpart: "valid",
+			domain:    "localhost",
+		},
+		{
+			name:      "complex username",
+			localpart: "f00_bar-baz.=40/",
+			domain:    "localhost",
+		},
+		{
+			name:      "rejects emoji username 💥",
+			localpart: "💥",
+			domain:    "localhost",
+			wantErr:   ErrUsernameInvalid,
+			wantJSON: &util.JSONResponse{
+				Code: http.StatusBadRequest,
+				JSON: jsonerror.InvalidUsername(ErrUsernameInvalid.Error()),
+			},
+		},
+		{
+			name:      "special characters are allowed",
+			localpart: "/dev/null",
+			domain:    "localhost",
+		},
+		{
+			name:      "special characters are allowed 2",
+			localpart: "i_am_allowed=1",
+			domain:    "localhost",
+		},
+		{
+			name:      "not all special characters are allowed",
+			localpart: "notallowed#", // contains #
+			domain:    "localhost",
+			wantErr:   ErrUsernameInvalid,
+			wantJSON: &util.JSONResponse{
+				Code: http.StatusBadRequest,
+				JSON: jsonerror.InvalidUsername(ErrUsernameInvalid.Error()),
+			},
+		},
+		{
+			name:      "username containing numbers",
+			localpart: "hello1337",
+			domain:    "localhost",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotErr := ValidateUsername(tt.localpart, tt.domain)
+			if !reflect.DeepEqual(gotErr, tt.wantErr) {
+				t.Errorf("ValidateUsername() = %v, wantErr %v", gotErr, tt.wantErr)
+			}
+			if gotJSON := UsernameResponse(gotErr); !reflect.DeepEqual(gotJSON, tt.wantJSON) {
+				t.Errorf("UsernameResponse() = %v, wantJSON %v", gotJSON, tt.wantJSON)
+			}
+
+			// Application services are allowed usernames starting with an underscore
+			if tt.wantErr == ErrUsernameUnderscore {
+				return
+			}
+			gotErr = ValidateApplicationServiceUsername(tt.localpart, tt.domain)
+			if !reflect.DeepEqual(gotErr, tt.wantErr) {
+				t.Errorf("ValidateUsername() = %v, wantErr %v", gotErr, tt.wantErr)
+			}
+			if gotJSON := UsernameResponse(gotErr); !reflect.DeepEqual(gotJSON, tt.wantJSON) {
+				t.Errorf("UsernameResponse() = %v, wantJSON %v", gotJSON, tt.wantJSON)
+			}
+		})
+	}
+}

--- a/setup/config/config.go
+++ b/setup/config/config.go
@@ -29,7 +29,7 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ed25519"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	jaegerconfig "github.com/uber/jaeger-client-go/config"
 	jaegermetrics "github.com/uber/jaeger-lib/metrics"
@@ -314,11 +314,13 @@ func (config *Dendrite) Derive() error {
 
 	if config.ClientAPI.RecaptchaEnabled {
 		config.Derived.Registration.Params[authtypes.LoginTypeRecaptcha] = map[string]string{"public_key": config.ClientAPI.RecaptchaPublicKey}
-		config.Derived.Registration.Flows = append(config.Derived.Registration.Flows,
-			authtypes.Flow{Stages: []authtypes.LoginType{authtypes.LoginTypeRecaptcha}})
+		config.Derived.Registration.Flows = []authtypes.Flow{
+			{Stages: []authtypes.LoginType{authtypes.LoginTypeRecaptcha}},
+		}
 	} else {
-		config.Derived.Registration.Flows = append(config.Derived.Registration.Flows,
-			authtypes.Flow{Stages: []authtypes.LoginType{authtypes.LoginTypeDummy}})
+		config.Derived.Registration.Flows = []authtypes.Flow{
+			{Stages: []authtypes.LoginType{authtypes.LoginTypeDummy}},
+		}
 	}
 
 	// Load application service configuration files

--- a/setup/config/config_clientapi.go
+++ b/setup/config/config_clientapi.go
@@ -78,9 +78,6 @@ func (c *ClientAPI) Verify(configErrs *ConfigErrors, isMonolith bool) {
 	c.TURN.Verify(configErrs)
 	c.RateLimiting.Verify(configErrs)
 	if c.RecaptchaEnabled {
-		checkNotEmpty(configErrs, "client_api.recaptcha_public_key", c.RecaptchaPublicKey)
-		checkNotEmpty(configErrs, "client_api.recaptcha_private_key", c.RecaptchaPrivateKey)
-		checkNotEmpty(configErrs, "client_api.recaptcha_siteverify_api", c.RecaptchaSiteVerifyAPI)
 		if c.RecaptchaSiteVerifyAPI == "" {
 			c.RecaptchaSiteVerifyAPI = "https://www.google.com/recaptcha/api/siteverify"
 		}
@@ -93,6 +90,10 @@ func (c *ClientAPI) Verify(configErrs *ConfigErrors, isMonolith bool) {
 		if c.RecaptchaSitekeyClass == "" {
 			c.RecaptchaSitekeyClass = "g-recaptcha-response"
 		}
+		checkNotEmpty(configErrs, "client_api.recaptcha_public_key", c.RecaptchaPublicKey)
+		checkNotEmpty(configErrs, "client_api.recaptcha_private_key", c.RecaptchaPrivateKey)
+		checkNotEmpty(configErrs, "client_api.recaptcha_siteverify_api", c.RecaptchaSiteVerifyAPI)
+		checkNotEmpty(configErrs, "client_api.recaptcha_sitekey_class", c.RecaptchaSitekeyClass)
 	}
 	// Ensure there is any spam counter measure when enabling registration
 	if !c.RegistrationDisabled && !c.OpenRegistrationWithoutVerificationEnabled {


### PR DESCRIPTION
This PR
- adds several tests for the clientapi, mostly around `/register` and auth fallback.
- removes the now deprecated `homeserver` field from responses to `/register`
- slightly refactors auth fallback handling