### PR TITLE
Handle DisplayName field in admin user registration endpoint

### DIFF
--- a/clientapi/routing/register_secret.go
+++ b/clientapi/routing/register_secret.go
@@ -18,12 +18,13 @@ import (
 )
 
 type SharedSecretRegistrationRequest struct {
-	User     string `json:"username"`
-	Password string `json:"password"`
-	Nonce    string `json:"nonce"`
-	MacBytes []byte
-	MacStr   string `json:"mac"`
-	Admin    bool   `json:"admin"`
+	User        string `json:"username"`
+	Password    string `json:"password"`
+	Nonce       string `json:"nonce"`
+	MacBytes    []byte
+	MacStr      string `json:"mac"`
+	Admin       bool   `json:"admin"`
+	DisplayName string `json:"displayname,omitempty"`
 }
 
 func NewSharedSecretRegistrationRequest(reader io.ReadCloser) (*SharedSecretRegistrationRequest, error) {

--- a/clientapi/routing/register_secret_test.go
+++ b/clientapi/routing/register_secret_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestSharedSecretRegister(t *testing.T) {
 	// these values have come from a local synapse instance to ensure compatibility
-	jsonStr := []byte(`{"admin":false,"mac":"f1ba8d37123866fd659b40de4bad9b0f8965c565","nonce":"759f047f312b99ff428b21d581256f8592b8976e58bc1b543972dc6147e529a79657605b52d7becd160ff5137f3de11975684319187e06901955f79e5a6c5a79","password":"wonderland","username":"alice"}`)
+	jsonStr := []byte(`{"admin":false,"mac":"f1ba8d37123866fd659b40de4bad9b0f8965c565","nonce":"759f047f312b99ff428b21d581256f8592b8976e58bc1b543972dc6147e529a79657605b52d7becd160ff5137f3de11975684319187e06901955f79e5a6c5a79","password":"wonderland","username":"alice","displayname":"rabbit"}`)
 	sharedSecret := "dendritetest"
 
 	req, err := NewSharedSecretRegistrationRequest(io.NopCloser(bytes.NewBuffer(jsonStr)))

--- a/clientapi/routing/register_test.go
+++ b/clientapi/routing/register_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -37,6 +38,7 @@ import (
 	"github.com/matrix-org/dendrite/userapi"
 	"github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/util"
+	"github.com/patrickmn/go-cache"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -599,7 +601,7 @@ func TestRegisterUserWithDisplayName(t *testing.T) {
 			false,
 			&deviceName,
 			&deviceID,
-			api.AccountTypeUser,
+			api.AccountTypeAdmin,
 		)
 
 		assert.Equal(t, http.StatusOK, response.Code)
@@ -609,5 +611,55 @@ func TestRegisterUserWithDisplayName(t *testing.T) {
 		err := userAPI.QueryProfile(base.Context(), &req, &res)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedDisplayName, res.DisplayName)
+	})
+}
+
+func TestRegisterAdminUsingSharedSecret(t *testing.T) {
+	test.WithAllDatabases(t, func(t *testing.T, dbType test.DBType) {
+		base, baseClose := testrig.CreateBaseDendrite(t, dbType)
+		defer baseClose()
+		base.Cfg.Global.ServerName = "server"
+		sharedSecret := "dendritetest"
+		base.Cfg.ClientAPI.RegistrationSharedSecret = sharedSecret
+
+		rsAPI := roomserver.NewInternalAPI(base)
+		keyAPI := keyserver.NewInternalAPI(base, &base.Cfg.KeyServer, nil, rsAPI)
+		userAPI := userapi.NewInternalAPI(base, &base.Cfg.UserAPI, nil, keyAPI, rsAPI, nil)
+		keyAPI.SetUserAPI(userAPI)
+
+		expectedDisplayName := "rabbit"
+		jsonStr := []byte(`{"admin":true,"mac":"24dca3bba410e43fe64b9b5c28306693bf3baa9f","nonce":"759f047f312b99ff428b21d581256f8592b8976e58bc1b543972dc6147e529a79657605b52d7becd160ff5137f3de11975684319187e06901955f79e5a6c5a79","password":"wonderland","username":"alice","displayname":"rabbit"}`)
+		req, err := NewSharedSecretRegistrationRequest(io.NopCloser(bytes.NewBuffer(jsonStr)))
+		assert.NoError(t, err)
+		if err != nil {
+			t.Fatalf("failed to read request: %s", err)
+		}
+
+		r := NewSharedSecretRegistration(sharedSecret)
+
+		// force the nonce to be known
+		r.nonces.Set(req.Nonce, true, cache.DefaultExpiration)
+
+		_, err = r.IsValidMacLogin(req.Nonce, req.User, req.Password, req.Admin, req.MacBytes)
+		assert.NoError(t, err)
+
+		body := &bytes.Buffer{}
+		err = json.NewEncoder(body).Encode(req)
+		assert.NoError(t, err)
+		ssrr := httptest.NewRequest(http.MethodPost, "/", body)
+
+		response := handleSharedSecretRegistration(
+			&base.Cfg.ClientAPI,
+			userAPI,
+			r,
+			ssrr,
+		)
+		assert.Equal(t, http.StatusOK, response.Code)
+
+		profilReq := api.QueryProfileRequest{UserID: "@alice:server"}
+		var profileRes api.QueryProfileResponse
+		err = userAPI.QueryProfile(base.Context(), &profilReq, &profileRes)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedDisplayName, profileRes.DisplayName)
 	})
 }


### PR DESCRIPTION
`/_synapse/admin/v1/register` has a `displayname` field that we were previously ignoring.
This handles that field and adds the displayname to the new user if one was provided.