### PR TITLE
Fix oversight in cmd/generate-config

### DIFF
--- a/cmd/generate-config/main.go
+++ b/cmd/generate-config/main.go
@@ -54,6 +54,9 @@ func main() {
 		} else {
 			cfg.Global.DatabaseOptions.ConnectionString = uri
 		}
+		cfg.MediaAPI.BasePath = config.Path(filepath.Join(*dirPath, "media"))
+		cfg.Global.JetStream.StoragePath = config.Path(*dirPath)
+		cfg.SyncAPI.Fulltext.IndexPath = config.Path(filepath.Join(*dirPath, "searchindex"))
 		cfg.Logging = []config.LogrusHook{
 			{
 				Type:  "file",


### PR DESCRIPTION
The -dir argument was ignored for media_api->base_path.
Signed-off-by: `Bernhard Feichtinger <43303168+BieHDC@users.noreply.github.com>`
