### PR TITLE
Roomserver published pkey migration

### DIFF
--- a/roomserver/storage/postgres/deltas/20230131091021_published_appservice_pkey.go
+++ b/roomserver/storage/postgres/deltas/20230131091021_published_appservice_pkey.go
@@ -1,4 +1,4 @@
-// Copyright 2022 The Matrix.org Foundation C.I.C.
+// Copyright 2023 The Matrix.org Foundation C.I.C.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/roomserver/storage/postgres/deltas/20230131091021_published_appservice_pkey.go
+++ b/roomserver/storage/postgres/deltas/20230131091021_published_appservice_pkey.go
@@ -1,0 +1,32 @@
+// Copyright 2022 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deltas
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+func UpPulishedAppservicePrimaryKey(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `ALTER TABLE roomserver_published RENAME CONSTRAINT roomserver_published_pkey TO roomserver_published_pkeyold;
+CREATE UNIQUE INDEX roomserver_published_pkey ON roomserver_published (room_id, appservice_id, network_id);
+ALTER TABLE roomserver_published DROP CONSTRAINT roomserver_published_pkeyold;
+ALTER TABLE roomserver_published ADD PRIMARY KEY USING INDEX roomserver_published_pkey;`)
+	if err != nil {
+		return fmt.Errorf("failed to execute upgrade: %w", err)
+	}
+	return nil
+}

--- a/roomserver/storage/postgres/published_table.go
+++ b/roomserver/storage/postgres/published_table.go
@@ -69,6 +69,10 @@ func CreatePublishedTable(db *sql.DB) error {
 		Version: "roomserver: published appservice",
 		Up:      deltas.UpPulishedAppservice,
 	})
+	m.AddMigrations(sqlutil.Migration{
+		Version: "roomserver: published appservice pkey",
+		Up:      deltas.UpPulishedAppservicePrimaryKey,
+	})
 	return m.Up(context.Background())
 }
 

--- a/roomserver/storage/postgres/published_table.go
+++ b/roomserver/storage/postgres/published_table.go
@@ -65,14 +65,16 @@ func CreatePublishedTable(db *sql.DB) error {
 		return err
 	}
 	m := sqlutil.NewMigrator(db)
-	m.AddMigrations(sqlutil.Migration{
-		Version: "roomserver: published appservice",
-		Up:      deltas.UpPulishedAppservice,
-	})
-	m.AddMigrations(sqlutil.Migration{
-		Version: "roomserver: published appservice pkey",
-		Up:      deltas.UpPulishedAppservicePrimaryKey,
-	})
+	m.AddMigrations([]sqlutil.Migration{
+		{
+			Version: "roomserver: published appservice",
+			Up:      deltas.UpPulishedAppservice,
+		},
+		{
+			Version: "roomserver: published appservice pkey",
+			Up:      deltas.UpPulishedAppservicePrimaryKey,
+		},
+	}...)
 	return m.Up(context.Background())
 }
 


### PR DESCRIPTION
Adds a missed migration to update the primary key on the roomserver_published table in postgres.
Primary key was changed in #2836.