### PR TITLE
Add Sytest/Complement coverage to scheduled runs

### DIFF
--- a/.github/workflows/dendrite.yml
+++ b/.github/workflows/dendrite.yml
@@ -460,7 +460,8 @@ jobs:
         name: Run Complement Tests
         env:
           COMPLEMENT_BASE_IMAGE: complement-dendrite:${{ matrix.postgres }}${{ matrix.api }}${{ matrix.cgo }}
-          API: ${{ matrix.api && 1 }}
+          COMPLEMENT_DENDRITE_API: ${{ matrix.api && 1 }}
+          COMPLEMENT_SHARE_ENV_PREFIX: COMPLEMENT_DENDRITE_
         working-directory: complement
 
   integration-tests-done:

--- a/.github/workflows/schedules.yaml
+++ b/.github/workflows/schedules.yaml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
   workflow_dispatch:
+  push:
+    branches:
+      - "s7evink/sytestcover"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -41,6 +44,7 @@ jobs:
         API: ${{ matrix.api && 1 }}
         SYTEST_BRANCH: ${{ github.head_ref }}
         RACE_DETECTION: 1
+        COVER: 1
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -75,6 +79,7 @@ jobs:
             /logs/**/*.log*
           
   element_web:
+    if: ${{ false }} # disable for now
     timeout-minutes: 120
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/schedules.yaml
+++ b/.github/workflows/schedules.yaml
@@ -83,8 +83,6 @@ jobs:
           cache: true
       - name: Download all artifacts
         uses: actions/download-artifact@v3
-        with:
-          name: Sytest*
       - name: Install gocovmerge
         run: go install github.com/wadey/gocovmerge@latest
       - name: Run gocovmerge
@@ -160,7 +158,7 @@ jobs:
           cat <<EOF > /tmp/posttest.sh
           #!/bin/bash
           mkdir -p /tmp/Complement/logs/\$2/\$1/
-          docker cp \$1:/dendrite/integrationcover.log /tmp/Complement/logs/\$2/\$1/
+          docker cp \$1:/dendrite/complementcover.log /tmp/Complement/logs/\$2/\$1/
           EOF
           
           chmod +x /tmp/posttest.sh
@@ -184,7 +182,7 @@ jobs:
         with:
           name: Complement Logs - (Dendrite, ${{ join(matrix.*, ', ') }})
           path: |
-            /tmp/Complement/**/integrationcover.log
+            /tmp/Complement/**/complementcover.log
 
   complement-coverage:
     timeout-minutes: 5
@@ -201,13 +199,11 @@ jobs:
           cache: true
       - name: Download all artifacts
         uses: actions/download-artifact@v3
-        with:
-          name: Complement*
       - name: Install gocovmerge
         run: go install github.com/wadey/gocovmerge@latest
       - name: Run gocovmerge
         run: |
-          find -name 'integrationcover.log' | xargs gocovmerge | grep -Ev 'relayapi|setup/mscs|api_trace' > complement.cov
+          find -name 'complementcover.log' | xargs gocovmerge | grep -Ev 'relayapi|setup/mscs|api_trace' > complement.cov
           go tool cover -func=complement.cov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/schedules.yaml
+++ b/.github/workflows/schedules.yaml
@@ -203,6 +203,12 @@ jobs:
         run: go install github.com/wadey/gocovmerge@latest
       - name: Run gocovmerge
         run: |
+          echo "env:"
+          env
+          echo "ls:"
+          ls -la
+          echo "Find:"
+          find -name 'complementcover.log'
           find -name 'complementcover.log' | xargs gocovmerge | grep -Ev 'relayapi|setup/mscs|api_trace' > complement.cov
           go tool cover -func=complement.cov
       - name: Upload coverage to Codecov

--- a/.github/workflows/schedules.yaml
+++ b/.github/workflows/schedules.yaml
@@ -83,11 +83,13 @@ jobs:
           cache: true
       - name: Download all artifacts
         uses: actions/download-artifact@v3
+        with:
+          name: Sytest*
       - name: Install gocovmerge
         run: go install github.com/wadey/gocovmerge@latest
       - name: Run gocovmerge
         run: |
-          find Sytest* -name 'integrationcover.log' | xargs gocovmerge | grep -Ev 'relayapi|setup/mscs|api_trace' > sytest.cov
+          find -name 'integrationcover.log' | xargs gocovmerge | grep -Ev 'relayapi|setup/mscs|api_trace' > sytest.cov
           go tool cover -func=sytest.cov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
@@ -156,6 +158,7 @@ jobs:
       - name: Create post test script
         run: |
           cat <<EOF > /tmp/posttest.sh
+          #!/bin/bash
           mkdir -p /tmp/Complement/logs/\$2/\$1/
           docker cp \$1:/dendrite/integrationcover.log /tmp/Complement/logs/\$2/\$1/
           EOF
@@ -198,11 +201,13 @@ jobs:
           cache: true
       - name: Download all artifacts
         uses: actions/download-artifact@v3
+        with:
+          name: Complement*
       - name: Install gocovmerge
         run: go install github.com/wadey/gocovmerge@latest
       - name: Run gocovmerge
         run: |
-          find Complement* -name 'integrationcover.log' | xargs gocovmerge | grep -Ev 'relayapi|setup/mscs|api_trace' > complement.cov
+          find -name 'integrationcover.log' | xargs gocovmerge | grep -Ev 'relayapi|setup/mscs|api_trace' > complement.cov
           go tool cover -func=complement.cov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/schedules.yaml
+++ b/.github/workflows/schedules.yaml
@@ -23,16 +23,6 @@ jobs:
       matrix:
         include:
           - label: SQLite
-
-          - label: SQLite, full HTTP APIs
-            api: full-http
-
-          - label: PostgreSQL
-            postgres: postgres
-
-          - label: PostgreSQL, full HTTP APIs
-            postgres: postgres
-            api: full-http
     container:
       image: matrixdotorg/sytest-dendrite:latest
       volumes:
@@ -117,26 +107,6 @@ jobs:
         include:
           - label: SQLite native
             cgo: 0
-
-          - label: SQLite Cgo
-            cgo: 1
-
-          - label: SQLite native, full HTTP APIs
-            api: full-http
-            cgo: 0
-
-          - label: SQLite Cgo, full HTTP APIs
-            api: full-http
-            cgo: 1
-
-          - label: PostgreSQL
-            postgres: Postgres
-            cgo: 0
-
-          - label: PostgreSQL, full HTTP APIs
-            postgres: Postgres
-            api: full-http
-            cgo: 0
     steps:
       # Env vars are set file a file given by $GITHUB_PATH. We need both Go 1.17 and GOPATH on env to run Complement.
       # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
@@ -211,13 +181,13 @@ jobs:
         with:
           name: Complement Logs - (Dendrite, ${{ join(matrix.*, ', ') }})
           path: |
-            /tmp/**/integrationcover.log
+            /tmp/Complement/**/integrationcover.log
 
   complement-coverage:
     timeout-minutes: 5
     name: "Complement Coverage"
     runs-on: ubuntu-latest
-    needs: complement # only run once Sytest is done
+    needs: complement # only run once Complement is done
     if: ${{ always() }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/schedules.yaml
+++ b/.github/workflows/schedules.yaml
@@ -207,7 +207,7 @@ jobs:
         name: Run Complement Tests
         env:
           COMPLEMENT_BASE_IMAGE: complement-dendrite:${{ matrix.postgres }}${{ matrix.api }}${{ matrix.cgo }}
-          API: ${{ matrix.api && 1 }}
+          COMPLEMENT_DENDRITE_API: ${{ matrix.api && 1 }}
           COMPLEMENT_SHARE_ENV_PREFIX: COMPLEMENT_DENDRITE_
           COMPLEMENT_DENDRITE_COVER: 1
           COMPLEMENT_POST_TEST_SCRIPT: /tmp/posttest.sh

--- a/.github/workflows/schedules.yaml
+++ b/.github/workflows/schedules.yaml
@@ -83,6 +83,7 @@ jobs:
     name: "Sytest Coverage"
     runs-on: ubuntu-latest
     needs: sytest # only run once Sytest is done
+    if: ${{ always() }}
     steps:
       - uses: actions/checkout@v3
       - name: Install Go

--- a/.github/workflows/schedules.yaml
+++ b/.github/workflows/schedules.yaml
@@ -22,7 +22,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: SQLite
+          - label: SQLite native
+
+          - label: SQLite Cgo
+            cgo: 1
+
+          - label: SQLite native, full HTTP APIs
+            api: full-http
+
+          - label: SQLite Cgo, full HTTP APIs
+            api: full-http
+            cgo: 1
+
+          - label: PostgreSQL
+            postgres: postgres
+
+          - label: PostgreSQL, full HTTP APIs
+            postgres: postgres
+            api: full-http
     container:
       image: matrixdotorg/sytest-dendrite:latest
       volumes:
@@ -87,7 +104,7 @@ jobs:
         run: go install github.com/wadey/gocovmerge@latest
       - name: Run gocovmerge
         run: |
-          find -name 'integrationcover.log' | xargs gocovmerge | grep -Ev 'relayapi|setup/mscs|api_trace' > sytest.cov
+          find -name 'integrationcover.log' -printf '"%p"\n' | xargs gocovmerge | grep -Ev 'relayapi|setup/mscs|api_trace' > sytest.cov
           go tool cover -func=sytest.cov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
@@ -106,6 +123,26 @@ jobs:
       matrix:
         include:
           - label: SQLite native
+            cgo: 0
+
+          - label: SQLite Cgo
+            cgo: 1
+
+          - label: SQLite native, full HTTP APIs
+            api: full-http
+            cgo: 0
+
+          - label: SQLite Cgo, full HTTP APIs
+            api: full-http
+            cgo: 1
+
+          - label: PostgreSQL
+            postgres: Postgres
+            cgo: 0
+
+          - label: PostgreSQL, full HTTP APIs
+            postgres: Postgres
+            api: full-http
             cgo: 0
     steps:
       # Env vars are set file a file given by $GITHUB_PATH. We need both Go 1.17 and GOPATH on env to run Complement.
@@ -203,13 +240,7 @@ jobs:
         run: go install github.com/wadey/gocovmerge@latest
       - name: Run gocovmerge
         run: |
-          echo "env:"
-          env
-          echo "ls:"
-          ls -la
-          echo "Find:"
-          find -name 'complementcover.log'
-          find -name 'complementcover.log' | xargs gocovmerge | grep -Ev 'relayapi|setup/mscs|api_trace' > complement.cov
+          find -name 'complementcover.log' -printf '"%p"\n' | xargs gocovmerge | grep -Ev 'relayapi|setup/mscs|api_trace' > complement.cov
           go tool cover -func=complement.cov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/schedules.yaml
+++ b/.github/workflows/schedules.yaml
@@ -77,6 +77,33 @@ jobs:
           path: |
             /logs/results.tap
             /logs/**/*.log*
+
+  sytest-coverage:
+    timeout-minutes: 5
+    name: "Sytest Coverage"
+    runs-on: ubuntu-latest
+    needs: sytest # only run once Sytest is done
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.20
+          cache: true
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+      - name: Install gocovmerge
+        run: go install github.com/wadey/gocovmerge@latest
+      - name: Run gocovmerge
+        run: |
+          find -name 'integrationcover.log' | xargs gocovmerge | grep -Ev 'relayapi|setup/mscs|api_trace' > sytest.cov
+          go tool cover -func=sytest.cov
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./sytest.cov
+          flags: sytest
+          fail_ci_if_error: true
           
   element_web:
     if: ${{ false }} # disable for now

--- a/.github/workflows/schedules.yaml
+++ b/.github/workflows/schedules.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: '>=1.19.0'
           cache: true
       - name: Download all artifacts
         uses: actions/download-artifact@v3
@@ -97,7 +97,7 @@ jobs:
         run: go install github.com/wadey/gocovmerge@latest
       - name: Run gocovmerge
         run: |
-          find -name 'integrationcover.log' | xargs gocovmerge | grep -Ev 'relayapi|setup/mscs|api_trace' > sytest.cov
+          find Sytest* -name 'integrationcover.log' | xargs gocovmerge | grep -Ev 'relayapi|setup/mscs|api_trace' > sytest.cov
           go tool cover -func=sytest.cov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
@@ -105,7 +105,142 @@ jobs:
           files: ./sytest.cov
           flags: sytest
           fail_ci_if_error: true
+
+  # run Complement
+  complement:
+    name: "Complement (${{ matrix.label }})"
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: SQLite native
+            cgo: 0
+
+          - label: SQLite Cgo
+            cgo: 1
+
+          - label: SQLite native, full HTTP APIs
+            api: full-http
+            cgo: 0
+
+          - label: SQLite Cgo, full HTTP APIs
+            api: full-http
+            cgo: 1
+
+          - label: PostgreSQL
+            postgres: Postgres
+            cgo: 0
+
+          - label: PostgreSQL, full HTTP APIs
+            postgres: Postgres
+            api: full-http
+            cgo: 0
+    steps:
+      # Env vars are set file a file given by $GITHUB_PATH. We need both Go 1.17 and GOPATH on env to run Complement.
+      # See https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-system-path
+      - name: "Set Go Version"
+        run: |
+          echo "$GOROOT_1_17_X64/bin" >> $GITHUB_PATH
+          echo "~/go/bin" >> $GITHUB_PATH
+      - name: "Install Complement Dependencies"
+        # We don't need to install Go because it is included on the Ubuntu 20.04 image:
+        # See https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md specifically GOROOT_1_17_X64
+        run: |
+          sudo apt-get update && sudo apt-get install -y libolm3 libolm-dev
+          go get -v github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+      - name: Run actions/checkout@v3 for dendrite
+        uses: actions/checkout@v3
+        with:
+          path: dendrite
+
+      # Attempt to check out the same branch of Complement as the PR. If it
+      # doesn't exist, fallback to main.
+      - name: Checkout complement
+        shell: bash
+        run: |
+          mkdir -p complement
+          # Attempt to use the version of complement which best matches the current
+          # build. Depending on whether this is a PR or release, etc. we need to
+          # use different fallbacks.
+          #
+          # 1. First check if there's a similarly named branch (GITHUB_HEAD_REF
+          #    for pull requests, otherwise GITHUB_REF).
+          # 2. Attempt to use the base branch, e.g. when merging into release-vX.Y
+          #    (GITHUB_BASE_REF for pull requests).
+          # 3. Use the default complement branch ("master").
+          for BRANCH_NAME in "$GITHUB_HEAD_REF" "$GITHUB_BASE_REF" "${GITHUB_REF#refs/heads/}" "master"; do
+            # Skip empty branch names and merge commits.
+            if [[ -z "$BRANCH_NAME" || $BRANCH_NAME =~ ^refs/pull/.* ]]; then
+              continue
+            fi
+            (wget -O - "https://github.com/matrix-org/complement/archive/$BRANCH_NAME.tar.gz" | tar -xz --strip-components=1 -C complement) && break
+          done
+      # Build initial Dendrite image
+      - run: docker build --build-arg=CGO=${{ matrix.cgo }} -t complement-dendrite:${{ matrix.postgres }}${{ matrix.api }}${{ matrix.cgo }} -f build/scripts/Complement${{ matrix.postgres }}.Dockerfile .
+        working-directory: dendrite
+        env:
+          DOCKER_BUILDKIT: 1
+
+      - name: Create post test script
+        run: |
+          cat <<EOF > /tmp/posttest.sh
+          mkdir -p /tmp/Complement/logs/\$2/\$1/
+          docker cp \$1:/dendrite/integrationcover.log /tmp/Complement/logs/\$2/\$1/
+          EOF
           
+          chmod +x /tmp/posttest.sh
+      # Run Complement
+      - run: |
+          set -o pipefail &&
+          go test -v -json -tags dendrite_blacklist ./tests/... 2>&1 | gotestfmt
+        shell: bash
+        name: Run Complement Tests
+        env:
+          COMPLEMENT_BASE_IMAGE: complement-dendrite:${{ matrix.postgres }}${{ matrix.api }}${{ matrix.cgo }}
+          API: ${{ matrix.api && 1 }}
+          COMPLEMENT_SHARE_ENV_PREFIX: COMPLEMENT_DENDRITE_
+          COMPLEMENT_DENDRITE_COVER: 1
+          COMPLEMENT_POST_TEST_SCRIPT: /tmp/posttest.sh
+        working-directory: complement
+
+      - name: Upload Complement logs
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: Complement Logs - (Dendrite, ${{ join(matrix.*, ', ') }})
+          path: |
+            /tmp/**/integrationcover.log
+
+  complement-coverage:
+    timeout-minutes: 5
+    name: "Complement Coverage"
+    runs-on: ubuntu-latest
+    needs: complement # only run once Sytest is done
+    if: ${{ always() }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.19.0'
+          cache: true
+      - name: Download all artifacts
+        uses: actions/download-artifact@v3
+      - name: Install gocovmerge
+        run: go install github.com/wadey/gocovmerge@latest
+      - name: Run gocovmerge
+        run: |
+          find Complement* -name 'integrationcover.log' | xargs gocovmerge | grep -Ev 'relayapi|setup/mscs|api_trace' > complement.cov
+          go tool cover -func=complement.cov
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./complement.cov
+          flags: complement
+          fail_ci_if_error: true
+
   element_web:
     if: ${{ false }} # disable for now
     timeout-minutes: 120

--- a/.github/workflows/schedules.yaml
+++ b/.github/workflows/schedules.yaml
@@ -247,7 +247,6 @@ jobs:
           fail_ci_if_error: true
 
   element_web:
-    if: ${{ false }} # disable for now
     timeout-minutes: 120
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/schedules.yaml
+++ b/.github/workflows/schedules.yaml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
   workflow_dispatch:
-  push:
-    branches:
-      - "s7evink/sytestcover"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/build/scripts/complement-cmd.sh
+++ b/build/scripts/complement-cmd.sh
@@ -10,7 +10,7 @@ if [[ "${COVER}" -eq 1 ]]; then
     --tls-key server.key \
     --config dendrite.yaml \
     -api=${API:-0} \
-    --test.coverprofile=integrationcover.log
+    --test.coverprofile=complementcover.log
 else
   echo "Not running with coverage"
   exec /dendrite/dendrite-monolith-server \

--- a/clientapi/routing/leaveroom.go
+++ b/clientapi/routing/leaveroom.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"github.com/matrix-org/dendrite/internal/httputil"
 	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/util"
@@ -42,6 +43,15 @@ func LeaveRoomByID(
 			return util.JSONResponse{
 				Code: leaveRes.Code,
 				JSON: jsonerror.LeaveServerNoticeError(),
+			}
+		}
+		switch e := err.(type) {
+		case httputil.InternalAPIError:
+			if e.Message == jsonerror.LeaveServerNoticeError().Error() {
+				return util.JSONResponse{
+					Code: http.StatusForbidden,
+					JSON: jsonerror.LeaveServerNoticeError(),
+				}
 			}
 		}
 		return util.JSONResponse{

--- a/roomserver/internal/perform/perform_leave.go
+++ b/roomserver/internal/perform/perform_leave.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/gomatrix"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
@@ -109,7 +110,7 @@ func (r *Leaver) performLeaveRoomByID(
 					// mimic the returned values from Synapse
 					res.Message = "You cannot reject this invite"
 					res.Code = 403
-					return nil, fmt.Errorf("You cannot reject this invite")
+					return nil, jsonerror.LeaveServerNoticeError()
 				}
 			}
 		}


### PR DESCRIPTION
This adds Sytest and Complement coverage reporting to the nightly scheduled CI runs.

Fixes a few API mode related issues as well, since we seemingly never really ran them with Complement.

Also fixes a bug related to device list changes: When we pass in an empty `newlyLeftRooms` slice, we got a list of all currently joined rooms with the corresponding members. When we then got the `newlyJoinedRooms`, we wouldn't update the `changed` slice, because we already got the user from the `newlyLeftRooms` query. This is fixed by simply ignoring empty `newlyLeftRooms`.