### PR TITLE
basic ldap authentication support

### DIFF
--- a/.github/workflows/dendrite.yml
+++ b/.github/workflows/dendrite.yml
@@ -91,6 +91,11 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      openldap:
+        image: bitnami/openldap:2.5.14
+        volumes:
+          - ${{ github.workspace }}/test/openldap:/ldifs
+
     steps:
       - uses: actions/checkout@v3
       - name: Setup go

--- a/.github/workflows/dendrite.yml
+++ b/.github/workflows/dendrite.yml
@@ -93,8 +93,10 @@ jobs:
           --health-retries 5
       openldap:
         image: bitnami/openldap:2.5.14
+        ports:
+          389:1389
         volumes:
-          - ${{ github.workspace }}/test/openldap:/ldifs
+          - ./test/openldap:/ldifs
 
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ complement/
 docs/_site
 
 media_store/
+build

--- a/clientapi/auth/ldap_authenticator.go
+++ b/clientapi/auth/ldap_authenticator.go
@@ -1,0 +1,112 @@
+package auth
+
+import (
+	"github.com/go-ldap/ldap/v3"
+	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"github.com/matrix-org/dendrite/setup/config"
+	"github.com/matrix-org/util"
+	"net/http"
+	"strings"
+)
+
+type LdapAuthenticator struct {
+	config config.Ldap
+}
+
+func NewLdapAuthenticator(config config.Ldap) *LdapAuthenticator {
+	return &LdapAuthenticator{
+		config: config,
+	}
+}
+
+func (l *LdapAuthenticator) Authenticate(username, password string) (bool, *util.JSONResponse) {
+	var conn *ldap.Conn
+	conn, err := ldap.DialURL(l.config.Uri)
+	if err != nil {
+		return false, &util.JSONResponse{
+			Code: http.StatusInternalServerError,
+			JSON: jsonerror.Unknown("unable to connect to ldap: " + err.Error()),
+		}
+	}
+	defer conn.Close()
+
+	if l.config.AdminBindEnabled {
+		err = conn.Bind(l.config.AdminBindDn, l.config.AdminBindPassword)
+		if err != nil {
+			return false, &util.JSONResponse{
+				Code: http.StatusInternalServerError,
+				JSON: jsonerror.Unknown("unable to bind to ldap: " + err.Error()),
+			}
+		}
+		filter := strings.ReplaceAll(l.config.SearchFilter, "{username}", username)
+		searchRequest := ldap.NewSearchRequest(
+			l.config.SearchBaseDn, ldap.ScopeWholeSubtree, ldap.NeverDerefAliases,
+			0, 0, false, filter, []string{l.config.SearchAttribute}, nil,
+		)
+		result, err := conn.Search(searchRequest)
+		if err != nil {
+			return false, &util.JSONResponse{
+				Code: http.StatusInternalServerError,
+				JSON: jsonerror.Unknown("unable to bind to search ldap: " + err.Error()),
+			}
+		}
+		if len(result.Entries) > 1 {
+			return false, &util.JSONResponse{
+				Code: http.StatusUnauthorized,
+				JSON: jsonerror.BadJSON("'user' must be duplicated."),
+			}
+		}
+		if len(result.Entries) < 1 {
+			return false, &util.JSONResponse{
+				Code: http.StatusUnauthorized,
+				JSON: jsonerror.BadJSON("'user' not found."),
+			}
+		}
+
+		userDN := result.Entries[0].DN
+		err = conn.Bind(userDN, password)
+		if err != nil {
+			return false, &util.JSONResponse{
+				Code: http.StatusUnauthorized,
+				JSON: jsonerror.InvalidUsername(err.Error()),
+			}
+		}
+	} else {
+		bindDn := strings.ReplaceAll(l.config.UserBindDn, "{username}", username)
+		err = conn.Bind(bindDn, password)
+		if err != nil {
+			return false, &util.JSONResponse{
+				Code: http.StatusUnauthorized,
+				JSON: jsonerror.InvalidUsername(err.Error()),
+			}
+		}
+	}
+
+	isAdmin, err := l.isLdapAdmin(conn, username)
+	if err != nil {
+		return false, &util.JSONResponse{
+			Code: http.StatusUnauthorized,
+			JSON: jsonerror.InvalidUsername(err.Error()),
+		}
+	}
+	return isAdmin, nil
+}
+
+func (l *LdapAuthenticator) isLdapAdmin(conn *ldap.Conn, username string) (bool, error) {
+	searchRequest := ldap.NewSearchRequest(
+		l.config.AdminGroupDn,
+		ldap.ScopeWholeSubtree, ldap.DerefAlways, 0, 0, false,
+		strings.ReplaceAll(l.config.AdminGroupFilter, "{username}", username),
+		[]string{l.config.AdminGroupAttribute},
+		nil)
+
+	sr, err := conn.Search(searchRequest)
+	if err != nil {
+		return false, err
+	}
+
+	if len(sr.Entries) < 1 {
+		return false, nil
+	}
+	return true, nil
+}

--- a/clientapi/auth/ldap_authenticator_test.go
+++ b/clientapi/auth/ldap_authenticator_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestLdapAuthenticator_Authenticate_DirectBind_AdminUser(t *testing.T) {
 	authenticator := NewLdapAuthenticator(config.Ldap{
-		Uri:                 "ldap://openldap:1389",
+		Uri:                 "ldap://openldap:389",
 		BaseDn:              "dc=example,dc=org",
 		AdminBindEnabled:    false,
 		UserBindDn:          "cn={username},ou=users,dc=example,dc=org",
@@ -25,7 +25,7 @@ func TestLdapAuthenticator_Authenticate_DirectBind_AdminUser(t *testing.T) {
 
 func TestLdapAuthenticator_Authenticate_DirectBind_RegularUser(t *testing.T) {
 	authenticator := NewLdapAuthenticator(config.Ldap{
-		Uri:                 "ldap://openldap:1389",
+		Uri:                 "ldap://openldap:389",
 		BaseDn:              "dc=example,dc=org",
 		AdminBindEnabled:    false,
 		UserBindDn:          "cn={username},ou=users,dc=example,dc=org",
@@ -42,7 +42,7 @@ func TestLdapAuthenticator_Authenticate_DirectBind_RegularUser(t *testing.T) {
 
 func TestLdapAuthenticator_Authenticate_AdminBind(t *testing.T) {
 	authenticator := NewLdapAuthenticator(config.Ldap{
-		Uri:                 "ldap://openldap:1389",
+		Uri:                 "ldap://openldap:389",
 		BaseDn:              "dc=example,dc=org",
 		AdminBindEnabled:    true,
 		AdminBindDn:         "cn=admin,dc=example,dc=org",
@@ -63,7 +63,7 @@ func TestLdapAuthenticator_Authenticate_AdminBind(t *testing.T) {
 
 func TestLdapAuthenticator_Authenticate_AdminBind_UserNotFound(t *testing.T) {
 	authenticator := NewLdapAuthenticator(config.Ldap{
-		Uri:                 "ldap://openldap:1389",
+		Uri:                 "ldap://openldap:389",
 		BaseDn:              "dc=example,dc=org",
 		AdminBindEnabled:    true,
 		AdminBindDn:         "cn=admin,dc=example,dc=org",

--- a/clientapi/auth/ldap_authenticator_test.go
+++ b/clientapi/auth/ldap_authenticator_test.go
@@ -1,0 +1,95 @@
+package auth
+
+import (
+	"github.com/matrix-org/dendrite/setup/config"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestLdapAuthenticator_Authenticate_DirectBind_AdminUser(t *testing.T) {
+	authenticator := NewLdapAuthenticator(config.Ldap{
+		Uri:                 "ldap://openldap:1389",
+		BaseDn:              "dc=example,dc=org",
+		AdminBindEnabled:    false,
+		UserBindDn:          "cn={username},ou=users,dc=example,dc=org",
+		AdminGroupDn:        "cn=admin,ou=groups,dc=example,dc=org",
+		AdminGroupFilter:    "(memberUid={username})",
+		AdminGroupAttribute: "memberUid",
+	})
+
+	isAdmin, err := authenticator.Authenticate("user1", "password")
+
+	assert.Nil(t, err)
+	assert.True(t, isAdmin)
+}
+
+func TestLdapAuthenticator_Authenticate_DirectBind_RegularUser(t *testing.T) {
+	authenticator := NewLdapAuthenticator(config.Ldap{
+		Uri:                 "ldap://openldap:1389",
+		BaseDn:              "dc=example,dc=org",
+		AdminBindEnabled:    false,
+		UserBindDn:          "cn={username},ou=users,dc=example,dc=org",
+		AdminGroupDn:        "cn=admin,ou=groups,dc=example,dc=org",
+		AdminGroupFilter:    "(memberUid={username})",
+		AdminGroupAttribute: "memberUid",
+	})
+
+	isAdmin, err := authenticator.Authenticate("user2", "password")
+
+	assert.Nil(t, err)
+	assert.False(t, isAdmin)
+}
+
+func TestLdapAuthenticator_Authenticate_AdminBind(t *testing.T) {
+	authenticator := NewLdapAuthenticator(config.Ldap{
+		Uri:                 "ldap://openldap:1389",
+		BaseDn:              "dc=example,dc=org",
+		AdminBindEnabled:    true,
+		AdminBindDn:         "cn=admin,dc=example,dc=org",
+		AdminBindPassword:   "password",
+		AdminGroupDn:        "cn=admin,ou=groups,dc=example,dc=org",
+		AdminGroupFilter:    "(memberUid={username})",
+		AdminGroupAttribute: "memberUid",
+		SearchBaseDn:        "ou=users,dc=example,dc=org",
+		SearchFilter:        "(&(objectclass=inetOrgPerson)(cn={username}))",
+		SearchAttribute:     "cn",
+	})
+
+	isAdmin, err := authenticator.Authenticate("user1", "password")
+
+	assert.Nil(t, err)
+	assert.True(t, isAdmin)
+}
+
+func TestLdapAuthenticator_Authenticate_AdminBind_UserNotFound(t *testing.T) {
+	authenticator := NewLdapAuthenticator(config.Ldap{
+		Uri:                 "ldap://openldap:1389",
+		BaseDn:              "dc=example,dc=org",
+		AdminBindEnabled:    true,
+		AdminBindDn:         "cn=admin,dc=example,dc=org",
+		AdminBindPassword:   "password",
+		AdminGroupDn:        "cn=admin,ou=groups,dc=example,dc=org",
+		AdminGroupFilter:    "(memberUid={username})",
+		AdminGroupAttribute: "memberUid",
+		SearchBaseDn:        "ou=users,dc=example,dc=org",
+		SearchFilter:        "(&(objectclass=inetOrgPerson)(cn={username}))",
+		SearchAttribute:     "cn",
+	})
+
+	_, err := authenticator.Authenticate("user_not_found", "")
+
+	assert.NotNil(t, err)
+}
+
+func TestLdapAuthenticator_Authenticate_DirectBind_WrongPassword(t *testing.T) {
+	authenticator := NewLdapAuthenticator(config.Ldap{
+		Uri:              "ldap://openldap:1389",
+		BaseDn:           "dc=example,dc=org",
+		UserBindDn:       "cn={username},ou=users,dc=example,dc=org",
+		AdminBindEnabled: false,
+	})
+
+	_, err := authenticator.Authenticate("user2", "password_wrong")
+
+	assert.NotNil(t, err)
+}

--- a/clientapi/auth/login.go
+++ b/clientapi/auth/login.go
@@ -57,8 +57,8 @@ func LoginFromJSONReader(ctx context.Context, r io.Reader, useraccountAPI uapi.U
 	switch header.Type {
 	case authtypes.LoginTypePassword:
 		typ = &LoginTypePassword{
-			GetAccountByPassword: useraccountAPI.QueryAccountByPassword,
-			Config:               cfg,
+			UserAPI: useraccountAPI,
+			Config:  cfg,
 		}
 	case authtypes.LoginTypeToken:
 		typ = &LoginTypeToken{

--- a/clientapi/auth/login.go
+++ b/clientapi/auth/login.go
@@ -32,7 +32,7 @@ import (
 // called after authorization has completed, with the result of the authorization.
 // If the final return value is non-nil, an error occurred and the cleanup function
 // is nil.
-func LoginFromJSONReader(ctx context.Context, r io.Reader, useraccountAPI uapi.UserLoginAPI, userAPI UserInternalAPIForLogin, cfg *config.ClientAPI) (*Login, LoginCleanupFunc, *util.JSONResponse) {
+func LoginFromJSONReader(ctx context.Context, r io.Reader, userAPI UserInternalAPIForLogin, cfg *config.ClientAPI) (*Login, LoginCleanupFunc, *util.JSONResponse) {
 	reqBytes, err := io.ReadAll(r)
 	if err != nil {
 		err := &util.JSONResponse{
@@ -57,7 +57,7 @@ func LoginFromJSONReader(ctx context.Context, r io.Reader, useraccountAPI uapi.U
 	switch header.Type {
 	case authtypes.LoginTypePassword:
 		typ = &LoginTypePassword{
-			UserAPI: useraccountAPI,
+			UserAPI: userAPI,
 			Config:  cfg,
 		}
 	case authtypes.LoginTypeToken:
@@ -79,4 +79,5 @@ func LoginFromJSONReader(ctx context.Context, r io.Reader, useraccountAPI uapi.U
 // UserInternalAPIForLogin contains the aspects of UserAPI required for logging in.
 type UserInternalAPIForLogin interface {
 	uapi.LoginTokenInternalAPI
+	uapi.UserLoginAPI
 }

--- a/clientapi/auth/login_test.go
+++ b/clientapi/auth/login_test.go
@@ -73,7 +73,7 @@ func TestLoginFromJSONReader(t *testing.T) {
 					},
 				},
 			}
-			login, cleanup, err := LoginFromJSONReader(ctx, strings.NewReader(tst.Body), &userAPI, &userAPI, cfg)
+			login, cleanup, err := LoginFromJSONReader(ctx, strings.NewReader(tst.Body), &userAPI, cfg)
 			if err != nil {
 				t.Fatalf("LoginFromJSONReader failed: %+v", err)
 			}
@@ -153,7 +153,7 @@ func TestBadLoginFromJSONReader(t *testing.T) {
 					},
 				},
 			}
-			_, cleanup, errRes := LoginFromJSONReader(ctx, strings.NewReader(tst.Body), &userAPI, &userAPI, cfg)
+			_, cleanup, errRes := LoginFromJSONReader(ctx, strings.NewReader(tst.Body), &userAPI, cfg)
 			if errRes == nil {
 				cleanup(ctx, nil)
 				t.Fatalf("LoginFromJSONReader err: got %+v, want code %q", errRes, tst.WantErrCode)

--- a/clientapi/auth/user_interactive.go
+++ b/clientapi/auth/user_interactive.go
@@ -113,8 +113,8 @@ type UserInteractive struct {
 
 func NewUserInteractive(userAccountAPI api.UserLoginAPI, cfg *config.ClientAPI) *UserInteractive {
 	typePassword := &LoginTypePassword{
-		GetAccountByPassword: userAccountAPI.QueryAccountByPassword,
-		Config:               cfg,
+		UserAPI: userAccountAPI,
+		Config:  cfg,
 	}
 	return &UserInteractive{
 		Flows: []userInteractiveFlow{
@@ -140,7 +140,7 @@ func (u *UserInteractive) IsSingleStageFlow(authType string) bool {
 	return false
 }
 
-func (u *UserInteractive) AddCompletedStage(sessionID, authType string) {
+func (u *UserInteractive) AddCompletedStage(sessionID, _ string) {
 	u.Lock()
 	// TODO: Handle multi-stage flows
 	delete(u.Sessions, sessionID)
@@ -214,7 +214,7 @@ func (u *UserInteractive) ResponseWithChallenge(sessionID string, response inter
 // Verify returns an error/challenge response to send to the client, or nil if the user is authenticated.
 // `bodyBytes` is the HTTP request body which must contain an `auth` key.
 // Returns the login that was verified for additional checks if required.
-func (u *UserInteractive) Verify(ctx context.Context, bodyBytes []byte, device *api.Device) (*Login, *util.JSONResponse) {
+func (u *UserInteractive) Verify(ctx context.Context, bodyBytes []byte, _ *api.Device) (*Login, *util.JSONResponse) {
 	// TODO: rate limit
 
 	// "A client should first make a request with no auth parameter. The homeserver returns an HTTP 401 response, with a JSON body"

--- a/clientapi/routing/key_crosssigning.go
+++ b/clientapi/routing/key_crosssigning.go
@@ -32,7 +32,7 @@ type crossSigningRequest struct {
 }
 
 func UploadCrossSigningDeviceKeys(
-	req *http.Request, userInteractiveAuth *auth.UserInteractive,
+	req *http.Request,
 	keyserverAPI api.ClientKeyAPI, device *api.Device,
 	accountAPI api.ClientUserAPI, cfg *config.ClientAPI,
 ) util.JSONResponse {
@@ -62,8 +62,8 @@ func UploadCrossSigningDeviceKeys(
 		}
 	}
 	typePassword := auth.LoginTypePassword{
-		GetAccountByPassword: accountAPI.QueryAccountByPassword,
-		Config:               cfg,
+		UserAPI: accountAPI,
+		Config:  cfg,
 	}
 	if _, authErr := typePassword.Login(req.Context(), &uploadReq.Auth.PasswordRequest); authErr != nil {
 		return *authErr

--- a/clientapi/routing/password.go
+++ b/clientapi/routing/password.go
@@ -73,8 +73,8 @@ func Password(
 
 	// Check if the existing password is correct.
 	typePassword := auth.LoginTypePassword{
-		GetAccountByPassword: userAPI.QueryAccountByPassword,
-		Config:               cfg,
+		UserAPI: userAPI,
+		Config:  cfg,
 	}
 	if _, authErr := typePassword.Login(req.Context(), &r.Auth.PasswordRequest); authErr != nil {
 		return *authErr

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -1370,7 +1370,7 @@ func Setup(
 	// Cross-signing device keys
 
 	postDeviceSigningKeys := httputil.MakeAuthAPI("post_device_signing_keys", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {
-		return UploadCrossSigningDeviceKeys(req, userInteractiveAuth, userAPI, device, userAPI, cfg)
+		return UploadCrossSigningDeviceKeys(req, userAPI, device, userAPI, cfg)
 	})
 
 	postDeviceSigningSignatures := httputil.MakeAuthAPI("post_device_signing_signatures", userAPI, func(req *http.Request, device *userapi.Device) util.JSONResponse {

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/docker/docker v20.10.19+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/getsentry/sentry-go v0.14.0
+	github.com/go-ldap/ldap/v3 v3.4.4
 	github.com/gologme/log v1.3.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
@@ -55,6 +56,7 @@ require (
 )
 
 require (
+	github.com/Azure/go-ntlmssp v0.0.0-20220621081337-cb9428e4ac1e // indirect
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/RoaringBitmap/roaring v1.2.3 // indirect
@@ -80,6 +82,7 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/go-asn1-ber/asn1-ber v1.5.4 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/geo v0.0.0-20210211234256-740aa86cb551 // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/Arceliar/phony v0.0.0-20210209235338-dde1a8dca979 h1:WndgpSW13S32VLQ3
 github.com/Arceliar/phony v0.0.0-20210209235338-dde1a8dca979/go.mod h1:6Lkn+/zJilRMsKmbmG1RPoamiArC6HS73xbwRyp3UyI=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/Azure/go-ntlmssp v0.0.0-20220621081337-cb9428e4ac1e h1:NeAW1fUYUEWhft7pkxDf6WoUvEZJ/uOKsvtpjLnn8MU=
+github.com/Azure/go-ntlmssp v0.0.0-20220621081337-cb9428e4ac1e/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
@@ -159,6 +161,8 @@ github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwv
 github.com/gin-gonic/gin v1.8.1 h1:4+fr/el88TOO3ewCmQr8cx/CtZ/umlIRIs5M4NTNjf8=
 github.com/glycerine/go-unsnap-stream v0.0.0-20180323001048-9f0cb55181dd/go.mod h1:/20jfyN9Y5QPEAprSgKAUr+glWDY39ZiUEAYOEv5dsE=
 github.com/glycerine/goconvey v0.0.0-20180728074245-46e3a41ad493/go.mod h1:Ogl1Tioa0aV7gstGFO7KhffUsb9M4ydbEbbxpcEDc24=
+github.com/go-asn1-ber/asn1-ber v1.5.4 h1:vXT6d/FNDiELJnLb6hGNa309LMsrCoYFvpwHDF0+Y1A=
+github.com/go-asn1-ber/asn1-ber v1.5.4/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -167,6 +171,8 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-kit/log v0.2.0/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
+github.com/go-ldap/ldap/v3 v3.4.4 h1:qPjipEpt+qDa6SI/h1fzuGWoRUY+qqQ9sOZq67/PYUs=
+github.com/go-ldap/ldap/v3 v3.4.4/go.mod h1:fe1MsuN5eJJ1FeLT/LEBVdWfNWKh459R7aXgXtJC+aI=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
@@ -454,6 +460,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
@@ -504,6 +511,7 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20210314154223-e6e6c4f2bb5b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.5.0 h1:U/0M97KRkSFvyD/3FSmdP5W5swImpNgle/EHFhOsQPE=
 golang.org/x/crypto v0.5.0/go.mod h1:NK/OQwhpMQP3MwtdjgLlYHnH9ebylxKWv3e0fK+mkQU=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -582,6 +590,7 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=

--- a/setup/config/config_clientapi.go
+++ b/setup/config/config_clientapi.go
@@ -60,11 +60,12 @@ type Ldap struct {
 	Enabled             bool   `yaml:"enabled"`
 	Uri                 string `yaml:"uri"`
 	BaseDn              string `yaml:"base_dn"`
-	SearchFilter        string `yaml:"search_filter"`
-	SearchAttribute     string `yaml:"search_attribute"`
 	AdminBindEnabled    bool   `yaml:"admin_bind_enabled"`
 	AdminBindDn         string `yaml:"admin_bind_dn"`
 	AdminBindPassword   string `yaml:"admin_bind_password"`
+	SearchBaseDn        string `yaml:"search_base_dn"`
+	SearchFilter        string `yaml:"search_filter"`
+	SearchAttribute     string `yaml:"search_attribute"`
 	UserBindDn          string `yaml:"user_bind_dn"`
 	AdminGroupDn        string `yaml:"admin_group_dn"`
 	AdminGroupFilter    string `yaml:"admin_group_filter"`

--- a/setup/config/config_clientapi.go
+++ b/setup/config/config_clientapi.go
@@ -52,9 +52,26 @@ type ClientAPI struct {
 	RateLimiting RateLimiting `yaml:"rate_limiting"`
 
 	MSCs *MSCs `yaml:"-"`
+
+	Ldap Ldap `yaml:"ldap"`
 }
 
-func (c *ClientAPI) Defaults(opts DefaultOpts) {
+type Ldap struct {
+	Enabled             bool   `yaml:"enabled"`
+	Uri                 string `yaml:"uri"`
+	BaseDn              string `yaml:"base_dn"`
+	SearchFilter        string `yaml:"search_filter"`
+	SearchAttribute     string `yaml:"search_attribute"`
+	AdminBindEnabled    bool   `yaml:"admin_bind_enabled"`
+	AdminBindDn         string `yaml:"admin_bind_dn"`
+	AdminBindPassword   string `yaml:"admin_bind_password"`
+	UserBindDn          string `yaml:"user_bind_dn"`
+	AdminGroupDn        string `yaml:"admin_group_dn"`
+	AdminGroupFilter    string `yaml:"admin_group_filter"`
+	AdminGroupAttribute string `yaml:"admin_group_attribute"`
+}
+
+func (c *ClientAPI) Defaults(_ DefaultOpts) {
 	c.RegistrationSharedSecret = ""
 	c.RecaptchaPublicKey = ""
 	c.RecaptchaPrivateKey = ""

--- a/test/openldap/bootstrap.ldif
+++ b/test/openldap/bootstrap.ldif
@@ -1,6 +1,7 @@
 dn: dc=example,dc=org
 objectClass: dcObject
-objectClass: organizationalUnit
+objectClass: organization
+o: Example, Inc
 
 # administrator
 dn:                    cn=admin,dc=example,dc=org
@@ -31,7 +32,7 @@ cn:                    user1
 sn:                    10
 displayName:           user1
 description:           user1
-userPassword:          user1
+userPassword:          password
 mail:                  user1@example.com
 
 # regular user
@@ -48,7 +49,7 @@ cn:                    user2
 sn:                    11
 displayName:           user2
 description:           user2
-userPassword:          user2
+userPassword:          password
 mail:                  user2@example.com
 
 # Subtree for Groups

--- a/test/openldap/bootstrap.ldif
+++ b/test/openldap/bootstrap.ldif
@@ -1,0 +1,68 @@
+dn: dc=example,dc=org
+objectClass: dcObject
+objectClass: organizationalUnit
+
+# administrator
+dn:                    cn=admin,dc=example,dc=org
+objectClass:           simpleSecurityObject
+objectClass:           organizationalRole
+cn:                    admin
+description:           Administrator
+userPassword:          password
+
+# Subtree for Users
+dn:                    ou=users,dc=example,dc=org
+ou:                    Users
+description:           Users
+objectClass:           organizationalUnit
+objectClass:           top
+
+# admin user
+dn:                    cn=user1,ou=users,dc=example,dc=org
+objectClass:           simpleSecurityObject
+objectClass:           Person
+objectClass:           inetOrgPerson
+objectClass:           posixAccount
+uidNumber:             10
+gidNumber:             10
+homeDirectory:         /home/user1
+uid:                   user1
+cn:                    user1
+sn:                    10
+displayName:           user1
+description:           user1
+userPassword:          user1
+mail:                  user1@example.com
+
+# regular user
+dn:                    cn=user2,ou=users,dc=example,dc=org
+objectClass:           simpleSecurityObject
+objectClass:           Person
+objectClass:           inetOrgPerson
+objectClass:           posixAccount
+uidNumber:             11
+gidNumber:             11
+homeDirectory:         /home/user2
+uid:                   user2
+cn:                    user2
+sn:                    11
+displayName:           user2
+description:           user2
+userPassword:          user2
+mail:                  user2@example.com
+
+# Subtree for Groups
+dn:                    ou=groups,dc=example,dc=org
+ou:                    Groups
+description:           Groups
+objectClass:           organizationalUnit
+objectClass:           top
+
+# Admin group
+dn:                    cn=admin,ou=groups,dc=example,dc=org
+objectClass:           posixGroup
+objectClass:           top
+gidNumber:             1
+cn:                    admin
+description:           admin
+memberUid:             user1

--- a/userapi/api/api.go
+++ b/userapi/api/api.go
@@ -125,6 +125,8 @@ type QueryAcccessTokenAPI interface {
 
 type UserLoginAPI interface {
 	QueryAccountByPassword(ctx context.Context, req *QueryAccountByPasswordRequest, res *QueryAccountByPasswordResponse) error
+	QueryAccountByLocalpart(ctx context.Context, req *QueryAccountByLocalpartRequest, res *QueryAccountByLocalpartResponse) error
+	PerformAccountCreation(ctx context.Context, req *PerformAccountCreationRequest, res *PerformAccountCreationResponse) error
 }
 
 type PerformKeyBackupRequest struct {


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [x] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

Signed-off-by: `Boris Rybalkin <ribalkin@gmail.com>`

```
  ldap:
    enabled: true
    uri: "ldap://localhost:389"
    base_dn: "dc=syncloud,dc=org"

    # admin bind modes uses a separate admin ldap account to perform user search
    admin_bind_enabled: true
    admin_bind_dn: "cn=admin,dc=syncloud,dc=org"
    admin_bind_password: "syncloud"
    search_base_dn: "ou=users,dc=syncloud,dc=org"
    search_filter: "(&(objectclass=inetOrgPerson)(cn={username}))"
    search_attribute: "cn"

    # direct user bind if admin bind is disabled
    user_bind_dn: "cn={username},ou=users,dc=syncloud,dc=org"

    # is user an admin or not
    admin_group_dn: "cn=syncloud,ou=groups,dc=syncloud,dc=org"
    admin_group_filter: "(memberUid={username})"
    admin_group_attribute: "memberUid"
```

In my case `user_bind_dn` was enough but as the original ldap pr had an `admin bind first -> user dn search -> user dn bind` logic I left it as an option `admin_bind_enabled`

Also added admin group check to make user an admin.
