### PR TITLE
Updated instructions and references to monolith to their new names

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ $ ./bin/generate-keys --tls-cert server.crt --tls-key server.key
 
 # Copy and modify the config file - you'll need to set a server name and paths to the keys
 # at the very least, along with setting up the database connection strings.
-$ cp dendrite-sample.monolith.yaml dendrite.yaml
+$ cp dendrite-sample.yaml dendrite.yaml
 
 # Build and run the server:
-$ ./bin/dendrite-monolith-server --tls-cert server.crt --tls-key server.key --config dendrite.yaml
+$ ./bin/dendrite --tls-cert server.crt --tls-key server.key --config dendrite.yaml
 
 # Create an user account (add -admin for an admin user).
 # Specify the localpart only, e.g. 'alice' for '@alice:domain.com'

--- a/cmd/dendrite/main_test.go
+++ b/cmd/dendrite/main_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // This is an instrumented main, used when running integration tests (sytest) with code coverage.
-// Compile: go test -c -race -cover -covermode=atomic -o monolith.debug -coverpkg "github.com/matrix-org/..." ./cmd/dendrite-monolith-server
+// Compile: go test -c -race -cover -covermode=atomic -o monolith.debug -coverpkg "github.com/matrix-org/..." ./cmd/dendrite
 // Run the monolith: ./monolith.debug -test.coverprofile=/somewhere/to/dump/integrationcover.out DEVEL --config dendrite.yaml
 // Generate HTML with coverage: go tool cover -html=/somewhere/where/there/is/integrationcover.out -o cover.html
 // Source: https://dzone.com/articles/measuring-integration-test-coverage-rate-in-pouchc

--- a/docs/development/PROFILING.md
+++ b/docs/development/PROFILING.md
@@ -15,7 +15,7 @@ Dendrite contains an embedded profiler called `pprof`, which is a part of the st
 To enable the profiler, start Dendrite with the `PPROFLISTEN` environment variable. This variable specifies which address and port to listen on, e.g.
 
 ```
-PPROFLISTEN=localhost:65432 ./bin/dendrite-monolith-server ...
+PPROFLISTEN=localhost:65432 ./bin/dendrite ...
 ```
 
 If pprof has been enabled successfully, a log line at startup will show that pprof is listening:

--- a/docs/development/coverage.md
+++ b/docs/development/coverage.md
@@ -14,8 +14,8 @@ index 8f0e209c..ad057e52 100644
  
     $output->diag( "Starting monolith server" );
     my @command = (
--      $self->{bindir} . '/dendrite-monolith-server',
-+      $self->{bindir} . '/dendrite-monolith-server', '--test.coverprofile=' . $self->{hs_dir} . '/integrationcover.log', "DEVEL",
+-      $self->{bindir} . '/dendrite',
++      $self->{bindir} . '/dendrite', '--test.coverprofile=' . $self->{hs_dir} . '/integrationcover.log', "DEVEL",
        '--config', $self->{paths}{config},
        '--http-bind-address', $self->{bind_host} . ':' . $self->unsecure_port,
        '--https-bind-address', $self->{bind_host} . ':' . $self->secure_port,
@@ -27,9 +27,9 @@ index f009332b..7ea79869 100755
  echo >&2 "--- Building dendrite from source"
  cd /src
  mkdir -p $GOBIN
--go install -v ./cmd/dendrite-monolith-server
-+# go install -v ./cmd/dendrite-monolith-server
-+go test -c -cover -covermode=atomic -o $GOBIN/dendrite-monolith-server -coverpkg "github.com/matrix-org/..." ./cmd/dendrite-monolith-server
+-go install -v ./cmd/dendrite
++# go install -v ./cmd/dendrite
++go test -c -cover -covermode=atomic -o $GOBIN/dendrite -coverpkg "github.com/matrix-org/..." ./cmd/dendrite
  go install -v ./cmd/generate-keys
  cd -
  ```

--- a/docs/development/tracing/setup.md
+++ b/docs/development/tracing/setup.md
@@ -49,7 +49,7 @@ tracing:
 then run the monolith server:
 
 ```
-./dendrite-monolith-server --tls-cert server.crt --tls-key server.key --config dendrite.yaml
+./dendrite --tls-cert server.crt --tls-key server.key --config dendrite.yaml
 ```
 
 ## Checking traces

--- a/docs/installation/3_build.md
+++ b/docs/installation/3_build.md
@@ -28,11 +28,11 @@ The resulting binaries will be placed in the `bin` subfolder.
 You can install the Dendrite monolith binary into `$GOPATH/bin` by using `go install`:
 
 ```sh
-go install ./cmd/dendrite-monolith-server
+go install ./cmd/dendrite
 ```
 
 Alternatively, you can specify a custom path for the binary to be written to using `go build`:
 
 ```sh
-go build -o /usr/local/bin/ ./cmd/dendrite-monolith-server
+go build -o /usr/local/bin/ ./cmd/dendrite
 ```

--- a/docs/installation/5_install_monolith.md
+++ b/docs/installation/5_install_monolith.md
@@ -11,11 +11,11 @@ permalink: /installation/install/monolith
 You can install the Dendrite monolith binary into `$GOPATH/bin` by using `go install`:
 
 ```sh
-go install ./cmd/dendrite-monolith-server
+go install ./cmd/dendrite
 ```
 
 Alternatively, you can specify a custom path for the binary to be written to using `go build`:
 
 ```sh
-go build -o /usr/local/bin/ ./cmd/dendrite-monolith-server
+go build -o /usr/local/bin/ ./cmd/dendrite
 ```

--- a/docs/installation/9_starting_monolith.md
+++ b/docs/installation/9_starting_monolith.md
@@ -9,10 +9,10 @@ permalink: /installation/start/monolith
 # Starting the monolith
 
 Once you have completed all of the preparation and installation steps,
-you can start your Dendrite monolith deployment by starting the `dendrite-monolith-server`:
+you can start your Dendrite monolith deployment by starting `dendrite`:
 
 ```bash
-./dendrite-monolith-server -config /path/to/dendrite.yaml
+./dendrite -config /path/to/dendrite.yaml
 ```
 
 By default, Dendrite will listen HTTP on port 8008. If you want to change the addresses
@@ -20,7 +20,7 @@ or ports that Dendrite listens on, you can use the `-http-bind-address` and
 `-https-bind-address` command line arguments:
 
 ```bash
-./dendrite-monolith-server -config /path/to/dendrite.yaml \
+./dendrite -config /path/to/dendrite.yaml \
     -http-bind-address 1.2.3.4:12345 \
     -https-bind-address 1.2.3.4:54321
 ```

--- a/docs/systemd/monolith-example.service
+++ b/docs/systemd/monolith-example.service
@@ -11,7 +11,7 @@ Type=simple
 User=dendrite
 Group=dendrite
 WorkingDirectory=/opt/dendrite/
-ExecStart=/opt/dendrite/bin/dendrite-monolith-server
+ExecStart=/opt/dendrite/bin/dendrite
 Restart=always
 LimitNOFILE=65535
 


### PR DESCRIPTION
Currently, the documentation makes use of the old names for the binary and configuration files. This updates the documentation so that users can follow the guide without issues again.
These changes don't require any go unit tests because it does not modify any golang code.

Signed-off-by: `Robin Westerik <gh@westerik.me>`
