### PR TITLE
Make redaction check easier to read

### DIFF
--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -283,6 +283,17 @@ func (r *Inputer) processRoomEvent(
 		logger.WithError(rejectionErr).Warnf("Event %s not allowed by auth events", event.EventID())
 	}
 
+	if event.Type() == gomatrixserverlib.MRoomRedaction {
+		ap, _ := authEvents.PowerLevels()
+		if ap != nil {
+			var powerLevels *gomatrixserverlib.PowerLevelContent
+			powerLevels, _ = ap.PowerLevels()
+			if powerLevels != nil {
+				redactAllowed = powerLevels.UserLevel(event.Sender()) >= powerLevels.Redact
+			}
+		}
+	}
+
 	// Accumulate the auth event NIDs.
 	authEventIDs := event.AuthEventIDs()
 	authEventNIDs := make([]types.EventNID, 0, len(authEventIDs))

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -966,11 +966,14 @@ func (d *EventDatabase) MaybeRedactEvent(
 			return nil
 		}
 
-		// 1. The power level of the redaction event’s sender is greater than or equal to the redact level. (redactAllowed)
-		// 2. The domain of the redaction event’s sender matches that of the original event’s sender.
 		_, sender1, _ := gomatrixserverlib.SplitID('@', redactedEvent.Sender())
 		_, sender2, _ := gomatrixserverlib.SplitID('@', redactionEvent.Sender())
-		if !redactAllowed || sender1 != sender2 {
+		switch {
+		case redactAllowed:
+			// 1. The power level of the redaction event’s sender is greater than or equal to the redact level.
+		case sender1 == sender2:
+			// 2. The domain of the redaction event’s sender matches that of the original event’s sender.
+		default:
 			ignoreRedaction = true
 			return nil
 		}


### PR DESCRIPTION
We need to check the redaction PL in Dendrite, if we do it in GMSL, we end up not sending the event to the output stream because it will be rejected.