### PR TITLE
Update admin-promotion instructions; clarify ID for evacuation

### DIFF
--- a/docs/administration/4_adminapi.md
+++ b/docs/administration/4_adminapi.md
@@ -22,12 +22,12 @@ curl --header "Authorization: Bearer <access_token>" -X <POST|GET|PUT> <Endpoint
 An `access_token` can be obtained through most Element-based matrix clients by going to `Settings` -> `Help & About` -> `Advanced` -> `Access Token`.
 Be aware that an `access_token` allows a client to perform actions as an user and should be kept **secret**.
 
-The user must be an administrator in the `account_accounts` table in order to use these endpoints.
+The user must be an administrator in the `userapi_accounts` table in order to use these endpoints.
 
-Existing user accounts can be set to administrative accounts by changing `account_type` to `3` in `account_accounts`
+Existing user accounts can be set to administrative accounts by changing `account_type` to `3` in `userapi_accounts`
 
 ```
-UPDATE account_accounts SET account_type = 3 WHERE localpart = '$localpart';
+UPDATE userapi_accounts SET account_type = 3 WHERE localpart = '$localpart';
 ```
 
 Where `$localpart` is the username only (e.g. `alice`).
@@ -37,6 +37,10 @@ Where `$localpart` is the username only (e.g. `alice`).
 This endpoint will instruct Dendrite to part all local users from the given `roomID`
 in the URL. It may take some time to complete. A JSON body will be returned containing
 the user IDs of all affected users.
+
+If the room has a published address set, the room's ID will not be in the URL, but may
+be found as the room's "internal ID" (e.g. under Advanced within the room settings in
+Element.)
 
 ## GET `/_dendrite/admin/evacuateUser/{userID}`
 

--- a/docs/administration/4_adminapi.md
+++ b/docs/administration/4_adminapi.md
@@ -38,9 +38,8 @@ This endpoint will instruct Dendrite to part all local users from the given `roo
 in the URL. It may take some time to complete. A JSON body will be returned containing
 the user IDs of all affected users.
 
-If the room has a published address set, the room's ID will not be in the URL, but may
-be found as the room's "internal ID" (e.g. under Advanced within the room settings in
-Element.)
+If the room has an alias set (e.g. is published), the room's ID will not be visible in the URL, but it can
+be found as the room's "internal ID" in Element Web (Settings -> Advanced)
 
 ## GET `/_dendrite/admin/evacuateUser/{userID}`
 


### PR DESCRIPTION
Table name has changed since instructions were written.

There's probably a better way to describe how to get the internal room ID than I've attempted here, so feel free to adjust as needed. (It may even be good to show an example of what an internal room ID looks like, e.g. `!nc93825:example.com`)

### Pull Request Checklist

* [x] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
  * Doc-only change
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off)

Signed-off-by: `Tim McCormack <cortex@brainonfire.net>`
