### PR TITLE
Unset `RoomServerEvent`, since we can't be sure that `Set` actually updates the cached entry

### DIFF
--- a/internal/caching/cache_roomevents.go
+++ b/internal/caching/cache_roomevents.go
@@ -10,6 +10,7 @@ import (
 type RoomServerEventsCache interface {
 	GetRoomServerEvent(eventNID types.EventNID) (*gomatrixserverlib.Event, bool)
 	StoreRoomServerEvent(eventNID types.EventNID, event *gomatrixserverlib.Event)
+	InvalidateRoomServerEvent(eventNID types.EventNID)
 }
 
 func (c Caches) GetRoomServerEvent(eventNID types.EventNID) (*gomatrixserverlib.Event, bool) {
@@ -18,4 +19,8 @@ func (c Caches) GetRoomServerEvent(eventNID types.EventNID) (*gomatrixserverlib.
 
 func (c Caches) StoreRoomServerEvent(eventNID types.EventNID, event *gomatrixserverlib.Event) {
 	c.RoomServerEvents.Set(int64(eventNID), event)
+}
+
+func (c Caches) InvalidateRoomServerEvent(eventNID types.EventNID) {
+	c.RoomServerEvents.Unset(int64(eventNID))
 }

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -1020,7 +1020,7 @@ func (d *EventDatabase) MaybeRedactEvent(
 			return fmt.Errorf("d.RedactionsTable.MarkRedactionValidated: %w", err)
 		}
 
-		d.Cache.StoreRoomServerEvent(redactedEvent.EventNID, redactedEvent.Event)
+		d.Cache.InvalidateRoomServerEvent(redactedEvent.EventNID)
 
 		return nil
 	})


### PR DESCRIPTION
This should deflake UTs and be more correct in terms of getting `Events`.
`Events` tries to fetch the event from the cache first and may get an unredacted event from it, while it should already be redacted.