### PR TITLE
Change default stats reporting endpoint

### DIFF
--- a/dendrite-sample.yaml
+++ b/dendrite-sample.yaml
@@ -95,7 +95,7 @@ global:
   # We use this information to understand how Dendrite is being used in the wild.
   report_stats:
     enabled: false
-    endpoint: https://matrix.org/report-usage-stats/push
+    endpoint: https://panopticon.matrix.org/push
 
   # Server notices allows server admins to send messages to all users on the server.
   server_notices:

--- a/setup/config/config_global.go
+++ b/setup/config/config_global.go
@@ -319,10 +319,15 @@ type ReportStats struct {
 
 func (c *ReportStats) Defaults() {
 	c.Enabled = false
-	c.Endpoint = "https://matrix.org/report-usage-stats/push"
+	c.Endpoint = "https://panopticon.matrix.org/push"
 }
 
 func (c *ReportStats) Verify(configErrs *ConfigErrors) {
+	// We prefer to hit panopticon (https://github.com/matrix-org/panopticon) directly over
+	// the "old" matrix.org endpoint.
+	if c.Endpoint == "https://matrix.org/report-usage-stats/push" {
+		c.Endpoint = "https://panopticon.matrix.org/push"
+	}
 	if c.Enabled {
 		checkNotEmpty(configErrs, "global.report_stats.endpoint", c.Endpoint)
 	}


### PR DESCRIPTION
It's the same instance we report to, only using the subdomain.