### PR TITLE
Update docs and sample config for the relay_api

### DIFF
--- a/dendrite-sample.yaml
+++ b/dendrite-sample.yaml
@@ -273,9 +273,6 @@ media_api:
       height: 480
       method: scale
 
-# Configuration for the Relay API.
-relay_api:
-
 # Configuration for enabling experimental MSCs on this homeserver.
 mscs:
   mscs:

--- a/dendrite-sample.yaml
+++ b/dendrite-sample.yaml
@@ -273,6 +273,9 @@ media_api:
       height: 480
       method: scale
 
+# Configuration for the Relay API.
+relay_api:
+
 # Configuration for enabling experimental MSCs on this homeserver.
 mscs:
   mscs:

--- a/docs/installation/7_configuration.md
+++ b/docs/installation/7_configuration.md
@@ -10,7 +10,7 @@ permalink: /installation/configuration
 A YAML configuration file is used to configure Dendrite. A sample configuration file is
 present in the top level of the Dendrite repository:
 
-* [`dendrite-sample.monolith.yaml`](https://github.com/matrix-org/dendrite/blob/main/dendrite-sample.monolith.yaml)
+* [`dendrite-sample.yaml`](https://github.com/matrix-org/dendrite/blob/main/dendrite-sample.yaml)
 
 You will need to duplicate the sample, calling it `dendrite.yaml` for example, and then
 tailor it to your installation. At a minimum, you will need to populate the following
@@ -86,9 +86,8 @@ that you chose.
 
 ### Global connection pool
 
-If you are running a monolith deployment and want to use a single connection pool to a
-single PostgreSQL database, then you must uncomment and configure the `database` section
-within the `global` section:
+If you  want to use a single connection pool to a single PostgreSQL database, then you must
+uncomment and configure the `database` section within the `global` section:
 
 ```yaml
 global:
@@ -102,15 +101,15 @@ global:
 
 **You must then remove or comment out** the `database` sections from other areas of the
 configuration file, e.g. under the `app_service_api`, `federation_api`, `key_server`,
-`media_api`, `mscs`, `room_server`, `sync_api` and `user_api` blocks, otherwise these will
-override the `global` database configuration.
+`media_api`, `mscs`, `relay_api`, `room_server`, `sync_api` and `user_api` blocks, otherwise
+these will override the `global` database configuration.
 
 ### Per-component connections (all other configurations)
 
 If you are are using SQLite databases or separate PostgreSQL
 databases per component, then you must instead configure the `database` sections under each
 of the component blocks ,e.g. under the `app_service_api`, `federation_api`, `key_server`,
-`media_api`, `mscs`, `room_server`, `sync_api` and `user_api` blocks.
+`media_api`, `mscs`, `relay_api`, `room_server`, `sync_api` and `user_api` blocks.
 
 For example, with PostgreSQL:
 

--- a/docs/installation/7_configuration.md
+++ b/docs/installation/7_configuration.md
@@ -86,7 +86,7 @@ that you chose.
 
 ### Global connection pool
 
-If you  want to use a single connection pool to a single PostgreSQL database, then you must
+If you want to use a single connection pool to a single PostgreSQL database, then you must
 uncomment and configure the `database` section within the `global` section:
 
 ```yaml


### PR DESCRIPTION
This adds an empty `relay_api` section to the sample configuration. For SQLite environments, or others where a `database.connection_string` is needed for each section, there should be an entry in the configuration sample as a basis.

This PR also changes the "Configuring Dendrite" documentation in that respect.

The requirement was introduced in #2917. When upgrading dendrite, it will complain about `relay_api.database.connection_string` not being configured.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [x] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

Signed-off-by: `Alex Kirk <akirk@users.noreply.github.com>`
