### PR TITLE
Don't fail config validation if existingSecret is provided but .Vaues.signing_key.create is false (use existing key)

### DIFF
--- a/helm/dendrite/templates/_helpers.tpl
+++ b/helm/dendrite/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 {{- define "validate.config" }}
-{{- if not .Values.signing_key.create -}}
-{{-  fail "You must create a signing key for configuration.signing_key. (see https://github.com/matrix-org/dendrite/blob/master/docs/INSTALL.md#server-key-generation)" -}}
+{{- if and (not .Values.signing_key.create) (eq .Values.signing_key.existingSecret "") -}}
+{{-  fail "You must create a signing key for configuration.signing_key OR specify an existing secret name in .Values.signing_key.existingSecret to mount it. (see https://github.com/matrix-org/dendrite/blob/master/docs/INSTALL.md#server-key-generation)" -}}
 {{- end -}}
 {{- if not (or .Values.dendrite_config.global.database.host .Values.postgresql.enabled) -}}
 {{-  fail "Database server must be set." -}}


### PR DESCRIPTION
This change allows Helm templating to proceed when using an existing key mounted from a Kubernetes Secret. Prior to this, templating would fail because `.Values.signing_key.create` is `false` as we don't want to create a new key, but this blocked templating even if we were mounting a secret and configuring it properly.

### Pull Request Checklist

* [x] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
  - Unneeded - Fix for Helm Chart deployment
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

Signed-off-by: Rhea Danzey <rdanzey@element.io>