### PR TITLE
Allow templating to succeed if postgres deployment is disabled but a connection string is defined

### DIFF
--- a/helm/dendrite/templates/_helpers.tpl
+++ b/helm/dendrite/templates/_helpers.tpl
@@ -2,13 +2,13 @@
 {{- if not .Values.signing_key.create -}}
 {{-  fail "You must create a signing key for configuration.signing_key. (see https://github.com/matrix-org/dendrite/blob/master/docs/INSTALL.md#server-key-generation)" -}}
 {{- end -}}
-{{- if not (or .Values.dendrite_config.global.database.host .Values.postgresql.enabled) -}}
+{{- if and (eq .Values.dendrite_config.global.database.connection_string "") (not (or .Values.dendrite_config.global.database.host .Values.postgresql.enabled)) -}}
 {{-  fail "Database server must be set." -}}
 {{- end -}}
-{{- if not (or .Values.dendrite_config.global.database.user .Values.postgresql.enabled) -}}
+{{- if and (eq .Values.dendrite_config.global.database.connection_string "") (not (or .Values.dendrite_config.global.database.user .Values.postgresql.enabled)) -}}
 {{-  fail "Database user must be set." -}}
 {{- end -}}
-{{- if not (or .Values.dendrite_config.global.database.password .Values.postgresql.enabled) -}}
+{{- if and (eq .Values.dendrite_config.global.database.connection_string "") (not .Values.dendrite_config.global.database.password) (not .Values.postgresql.enabled) -}}
 {{-  fail "Database password must be set." -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
This allows templating to succeed when using an existing database and not provisioning one alongside the chart.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [x] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
  - Helm chart changes
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

Signed-off-by: Rhea Danzey <rdanzey@element.io>