### PR TITLE
Rdanzey/helm-fixes-existing-db-secrets

### DIFF
--- a/helm/dendrite/Chart.yaml
+++ b/helm/dendrite/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dendrite
-version: "0.12.0"
+version: "0.12.1"
 appVersion: "0.12.0"
 description: Dendrite Matrix Homeserver
 type: application

--- a/helm/dendrite/templates/_helpers.tpl
+++ b/helm/dendrite/templates/_helpers.tpl
@@ -2,14 +2,8 @@
 {{- if and (not .Values.signing_key.create) (eq .Values.signing_key.existingSecret "") -}}
 {{-  fail "You must create a signing key for configuration.signing_key OR specify an existing secret name in .Values.signing_key.existingSecret to mount it. (see https://github.com/matrix-org/dendrite/blob/master/docs/INSTALL.md#server-key-generation)" -}}
 {{- end -}}
-{{- if and (eq .Values.dendrite_config.global.database.connection_string "") (not (or .Values.dendrite_config.global.database.host .Values.postgresql.enabled)) -}}
-{{-  fail "Database server must be set." -}}
-{{- end -}}
-{{- if and (eq .Values.dendrite_config.global.database.connection_string "") (not (or .Values.dendrite_config.global.database.user .Values.postgresql.enabled)) -}}
-{{-  fail "Database user must be set." -}}
-{{- end -}}
-{{- if and (eq .Values.dendrite_config.global.database.connection_string "") (not .Values.dendrite_config.global.database.password) (not .Values.postgresql.enabled) -}}
-{{-  fail "Database password must be set." -}}
+{{- if and (not .Values.postgresql.enabled) (eq .Values.dendrite_config.global.database.connection_string "") -}}
+{{-  fail "Database connection string must be set." -}}
 {{- end -}}
 {{- end -}}
 

--- a/helm/dendrite/templates/_helpers.tpl
+++ b/helm/dendrite/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 {{- define "validate.config" }}
-{{- if not .Values.signing_key.create -}}
-{{-  fail "You must create a signing key for configuration.signing_key. (see https://github.com/matrix-org/dendrite/blob/master/docs/INSTALL.md#server-key-generation)" -}}
+{{- if and (not .Values.signing_key.create) (eq .Values.signing_key.existingSecret "") -}}
+{{-  fail "You must create a signing key for configuration.signing_key OR specify an existing secret name in .Values.signing_key.existingSecret to mount it. (see https://github.com/matrix-org/dendrite/blob/master/docs/INSTALL.md#server-key-generation)" -}}
 {{- end -}}
 {{- if not (or .Values.dendrite_config.global.database.host .Values.postgresql.enabled) -}}
 {{-  fail "Database server must be set." -}}

--- a/helm/dendrite/templates/deployment.yaml
+++ b/helm/dendrite/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
         {{- if $.Values.dendrite_config.global.profiling.enabled }}
         env:
           - name: PPROFLISTEN
-            value: "localhost:{{- $.Values.global.profiling.port -}}"
+            value: "localhost:{{- $.Values.dendrite_config.global.profiling.port -}}"
         {{- end }}
         resources:
         {{- toYaml $.Values.resources | nindent 10 }}

--- a/helm/dendrite/templates/deployment.yaml
+++ b/helm/dendrite/templates/deployment.yaml
@@ -17,11 +17,7 @@ spec:
       labels:
         {{- include "dendrite.selectorLabels" . | nindent 8 }}
       annotations:
-        confighash-global: secret-{{ .Values.global | toYaml | sha256sum | trunc 32 }}
-        confighash-clientapi: clientapi-{{ .Values.clientapi | toYaml | sha256sum | trunc 32 }}
-        confighash-federationapi: federationapi-{{ .Values.federationapi | toYaml | sha256sum | trunc 32 }}
-        confighash-mediaapi: mediaapi-{{ .Values.mediaapi | toYaml | sha256sum | trunc 32 }}
-        confighash-syncapi: syncapi-{{ .Values.syncapi | toYaml | sha256sum | trunc 32 }}
+        confighash: secret-{{ .Values.dendrite_config | toYaml | sha256sum | trunc 32 }}
     spec:
       volumes:
       - name: {{ include "dendrite.fullname" . }}-conf-vol


### PR DESCRIPTION
Fixes some Helm templating issues when setting up a deployment with an existing database / signing keys.

- Allows for `.Values.postgresql.enabled: false` as long as `.Values.global.dendrite_config.database.connection_string` is defined
- Allows for '.Values.signing_key.create: false' if `.Values.signing_key.existingSecret` is set

Also fixes an error in the template resulting in profiling port not being set correctly:

```
Error: template: dendrite-meta/charts/dendrite/templates/deployment.yaml:60:35: executing "dendrite-meta/charts/dendrite/templates/deployment.yaml" at <$.Values.global.profiling.port>: nil pointer evaluating interface {}.port
```

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [x] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
  - Helm template fixes, no golang changes
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

Signed-off-by: Rhea Danzey <rdanzey@element.io>

