### PR TITLE
chart - Add configuration for extra volumes / volume mounts

### DIFF
--- a/helm/dendrite/Chart.yaml
+++ b/helm/dendrite/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dendrite
-version: "0.12.1"
+version: "0.12.2"
 appVersion: "0.12.0"
 description: Dendrite Matrix Homeserver
 type: application

--- a/helm/dendrite/templates/deployment.yaml
+++ b/helm/dendrite/templates/deployment.yaml
@@ -12,6 +12,13 @@ spec:
     matchLabels:
       {{- include "dendrite.selectorLabels" . | nindent 6 }}
   replicas: 1
+  strategy:
+    type: {{ $.Values.strategy.type }}
+    {{- if eq $.Values.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ $.Values.strategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ $.Values.strategy.rollingUpdate.maxUnavailable }}
+    {{- end }}
   template:
     metadata:
       labels:
@@ -19,13 +26,6 @@ spec:
       annotations:
         confighash: secret-{{ .Values.dendrite_config | toYaml | sha256sum | trunc 32 }}
     spec:
-      strategy:
-        type: {{ $.Values.strategy.type }}
-        {{- if eq $.Values.strategy.type "RollingUpdate" }}
-        rollingUpdate:
-          maxSurge: {{ $.Values.strategy.rollingUpdate.maxSurge }}
-          maxUnavailable: {{ $.Values.strategy.rollingUpdate.maxUnavailable }}
-        {{- end }}
       volumes:
       - name: {{ include "dendrite.fullname" . }}-conf-vol
         secret:

--- a/helm/dendrite/templates/deployment.yaml
+++ b/helm/dendrite/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
       - name: {{ include "dendrite.fullname" . }}-search
         persistentVolumeClaim:
           claimName: {{ default (print ( include "dendrite.fullname" . ) "-search-pvc") $.Values.persistence.search.existingClaim | quote }}
+      {{- with .Values.extraVolumes }}
+      {{ . | toYaml | nindent 6 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         {{- include "image.name" . | nindent 8 }}
@@ -73,6 +76,9 @@ spec:
           name: {{ include "dendrite.fullname" . }}-jetstream
         - mountPath: {{ .Values.dendrite_config.sync_api.search.index_path }}
           name: {{ include "dendrite.fullname" . }}-search
+        {{- with .Values.extraVolumeMounts }}
+        {{ . | toYaml | nindent 8 }}
+        {{- end }}
         livenessProbe:
           initialDelaySeconds: 10
           periodSeconds: 10

--- a/helm/dendrite/values.yaml
+++ b/helm/dendrite/values.yaml
@@ -43,6 +43,21 @@ persistence:
     # -- PVC Storage Request for the search volume
     capacity: "1Gi"
 
+# Add additional volumes to the Dendrite Pod
+extraVolumes: []
+# ex.
+# - name: extra-config
+#   secret:
+#     secretName: extra-config
+
+
+# Configure additional mount points volumes in the Dendrite Pod
+extraVolumeMounts: []
+# ex.
+# - mountPath: /etc/dendrite/extra-config
+#   name: extra-config
+
+
 dendrite_config:
   version: 2
   global:


### PR DESCRIPTION
Adds configuration for additional volumes / volumeMounts to the Dendrite pod to inject configuration / secrets outside of the chart's templates

### Pull Request Checklist

* [x] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests - Helm chart changes
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

Signed-off-by: Rhea Danzey <rdanzey@element.io>
