### PR TITLE
refactor: use latest GMSL which splits fed client from matrix room logic

### DIFF
--- a/clientapi/admin_test.go
+++ b/clientapi/admin_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/matrix-org/dendrite/setup/jetstream"
 	"github.com/matrix-org/dendrite/syncapi"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 	"github.com/tidwall/gjson"
 
@@ -40,7 +41,7 @@ func TestAdminResetPassword(t *testing.T) {
 		natsInstance := jetstream.NATSInstance{}
 		// add a vhost
 		cfg.Global.VirtualHosts = append(cfg.Global.VirtualHosts, &config.VirtualHost{
-			SigningIdentity: gomatrixserverlib.SigningIdentity{ServerName: "vh1"},
+			SigningIdentity: fclient.SigningIdentity{ServerName: "vh1"},
 		})
 
 		routers := httputil.NewRouters()

--- a/clientapi/api/api.go
+++ b/clientapi/api/api.go
@@ -14,10 +14,10 @@
 
 package api
 
-import "github.com/matrix-org/gomatrixserverlib"
+import "github.com/matrix-org/gomatrixserverlib/fclient"
 
 // ExtraPublicRoomsProvider provides a way to inject extra published rooms into /publicRooms requests.
 type ExtraPublicRoomsProvider interface {
 	// Rooms returns the extra rooms. This is called on-demand by clients, so cache appropriately.
-	Rooms() []gomatrixserverlib.PublicRoom
+	Rooms() []fclient.PublicRoom
 }

--- a/clientapi/auth/login_test.go
+++ b/clientapi/auth/login_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/userutil"
 	"github.com/matrix-org/dendrite/setup/config"
 	uapi "github.com/matrix-org/dendrite/userapi/api"
-	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 )
 
@@ -68,7 +68,7 @@ func TestLoginFromJSONReader(t *testing.T) {
 			var userAPI fakeUserInternalAPI
 			cfg := &config.ClientAPI{
 				Matrix: &config.Global{
-					SigningIdentity: gomatrixserverlib.SigningIdentity{
+					SigningIdentity: fclient.SigningIdentity{
 						ServerName: serverName,
 					},
 				},
@@ -148,7 +148,7 @@ func TestBadLoginFromJSONReader(t *testing.T) {
 			var userAPI fakeUserInternalAPI
 			cfg := &config.ClientAPI{
 				Matrix: &config.Global{
-					SigningIdentity: gomatrixserverlib.SigningIdentity{
+					SigningIdentity: fclient.SigningIdentity{
 						ServerName: serverName,
 					},
 				},

--- a/clientapi/auth/user_interactive_test.go
+++ b/clientapi/auth/user_interactive_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 )
 
@@ -47,7 +48,7 @@ func (d *fakeAccountDatabase) QueryAccountByPassword(ctx context.Context, req *a
 func setup() *UserInteractive {
 	cfg := &config.ClientAPI{
 		Matrix: &config.Global{
-			SigningIdentity: gomatrixserverlib.SigningIdentity{
+			SigningIdentity: fclient.SigningIdentity{
 				ServerName: serverName,
 			},
 		},

--- a/clientapi/clientapi.go
+++ b/clientapi/clientapi.go
@@ -19,7 +19,7 @@ import (
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/dendrite/setup/process"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
-	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 
 	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"
 	"github.com/matrix-org/dendrite/clientapi/api"
@@ -37,7 +37,7 @@ func AddPublicRoutes(
 	routers httputil.Routers,
 	cfg *config.Dendrite,
 	natsInstance *jetstream.NATSInstance,
-	federation *gomatrixserverlib.FederationClient,
+	federation *fclient.FederationClient,
 	rsAPI roomserverAPI.ClientRoomserverAPI,
 	asAPI appserviceAPI.AppServiceInternalAPI,
 	transactionsCache *transactions.Cache,

--- a/clientapi/routing/directory.go
+++ b/clientapi/routing/directory.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 
 	"github.com/matrix-org/dendrite/clientapi/httputil"
@@ -45,7 +46,7 @@ func (r *roomDirectoryResponse) fillServers(servers []gomatrixserverlib.ServerNa
 func DirectoryRoom(
 	req *http.Request,
 	roomAlias string,
-	federation *gomatrixserverlib.FederationClient,
+	federation *fclient.FederationClient,
 	cfg *config.ClientAPI,
 	rsAPI roomserverAPI.ClientRoomserverAPI,
 	fedSenderAPI federationAPI.ClientFederationAPI,

--- a/clientapi/routing/directory_public.go
+++ b/clientapi/routing/directory_public.go
@@ -24,6 +24,7 @@ import (
 	"sync"
 
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 
 	"github.com/matrix-org/dendrite/clientapi/api"
@@ -35,7 +36,7 @@ import (
 
 var (
 	cacheMu          sync.Mutex
-	publicRoomsCache []gomatrixserverlib.PublicRoom
+	publicRoomsCache []fclient.PublicRoom
 )
 
 type PublicRoomReq struct {
@@ -56,7 +57,7 @@ type filter struct {
 func GetPostPublicRooms(
 	req *http.Request, rsAPI roomserverAPI.ClientRoomserverAPI,
 	extRoomsProvider api.ExtraPublicRoomsProvider,
-	federation *gomatrixserverlib.FederationClient,
+	federation *fclient.FederationClient,
 	cfg *config.ClientAPI,
 ) util.JSONResponse {
 	var request PublicRoomReq
@@ -102,10 +103,10 @@ func GetPostPublicRooms(
 
 func publicRooms(
 	ctx context.Context, request PublicRoomReq, rsAPI roomserverAPI.ClientRoomserverAPI, extRoomsProvider api.ExtraPublicRoomsProvider,
-) (*gomatrixserverlib.RespPublicRooms, error) {
+) (*fclient.RespPublicRooms, error) {
 
-	response := gomatrixserverlib.RespPublicRooms{
-		Chunk: []gomatrixserverlib.PublicRoom{},
+	response := fclient.RespPublicRooms{
+		Chunk: []fclient.PublicRoom{},
 	}
 	var limit int64
 	var offset int64
@@ -122,7 +123,7 @@ func publicRooms(
 	}
 	err = nil
 
-	var rooms []gomatrixserverlib.PublicRoom
+	var rooms []fclient.PublicRoom
 	if request.Since == "" {
 		rooms = refreshPublicRoomCache(ctx, rsAPI, extRoomsProvider, request)
 	} else {
@@ -146,14 +147,14 @@ func publicRooms(
 	return &response, err
 }
 
-func filterRooms(rooms []gomatrixserverlib.PublicRoom, searchTerm string) []gomatrixserverlib.PublicRoom {
+func filterRooms(rooms []fclient.PublicRoom, searchTerm string) []fclient.PublicRoom {
 	if searchTerm == "" {
 		return rooms
 	}
 
 	normalizedTerm := strings.ToLower(searchTerm)
 
-	result := make([]gomatrixserverlib.PublicRoom, 0)
+	result := make([]fclient.PublicRoom, 0)
 	for _, room := range rooms {
 		if strings.Contains(strings.ToLower(room.Name), normalizedTerm) ||
 			strings.Contains(strings.ToLower(room.Topic), normalizedTerm) ||
@@ -214,7 +215,7 @@ func fillPublicRoomsReq(httpReq *http.Request, request *PublicRoomReq) *util.JSO
 //	 limit=3&since=6  => G     (prev='3', next='')
 //
 //	A value of '-1' for prev/next indicates no position.
-func sliceInto(slice []gomatrixserverlib.PublicRoom, since int64, limit int64) (subset []gomatrixserverlib.PublicRoom, prev, next int) {
+func sliceInto(slice []fclient.PublicRoom, since int64, limit int64) (subset []fclient.PublicRoom, prev, next int) {
 	prev = -1
 	next = -1
 
@@ -241,10 +242,10 @@ func sliceInto(slice []gomatrixserverlib.PublicRoom, since int64, limit int64) (
 func refreshPublicRoomCache(
 	ctx context.Context, rsAPI roomserverAPI.ClientRoomserverAPI, extRoomsProvider api.ExtraPublicRoomsProvider,
 	request PublicRoomReq,
-) []gomatrixserverlib.PublicRoom {
+) []fclient.PublicRoom {
 	cacheMu.Lock()
 	defer cacheMu.Unlock()
-	var extraRooms []gomatrixserverlib.PublicRoom
+	var extraRooms []fclient.PublicRoom
 	if extRoomsProvider != nil {
 		extraRooms = extRoomsProvider.Rooms()
 	}
@@ -269,7 +270,7 @@ func refreshPublicRoomCache(
 		util.GetLogger(ctx).WithError(err).Error("PopulatePublicRooms failed")
 		return publicRoomsCache
 	}
-	publicRoomsCache = []gomatrixserverlib.PublicRoom{}
+	publicRoomsCache = []fclient.PublicRoom{}
 	publicRoomsCache = append(publicRoomsCache, pubRooms...)
 	publicRoomsCache = append(publicRoomsCache, extraRooms...)
 	publicRoomsCache = dedupeAndShuffle(publicRoomsCache)
@@ -281,16 +282,16 @@ func refreshPublicRoomCache(
 	return publicRoomsCache
 }
 
-func getPublicRoomsFromCache() []gomatrixserverlib.PublicRoom {
+func getPublicRoomsFromCache() []fclient.PublicRoom {
 	cacheMu.Lock()
 	defer cacheMu.Unlock()
 	return publicRoomsCache
 }
 
-func dedupeAndShuffle(in []gomatrixserverlib.PublicRoom) []gomatrixserverlib.PublicRoom {
+func dedupeAndShuffle(in []fclient.PublicRoom) []fclient.PublicRoom {
 	// de-duplicate rooms with the same room ID. We can join the room via any of these aliases as we know these servers
 	// are alive and well, so we arbitrarily pick one (purposefully shuffling them to spread the load a bit)
-	var publicRooms []gomatrixserverlib.PublicRoom
+	var publicRooms []fclient.PublicRoom
 	haveRoomIDs := make(map[string]bool)
 	rand.Shuffle(len(in), func(i, j int) {
 		in[i], in[j] = in[j], in[i]

--- a/clientapi/routing/directory_public_test.go
+++ b/clientapi/routing/directory_public_test.go
@@ -4,17 +4,17 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 )
 
-func pubRoom(name string) gomatrixserverlib.PublicRoom {
-	return gomatrixserverlib.PublicRoom{
+func pubRoom(name string) fclient.PublicRoom {
+	return fclient.PublicRoom{
 		Name: name,
 	}
 }
 
 func TestSliceInto(t *testing.T) {
-	slice := []gomatrixserverlib.PublicRoom{
+	slice := []fclient.PublicRoom{
 		pubRoom("a"), pubRoom("b"), pubRoom("c"), pubRoom("d"), pubRoom("e"), pubRoom("f"), pubRoom("g"),
 	}
 	limit := int64(3)
@@ -22,7 +22,7 @@ func TestSliceInto(t *testing.T) {
 		since      int64
 		wantPrev   int
 		wantNext   int
-		wantSubset []gomatrixserverlib.PublicRoom
+		wantSubset []fclient.PublicRoom
 	}{
 		{
 			since:      0,

--- a/clientapi/routing/login_test.go
+++ b/clientapi/routing/login_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/dendrite/setup/jetstream"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 
 	"github.com/matrix-org/dendrite/test"
@@ -39,7 +40,7 @@ func TestLogin(t *testing.T) {
 		natsInstance := jetstream.NATSInstance{}
 		// add a vhost
 		cfg.Global.VirtualHosts = append(cfg.Global.VirtualHosts, &config.VirtualHost{
-			SigningIdentity: gomatrixserverlib.SigningIdentity{ServerName: "vh1"},
+			SigningIdentity: fclient.SigningIdentity{ServerName: "vh1"},
 		})
 
 		cm := sqlutil.NewConnectionManager(processCtx, cfg.Global.DatabaseOptions)

--- a/clientapi/routing/profile.go
+++ b/clientapi/routing/profile.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 
 	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
@@ -39,7 +40,7 @@ func GetProfile(
 	req *http.Request, profileAPI userapi.ProfileAPI, cfg *config.ClientAPI,
 	userID string,
 	asAPI appserviceAPI.AppServiceInternalAPI,
-	federation *gomatrixserverlib.FederationClient,
+	federation *fclient.FederationClient,
 ) util.JSONResponse {
 	profile, err := getProfile(req.Context(), profileAPI, cfg, userID, asAPI, federation)
 	if err != nil {
@@ -67,7 +68,7 @@ func GetProfile(
 func GetAvatarURL(
 	req *http.Request, profileAPI userapi.ProfileAPI, cfg *config.ClientAPI,
 	userID string, asAPI appserviceAPI.AppServiceInternalAPI,
-	federation *gomatrixserverlib.FederationClient,
+	federation *fclient.FederationClient,
 ) util.JSONResponse {
 	profile := GetProfile(req, profileAPI, cfg, userID, asAPI, federation)
 	p, ok := profile.JSON.(eventutil.UserProfile)
@@ -156,7 +157,7 @@ func SetAvatarURL(
 func GetDisplayName(
 	req *http.Request, profileAPI userapi.ProfileAPI, cfg *config.ClientAPI,
 	userID string, asAPI appserviceAPI.AppServiceInternalAPI,
-	federation *gomatrixserverlib.FederationClient,
+	federation *fclient.FederationClient,
 ) util.JSONResponse {
 	profile := GetProfile(req, profileAPI, cfg, userID, asAPI, federation)
 	p, ok := profile.JSON.(eventutil.UserProfile)
@@ -292,7 +293,7 @@ func getProfile(
 	ctx context.Context, profileAPI userapi.ProfileAPI, cfg *config.ClientAPI,
 	userID string,
 	asAPI appserviceAPI.AppServiceInternalAPI,
-	federation *gomatrixserverlib.FederationClient,
+	federation *fclient.FederationClient,
 ) (*authtypes.Profile, error) {
 	localpart, domain, err := gomatrixserverlib.SplitID('@', userID)
 	if err != nil {

--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -23,6 +23,7 @@ import (
 	"github.com/matrix-org/dendrite/setup/base"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 	"github.com/nats-io/nats.go"
 	"github.com/prometheus/client_golang/prometheus"
@@ -55,7 +56,7 @@ func Setup(
 	asAPI appserviceAPI.AppServiceInternalAPI,
 	userAPI userapi.ClientUserAPI,
 	userDirectoryProvider userapi.QuerySearchProfilesAPI,
-	federation *gomatrixserverlib.FederationClient,
+	federation *fclient.FederationClient,
 	syncProducer *producers.SyncAPIProducer,
 	transactionsCache *transactions.Cache,
 	federationSender federationAPI.ClientFederationAPI,

--- a/clientapi/routing/threepid.go
+++ b/clientapi/routing/threepid.go
@@ -24,6 +24,7 @@ import (
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/dendrite/userapi/api"
 	userdb "github.com/matrix-org/dendrite/userapi/storage"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
@@ -41,7 +42,7 @@ type ThreePIDsResponse struct {
 //
 //	POST /account/3pid/email/requestToken
 //	POST /register/email/requestToken
-func RequestEmailToken(req *http.Request, threePIDAPI api.ClientUserAPI, cfg *config.ClientAPI, client *gomatrixserverlib.Client) util.JSONResponse {
+func RequestEmailToken(req *http.Request, threePIDAPI api.ClientUserAPI, cfg *config.ClientAPI, client *fclient.Client) util.JSONResponse {
 	var body threepid.EmailAssociationRequest
 	if reqErr := httputil.UnmarshalJSONRequest(req, &body); reqErr != nil {
 		return *reqErr
@@ -92,7 +93,7 @@ func RequestEmailToken(req *http.Request, threePIDAPI api.ClientUserAPI, cfg *co
 // CheckAndSave3PIDAssociation implements POST /account/3pid
 func CheckAndSave3PIDAssociation(
 	req *http.Request, threePIDAPI api.ClientUserAPI, device *api.Device,
-	cfg *config.ClientAPI, client *gomatrixserverlib.Client,
+	cfg *config.ClientAPI, client *fclient.Client,
 ) util.JSONResponse {
 	var body threepid.EmailAssociationCheckRequest
 	if reqErr := httputil.UnmarshalJSONRequest(req, &body); reqErr != nil {

--- a/clientapi/routing/userdirectory.go
+++ b/clientapi/routing/userdirectory.go
@@ -26,6 +26,7 @@ import (
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrix"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 )
 
@@ -41,7 +42,7 @@ func SearchUserDirectory(
 	provider userapi.QuerySearchProfilesAPI,
 	searchString string,
 	limit int,
-	federation *gomatrixserverlib.FederationClient,
+	federation *fclient.FederationClient,
 	localServerName gomatrixserverlib.ServerName,
 ) util.JSONResponse {
 	if limit < 10 {

--- a/clientapi/threepid/threepid.go
+++ b/clientapi/threepid/threepid.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/matrix-org/dendrite/setup/config"
-	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 )
 
 // EmailAssociationRequest represents the request defined at https://matrix.org/docs/spec/client_server/r0.2.0.html#post-matrix-client-r0-register-email-requesttoken
@@ -58,7 +58,7 @@ type SID struct {
 // Returns an error if there was a problem sending the request or decoding the
 // response, or if the identity server responded with a non-OK status.
 func CreateSession(
-	ctx context.Context, req EmailAssociationRequest, cfg *config.ClientAPI, client *gomatrixserverlib.Client,
+	ctx context.Context, req EmailAssociationRequest, cfg *config.ClientAPI, client *fclient.Client,
 ) (string, error) {
 	if err := isTrusted(req.IDServer, cfg); err != nil {
 		return "", err
@@ -112,7 +112,7 @@ type GetValidatedResponse struct {
 // response, or if the identity server responded with a non-OK status.
 func CheckAssociation(
 	ctx context.Context, creds Credentials, cfg *config.ClientAPI,
-	client *gomatrixserverlib.Client,
+	client *fclient.Client,
 ) (bool, string, string, error) {
 	if err := isTrusted(creds.IDServer, cfg); err != nil {
 		return false, "", "", err
@@ -146,7 +146,7 @@ func CheckAssociation(
 // identifier and a Matrix ID.
 // Returns an error if there was a problem sending the request or decoding the
 // response, or if the identity server responded with a non-OK status.
-func PublishAssociation(ctx context.Context, creds Credentials, userID string, cfg *config.ClientAPI, client *gomatrixserverlib.Client) error {
+func PublishAssociation(ctx context.Context, creds Credentials, userID string, cfg *config.ClientAPI, client *fclient.Client) error {
 	if err := isTrusted(creds.IDServer, cfg); err != nil {
 		return err
 	}

--- a/clientapi/userutil/userutil_test.go
+++ b/clientapi/userutil/userutil_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 )
 
 var (
@@ -30,7 +31,7 @@ var (
 // TestGoodUserID checks that correct localpart is returned for a valid user ID.
 func TestGoodUserID(t *testing.T) {
 	cfg := &config.Global{
-		SigningIdentity: gomatrixserverlib.SigningIdentity{
+		SigningIdentity: fclient.SigningIdentity{
 			ServerName: serverName,
 		},
 	}
@@ -49,7 +50,7 @@ func TestGoodUserID(t *testing.T) {
 // TestWithLocalpartOnly checks that localpart is returned when usernameParam contains only localpart.
 func TestWithLocalpartOnly(t *testing.T) {
 	cfg := &config.Global{
-		SigningIdentity: gomatrixserverlib.SigningIdentity{
+		SigningIdentity: fclient.SigningIdentity{
 			ServerName: serverName,
 		},
 	}
@@ -68,7 +69,7 @@ func TestWithLocalpartOnly(t *testing.T) {
 // TestIncorrectDomain checks for error when there's server name mismatch.
 func TestIncorrectDomain(t *testing.T) {
 	cfg := &config.Global{
-		SigningIdentity: gomatrixserverlib.SigningIdentity{
+		SigningIdentity: fclient.SigningIdentity{
 			ServerName: invalidServerName,
 		},
 	}
@@ -83,7 +84,7 @@ func TestIncorrectDomain(t *testing.T) {
 // TestBadUserID checks that ParseUsernameParam fails for invalid user ID
 func TestBadUserID(t *testing.T) {
 	cfg := &config.Global{
-		SigningIdentity: gomatrixserverlib.SigningIdentity{
+		SigningIdentity: fclient.SigningIdentity{
 			ServerName: serverName,
 		},
 	}

--- a/cmd/dendrite-demo-pinecone/conn/client.go
+++ b/cmd/dendrite-demo-pinecone/conn/client.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/matrix-org/dendrite/setup/config"
-	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"nhooyr.io/websocket"
 
 	pineconeRouter "github.com/matrix-org/pinecone/router"
@@ -91,17 +91,17 @@ func createTransport(s *pineconeSessions.Sessions) *http.Transport {
 
 func CreateClient(
 	s *pineconeSessions.Sessions,
-) *gomatrixserverlib.Client {
-	return gomatrixserverlib.NewClient(
-		gomatrixserverlib.WithTransport(createTransport(s)),
+) *fclient.Client {
+	return fclient.NewClient(
+		fclient.WithTransport(createTransport(s)),
 	)
 }
 
 func CreateFederationClient(
 	cfg *config.Dendrite, s *pineconeSessions.Sessions,
-) *gomatrixserverlib.FederationClient {
-	return gomatrixserverlib.NewFederationClient(
+) *fclient.FederationClient {
+	return fclient.NewFederationClient(
 		cfg.Global.SigningIdentities(),
-		gomatrixserverlib.WithTransport(createTransport(s)),
+		fclient.WithTransport(createTransport(s)),
 	)
 }

--- a/cmd/dendrite-demo-pinecone/rooms/rooms.go
+++ b/cmd/dendrite-demo-pinecone/rooms/rooms.go
@@ -22,6 +22,7 @@ import (
 	"github.com/matrix-org/dendrite/cmd/dendrite-demo-pinecone/defaults"
 	"github.com/matrix-org/dendrite/federationapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 
 	pineconeRouter "github.com/matrix-org/pinecone/router"
@@ -32,14 +33,14 @@ type PineconeRoomProvider struct {
 	r         *pineconeRouter.Router
 	s         *pineconeSessions.Sessions
 	fedSender api.FederationInternalAPI
-	fedClient *gomatrixserverlib.FederationClient
+	fedClient *fclient.FederationClient
 }
 
 func NewPineconeRoomProvider(
 	r *pineconeRouter.Router,
 	s *pineconeSessions.Sessions,
 	fedSender api.FederationInternalAPI,
-	fedClient *gomatrixserverlib.FederationClient,
+	fedClient *fclient.FederationClient,
 ) *PineconeRoomProvider {
 	p := &PineconeRoomProvider{
 		r:         r,
@@ -50,7 +51,7 @@ func NewPineconeRoomProvider(
 	return p
 }
 
-func (p *PineconeRoomProvider) Rooms() []gomatrixserverlib.PublicRoom {
+func (p *PineconeRoomProvider) Rooms() []fclient.PublicRoom {
 	list := map[gomatrixserverlib.ServerName]struct{}{}
 	for k := range defaults.DefaultServerNames {
 		list[k] = struct{}{}
@@ -67,14 +68,14 @@ func (p *PineconeRoomProvider) Rooms() []gomatrixserverlib.PublicRoom {
 // bulkFetchPublicRoomsFromServers fetches public rooms from the list of homeservers.
 // Returns a list of public rooms.
 func bulkFetchPublicRoomsFromServers(
-	ctx context.Context, fedClient *gomatrixserverlib.FederationClient,
+	ctx context.Context, fedClient *fclient.FederationClient,
 	origin gomatrixserverlib.ServerName,
 	homeservers map[gomatrixserverlib.ServerName]struct{},
-) (publicRooms []gomatrixserverlib.PublicRoom) {
+) (publicRooms []fclient.PublicRoom) {
 	limit := 200
 	// follow pipeline semantics, see https://blog.golang.org/pipelines for more info.
 	// goroutines send rooms to this channel
-	roomCh := make(chan gomatrixserverlib.PublicRoom, int(limit))
+	roomCh := make(chan fclient.PublicRoom, int(limit))
 	// signalling channel to tell goroutines to stop sending rooms and quit
 	done := make(chan bool)
 	// signalling to say when we can close the room channel

--- a/cmd/dendrite-demo-pinecone/users/users.go
+++ b/cmd/dendrite-demo-pinecone/users/users.go
@@ -28,6 +28,7 @@ import (
 	"github.com/matrix-org/dendrite/cmd/dendrite-demo-pinecone/defaults"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 
 	pineconeRouter "github.com/matrix-org/pinecone/router"
@@ -38,7 +39,7 @@ type PineconeUserProvider struct {
 	r         *pineconeRouter.Router
 	s         *pineconeSessions.Sessions
 	userAPI   userapi.QuerySearchProfilesAPI
-	fedClient *gomatrixserverlib.FederationClient
+	fedClient *fclient.FederationClient
 }
 
 const PublicURL = "/_matrix/p2p/profiles"
@@ -47,7 +48,7 @@ func NewPineconeUserProvider(
 	r *pineconeRouter.Router,
 	s *pineconeSessions.Sessions,
 	userAPI userapi.QuerySearchProfilesAPI,
-	fedClient *gomatrixserverlib.FederationClient,
+	fedClient *fclient.FederationClient,
 ) *PineconeUserProvider {
 	p := &PineconeUserProvider{
 		r:         r,
@@ -94,7 +95,7 @@ func (p *PineconeUserProvider) QuerySearchProfiles(ctx context.Context, req *use
 // Returns a list of user profiles.
 func bulkFetchUserDirectoriesFromServers(
 	ctx context.Context, req *userapi.QuerySearchProfilesRequest,
-	fedClient *gomatrixserverlib.FederationClient,
+	fedClient *fclient.FederationClient,
 	homeservers map[gomatrixserverlib.ServerName]struct{},
 ) (profiles []authtypes.Profile) {
 	jsonBody, err := json.Marshal(req)

--- a/cmd/dendrite-demo-yggdrasil/yggconn/client.go
+++ b/cmd/dendrite-demo-yggdrasil/yggconn/client.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/matrix-org/dendrite/setup/config"
-	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 )
 
 type yggroundtripper struct {
@@ -17,7 +17,7 @@ func (y *yggroundtripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return y.inner.RoundTrip(req)
 }
 
-func (n *Node) CreateClient() *gomatrixserverlib.Client {
+func (n *Node) CreateClient() *fclient.Client {
 	tr := &http.Transport{}
 	tr.RegisterProtocol(
 		"matrix", &yggroundtripper{
@@ -31,14 +31,14 @@ func (n *Node) CreateClient() *gomatrixserverlib.Client {
 			},
 		},
 	)
-	return gomatrixserverlib.NewClient(
-		gomatrixserverlib.WithTransport(tr),
+	return fclient.NewClient(
+		fclient.WithTransport(tr),
 	)
 }
 
 func (n *Node) CreateFederationClient(
 	cfg *config.Dendrite,
-) *gomatrixserverlib.FederationClient {
+) *fclient.FederationClient {
 	tr := &http.Transport{}
 	tr.RegisterProtocol(
 		"matrix", &yggroundtripper{
@@ -52,8 +52,8 @@ func (n *Node) CreateFederationClient(
 			},
 		},
 	)
-	return gomatrixserverlib.NewFederationClient(
+	return fclient.NewFederationClient(
 		cfg.Global.SigningIdentities(),
-		gomatrixserverlib.WithTransport(tr),
+		fclient.WithTransport(tr),
 	)
 }

--- a/cmd/dendrite-demo-yggdrasil/yggrooms/yggrooms.go
+++ b/cmd/dendrite-demo-yggdrasil/yggrooms/yggrooms.go
@@ -22,17 +22,18 @@ import (
 	"github.com/matrix-org/dendrite/cmd/dendrite-demo-yggdrasil/yggconn"
 	"github.com/matrix-org/dendrite/federationapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 )
 
 type YggdrasilRoomProvider struct {
 	node      *yggconn.Node
 	fedSender api.FederationInternalAPI
-	fedClient *gomatrixserverlib.FederationClient
+	fedClient *fclient.FederationClient
 }
 
 func NewYggdrasilRoomProvider(
-	node *yggconn.Node, fedSender api.FederationInternalAPI, fedClient *gomatrixserverlib.FederationClient,
+	node *yggconn.Node, fedSender api.FederationInternalAPI, fedClient *fclient.FederationClient,
 ) *YggdrasilRoomProvider {
 	p := &YggdrasilRoomProvider{
 		node:      node,
@@ -42,7 +43,7 @@ func NewYggdrasilRoomProvider(
 	return p
 }
 
-func (p *YggdrasilRoomProvider) Rooms() []gomatrixserverlib.PublicRoom {
+func (p *YggdrasilRoomProvider) Rooms() []fclient.PublicRoom {
 	return bulkFetchPublicRoomsFromServers(
 		context.Background(), p.fedClient,
 		gomatrixserverlib.ServerName(p.node.DerivedServerName()),
@@ -53,14 +54,14 @@ func (p *YggdrasilRoomProvider) Rooms() []gomatrixserverlib.PublicRoom {
 // bulkFetchPublicRoomsFromServers fetches public rooms from the list of homeservers.
 // Returns a list of public rooms.
 func bulkFetchPublicRoomsFromServers(
-	ctx context.Context, fedClient *gomatrixserverlib.FederationClient,
+	ctx context.Context, fedClient *fclient.FederationClient,
 	origin gomatrixserverlib.ServerName,
 	homeservers []gomatrixserverlib.ServerName,
-) (publicRooms []gomatrixserverlib.PublicRoom) {
+) (publicRooms []fclient.PublicRoom) {
 	limit := 200
 	// follow pipeline semantics, see https://blog.golang.org/pipelines for more info.
 	// goroutines send rooms to this channel
-	roomCh := make(chan gomatrixserverlib.PublicRoom, int(limit))
+	roomCh := make(chan fclient.PublicRoom, int(limit))
 	// signalling channel to tell goroutines to stop sending rooms and quit
 	done := make(chan bool)
 	// signalling to say when we can close the room channel

--- a/cmd/dendrite/main.go
+++ b/cmd/dendrite/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/setup/jetstream"
 	"github.com/matrix-org/dendrite/setup/process"
-	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/sirupsen/logrus"
 
 	"github.com/matrix-org/dendrite/appservice"
@@ -96,9 +96,9 @@ func main() {
 	}
 
 	// create DNS cache
-	var dnsCache *gomatrixserverlib.DNSCache
+	var dnsCache *fclient.DNSCache
 	if cfg.Global.DNSCache.Enabled {
-		dnsCache = gomatrixserverlib.NewDNSCache(
+		dnsCache = fclient.NewDNSCache(
 			cfg.Global.DNSCache.CacheSize,
 			cfg.Global.DNSCache.CacheLifetime,
 		)

--- a/cmd/furl/main.go
+++ b/cmd/furl/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 )
 
 var requestFrom = flag.String("from", "", "the server name that the request should originate from")
@@ -49,8 +50,8 @@ func main() {
 	}
 
 	serverName := gomatrixserverlib.ServerName(*requestFrom)
-	client := gomatrixserverlib.NewFederationClient(
-		[]*gomatrixserverlib.SigningIdentity{
+	client := fclient.NewFederationClient(
+		[]*fclient.SigningIdentity{
 			{
 				ServerName: serverName,
 				KeyID:      gomatrixserverlib.KeyID(keyBlock.Headers["Key-ID"]),

--- a/federationapi/api/api.go
+++ b/federationapi/api/api.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/matrix-org/gomatrix"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 
 	"github.com/matrix-org/dendrite/federationapi/types"
 )
@@ -22,8 +23,8 @@ type FederationInternalAPI interface {
 
 	QueryServerKeys(ctx context.Context, request *QueryServerKeysRequest, response *QueryServerKeysResponse) error
 	LookupServerKeys(ctx context.Context, s gomatrixserverlib.ServerName, keyRequests map[gomatrixserverlib.PublicKeyLookupRequest]gomatrixserverlib.Timestamp) ([]gomatrixserverlib.ServerKeys, error)
-	MSC2836EventRelationships(ctx context.Context, origin, dst gomatrixserverlib.ServerName, r gomatrixserverlib.MSC2836EventRelationshipsRequest, roomVersion gomatrixserverlib.RoomVersion) (res gomatrixserverlib.MSC2836EventRelationshipsResponse, err error)
-	MSC2946Spaces(ctx context.Context, origin, dst gomatrixserverlib.ServerName, roomID string, suggestedOnly bool) (res gomatrixserverlib.MSC2946SpacesResponse, err error)
+	MSC2836EventRelationships(ctx context.Context, origin, dst gomatrixserverlib.ServerName, r fclient.MSC2836EventRelationshipsRequest, roomVersion gomatrixserverlib.RoomVersion) (res fclient.MSC2836EventRelationshipsResponse, err error)
+	MSC2946Spaces(ctx context.Context, origin, dst gomatrixserverlib.ServerName, roomID string, suggestedOnly bool) (res fclient.MSC2946SpacesResponse, err error)
 
 	// Broadcasts an EDU to all servers in rooms we are joined to. Used in the yggdrasil demos.
 	PerformBroadcastEDU(
@@ -66,9 +67,9 @@ type RoomserverFederationAPI interface {
 	// containing only the server names (without information for membership events).
 	// The response will include this server if they are joined to the room.
 	QueryJoinedHostServerNamesInRoom(ctx context.Context, request *QueryJoinedHostServerNamesInRoomRequest, response *QueryJoinedHostServerNamesInRoomResponse) error
-	GetEventAuth(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomVersion gomatrixserverlib.RoomVersion, roomID, eventID string) (res gomatrixserverlib.RespEventAuth, err error)
+	GetEventAuth(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomVersion gomatrixserverlib.RoomVersion, roomID, eventID string) (res fclient.RespEventAuth, err error)
 	GetEvent(ctx context.Context, origin, s gomatrixserverlib.ServerName, eventID string) (res gomatrixserverlib.Transaction, err error)
-	LookupMissingEvents(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID string, missing gomatrixserverlib.MissingEvents, roomVersion gomatrixserverlib.RoomVersion) (res gomatrixserverlib.RespMissingEvents, err error)
+	LookupMissingEvents(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID string, missing fclient.MissingEvents, roomVersion gomatrixserverlib.RoomVersion) (res fclient.RespMissingEvents, err error)
 }
 
 type P2PFederationAPI interface {
@@ -98,45 +99,45 @@ type P2PFederationAPI interface {
 // implements as proxy calls, with built-in backoff/retries/etc. Errors returned from functions in
 // this interface are of type FederationClientError
 type KeyserverFederationAPI interface {
-	GetUserDevices(ctx context.Context, origin, s gomatrixserverlib.ServerName, userID string) (res gomatrixserverlib.RespUserDevices, err error)
-	ClaimKeys(ctx context.Context, origin, s gomatrixserverlib.ServerName, oneTimeKeys map[string]map[string]string) (res gomatrixserverlib.RespClaimKeys, err error)
-	QueryKeys(ctx context.Context, origin, s gomatrixserverlib.ServerName, keys map[string][]string) (res gomatrixserverlib.RespQueryKeys, err error)
+	GetUserDevices(ctx context.Context, origin, s gomatrixserverlib.ServerName, userID string) (res fclient.RespUserDevices, err error)
+	ClaimKeys(ctx context.Context, origin, s gomatrixserverlib.ServerName, oneTimeKeys map[string]map[string]string) (res fclient.RespClaimKeys, err error)
+	QueryKeys(ctx context.Context, origin, s gomatrixserverlib.ServerName, keys map[string][]string) (res fclient.RespQueryKeys, err error)
 }
 
 // an interface for gmsl.FederationClient - contains functions called by federationapi only.
 type FederationClient interface {
 	P2PFederationClient
 	gomatrixserverlib.KeyClient
-	SendTransaction(ctx context.Context, t gomatrixserverlib.Transaction) (res gomatrixserverlib.RespSend, err error)
+	SendTransaction(ctx context.Context, t gomatrixserverlib.Transaction) (res fclient.RespSend, err error)
 
 	// Perform operations
-	LookupRoomAlias(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomAlias string) (res gomatrixserverlib.RespDirectory, err error)
-	Peek(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID, peekID string, roomVersions []gomatrixserverlib.RoomVersion) (res gomatrixserverlib.RespPeek, err error)
-	MakeJoin(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID, userID string, roomVersions []gomatrixserverlib.RoomVersion) (res gomatrixserverlib.RespMakeJoin, err error)
-	SendJoin(ctx context.Context, origin, s gomatrixserverlib.ServerName, event *gomatrixserverlib.Event) (res gomatrixserverlib.RespSendJoin, err error)
-	MakeLeave(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID, userID string) (res gomatrixserverlib.RespMakeLeave, err error)
+	LookupRoomAlias(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomAlias string) (res fclient.RespDirectory, err error)
+	Peek(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID, peekID string, roomVersions []gomatrixserverlib.RoomVersion) (res fclient.RespPeek, err error)
+	MakeJoin(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID, userID string, roomVersions []gomatrixserverlib.RoomVersion) (res fclient.RespMakeJoin, err error)
+	SendJoin(ctx context.Context, origin, s gomatrixserverlib.ServerName, event *gomatrixserverlib.Event) (res fclient.RespSendJoin, err error)
+	MakeLeave(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID, userID string) (res fclient.RespMakeLeave, err error)
 	SendLeave(ctx context.Context, origin, s gomatrixserverlib.ServerName, event *gomatrixserverlib.Event) (err error)
-	SendInviteV2(ctx context.Context, origin, s gomatrixserverlib.ServerName, request gomatrixserverlib.InviteV2Request) (res gomatrixserverlib.RespInviteV2, err error)
+	SendInviteV2(ctx context.Context, origin, s gomatrixserverlib.ServerName, request gomatrixserverlib.InviteV2Request) (res fclient.RespInviteV2, err error)
 
 	GetEvent(ctx context.Context, origin, s gomatrixserverlib.ServerName, eventID string) (res gomatrixserverlib.Transaction, err error)
 
-	GetEventAuth(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomVersion gomatrixserverlib.RoomVersion, roomID, eventID string) (res gomatrixserverlib.RespEventAuth, err error)
-	GetUserDevices(ctx context.Context, origin, s gomatrixserverlib.ServerName, userID string) (gomatrixserverlib.RespUserDevices, error)
-	ClaimKeys(ctx context.Context, origin, s gomatrixserverlib.ServerName, oneTimeKeys map[string]map[string]string) (gomatrixserverlib.RespClaimKeys, error)
-	QueryKeys(ctx context.Context, origin, s gomatrixserverlib.ServerName, keys map[string][]string) (gomatrixserverlib.RespQueryKeys, error)
+	GetEventAuth(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomVersion gomatrixserverlib.RoomVersion, roomID, eventID string) (res fclient.RespEventAuth, err error)
+	GetUserDevices(ctx context.Context, origin, s gomatrixserverlib.ServerName, userID string) (fclient.RespUserDevices, error)
+	ClaimKeys(ctx context.Context, origin, s gomatrixserverlib.ServerName, oneTimeKeys map[string]map[string]string) (fclient.RespClaimKeys, error)
+	QueryKeys(ctx context.Context, origin, s gomatrixserverlib.ServerName, keys map[string][]string) (fclient.RespQueryKeys, error)
 	Backfill(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID string, limit int, eventIDs []string) (res gomatrixserverlib.Transaction, err error)
-	MSC2836EventRelationships(ctx context.Context, origin, dst gomatrixserverlib.ServerName, r gomatrixserverlib.MSC2836EventRelationshipsRequest, roomVersion gomatrixserverlib.RoomVersion) (res gomatrixserverlib.MSC2836EventRelationshipsResponse, err error)
-	MSC2946Spaces(ctx context.Context, origin, dst gomatrixserverlib.ServerName, roomID string, suggestedOnly bool) (res gomatrixserverlib.MSC2946SpacesResponse, err error)
+	MSC2836EventRelationships(ctx context.Context, origin, dst gomatrixserverlib.ServerName, r fclient.MSC2836EventRelationshipsRequest, roomVersion gomatrixserverlib.RoomVersion) (res fclient.MSC2836EventRelationshipsResponse, err error)
+	MSC2946Spaces(ctx context.Context, origin, dst gomatrixserverlib.ServerName, roomID string, suggestedOnly bool) (res fclient.MSC2946SpacesResponse, err error)
 
 	ExchangeThirdPartyInvite(ctx context.Context, origin, s gomatrixserverlib.ServerName, builder gomatrixserverlib.EventBuilder) (err error)
-	LookupState(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID string, eventID string, roomVersion gomatrixserverlib.RoomVersion) (res gomatrixserverlib.RespState, err error)
-	LookupStateIDs(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID string, eventID string) (res gomatrixserverlib.RespStateIDs, err error)
-	LookupMissingEvents(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID string, missing gomatrixserverlib.MissingEvents, roomVersion gomatrixserverlib.RoomVersion) (res gomatrixserverlib.RespMissingEvents, err error)
+	LookupState(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID string, eventID string, roomVersion gomatrixserverlib.RoomVersion) (res fclient.RespState, err error)
+	LookupStateIDs(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID string, eventID string) (res fclient.RespStateIDs, err error)
+	LookupMissingEvents(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID string, missing fclient.MissingEvents, roomVersion gomatrixserverlib.RoomVersion) (res fclient.RespMissingEvents, err error)
 }
 
 type P2PFederationClient interface {
-	P2PSendTransactionToRelay(ctx context.Context, u gomatrixserverlib.UserID, t gomatrixserverlib.Transaction, forwardingServer gomatrixserverlib.ServerName) (res gomatrixserverlib.EmptyResp, err error)
-	P2PGetTransactionFromRelay(ctx context.Context, u gomatrixserverlib.UserID, prev gomatrixserverlib.RelayEntry, relayServer gomatrixserverlib.ServerName) (res gomatrixserverlib.RespGetRelayTransaction, err error)
+	P2PSendTransactionToRelay(ctx context.Context, u gomatrixserverlib.UserID, t gomatrixserverlib.Transaction, forwardingServer gomatrixserverlib.ServerName) (res fclient.EmptyResp, err error)
+	P2PGetTransactionFromRelay(ctx context.Context, u gomatrixserverlib.UserID, prev fclient.RelayEntry, relayServer gomatrixserverlib.ServerName) (res fclient.RespGetRelayTransaction, err error)
 }
 
 // FederationClientError is returned from FederationClient methods in the event of a problem.

--- a/federationapi/federationapi.go
+++ b/federationapi/federationapi.go
@@ -21,6 +21,7 @@ import (
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/dendrite/setup/process"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/sirupsen/logrus"
 
 	"github.com/matrix-org/dendrite/federationapi/api"
@@ -48,7 +49,7 @@ func AddPublicRoutes(
 	dendriteConfig *config.Dendrite,
 	natsInstance *jetstream.NATSInstance,
 	userAPI userapi.FederationUserAPI,
-	federation *gomatrixserverlib.FederationClient,
+	federation *fclient.FederationClient,
 	keyRing gomatrixserverlib.JSONVerifier,
 	rsAPI roomserverAPI.FederationRoomserverAPI,
 	fedAPI federationAPI.FederationInternalAPI,

--- a/federationapi/federationapi_keys_test.go
+++ b/federationapi/federationapi_keys_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/matrix-org/dendrite/setup/jetstream"
 	"github.com/matrix-org/dendrite/setup/process"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 
 	"github.com/matrix-org/dendrite/federationapi/api"
 	"github.com/matrix-org/dendrite/federationapi/routing"
@@ -24,12 +25,12 @@ import (
 )
 
 type server struct {
-	name      gomatrixserverlib.ServerName        // server name
-	validity  time.Duration                       // key validity duration from now
-	config    *config.FederationAPI               // skeleton config, from TestMain
-	fedclient *gomatrixserverlib.FederationClient // uses MockRoundTripper
-	cache     *caching.Caches                     // server-specific cache
-	api       api.FederationInternalAPI           // server-specific server key API
+	name      gomatrixserverlib.ServerName // server name
+	validity  time.Duration                // key validity duration from now
+	config    *config.FederationAPI        // skeleton config, from TestMain
+	fedclient *fclient.FederationClient    // uses MockRoundTripper
+	cache     *caching.Caches              // server-specific cache
+	api       api.FederationInternalAPI    // server-specific server key API
 }
 
 func (s *server) renew() {
@@ -105,9 +106,9 @@ func TestMain(m *testing.M) {
 			transport.RegisterProtocol("matrix", &MockRoundTripper{})
 
 			// Create the federation client.
-			s.fedclient = gomatrixserverlib.NewFederationClient(
+			s.fedclient = fclient.NewFederationClient(
 				s.config.Matrix.SigningIdentities(),
-				gomatrixserverlib.WithTransport(transport),
+				fclient.WithTransport(transport),
 			)
 
 			// Finally, build the server key APIs.

--- a/federationapi/federationapi_test.go
+++ b/federationapi/federationapi_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/gomatrix"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/nats-io/nats.go"
 
 	"github.com/matrix-org/dendrite/federationapi"
@@ -104,7 +105,7 @@ func (f *fedClient) GetServerKeys(ctx context.Context, matrixServer gomatrixserv
 	return keys, nil
 }
 
-func (f *fedClient) MakeJoin(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID, userID string, roomVersions []gomatrixserverlib.RoomVersion) (res gomatrixserverlib.RespMakeJoin, err error) {
+func (f *fedClient) MakeJoin(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID, userID string, roomVersions []gomatrixserverlib.RoomVersion) (res fclient.RespMakeJoin, err error) {
 	for _, r := range f.allowJoins {
 		if r.ID == roomID {
 			res.RoomVersion = r.Version
@@ -128,7 +129,7 @@ func (f *fedClient) MakeJoin(ctx context.Context, origin, s gomatrixserverlib.Se
 	}
 	return
 }
-func (f *fedClient) SendJoin(ctx context.Context, origin, s gomatrixserverlib.ServerName, event *gomatrixserverlib.Event) (res gomatrixserverlib.RespSendJoin, err error) {
+func (f *fedClient) SendJoin(ctx context.Context, origin, s gomatrixserverlib.ServerName, event *gomatrixserverlib.Event) (res fclient.RespSendJoin, err error) {
 	f.fedClientMutex.Lock()
 	defer f.fedClientMutex.Unlock()
 	for _, r := range f.allowJoins {
@@ -142,7 +143,7 @@ func (f *fedClient) SendJoin(ctx context.Context, origin, s gomatrixserverlib.Se
 	return
 }
 
-func (f *fedClient) SendTransaction(ctx context.Context, t gomatrixserverlib.Transaction) (res gomatrixserverlib.RespSend, err error) {
+func (f *fedClient) SendTransaction(ctx context.Context, t gomatrixserverlib.Transaction) (res fclient.RespSend, err error) {
 	f.fedClientMutex.Lock()
 	defer f.fedClientMutex.Unlock()
 	for _, edu := range t.EDUs {
@@ -313,9 +314,9 @@ func TestRoomsV3URLEscapeDoNot404(t *testing.T) {
 	defer cancel()
 	serverName := gomatrixserverlib.ServerName(strings.TrimPrefix(baseURL, "https://"))
 
-	fedCli := gomatrixserverlib.NewFederationClient(
+	fedCli := fclient.NewFederationClient(
 		cfg.Global.SigningIdentities(),
-		gomatrixserverlib.WithSkipVerify(true),
+		fclient.WithSkipVerify(true),
 	)
 
 	for _, tc := range testCases {

--- a/federationapi/internal/federationclient.go
+++ b/federationapi/internal/federationclient.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 )
 
 // Functions here are "proxying" calls to the gomatrixserverlib federation
@@ -13,56 +14,56 @@ import (
 func (a *FederationInternalAPI) GetEventAuth(
 	ctx context.Context, origin, s gomatrixserverlib.ServerName,
 	roomVersion gomatrixserverlib.RoomVersion, roomID, eventID string,
-) (res gomatrixserverlib.RespEventAuth, err error) {
+) (res fclient.RespEventAuth, err error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 	ires, err := a.doRequestIfNotBlacklisted(s, func() (interface{}, error) {
 		return a.federation.GetEventAuth(ctx, origin, s, roomVersion, roomID, eventID)
 	})
 	if err != nil {
-		return gomatrixserverlib.RespEventAuth{}, err
+		return fclient.RespEventAuth{}, err
 	}
-	return ires.(gomatrixserverlib.RespEventAuth), nil
+	return ires.(fclient.RespEventAuth), nil
 }
 
 func (a *FederationInternalAPI) GetUserDevices(
 	ctx context.Context, origin, s gomatrixserverlib.ServerName, userID string,
-) (gomatrixserverlib.RespUserDevices, error) {
+) (fclient.RespUserDevices, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 	ires, err := a.doRequestIfNotBlacklisted(s, func() (interface{}, error) {
 		return a.federation.GetUserDevices(ctx, origin, s, userID)
 	})
 	if err != nil {
-		return gomatrixserverlib.RespUserDevices{}, err
+		return fclient.RespUserDevices{}, err
 	}
-	return ires.(gomatrixserverlib.RespUserDevices), nil
+	return ires.(fclient.RespUserDevices), nil
 }
 
 func (a *FederationInternalAPI) ClaimKeys(
 	ctx context.Context, origin, s gomatrixserverlib.ServerName, oneTimeKeys map[string]map[string]string,
-) (gomatrixserverlib.RespClaimKeys, error) {
+) (fclient.RespClaimKeys, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 	ires, err := a.doRequestIfNotBlacklisted(s, func() (interface{}, error) {
 		return a.federation.ClaimKeys(ctx, origin, s, oneTimeKeys)
 	})
 	if err != nil {
-		return gomatrixserverlib.RespClaimKeys{}, err
+		return fclient.RespClaimKeys{}, err
 	}
-	return ires.(gomatrixserverlib.RespClaimKeys), nil
+	return ires.(fclient.RespClaimKeys), nil
 }
 
 func (a *FederationInternalAPI) QueryKeys(
 	ctx context.Context, origin, s gomatrixserverlib.ServerName, keys map[string][]string,
-) (gomatrixserverlib.RespQueryKeys, error) {
+) (fclient.RespQueryKeys, error) {
 	ires, err := a.doRequestIfNotBackingOffOrBlacklisted(s, func() (interface{}, error) {
 		return a.federation.QueryKeys(ctx, origin, s, keys)
 	})
 	if err != nil {
-		return gomatrixserverlib.RespQueryKeys{}, err
+		return fclient.RespQueryKeys{}, err
 	}
-	return ires.(gomatrixserverlib.RespQueryKeys), nil
+	return ires.(fclient.RespQueryKeys), nil
 }
 
 func (a *FederationInternalAPI) Backfill(
@@ -81,45 +82,46 @@ func (a *FederationInternalAPI) Backfill(
 
 func (a *FederationInternalAPI) LookupState(
 	ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID, eventID string, roomVersion gomatrixserverlib.RoomVersion,
-) (res gomatrixserverlib.RespState, err error) {
+) (res gomatrixserverlib.StateResponse, err error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 	ires, err := a.doRequestIfNotBlacklisted(s, func() (interface{}, error) {
 		return a.federation.LookupState(ctx, origin, s, roomID, eventID, roomVersion)
 	})
 	if err != nil {
-		return gomatrixserverlib.RespState{}, err
+		return &fclient.RespState{}, err
 	}
-	return ires.(gomatrixserverlib.RespState), nil
+	r := ires.(fclient.RespState)
+	return &r, nil
 }
 
 func (a *FederationInternalAPI) LookupStateIDs(
 	ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID, eventID string,
-) (res gomatrixserverlib.RespStateIDs, err error) {
+) (res gomatrixserverlib.StateIDResponse, err error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 	ires, err := a.doRequestIfNotBlacklisted(s, func() (interface{}, error) {
 		return a.federation.LookupStateIDs(ctx, origin, s, roomID, eventID)
 	})
 	if err != nil {
-		return gomatrixserverlib.RespStateIDs{}, err
+		return fclient.RespStateIDs{}, err
 	}
-	return ires.(gomatrixserverlib.RespStateIDs), nil
+	return ires.(fclient.RespStateIDs), nil
 }
 
 func (a *FederationInternalAPI) LookupMissingEvents(
 	ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID string,
-	missing gomatrixserverlib.MissingEvents, roomVersion gomatrixserverlib.RoomVersion,
-) (res gomatrixserverlib.RespMissingEvents, err error) {
+	missing fclient.MissingEvents, roomVersion gomatrixserverlib.RoomVersion,
+) (res fclient.RespMissingEvents, err error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 	ires, err := a.doRequestIfNotBlacklisted(s, func() (interface{}, error) {
 		return a.federation.LookupMissingEvents(ctx, origin, s, roomID, missing, roomVersion)
 	})
 	if err != nil {
-		return gomatrixserverlib.RespMissingEvents{}, err
+		return fclient.RespMissingEvents{}, err
 	}
-	return ires.(gomatrixserverlib.RespMissingEvents), nil
+	return ires.(fclient.RespMissingEvents), nil
 }
 
 func (a *FederationInternalAPI) GetEvent(
@@ -151,9 +153,9 @@ func (a *FederationInternalAPI) LookupServerKeys(
 }
 
 func (a *FederationInternalAPI) MSC2836EventRelationships(
-	ctx context.Context, origin, s gomatrixserverlib.ServerName, r gomatrixserverlib.MSC2836EventRelationshipsRequest,
+	ctx context.Context, origin, s gomatrixserverlib.ServerName, r fclient.MSC2836EventRelationshipsRequest,
 	roomVersion gomatrixserverlib.RoomVersion,
-) (res gomatrixserverlib.MSC2836EventRelationshipsResponse, err error) {
+) (res fclient.MSC2836EventRelationshipsResponse, err error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	ires, err := a.doRequestIfNotBlacklisted(s, func() (interface{}, error) {
@@ -162,12 +164,12 @@ func (a *FederationInternalAPI) MSC2836EventRelationships(
 	if err != nil {
 		return res, err
 	}
-	return ires.(gomatrixserverlib.MSC2836EventRelationshipsResponse), nil
+	return ires.(fclient.MSC2836EventRelationshipsResponse), nil
 }
 
 func (a *FederationInternalAPI) MSC2946Spaces(
 	ctx context.Context, origin, s gomatrixserverlib.ServerName, roomID string, suggestedOnly bool,
-) (res gomatrixserverlib.MSC2946SpacesResponse, err error) {
+) (res fclient.MSC2946SpacesResponse, err error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 	ires, err := a.doRequestIfNotBlacklisted(s, func() (interface{}, error) {
@@ -176,5 +178,5 @@ func (a *FederationInternalAPI) MSC2946Spaces(
 	if err != nil {
 		return res, err
 	}
-	return ires.(gomatrixserverlib.MSC2946SpacesResponse), nil
+	return ires.(fclient.MSC2946SpacesResponse), nil
 }

--- a/federationapi/internal/federationclient_test.go
+++ b/federationapi/internal/federationclient_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/matrix-org/dendrite/setup/process"
 	"github.com/matrix-org/dendrite/test"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,20 +34,20 @@ const (
 	FailuresUntilBlacklist      = 8
 )
 
-func (t *testFedClient) QueryKeys(ctx context.Context, origin, s gomatrixserverlib.ServerName, keys map[string][]string) (gomatrixserverlib.RespQueryKeys, error) {
+func (t *testFedClient) QueryKeys(ctx context.Context, origin, s gomatrixserverlib.ServerName, keys map[string][]string) (fclient.RespQueryKeys, error) {
 	t.queryKeysCalled = true
 	if t.shouldFail {
-		return gomatrixserverlib.RespQueryKeys{}, fmt.Errorf("Failure")
+		return fclient.RespQueryKeys{}, fmt.Errorf("Failure")
 	}
-	return gomatrixserverlib.RespQueryKeys{}, nil
+	return fclient.RespQueryKeys{}, nil
 }
 
-func (t *testFedClient) ClaimKeys(ctx context.Context, origin, s gomatrixserverlib.ServerName, oneTimeKeys map[string]map[string]string) (gomatrixserverlib.RespClaimKeys, error) {
+func (t *testFedClient) ClaimKeys(ctx context.Context, origin, s gomatrixserverlib.ServerName, oneTimeKeys map[string]map[string]string) (fclient.RespClaimKeys, error) {
 	t.claimKeysCalled = true
 	if t.shouldFail {
-		return gomatrixserverlib.RespClaimKeys{}, fmt.Errorf("Failure")
+		return fclient.RespClaimKeys{}, fmt.Errorf("Failure")
 	}
-	return gomatrixserverlib.RespClaimKeys{}, nil
+	return fclient.RespClaimKeys{}, nil
 }
 
 func TestFederationClientQueryKeys(t *testing.T) {
@@ -54,7 +55,7 @@ func TestFederationClientQueryKeys(t *testing.T) {
 
 	cfg := config.FederationAPI{
 		Matrix: &config.Global{
-			SigningIdentity: gomatrixserverlib.SigningIdentity{
+			SigningIdentity: fclient.SigningIdentity{
 				ServerName: "server",
 			},
 		},
@@ -85,7 +86,7 @@ func TestFederationClientQueryKeysBlacklisted(t *testing.T) {
 
 	cfg := config.FederationAPI{
 		Matrix: &config.Global{
-			SigningIdentity: gomatrixserverlib.SigningIdentity{
+			SigningIdentity: fclient.SigningIdentity{
 				ServerName: "server",
 			},
 		},
@@ -115,7 +116,7 @@ func TestFederationClientQueryKeysFailure(t *testing.T) {
 
 	cfg := config.FederationAPI{
 		Matrix: &config.Global{
-			SigningIdentity: gomatrixserverlib.SigningIdentity{
+			SigningIdentity: fclient.SigningIdentity{
 				ServerName: "server",
 			},
 		},
@@ -145,7 +146,7 @@ func TestFederationClientClaimKeys(t *testing.T) {
 
 	cfg := config.FederationAPI{
 		Matrix: &config.Global{
-			SigningIdentity: gomatrixserverlib.SigningIdentity{
+			SigningIdentity: fclient.SigningIdentity{
 				ServerName: "server",
 			},
 		},
@@ -176,7 +177,7 @@ func TestFederationClientClaimKeysBlacklisted(t *testing.T) {
 
 	cfg := config.FederationAPI{
 		Matrix: &config.Global{
-			SigningIdentity: gomatrixserverlib.SigningIdentity{
+			SigningIdentity: fclient.SigningIdentity{
 				ServerName: "server",
 			},
 		},

--- a/federationapi/internal/perform.go
+++ b/federationapi/internal/perform.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/matrix-org/gomatrix"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 	"github.com/sirupsen/logrus"
 
@@ -255,7 +256,7 @@ func (r *FederationInternalAPI) performJoinUsingServer(
 	// waste the effort.
 	// TODO: Can we expand Check here to return a list of missing auth
 	// events rather than failing one at a time?
-	var respState *gomatrixserverlib.RespState
+	var respState *fclient.RespState
 	respState, err = respSendJoin.Check(
 		context.Background(),
 		respMakeJoin.RoomVersion,

--- a/federationapi/internal/perform_test.go
+++ b/federationapi/internal/perform_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/matrix-org/dendrite/setup/process"
 	"github.com/matrix-org/dendrite/test"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -35,8 +36,8 @@ type testFedClient struct {
 	shouldFail      bool
 }
 
-func (t *testFedClient) LookupRoomAlias(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomAlias string) (res gomatrixserverlib.RespDirectory, err error) {
-	return gomatrixserverlib.RespDirectory{}, nil
+func (t *testFedClient) LookupRoomAlias(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomAlias string) (res fclient.RespDirectory, err error) {
+	return fclient.RespDirectory{}, nil
 }
 
 func TestPerformWakeupServers(t *testing.T) {
@@ -54,7 +55,7 @@ func TestPerformWakeupServers(t *testing.T) {
 
 	cfg := config.FederationAPI{
 		Matrix: &config.Global{
-			SigningIdentity: gomatrixserverlib.SigningIdentity{
+			SigningIdentity: fclient.SigningIdentity{
 				ServerName: "relay",
 			},
 		},
@@ -96,7 +97,7 @@ func TestQueryRelayServers(t *testing.T) {
 
 	cfg := config.FederationAPI{
 		Matrix: &config.Global{
-			SigningIdentity: gomatrixserverlib.SigningIdentity{
+			SigningIdentity: fclient.SigningIdentity{
 				ServerName: "relay",
 			},
 		},
@@ -133,7 +134,7 @@ func TestRemoveRelayServers(t *testing.T) {
 
 	cfg := config.FederationAPI{
 		Matrix: &config.Global{
-			SigningIdentity: gomatrixserverlib.SigningIdentity{
+			SigningIdentity: fclient.SigningIdentity{
 				ServerName: "relay",
 			},
 		},
@@ -169,7 +170,7 @@ func TestPerformDirectoryLookup(t *testing.T) {
 
 	cfg := config.FederationAPI{
 		Matrix: &config.Global{
-			SigningIdentity: gomatrixserverlib.SigningIdentity{
+			SigningIdentity: fclient.SigningIdentity{
 				ServerName: "relay",
 			},
 		},
@@ -204,7 +205,7 @@ func TestPerformDirectoryLookupRelaying(t *testing.T) {
 
 	cfg := config.FederationAPI{
 		Matrix: &config.Global{
-			SigningIdentity: gomatrixserverlib.SigningIdentity{
+			SigningIdentity: fclient.SigningIdentity{
 				ServerName: server,
 			},
 		},

--- a/federationapi/queue/destinationqueue.go
+++ b/federationapi/queue/destinationqueue.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/matrix-org/gomatrix"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/atomic"
 
@@ -50,7 +51,7 @@ type destinationQueue struct {
 	queues             *OutgoingQueues
 	db                 storage.Database
 	process            *process.ProcessContext
-	signing            map[gomatrixserverlib.ServerName]*gomatrixserverlib.SigningIdentity
+	signing            map[gomatrixserverlib.ServerName]*fclient.SigningIdentity
 	rsAPI              api.FederationRoomserverAPI
 	client             fedapi.FederationClient         // federation client
 	origin             gomatrixserverlib.ServerName    // origin of requests

--- a/federationapi/queue/queue.go
+++ b/federationapi/queue/queue.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
@@ -45,7 +46,7 @@ type OutgoingQueues struct {
 	origin      gomatrixserverlib.ServerName
 	client      fedapi.FederationClient
 	statistics  *statistics.Statistics
-	signing     map[gomatrixserverlib.ServerName]*gomatrixserverlib.SigningIdentity
+	signing     map[gomatrixserverlib.ServerName]*fclient.SigningIdentity
 	queuesMutex sync.Mutex // protects the below
 	queues      map[gomatrixserverlib.ServerName]*destinationQueue
 }
@@ -90,7 +91,7 @@ func NewOutgoingQueues(
 	client fedapi.FederationClient,
 	rsAPI api.FederationRoomserverAPI,
 	statistics *statistics.Statistics,
-	signing []*gomatrixserverlib.SigningIdentity,
+	signing []*fclient.SigningIdentity,
 ) *OutgoingQueues {
 	queues := &OutgoingQueues{
 		disabled:   disabled,
@@ -100,7 +101,7 @@ func NewOutgoingQueues(
 		origin:     origin,
 		client:     client,
 		statistics: statistics,
-		signing:    map[gomatrixserverlib.ServerName]*gomatrixserverlib.SigningIdentity{},
+		signing:    map[gomatrixserverlib.ServerName]*fclient.SigningIdentity{},
 		queues:     map[gomatrixserverlib.ServerName]*destinationQueue{},
 	}
 	for _, identity := range signing {

--- a/federationapi/queue/queue_test.go
+++ b/federationapi/queue/queue_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/matrix-org/dendrite/internal/caching"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/test/testrig"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"go.uber.org/atomic"
 	"gotest.tools/v3/poll"
 
@@ -80,24 +81,24 @@ type stubFederationClient struct {
 	txRelayCount         atomic.Uint32
 }
 
-func (f *stubFederationClient) SendTransaction(ctx context.Context, t gomatrixserverlib.Transaction) (res gomatrixserverlib.RespSend, err error) {
+func (f *stubFederationClient) SendTransaction(ctx context.Context, t gomatrixserverlib.Transaction) (res fclient.RespSend, err error) {
 	var result error
 	if !f.shouldTxSucceed {
 		result = fmt.Errorf("transaction failed")
 	}
 
 	f.txCount.Add(1)
-	return gomatrixserverlib.RespSend{}, result
+	return fclient.RespSend{}, result
 }
 
-func (f *stubFederationClient) P2PSendTransactionToRelay(ctx context.Context, u gomatrixserverlib.UserID, t gomatrixserverlib.Transaction, forwardingServer gomatrixserverlib.ServerName) (res gomatrixserverlib.EmptyResp, err error) {
+func (f *stubFederationClient) P2PSendTransactionToRelay(ctx context.Context, u gomatrixserverlib.UserID, t gomatrixserverlib.Transaction, forwardingServer gomatrixserverlib.ServerName) (res fclient.EmptyResp, err error) {
 	var result error
 	if !f.shouldTxRelaySucceed {
 		result = fmt.Errorf("relay transaction failed")
 	}
 
 	f.txRelayCount.Add(1)
-	return gomatrixserverlib.EmptyResp{}, result
+	return fclient.EmptyResp{}, result
 }
 
 func mustCreatePDU(t *testing.T) *gomatrixserverlib.HeaderedEvent {
@@ -127,7 +128,7 @@ func testSetup(failuresUntilBlacklist uint32, failuresUntilAssumedOffline uint32
 	rs := &stubFederationRoomServerAPI{}
 
 	stats := statistics.NewStatistics(db, failuresUntilBlacklist, failuresUntilAssumedOffline)
-	signingInfo := []*gomatrixserverlib.SigningIdentity{
+	signingInfo := []*fclient.SigningIdentity{
 		{
 			KeyID:      "ed21019:auto",
 			PrivateKey: test.PrivateKeyA,

--- a/federationapi/routing/devices.go
+++ b/federationapi/routing/devices.go
@@ -19,6 +19,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 	"github.com/tidwall/gjson"
 )
@@ -53,10 +54,10 @@ func GetUserDevices(
 		return jsonerror.InternalAPIError(req.Context(), err)
 	}
 
-	response := gomatrixserverlib.RespUserDevices{
+	response := fclient.RespUserDevices{
 		UserID:   userID,
 		StreamID: res.StreamID,
-		Devices:  []gomatrixserverlib.RespUserDevice{},
+		Devices:  []fclient.RespUserDevice{},
 	}
 
 	if masterKey, ok := sigRes.MasterKeys[userID]; ok {
@@ -67,7 +68,7 @@ func GetUserDevices(
 	}
 
 	for _, dev := range res.Devices {
-		var key gomatrixserverlib.RespUserDeviceKeys
+		var key fclient.RespUserDeviceKeys
 		err := json.Unmarshal(dev.DeviceKeys.KeyJSON, &key)
 		if err != nil {
 			util.GetLogger(req.Context()).WithError(err).Warnf("malformed device key: %s", string(dev.DeviceKeys.KeyJSON))
@@ -79,7 +80,7 @@ func GetUserDevices(
 			displayName = gjson.GetBytes(dev.DeviceKeys.KeyJSON, "unsigned.device_display_name").Str
 		}
 
-		device := gomatrixserverlib.RespUserDevice{
+		device := fclient.RespUserDevice{
 			DeviceID:    dev.DeviceID,
 			DisplayName: displayName,
 			Keys:        key,

--- a/federationapi/routing/eventauth.go
+++ b/federationapi/routing/eventauth.go
@@ -19,6 +19,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 )
 
@@ -70,7 +71,7 @@ func GetEventAuth(
 
 	return util.JSONResponse{
 		Code: http.StatusOK,
-		JSON: gomatrixserverlib.RespEventAuth{
+		JSON: fclient.RespEventAuth{
 			AuthEvents: gomatrixserverlib.NewEventJSONsFromHeaderedEvents(response.AuthChainEvents),
 		},
 	}

--- a/federationapi/routing/invite.go
+++ b/federationapi/routing/invite.go
@@ -25,6 +25,7 @@ import (
 	roomserverVersion "github.com/matrix-org/dendrite/roomserver/version"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 )
 
@@ -218,12 +219,12 @@ func processInvite(
 	if isInviteV2 {
 		return util.JSONResponse{
 			Code: http.StatusOK,
-			JSON: gomatrixserverlib.RespInviteV2{Event: signedEvent.JSON()},
+			JSON: fclient.RespInviteV2{Event: signedEvent.JSON()},
 		}
 	} else {
 		return util.JSONResponse{
 			Code: http.StatusOK,
-			JSON: gomatrixserverlib.RespInvite{Event: signedEvent.JSON()},
+			JSON: fclient.RespInvite{Event: signedEvent.JSON()},
 		}
 	}
 }

--- a/federationapi/routing/join.go
+++ b/federationapi/routing/join.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 	"github.com/sirupsen/logrus"
 
@@ -433,7 +434,7 @@ func SendJoin(
 	// https://matrix.org/docs/spec/server_server/latest#put-matrix-federation-v1-send-join-roomid-eventid
 	return util.JSONResponse{
 		Code: http.StatusOK,
-		JSON: gomatrixserverlib.RespSendJoin{
+		JSON: fclient.RespSendJoin{
 			StateEvents: gomatrixserverlib.NewEventJSONsFromHeaderedEvents(stateAndAuthChainResponse.StateEvents),
 			AuthEvents:  gomatrixserverlib.NewEventJSONsFromHeaderedEvents(stateAndAuthChainResponse.AuthChainEvents),
 			Origin:      cfg.Matrix.ServerName,

--- a/federationapi/routing/keys.go
+++ b/federationapi/routing/keys.go
@@ -25,6 +25,7 @@ import (
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ed25519"
@@ -144,7 +145,7 @@ func LocalKeys(cfg *config.FederationAPI, serverName gomatrixserverlib.ServerNam
 
 func localKeys(cfg *config.FederationAPI, serverName gomatrixserverlib.ServerName) (*gomatrixserverlib.ServerKeys, error) {
 	var keys gomatrixserverlib.ServerKeys
-	var identity *gomatrixserverlib.SigningIdentity
+	var identity *fclient.SigningIdentity
 	var err error
 	if virtualHost := cfg.Matrix.VirtualHostForHTTPHost(serverName); virtualHost == nil {
 		if identity, err = cfg.Matrix.SigningIdentityFor(cfg.Matrix.ServerName); err != nil {

--- a/federationapi/routing/missingevents.go
+++ b/federationapi/routing/missingevents.go
@@ -19,6 +19,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 )
 
@@ -67,7 +68,7 @@ func GetMissingEvents(
 
 	eventsResponse.Events = filterEvents(eventsResponse.Events, roomID)
 
-	resp := gomatrixserverlib.RespMissingEvents{
+	resp := fclient.RespMissingEvents{
 		Events: gomatrixserverlib.NewEventJSONsFromHeaderedEvents(eventsResponse.Events),
 	}
 

--- a/federationapi/routing/peek.go
+++ b/federationapi/routing/peek.go
@@ -21,6 +21,7 @@ import (
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 )
 
@@ -87,7 +88,7 @@ func Peek(
 		return util.JSONResponse{Code: http.StatusNotFound, JSON: nil}
 	}
 
-	respPeek := gomatrixserverlib.RespPeek{
+	respPeek := fclient.RespPeek{
 		StateEvents:     gomatrixserverlib.NewEventJSONsFromHeaderedEvents(response.StateEvents),
 		AuthEvents:      gomatrixserverlib.NewEventJSONsFromHeaderedEvents(response.AuthChainEvents),
 		RoomVersion:     response.RoomVersion,

--- a/federationapi/routing/publicrooms.go
+++ b/federationapi/routing/publicrooms.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 
 	"github.com/matrix-org/dendrite/clientapi/httputil"
@@ -48,9 +49,9 @@ func GetPostPublicRooms(req *http.Request, rsAPI roomserverAPI.FederationRoomser
 
 func publicRooms(
 	ctx context.Context, request PublicRoomReq, rsAPI roomserverAPI.FederationRoomserverAPI,
-) (*gomatrixserverlib.RespPublicRooms, error) {
+) (*fclient.RespPublicRooms, error) {
 
-	var response gomatrixserverlib.RespPublicRooms
+	var response fclient.RespPublicRooms
 	var limit int16
 	var offset int64
 	limit = request.Limit
@@ -122,7 +123,7 @@ func fillPublicRoomsReq(httpReq *http.Request, request *PublicRoomReq) *util.JSO
 }
 
 // due to lots of switches
-func fillInRooms(ctx context.Context, roomIDs []string, rsAPI roomserverAPI.FederationRoomserverAPI) ([]gomatrixserverlib.PublicRoom, error) {
+func fillInRooms(ctx context.Context, roomIDs []string, rsAPI roomserverAPI.FederationRoomserverAPI) ([]fclient.PublicRoom, error) {
 	avatarTuple := gomatrixserverlib.StateKeyTuple{EventType: "m.room.avatar", StateKey: ""}
 	nameTuple := gomatrixserverlib.StateKeyTuple{EventType: "m.room.name", StateKey: ""}
 	canonicalTuple := gomatrixserverlib.StateKeyTuple{EventType: gomatrixserverlib.MRoomCanonicalAlias, StateKey: ""}
@@ -144,10 +145,10 @@ func fillInRooms(ctx context.Context, roomIDs []string, rsAPI roomserverAPI.Fede
 		util.GetLogger(ctx).WithError(err).Error("QueryBulkStateContent failed")
 		return nil, err
 	}
-	chunk := make([]gomatrixserverlib.PublicRoom, len(roomIDs))
+	chunk := make([]fclient.PublicRoom, len(roomIDs))
 	i := 0
 	for roomID, data := range stateRes.Rooms {
-		pub := gomatrixserverlib.PublicRoom{
+		pub := fclient.PublicRoom{
 			RoomID: roomID,
 		}
 		joinCount := 0

--- a/federationapi/routing/query.go
+++ b/federationapi/routing/query.go
@@ -24,6 +24,7 @@ import (
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/gomatrix"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 )
 
@@ -50,7 +51,7 @@ func RoomAliasToID(
 		}
 	}
 
-	var resp gomatrixserverlib.RespDirectory
+	var resp fclient.RespDirectory
 
 	if domain == cfg.Matrix.ServerName {
 		queryReq := &roomserverAPI.GetRoomIDForAliasRequest{
@@ -71,7 +72,7 @@ func RoomAliasToID(
 				return jsonerror.InternalServerError()
 			}
 
-			resp = gomatrixserverlib.RespDirectory{
+			resp = fclient.RespDirectory{
 				RoomID:  queryRes.RoomID,
 				Servers: serverQueryRes.ServerNames,
 			}

--- a/federationapi/routing/query_test.go
+++ b/federationapi/routing/query_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/matrix-org/dendrite/test"
 	"github.com/matrix-org/dendrite/test/testrig"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/ed25519"
 )
@@ -43,7 +44,7 @@ type fakeFedClient struct {
 	fedclient.FederationClient
 }
 
-func (f *fakeFedClient) LookupRoomAlias(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomAlias string) (res gomatrixserverlib.RespDirectory, err error) {
+func (f *fakeFedClient) LookupRoomAlias(ctx context.Context, origin, s gomatrixserverlib.ServerName, roomAlias string) (res fclient.RespDirectory, err error) {
 	return
 }
 

--- a/federationapi/routing/state.go
+++ b/federationapi/routing/state.go
@@ -20,6 +20,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 )
 
@@ -40,7 +41,7 @@ func GetState(
 		return *err
 	}
 
-	return util.JSONResponse{Code: http.StatusOK, JSON: &gomatrixserverlib.RespState{
+	return util.JSONResponse{Code: http.StatusOK, JSON: &fclient.RespState{
 		AuthEvents:  gomatrixserverlib.NewEventJSONsFromHeaderedEvents(authChain),
 		StateEvents: gomatrixserverlib.NewEventJSONsFromHeaderedEvents(stateEvents),
 	}}
@@ -66,7 +67,7 @@ func GetStateIDs(
 	stateEventIDs := getIDsFromEvent(stateEvents)
 	authEventIDs := getIDsFromEvent(authEvents)
 
-	return util.JSONResponse{Code: http.StatusOK, JSON: gomatrixserverlib.RespStateIDs{
+	return util.JSONResponse{Code: http.StatusOK, JSON: fclient.RespStateIDs{
 		StateEventIDs: stateEventIDs,
 		AuthEventIDs:  authEventIDs,
 	},

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/matrix-org/dugong v0.0.0-20210921133753-66e6b1c67e2e
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91
 	github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20230320105331-4dd7ff2f0e3a
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20230405171344-5f597d85ba4f
 	github.com/matrix-org/pinecone v0.11.1-0.20230210171230-8c3b24f2649a
 	github.com/matrix-org/util v0.0.0-20221111132719-399730281e66
 	github.com/mattn/go-sqlite3 v1.14.16

--- a/internal/caching/cache_space_rooms.go
+++ b/internal/caching/cache_space_rooms.go
@@ -1,18 +1,16 @@
 package caching
 
-import (
-	"github.com/matrix-org/gomatrixserverlib"
-)
+import "github.com/matrix-org/gomatrixserverlib/fclient"
 
 type SpaceSummaryRoomsCache interface {
-	GetSpaceSummary(roomID string) (r gomatrixserverlib.MSC2946SpacesResponse, ok bool)
-	StoreSpaceSummary(roomID string, r gomatrixserverlib.MSC2946SpacesResponse)
+	GetSpaceSummary(roomID string) (r fclient.MSC2946SpacesResponse, ok bool)
+	StoreSpaceSummary(roomID string, r fclient.MSC2946SpacesResponse)
 }
 
-func (c Caches) GetSpaceSummary(roomID string) (r gomatrixserverlib.MSC2946SpacesResponse, ok bool) {
+func (c Caches) GetSpaceSummary(roomID string) (r fclient.MSC2946SpacesResponse, ok bool) {
 	return c.SpaceSummaryRooms.Get(roomID)
 }
 
-func (c Caches) StoreSpaceSummary(roomID string, r gomatrixserverlib.MSC2946SpacesResponse) {
+func (c Caches) StoreSpaceSummary(roomID string, r fclient.MSC2946SpacesResponse) {
 	c.SpaceSummaryRooms.Set(roomID, r)
 }

--- a/internal/caching/caches.go
+++ b/internal/caching/caches.go
@@ -17,6 +17,7 @@ package caching
 import (
 	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 )
 
 // Caches contains a set of references to caches. They may be
@@ -34,7 +35,7 @@ type Caches struct {
 	RoomServerEventTypes    Cache[types.EventTypeNID, string]                      // eventType NID -> eventType
 	FederationPDUs          Cache[int64, *gomatrixserverlib.HeaderedEvent]         // queue NID -> PDU
 	FederationEDUs          Cache[int64, *gomatrixserverlib.EDU]                   // queue NID -> EDU
-	SpaceSummaryRooms       Cache[string, gomatrixserverlib.MSC2946SpacesResponse] // room ID -> space response
+	SpaceSummaryRooms       Cache[string, fclient.MSC2946SpacesResponse]           // room ID -> space response
 	LazyLoading             Cache[lazyLoadingCacheKey, string]                     // composite key -> event ID
 }
 

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -23,6 +23,7 @@ import (
 	"github.com/dgraph-io/ristretto"
 	"github.com/dgraph-io/ristretto/z"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -146,7 +147,7 @@ func NewRistrettoCache(maxCost config.DataUnit, maxAge time.Duration, enableProm
 				MaxAge:  lesserOf(time.Hour/2, maxAge),
 			},
 		},
-		SpaceSummaryRooms: &RistrettoCachePartition[string, gomatrixserverlib.MSC2946SpacesResponse]{ // room ID -> space response
+		SpaceSummaryRooms: &RistrettoCachePartition[string, fclient.MSC2946SpacesResponse]{ // room ID -> space response
 			cache:   cache,
 			Prefix:  spaceSummaryRoomsCache,
 			Mutable: true,

--- a/internal/eventutil/events.go
+++ b/internal/eventutil/events.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/setup/config"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 
 	"github.com/matrix-org/gomatrixserverlib"
 )
@@ -39,7 +40,7 @@ var ErrRoomNoExists = errors.New("room does not exist")
 func QueryAndBuildEvent(
 	ctx context.Context,
 	builder *gomatrixserverlib.EventBuilder, cfg *config.Global,
-	identity *gomatrixserverlib.SigningIdentity, evTime time.Time,
+	identity *fclient.SigningIdentity, evTime time.Time,
 	rsAPI api.QueryLatestEventsAndStateAPI, queryRes *api.QueryLatestEventsAndStateResponse,
 ) (*gomatrixserverlib.HeaderedEvent, error) {
 	if queryRes == nil {
@@ -59,7 +60,7 @@ func QueryAndBuildEvent(
 func BuildEvent(
 	ctx context.Context,
 	builder *gomatrixserverlib.EventBuilder, cfg *config.Global,
-	identity *gomatrixserverlib.SigningIdentity, evTime time.Time,
+	identity *fclient.SigningIdentity, evTime time.Time,
 	eventsNeeded *gomatrixserverlib.StateNeeded, queryRes *api.QueryLatestEventsAndStateResponse,
 ) (*gomatrixserverlib.HeaderedEvent, error) {
 	if err := addPrevEventsToEvent(builder, eventsNeeded, queryRes); err != nil {

--- a/mediaapi/mediaapi.go
+++ b/mediaapi/mediaapi.go
@@ -21,7 +21,7 @@ import (
 	"github.com/matrix-org/dendrite/mediaapi/storage"
 	"github.com/matrix-org/dendrite/setup/config"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
-	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/sirupsen/logrus"
 )
 
@@ -31,7 +31,7 @@ func AddPublicRoutes(
 	cm sqlutil.Connections,
 	cfg *config.Dendrite,
 	userAPI userapi.MediaUserAPI,
-	client *gomatrixserverlib.Client,
+	client *fclient.Client,
 ) {
 	mediaDB, err := storage.NewMediaAPIDatasource(cm, &cfg.MediaAPI.Database)
 	if err != nil {

--- a/mediaapi/routing/download.go
+++ b/mediaapi/routing/download.go
@@ -37,6 +37,7 @@ import (
 	"github.com/matrix-org/dendrite/mediaapi/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
@@ -75,7 +76,7 @@ func Download(
 	mediaID types.MediaID,
 	cfg *config.MediaAPI,
 	db storage.Database,
-	client *gomatrixserverlib.Client,
+	client *fclient.Client,
 	activeRemoteRequests *types.ActiveRemoteRequests,
 	activeThumbnailGeneration *types.ActiveThumbnailGeneration,
 	isThumbnailRequest bool,
@@ -205,7 +206,7 @@ func (r *downloadRequest) doDownload(
 	w http.ResponseWriter,
 	cfg *config.MediaAPI,
 	db storage.Database,
-	client *gomatrixserverlib.Client,
+	client *fclient.Client,
 	activeRemoteRequests *types.ActiveRemoteRequests,
 	activeThumbnailGeneration *types.ActiveThumbnailGeneration,
 ) (*types.MediaMetadata, error) {
@@ -513,7 +514,7 @@ func (r *downloadRequest) generateThumbnail(
 // Note: The named errorResponse return variable is used in a deferred broadcast of the metadata and error response to waiting goroutines.
 func (r *downloadRequest) getRemoteFile(
 	ctx context.Context,
-	client *gomatrixserverlib.Client,
+	client *fclient.Client,
 	cfg *config.MediaAPI,
 	db storage.Database,
 	activeRemoteRequests *types.ActiveRemoteRequests,
@@ -615,7 +616,7 @@ func (r *downloadRequest) broadcastMediaMetadata(activeRemoteRequests *types.Act
 // fetchRemoteFileAndStoreMetadata fetches the file from the remote server and stores its metadata in the database
 func (r *downloadRequest) fetchRemoteFileAndStoreMetadata(
 	ctx context.Context,
-	client *gomatrixserverlib.Client,
+	client *fclient.Client,
 	absBasePath config.Path,
 	maxFileSizeBytes config.FileSizeBytes,
 	db storage.Database,
@@ -713,7 +714,7 @@ func (r *downloadRequest) GetContentLengthAndReader(contentLengthHeader string, 
 
 func (r *downloadRequest) fetchRemoteFile(
 	ctx context.Context,
-	client *gomatrixserverlib.Client,
+	client *fclient.Client,
 	absBasePath config.Path,
 	maxFileSizeBytes config.FileSizeBytes,
 ) (types.Path, bool, error) {

--- a/mediaapi/routing/routing.go
+++ b/mediaapi/routing/routing.go
@@ -26,6 +26,7 @@ import (
 	"github.com/matrix-org/dendrite/setup/config"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -48,7 +49,7 @@ func Setup(
 	cfg *config.Dendrite,
 	db storage.Database,
 	userAPI userapi.MediaUserAPI,
-	client *gomatrixserverlib.Client,
+	client *fclient.Client,
 ) {
 	rateLimits := httputil.NewRateLimits(&cfg.ClientAPI.RateLimiting)
 
@@ -103,7 +104,7 @@ func makeDownloadAPI(
 	cfg *config.MediaAPI,
 	rateLimits *httputil.RateLimits,
 	db storage.Database,
-	client *gomatrixserverlib.Client,
+	client *fclient.Client,
 	activeRemoteRequests *types.ActiveRemoteRequests,
 	activeThumbnailGeneration *types.ActiveThumbnailGeneration,
 ) http.HandlerFunc {

--- a/relayapi/api/api.go
+++ b/relayapi/api/api.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 )
 
 // RelayInternalAPI is used to query information from the relay server.
@@ -51,7 +52,7 @@ type RelayServerAPI interface {
 	QueryTransactions(
 		ctx context.Context,
 		userID gomatrixserverlib.UserID,
-		previousEntry gomatrixserverlib.RelayEntry,
+		previousEntry fclient.RelayEntry,
 	) (QueryRelayTransactionsResponse, error)
 }
 

--- a/relayapi/internal/perform_test.go
+++ b/relayapi/internal/perform_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/matrix-org/dendrite/relayapi/storage/shared"
 	"github.com/matrix-org/dendrite/test"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -37,15 +38,15 @@ type testFedClient struct {
 func (f *testFedClient) P2PGetTransactionFromRelay(
 	ctx context.Context,
 	u gomatrixserverlib.UserID,
-	prev gomatrixserverlib.RelayEntry,
+	prev fclient.RelayEntry,
 	relayServer gomatrixserverlib.ServerName,
-) (res gomatrixserverlib.RespGetRelayTransaction, err error) {
+) (res fclient.RespGetRelayTransaction, err error) {
 	f.queryCount++
 	if f.shouldFail {
 		return res, fmt.Errorf("Error")
 	}
 
-	res = gomatrixserverlib.RespGetRelayTransaction{
+	res = fclient.RespGetRelayTransaction{
 		Transaction: gomatrixserverlib.Transaction{},
 		EntryID:     0,
 	}

--- a/relayapi/relayapi.go
+++ b/relayapi/relayapi.go
@@ -26,6 +26,7 @@ import (
 	rsAPI "github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/sirupsen/logrus"
 )
 
@@ -53,7 +54,7 @@ func AddPublicRoutes(
 func NewRelayInternalAPI(
 	dendriteCfg *config.Dendrite,
 	cm sqlutil.Connections,
-	fedClient *gomatrixserverlib.FederationClient,
+	fedClient *fclient.FederationClient,
 	rsAPI rsAPI.RoomserverInternalAPI,
 	keyRing *gomatrixserverlib.KeyRing,
 	producer *producers.SyncAPIProducer,

--- a/relayapi/relayapi_test.go
+++ b/relayapi/relayapi_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/matrix-org/dendrite/test"
 	"github.com/matrix-org/dendrite/test/testrig"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -79,7 +80,7 @@ func createGetRelayTxnHTTPRequest(serverName gomatrixserverlib.ServerName, userI
 	pk := sk.Public().(ed25519.PublicKey)
 	origin := gomatrixserverlib.ServerName(hex.EncodeToString(pk))
 	req := gomatrixserverlib.NewFederationRequest("GET", origin, serverName, "/_matrix/federation/v1/relay_txn/"+userID)
-	content := gomatrixserverlib.RelayEntry{EntryID: 0}
+	content := fclient.RelayEntry{EntryID: 0}
 	req.SetContent(content)
 	req.Sign(origin, gomatrixserverlib.KeyID(keyID), sk)
 	httpreq, _ := req.HTTPRequest()

--- a/relayapi/routing/relaytxn.go
+++ b/relayapi/routing/relaytxn.go
@@ -21,6 +21,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/relayapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 	"github.com/sirupsen/logrus"
 )
@@ -35,7 +36,7 @@ func GetTransactionFromRelay(
 ) util.JSONResponse {
 	logrus.Infof("Processing relay_txn for %s", userID.Raw())
 
-	var previousEntry gomatrixserverlib.RelayEntry
+	var previousEntry fclient.RelayEntry
 	if err := json.Unmarshal(fedReq.Content(), &previousEntry); err != nil {
 		return util.JSONResponse{
 			Code: http.StatusInternalServerError,
@@ -59,7 +60,7 @@ func GetTransactionFromRelay(
 
 	return util.JSONResponse{
 		Code: http.StatusOK,
-		JSON: gomatrixserverlib.RespGetRelayTransaction{
+		JSON: fclient.RespGetRelayTransaction{
 			Transaction:   response.Transaction,
 			EntryID:       response.EntryID,
 			EntriesQueued: response.EntriesQueued,

--- a/relayapi/routing/relaytxn_test.go
+++ b/relayapi/routing/relaytxn_test.go
@@ -25,12 +25,13 @@ import (
 	"github.com/matrix-org/dendrite/relayapi/storage/shared"
 	"github.com/matrix-org/dendrite/test"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/stretchr/testify/assert"
 )
 
 func createQuery(
 	userID gomatrixserverlib.UserID,
-	prevEntry gomatrixserverlib.RelayEntry,
+	prevEntry fclient.RelayEntry,
 ) gomatrixserverlib.FederationRequest {
 	var federationPathPrefixV1 = "/_matrix/federation/v1"
 	path := federationPathPrefixV1 + "/relay_txn/" + userID.Raw()
@@ -60,11 +61,11 @@ func TestGetEmptyDatabaseReturnsNothing(t *testing.T) {
 		&db, nil, nil, nil, nil, false, "", true,
 	)
 
-	request := createQuery(*userID, gomatrixserverlib.RelayEntry{})
+	request := createQuery(*userID, fclient.RelayEntry{})
 	response := routing.GetTransactionFromRelay(httpReq, &request, relayAPI, *userID)
 	assert.Equal(t, http.StatusOK, response.Code)
 
-	jsonResponse := response.JSON.(gomatrixserverlib.RespGetRelayTransaction)
+	jsonResponse := response.JSON.(fclient.RespGetRelayTransaction)
 	assert.Equal(t, false, jsonResponse.EntriesQueued)
 	assert.Equal(t, gomatrixserverlib.Transaction{}, jsonResponse.Transaction)
 
@@ -93,7 +94,7 @@ func TestGetInvalidPrevEntryFails(t *testing.T) {
 		&db, nil, nil, nil, nil, false, "", true,
 	)
 
-	request := createQuery(*userID, gomatrixserverlib.RelayEntry{EntryID: -1})
+	request := createQuery(*userID, fclient.RelayEntry{EntryID: -1})
 	response := routing.GetTransactionFromRelay(httpReq, &request, relayAPI, *userID)
 	assert.Equal(t, http.StatusInternalServerError, response.Code)
 }
@@ -126,20 +127,20 @@ func TestGetReturnsSavedTransaction(t *testing.T) {
 		&db, nil, nil, nil, nil, false, "", true,
 	)
 
-	request := createQuery(*userID, gomatrixserverlib.RelayEntry{})
+	request := createQuery(*userID, fclient.RelayEntry{})
 	response := routing.GetTransactionFromRelay(httpReq, &request, relayAPI, *userID)
 	assert.Equal(t, http.StatusOK, response.Code)
 
-	jsonResponse := response.JSON.(gomatrixserverlib.RespGetRelayTransaction)
+	jsonResponse := response.JSON.(fclient.RespGetRelayTransaction)
 	assert.True(t, jsonResponse.EntriesQueued)
 	assert.Equal(t, transaction, jsonResponse.Transaction)
 
 	// And once more to clear the queue
-	request = createQuery(*userID, gomatrixserverlib.RelayEntry{EntryID: jsonResponse.EntryID})
+	request = createQuery(*userID, fclient.RelayEntry{EntryID: jsonResponse.EntryID})
 	response = routing.GetTransactionFromRelay(httpReq, &request, relayAPI, *userID)
 	assert.Equal(t, http.StatusOK, response.Code)
 
-	jsonResponse = response.JSON.(gomatrixserverlib.RespGetRelayTransaction)
+	jsonResponse = response.JSON.(fclient.RespGetRelayTransaction)
 	assert.False(t, jsonResponse.EntriesQueued)
 	assert.Equal(t, gomatrixserverlib.Transaction{}, jsonResponse.Transaction)
 
@@ -189,28 +190,28 @@ func TestGetReturnsMultipleSavedTransactions(t *testing.T) {
 		&db, nil, nil, nil, nil, false, "", true,
 	)
 
-	request := createQuery(*userID, gomatrixserverlib.RelayEntry{})
+	request := createQuery(*userID, fclient.RelayEntry{})
 	response := routing.GetTransactionFromRelay(httpReq, &request, relayAPI, *userID)
 	assert.Equal(t, http.StatusOK, response.Code)
 
-	jsonResponse := response.JSON.(gomatrixserverlib.RespGetRelayTransaction)
+	jsonResponse := response.JSON.(fclient.RespGetRelayTransaction)
 	assert.True(t, jsonResponse.EntriesQueued)
 	assert.Equal(t, transaction, jsonResponse.Transaction)
 
-	request = createQuery(*userID, gomatrixserverlib.RelayEntry{EntryID: jsonResponse.EntryID})
+	request = createQuery(*userID, fclient.RelayEntry{EntryID: jsonResponse.EntryID})
 	response = routing.GetTransactionFromRelay(httpReq, &request, relayAPI, *userID)
 	assert.Equal(t, http.StatusOK, response.Code)
 
-	jsonResponse = response.JSON.(gomatrixserverlib.RespGetRelayTransaction)
+	jsonResponse = response.JSON.(fclient.RespGetRelayTransaction)
 	assert.True(t, jsonResponse.EntriesQueued)
 	assert.Equal(t, transaction2, jsonResponse.Transaction)
 
 	// And once more to clear the queue
-	request = createQuery(*userID, gomatrixserverlib.RelayEntry{EntryID: jsonResponse.EntryID})
+	request = createQuery(*userID, fclient.RelayEntry{EntryID: jsonResponse.EntryID})
 	response = routing.GetTransactionFromRelay(httpReq, &request, relayAPI, *userID)
 	assert.Equal(t, http.StatusOK, response.Code)
 
-	jsonResponse = response.JSON.(gomatrixserverlib.RespGetRelayTransaction)
+	jsonResponse = response.JSON.(fclient.RespGetRelayTransaction)
 	assert.False(t, jsonResponse.EntriesQueued)
 	assert.Equal(t, gomatrixserverlib.Transaction{}, jsonResponse.Transaction)
 

--- a/relayapi/routing/sendrelay.go
+++ b/relayapi/routing/sendrelay.go
@@ -21,6 +21,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/relayapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 	"github.com/sirupsen/logrus"
 )
@@ -36,7 +37,7 @@ func SendTransactionToRelay(
 ) util.JSONResponse {
 	logrus.Infof("Processing send_relay for %s", userID.Raw())
 
-	var txnEvents gomatrixserverlib.RelayEvents
+	var txnEvents fclient.RelayEvents
 	if err := json.Unmarshal(fedReq.Content(), &txnEvents); err != nil {
 		logrus.Info("The request body could not be decoded into valid JSON." + err.Error())
 		return util.JSONResponse{

--- a/roomserver/api/wrapper.go
+++ b/roomserver/api/wrapper.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 	"github.com/sirupsen/logrus"
 )
@@ -49,7 +50,7 @@ func SendEvents(
 func SendEventWithState(
 	ctx context.Context, rsAPI InputRoomEventsAPI,
 	virtualHost gomatrixserverlib.ServerName, kind Kind,
-	state *gomatrixserverlib.RespState, event *gomatrixserverlib.HeaderedEvent,
+	state *fclient.RespState, event *gomatrixserverlib.HeaderedEvent,
 	origin gomatrixserverlib.ServerName, haveEventIDs map[string]bool, async bool,
 ) error {
 	outliers := state.Events(event.RoomVersion)
@@ -159,7 +160,7 @@ func IsServerBannedFromRoom(ctx context.Context, rsAPI FederationRoomserverAPI, 
 // PopulatePublicRooms extracts PublicRoom information for all the provided room IDs. The IDs are not checked to see if they are visible in the
 // published room directory.
 // due to lots of switches
-func PopulatePublicRooms(ctx context.Context, roomIDs []string, rsAPI QueryBulkStateContentAPI) ([]gomatrixserverlib.PublicRoom, error) {
+func PopulatePublicRooms(ctx context.Context, roomIDs []string, rsAPI QueryBulkStateContentAPI) ([]fclient.PublicRoom, error) {
 	avatarTuple := gomatrixserverlib.StateKeyTuple{EventType: "m.room.avatar", StateKey: ""}
 	nameTuple := gomatrixserverlib.StateKeyTuple{EventType: "m.room.name", StateKey: ""}
 	canonicalTuple := gomatrixserverlib.StateKeyTuple{EventType: gomatrixserverlib.MRoomCanonicalAlias, StateKey: ""}
@@ -181,10 +182,10 @@ func PopulatePublicRooms(ctx context.Context, roomIDs []string, rsAPI QueryBulkS
 		util.GetLogger(ctx).WithError(err).Error("QueryBulkStateContent failed")
 		return nil, err
 	}
-	chunk := make([]gomatrixserverlib.PublicRoom, len(roomIDs))
+	chunk := make([]fclient.PublicRoom, len(roomIDs))
 	i := 0
 	for roomID, data := range stateRes.Rooms {
-		pub := gomatrixserverlib.PublicRoom{
+		pub := fclient.PublicRoom{
 			RoomID: roomID,
 		}
 		joinCount := 0

--- a/roomserver/internal/input/input.go
+++ b/roomserver/internal/input/input.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	userapi "github.com/matrix-org/dendrite/userapi/api"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 
 	"github.com/Arceliar/phony"
 	"github.com/getsentry/sentry-go"
@@ -79,7 +80,7 @@ type Inputer struct {
 	JetStream           nats.JetStreamContext
 	Durable             nats.SubOpt
 	ServerName          gomatrixserverlib.ServerName
-	SigningIdentity     *gomatrixserverlib.SigningIdentity
+	SigningIdentity     *fclient.SigningIdentity
 	FSAPI               fedapi.RoomserverFederationAPI
 	KeyRing             gomatrixserverlib.JSONVerifier
 	ACLs                *acls.ServerACLs

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
@@ -646,7 +647,7 @@ func (r *Inputer) fetchAuthEvents(
 	}
 
 	var err error
-	var res gomatrixserverlib.RespEventAuth
+	var res fclient.RespEventAuth
 	var found bool
 	for _, serverName := range servers {
 		// Request the entire auth chain for the event in question. This should

--- a/roomserver/internal/input/input_missing.go
+++ b/roomserver/internal/input/input_missing.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 	"github.com/sirupsen/logrus"
 
@@ -517,10 +518,10 @@ func (t *missingStateReq) getMissingEvents(ctx context.Context, e *gomatrixserve
 		t.hadEvent(ev.EventID)
 	}
 
-	var missingResp *gomatrixserverlib.RespMissingEvents
+	var missingResp *fclient.RespMissingEvents
 	for _, server := range t.servers {
-		var m gomatrixserverlib.RespMissingEvents
-		if m, err = t.federation.LookupMissingEvents(ctx, t.virtualHost, server, e.RoomID(), gomatrixserverlib.MissingEvents{
+		var m fclient.RespMissingEvents
+		if m, err = t.federation.LookupMissingEvents(ctx, t.virtualHost, server, e.RoomID(), fclient.MissingEvents{
 			Limit: 20,
 			// The latest event IDs that the sender already has. These are skipped when retrieving the previous events of latest_events.
 			EarliestEvents: latestEvents,
@@ -640,8 +641,12 @@ func (t *missingStateReq) lookupMissingStateViaState(
 	if err != nil {
 		return nil, err
 	}
+	s := fclient.RespState{
+		StateEvents: state.GetStateEvents(),
+		AuthEvents:  state.GetAuthEvents(),
+	}
 	// Check that the returned state is valid.
-	authEvents, stateEvents, err := state.Check(ctx, roomVersion, t.keys, nil)
+	authEvents, stateEvents, err := s.Check(ctx, roomVersion, t.keys, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -652,11 +657,11 @@ func (t *missingStateReq) lookupMissingStateViaState(
 	// Cache the results of this state lookup and deduplicate anything we already
 	// have in the cache, freeing up memory.
 	// We load these as trusted as we called state.Check before which loaded them as untrusted.
-	for i, evJSON := range state.AuthEvents {
+	for i, evJSON := range s.AuthEvents {
 		ev, _ := gomatrixserverlib.NewEventFromTrustedJSON(evJSON, false, roomVersion)
 		parsedState.AuthEvents[i] = t.cacheAndReturn(ev)
 	}
-	for i, evJSON := range state.StateEvents {
+	for i, evJSON := range s.StateEvents {
 		ev, _ := gomatrixserverlib.NewEventFromTrustedJSON(evJSON, false, roomVersion)
 		parsedState.StateEvents[i] = t.cacheAndReturn(ev)
 	}
@@ -670,7 +675,7 @@ func (t *missingStateReq) lookupMissingStateViaStateIDs(ctx context.Context, roo
 
 	t.log.Infof("lookupMissingStateViaStateIDs %s", eventID)
 	// fetch the state event IDs at the time of the event
-	var stateIDs gomatrixserverlib.RespStateIDs
+	var stateIDs gomatrixserverlib.StateIDResponse
 	var err error
 	count := 0
 	totalctx, totalcancel := context.WithTimeout(ctx, time.Minute*5)
@@ -688,7 +693,7 @@ func (t *missingStateReq) lookupMissingStateViaStateIDs(ctx context.Context, roo
 		return nil, fmt.Errorf("t.federation.LookupStateIDs tried %d server(s), last error: %w", count, err)
 	}
 	// work out which auth/state IDs are missing
-	wantIDs := append(stateIDs.StateEventIDs, stateIDs.AuthEventIDs...)
+	wantIDs := append(stateIDs.GetStateEventIDs(), stateIDs.GetAuthEventIDs()...)
 	missing := make(map[string]bool)
 	var missingEventList []string
 	t.haveEventsMutex.Lock()
@@ -730,8 +735,8 @@ func (t *missingStateReq) lookupMissingStateViaStateIDs(ctx context.Context, roo
 		t.log.WithFields(logrus.Fields{
 			"missing":           missingCount,
 			"event_id":          eventID,
-			"total_state":       len(stateIDs.StateEventIDs),
-			"total_auth_events": len(stateIDs.AuthEventIDs),
+			"total_state":       len(stateIDs.GetStateEventIDs()),
+			"total_auth_events": len(stateIDs.GetAuthEventIDs()),
 		}).Debug("Fetching all state at event")
 		return t.lookupMissingStateViaState(ctx, roomID, eventID, roomVersion)
 	}
@@ -740,8 +745,8 @@ func (t *missingStateReq) lookupMissingStateViaStateIDs(ctx context.Context, roo
 		t.log.WithFields(logrus.Fields{
 			"missing":             missingCount,
 			"event_id":            eventID,
-			"total_state":         len(stateIDs.StateEventIDs),
-			"total_auth_events":   len(stateIDs.AuthEventIDs),
+			"total_state":         len(stateIDs.GetStateEventIDs()),
+			"total_auth_events":   len(stateIDs.GetAuthEventIDs()),
 			"concurrent_requests": concurrentRequests,
 		}).Debug("Fetching missing state at event")
 
@@ -808,7 +813,7 @@ func (t *missingStateReq) lookupMissingStateViaStateIDs(ctx context.Context, roo
 }
 
 func (t *missingStateReq) createRespStateFromStateIDs(
-	stateIDs gomatrixserverlib.RespStateIDs,
+	stateIDs gomatrixserverlib.StateIDResponse,
 ) (*parsedRespState, error) { // nolint:unparam
 	t.haveEventsMutex.Lock()
 	defer t.haveEventsMutex.Unlock()
@@ -816,18 +821,20 @@ func (t *missingStateReq) createRespStateFromStateIDs(
 	// create a RespState response using the response to /state_ids as a guide
 	respState := parsedRespState{}
 
-	for i := range stateIDs.StateEventIDs {
-		ev, ok := t.haveEvents[stateIDs.StateEventIDs[i]]
+	stateEventIDs := stateIDs.GetStateEventIDs()
+	authEventIDs := stateIDs.GetAuthEventIDs()
+	for i := range stateEventIDs {
+		ev, ok := t.haveEvents[stateEventIDs[i]]
 		if !ok {
-			logrus.Tracef("Missing state event in createRespStateFromStateIDs: %s", stateIDs.StateEventIDs[i])
+			logrus.Tracef("Missing state event in createRespStateFromStateIDs: %s", stateEventIDs[i])
 			continue
 		}
 		respState.StateEvents = append(respState.StateEvents, ev)
 	}
-	for i := range stateIDs.AuthEventIDs {
-		ev, ok := t.haveEvents[stateIDs.AuthEventIDs[i]]
+	for i := range authEventIDs {
+		ev, ok := t.haveEvents[authEventIDs[i]]
 		if !ok {
-			logrus.Tracef("Missing auth event in createRespStateFromStateIDs: %s", stateIDs.AuthEventIDs[i])
+			logrus.Tracef("Missing auth event in createRespStateFromStateIDs: %s", authEventIDs[i])
 			continue
 		}
 		respState.AuthEvents = append(respState.AuthEvents, ev)

--- a/roomserver/internal/perform/perform_admin.go
+++ b/roomserver/internal/perform/perform_admin.go
@@ -322,7 +322,7 @@ func (r *Admin) PerformAdminDownloadState(
 	stateEventMap := map[string]*gomatrixserverlib.Event{}
 
 	for _, fwdExtremity := range fwdExtremities {
-		var state gomatrixserverlib.RespState
+		var state gomatrixserverlib.StateResponse
 		state, err = r.Inputer.FSAPI.LookupState(ctx, r.Inputer.ServerName, req.ServerName, req.RoomID, fwdExtremity.EventID, roomInfo.RoomVersion)
 		if err != nil {
 			res.Error = &api.PerformError{
@@ -331,13 +331,13 @@ func (r *Admin) PerformAdminDownloadState(
 			}
 			return nil
 		}
-		for _, authEvent := range state.AuthEvents.UntrustedEvents(roomInfo.RoomVersion) {
+		for _, authEvent := range state.GetAuthEvents().UntrustedEvents(roomInfo.RoomVersion) {
 			if err = authEvent.VerifyEventSignatures(ctx, r.Inputer.KeyRing); err != nil {
 				continue
 			}
 			authEventMap[authEvent.EventID()] = authEvent
 		}
-		for _, stateEvent := range state.StateEvents.UntrustedEvents(roomInfo.RoomVersion) {
+		for _, stateEvent := range state.GetStateEvents().UntrustedEvents(roomInfo.RoomVersion) {
 			if err = stateEvent.VerifyEventSignatures(ctx, r.Inputer.KeyRing); err != nil {
 				continue
 			}

--- a/setup/config/config_global.go
+++ b/setup/config/config_global.go
@@ -8,13 +8,14 @@ import (
 	"time"
 
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"golang.org/x/crypto/ed25519"
 )
 
 type Global struct {
 	// Signing identity contains the server name, private key and key ID of
 	// the deployment.
-	gomatrixserverlib.SigningIdentity `yaml:",inline"`
+	fclient.SigningIdentity `yaml:",inline"`
 
 	// The secondary server names, used for virtual hosting.
 	VirtualHosts []*VirtualHost `yaml:"-"`
@@ -167,7 +168,7 @@ func (c *Global) VirtualHostForHTTPHost(serverName gomatrixserverlib.ServerName)
 	return nil
 }
 
-func (c *Global) SigningIdentityFor(serverName gomatrixserverlib.ServerName) (*gomatrixserverlib.SigningIdentity, error) {
+func (c *Global) SigningIdentityFor(serverName gomatrixserverlib.ServerName) (*fclient.SigningIdentity, error) {
 	for _, id := range c.SigningIdentities() {
 		if id.ServerName == serverName {
 			return id, nil
@@ -176,8 +177,8 @@ func (c *Global) SigningIdentityFor(serverName gomatrixserverlib.ServerName) (*g
 	return nil, fmt.Errorf("no signing identity for %q", serverName)
 }
 
-func (c *Global) SigningIdentities() []*gomatrixserverlib.SigningIdentity {
-	identities := make([]*gomatrixserverlib.SigningIdentity, 0, len(c.VirtualHosts)+1)
+func (c *Global) SigningIdentities() []*fclient.SigningIdentity {
+	identities := make([]*fclient.SigningIdentity, 0, len(c.VirtualHosts)+1)
 	identities = append(identities, &c.SigningIdentity)
 	for _, v := range c.VirtualHosts {
 		identities = append(identities, &v.SigningIdentity)
@@ -188,7 +189,7 @@ func (c *Global) SigningIdentities() []*gomatrixserverlib.SigningIdentity {
 type VirtualHost struct {
 	// Signing identity contains the server name, private key and key ID of
 	// the virtual host.
-	gomatrixserverlib.SigningIdentity `yaml:",inline"`
+	fclient.SigningIdentity `yaml:",inline"`
 
 	// Path to the private key. If not specified, the default global private key
 	// will be used instead.

--- a/setup/config/config_test.go
+++ b/setup/config/config_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
@@ -275,7 +276,7 @@ func Test_SigningIdentityFor(t *testing.T) {
 		name         string
 		virtualHosts []*VirtualHost
 		serverName   gomatrixserverlib.ServerName
-		want         *gomatrixserverlib.SigningIdentity
+		want         *fclient.SigningIdentity
 		wantErr      bool
 	}{
 		{
@@ -290,23 +291,23 @@ func Test_SigningIdentityFor(t *testing.T) {
 		{
 			name:       "found identity",
 			serverName: gomatrixserverlib.ServerName("main"),
-			want:       &gomatrixserverlib.SigningIdentity{ServerName: "main"},
+			want:       &fclient.SigningIdentity{ServerName: "main"},
 		},
 		{
 			name:       "identity found on virtual hosts",
 			serverName: gomatrixserverlib.ServerName("vh2"),
 			virtualHosts: []*VirtualHost{
-				{SigningIdentity: gomatrixserverlib.SigningIdentity{ServerName: "vh1"}},
-				{SigningIdentity: gomatrixserverlib.SigningIdentity{ServerName: "vh2"}},
+				{SigningIdentity: fclient.SigningIdentity{ServerName: "vh1"}},
+				{SigningIdentity: fclient.SigningIdentity{ServerName: "vh2"}},
 			},
-			want: &gomatrixserverlib.SigningIdentity{ServerName: "vh2"},
+			want: &fclient.SigningIdentity{ServerName: "vh2"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &Global{
 				VirtualHosts: tt.virtualHosts,
-				SigningIdentity: gomatrixserverlib.SigningIdentity{
+				SigningIdentity: fclient.SigningIdentity{
 					ServerName: "main",
 				},
 			}

--- a/setup/monolith.go
+++ b/setup/monolith.go
@@ -34,6 +34,7 @@ import (
 	"github.com/matrix-org/dendrite/syncapi"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 )
 
 // Monolith represents an instantiation of all dependencies required to build
@@ -41,8 +42,8 @@ import (
 type Monolith struct {
 	Config    *config.Dendrite
 	KeyRing   *gomatrixserverlib.KeyRing
-	Client    *gomatrixserverlib.Client
-	FedClient *gomatrixserverlib.FederationClient
+	Client    *fclient.Client
+	FedClient *fclient.FederationClient
 
 	AppserviceAPI appserviceAPI.AppServiceInternalAPI
 	FederationAPI federationAPI.FederationInternalAPI

--- a/setup/mscs/msc2836/msc2836.go
+++ b/setup/mscs/msc2836/msc2836.go
@@ -37,6 +37,7 @@ import (
 	"github.com/matrix-org/dendrite/syncapi/synctypes"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 )
 
@@ -85,7 +86,7 @@ type EventRelationshipResponse struct {
 }
 
 type MSC2836EventRelationshipsResponse struct {
-	gomatrixserverlib.MSC2836EventRelationshipsResponse
+	fclient.MSC2836EventRelationshipsResponse
 	ParsedEvents    []*gomatrixserverlib.Event
 	ParsedAuthChain []*gomatrixserverlib.Event
 }
@@ -399,7 +400,7 @@ func (rc *reqCtx) includeChildren(db Database, parentID string, limit int, recen
 		serversToQuery := rc.getServersForEventID(parentID)
 		var result *MSC2836EventRelationshipsResponse
 		for _, srv := range serversToQuery {
-			res, err := rc.fsAPI.MSC2836EventRelationships(rc.ctx, rc.serverName, srv, gomatrixserverlib.MSC2836EventRelationshipsRequest{
+			res, err := rc.fsAPI.MSC2836EventRelationships(rc.ctx, rc.serverName, srv, fclient.MSC2836EventRelationshipsRequest{
 				EventID:     parentID,
 				Direction:   "down",
 				Limit:       100,
@@ -486,7 +487,7 @@ func walkThread(
 
 // MSC2836EventRelationships performs an /event_relationships request to a remote server
 func (rc *reqCtx) MSC2836EventRelationships(eventID string, srv gomatrixserverlib.ServerName, ver gomatrixserverlib.RoomVersion) (*MSC2836EventRelationshipsResponse, error) {
-	res, err := rc.fsAPI.MSC2836EventRelationships(rc.ctx, rc.serverName, srv, gomatrixserverlib.MSC2836EventRelationshipsRequest{
+	res, err := rc.fsAPI.MSC2836EventRelationships(rc.ctx, rc.serverName, srv, fclient.MSC2836EventRelationshipsRequest{
 		EventID:     eventID,
 		DepthFirst:  rc.req.DepthFirst,
 		Direction:   rc.req.Direction,
@@ -653,7 +654,7 @@ func (rc *reqCtx) injectResponseToRoomserver(res *MSC2836EventRelationshipsRespo
 			messageEvents = append(messageEvents, ev)
 		}
 	}
-	respState := gomatrixserverlib.RespState{
+	respState := fclient.RespState{
 		AuthEvents:  res.AuthChain,
 		StateEvents: stateEvents,
 	}

--- a/userapi/api/api.go
+++ b/userapi/api/api.go
@@ -24,6 +24,7 @@ import (
 	"github.com/matrix-org/dendrite/syncapi/synctypes"
 	"github.com/matrix-org/dendrite/userapi/types"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/internal/pushrules"
@@ -719,9 +720,9 @@ type OutputCrossSigningKeyUpdate struct {
 }
 
 type CrossSigningKeyUpdate struct {
-	MasterKey      *gomatrixserverlib.CrossSigningKey `json:"master_key,omitempty"`
-	SelfSigningKey *gomatrixserverlib.CrossSigningKey `json:"self_signing_key,omitempty"`
-	UserID         string                             `json:"user_id"`
+	MasterKey      *fclient.CrossSigningKey `json:"master_key,omitempty"`
+	SelfSigningKey *fclient.CrossSigningKey `json:"self_signing_key,omitempty"`
+	UserID         string                   `json:"user_id"`
 }
 
 // DeviceKeysEqual returns true if the device keys updates contain the
@@ -854,7 +855,7 @@ type PerformClaimKeysResponse struct {
 }
 
 type PerformUploadDeviceKeysRequest struct {
-	gomatrixserverlib.CrossSigningKeys
+	fclient.CrossSigningKeys
 	// The user that uploaded the key, should be populated by the clientapi.
 	UserID string
 }
@@ -864,7 +865,7 @@ type PerformUploadDeviceKeysResponse struct {
 }
 
 type PerformUploadDeviceSignaturesRequest struct {
-	Signatures map[string]map[gomatrixserverlib.KeyID]gomatrixserverlib.CrossSigningForKeyOrDevice
+	Signatures map[string]map[gomatrixserverlib.KeyID]fclient.CrossSigningForKeyOrDevice
 	// The user that uploaded the sig, should be populated by the clientapi.
 	UserID string
 }
@@ -888,9 +889,9 @@ type QueryKeysResponse struct {
 	// Map of user_id to device_id to device_key
 	DeviceKeys map[string]map[string]json.RawMessage
 	// Maps of user_id to cross signing key
-	MasterKeys      map[string]gomatrixserverlib.CrossSigningKey
-	SelfSigningKeys map[string]gomatrixserverlib.CrossSigningKey
-	UserSigningKeys map[string]gomatrixserverlib.CrossSigningKey
+	MasterKeys      map[string]fclient.CrossSigningKey
+	SelfSigningKeys map[string]fclient.CrossSigningKey
+	UserSigningKeys map[string]fclient.CrossSigningKey
 	// Set if there was a fatal error processing this query
 	Error *KeyError
 }
@@ -945,11 +946,11 @@ type QuerySignaturesResponse struct {
 	// A map of target user ID -> target key/device ID -> origin user ID -> origin key/device ID -> signatures
 	Signatures map[string]map[gomatrixserverlib.KeyID]types.CrossSigningSigMap
 	// A map of target user ID -> cross-signing master key
-	MasterKeys map[string]gomatrixserverlib.CrossSigningKey
+	MasterKeys map[string]fclient.CrossSigningKey
 	// A map of target user ID -> cross-signing self-signing key
-	SelfSigningKeys map[string]gomatrixserverlib.CrossSigningKey
+	SelfSigningKeys map[string]fclient.CrossSigningKey
 	// A map of target user ID -> cross-signing user-signing key
-	UserSigningKeys map[string]gomatrixserverlib.CrossSigningKey
+	UserSigningKeys map[string]fclient.CrossSigningKey
 	// The request error, if any
 	Error *KeyError
 }

--- a/userapi/consumers/signingkeyupdate.go
+++ b/userapi/consumers/signingkeyupdate.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/nats-io/nats.go"
 	"github.com/sirupsen/logrus"
 
@@ -86,7 +87,7 @@ func (t *SigningKeyUpdateConsumer) onMessage(ctx context.Context, msgs []*nats.M
 		return true
 	}
 
-	keys := gomatrixserverlib.CrossSigningKeys{}
+	keys := fclient.CrossSigningKeys{}
 	if updatePayload.MasterKey != nil {
 		keys.MasterKey = *updatePayload.MasterKey
 	}

--- a/userapi/internal/device_list_update.go
+++ b/userapi/internal/device_list_update.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	rsapi "github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 
 	"github.com/matrix-org/gomatrix"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -508,12 +509,12 @@ func (u *DeviceListUpdater) processServerUser(ctx context.Context, serverName go
 		}
 		uploadRes := &api.PerformUploadDeviceKeysResponse{}
 		if res.MasterKey != nil {
-			if err = sanityCheckKey(*res.MasterKey, userID, gomatrixserverlib.CrossSigningKeyPurposeMaster); err == nil {
+			if err = sanityCheckKey(*res.MasterKey, userID, fclient.CrossSigningKeyPurposeMaster); err == nil {
 				uploadReq.MasterKey = *res.MasterKey
 			}
 		}
 		if res.SelfSigningKey != nil {
-			if err = sanityCheckKey(*res.SelfSigningKey, userID, gomatrixserverlib.CrossSigningKeyPurposeSelfSigning); err == nil {
+			if err = sanityCheckKey(*res.SelfSigningKey, userID, fclient.CrossSigningKeyPurposeSelfSigning); err == nil {
 				uploadReq.SelfSigningKey = *res.SelfSigningKey
 			}
 		}
@@ -527,7 +528,7 @@ func (u *DeviceListUpdater) processServerUser(ctx context.Context, serverName go
 	return defaultWaitTime, nil
 }
 
-func (u *DeviceListUpdater) updateDeviceList(res *gomatrixserverlib.RespUserDevices) error {
+func (u *DeviceListUpdater) updateDeviceList(res *fclient.RespUserDevices) error {
 	ctx := context.Background() // we've got the keys, don't time out when persisting them to the database.
 	keys := make([]api.DeviceMessage, len(res.Devices))
 	existingKeys := make([]api.DeviceMessage, len(res.Devices))

--- a/userapi/internal/device_list_update_test.go
+++ b/userapi/internal/device_list_update_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 
 	roomserver "github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/setup/config"
@@ -135,10 +136,10 @@ func (t *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.fn(req)
 }
 
-func newFedClient(tripper func(*http.Request) (*http.Response, error)) *gomatrixserverlib.FederationClient {
+func newFedClient(tripper func(*http.Request) (*http.Response, error)) *fclient.FederationClient {
 	_, pkey, _ := ed25519.GenerateKey(nil)
-	fedClient := gomatrixserverlib.NewFederationClient(
-		[]*gomatrixserverlib.SigningIdentity{
+	fedClient := fclient.NewFederationClient(
+		[]*fclient.SigningIdentity{
 			{
 				ServerName: gomatrixserverlib.ServerName("example.test"),
 				KeyID:      gomatrixserverlib.KeyID("ed25519:test"),
@@ -146,8 +147,8 @@ func newFedClient(tripper func(*http.Request) (*http.Response, error)) *gomatrix
 			},
 		},
 	)
-	fedClient.Client = *gomatrixserverlib.NewClient(
-		gomatrixserverlib.WithTransport(&roundTripper{tripper}),
+	fedClient.Client = *fclient.NewClient(
+		fclient.WithTransport(&roundTripper{tripper}),
 	)
 	return fedClient
 }

--- a/userapi/storage/interface.go
+++ b/userapi/storage/interface.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/internal/pushrules"
@@ -203,7 +204,7 @@ type KeyDatabase interface {
 	// MarkDeviceListStale sets the stale bit for this user to isStale.
 	MarkDeviceListStale(ctx context.Context, userID string, isStale bool) error
 
-	CrossSigningKeysForUser(ctx context.Context, userID string) (map[gomatrixserverlib.CrossSigningKeyPurpose]gomatrixserverlib.CrossSigningKey, error)
+	CrossSigningKeysForUser(ctx context.Context, userID string) (map[fclient.CrossSigningKeyPurpose]fclient.CrossSigningKey, error)
 	CrossSigningKeysDataForUser(ctx context.Context, userID string) (types.CrossSigningKeyMap, error)
 	CrossSigningSigsForTarget(ctx context.Context, originUserID, targetUserID string, targetKeyID gomatrixserverlib.KeyID) (types.CrossSigningSigMap, error)
 

--- a/userapi/storage/postgres/cross_signing_keys_table.go
+++ b/userapi/storage/postgres/cross_signing_keys_table.go
@@ -24,6 +24,7 @@ import (
 	"github.com/matrix-org/dendrite/userapi/storage/tables"
 	"github.com/matrix-org/dendrite/userapi/types"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 )
 
 var crossSigningKeysSchema = `
@@ -89,7 +90,7 @@ func (s *crossSigningKeysStatements) SelectCrossSigningKeysForUser(
 }
 
 func (s *crossSigningKeysStatements) UpsertCrossSigningKeysForUser(
-	ctx context.Context, txn *sql.Tx, userID string, keyType gomatrixserverlib.CrossSigningKeyPurpose, keyData gomatrixserverlib.Base64Bytes,
+	ctx context.Context, txn *sql.Tx, userID string, keyType fclient.CrossSigningKeyPurpose, keyData gomatrixserverlib.Base64Bytes,
 ) error {
 	keyTypeInt, ok := types.KeyTypePurposeToInt[keyType]
 	if !ok {

--- a/userapi/storage/shared/storage.go
+++ b/userapi/storage/shared/storage.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
@@ -1026,17 +1027,17 @@ func (d *KeyDatabase) DeleteDeviceKeys(ctx context.Context, userID string, devic
 }
 
 // CrossSigningKeysForUser returns the latest known cross-signing keys for a user, if any.
-func (d *KeyDatabase) CrossSigningKeysForUser(ctx context.Context, userID string) (map[gomatrixserverlib.CrossSigningKeyPurpose]gomatrixserverlib.CrossSigningKey, error) {
+func (d *KeyDatabase) CrossSigningKeysForUser(ctx context.Context, userID string) (map[fclient.CrossSigningKeyPurpose]fclient.CrossSigningKey, error) {
 	keyMap, err := d.CrossSigningKeysTable.SelectCrossSigningKeysForUser(ctx, nil, userID)
 	if err != nil {
 		return nil, fmt.Errorf("d.CrossSigningKeysTable.SelectCrossSigningKeysForUser: %w", err)
 	}
-	results := map[gomatrixserverlib.CrossSigningKeyPurpose]gomatrixserverlib.CrossSigningKey{}
+	results := map[fclient.CrossSigningKeyPurpose]fclient.CrossSigningKey{}
 	for purpose, key := range keyMap {
 		keyID := gomatrixserverlib.KeyID("ed25519:" + key.Encode())
-		result := gomatrixserverlib.CrossSigningKey{
+		result := fclient.CrossSigningKey{
 			UserID: userID,
-			Usage:  []gomatrixserverlib.CrossSigningKeyPurpose{purpose},
+			Usage:  []fclient.CrossSigningKeyPurpose{purpose},
 			Keys: map[gomatrixserverlib.KeyID]gomatrixserverlib.Base64Bytes{
 				keyID: key,
 			},

--- a/userapi/storage/sqlite3/cross_signing_keys_table.go
+++ b/userapi/storage/sqlite3/cross_signing_keys_table.go
@@ -24,6 +24,7 @@ import (
 	"github.com/matrix-org/dendrite/userapi/storage/tables"
 	"github.com/matrix-org/dendrite/userapi/types"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 )
 
 var crossSigningKeysSchema = `
@@ -88,7 +89,7 @@ func (s *crossSigningKeysStatements) SelectCrossSigningKeysForUser(
 }
 
 func (s *crossSigningKeysStatements) UpsertCrossSigningKeysForUser(
-	ctx context.Context, txn *sql.Tx, userID string, keyType gomatrixserverlib.CrossSigningKeyPurpose, keyData gomatrixserverlib.Base64Bytes,
+	ctx context.Context, txn *sql.Tx, userID string, keyType fclient.CrossSigningKeyPurpose, keyData gomatrixserverlib.Base64Bytes,
 ) error {
 	keyTypeInt, ok := types.KeyTypePurposeToInt[keyType]
 	if !ok {

--- a/userapi/storage/tables/interface.go
+++ b/userapi/storage/tables/interface.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/userapi/types"
@@ -181,7 +182,7 @@ type StaleDeviceLists interface {
 
 type CrossSigningKeys interface {
 	SelectCrossSigningKeysForUser(ctx context.Context, txn *sql.Tx, userID string) (r types.CrossSigningKeyMap, err error)
-	UpsertCrossSigningKeysForUser(ctx context.Context, txn *sql.Tx, userID string, keyType gomatrixserverlib.CrossSigningKeyPurpose, keyData gomatrixserverlib.Base64Bytes) error
+	UpsertCrossSigningKeysForUser(ctx context.Context, txn *sql.Tx, userID string, keyType fclient.CrossSigningKeyPurpose, keyData gomatrixserverlib.Base64Bytes) error
 }
 
 type CrossSigningSigs interface {

--- a/userapi/types/storage.go
+++ b/userapi/types/storage.go
@@ -18,6 +18,7 @@ import (
 	"math"
 
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 )
 
 const (
@@ -29,22 +30,22 @@ const (
 
 // KeyTypePurposeToInt maps a purpose to an integer, which is used in the
 // database to reduce the amount of space taken up by this column.
-var KeyTypePurposeToInt = map[gomatrixserverlib.CrossSigningKeyPurpose]int16{
-	gomatrixserverlib.CrossSigningKeyPurposeMaster:      1,
-	gomatrixserverlib.CrossSigningKeyPurposeSelfSigning: 2,
-	gomatrixserverlib.CrossSigningKeyPurposeUserSigning: 3,
+var KeyTypePurposeToInt = map[fclient.CrossSigningKeyPurpose]int16{
+	fclient.CrossSigningKeyPurposeMaster:      1,
+	fclient.CrossSigningKeyPurposeSelfSigning: 2,
+	fclient.CrossSigningKeyPurposeUserSigning: 3,
 }
 
 // KeyTypeIntToPurpose maps an integer to a purpose, which is used in the
 // database to reduce the amount of space taken up by this column.
-var KeyTypeIntToPurpose = map[int16]gomatrixserverlib.CrossSigningKeyPurpose{
-	1: gomatrixserverlib.CrossSigningKeyPurposeMaster,
-	2: gomatrixserverlib.CrossSigningKeyPurposeSelfSigning,
-	3: gomatrixserverlib.CrossSigningKeyPurposeUserSigning,
+var KeyTypeIntToPurpose = map[int16]fclient.CrossSigningKeyPurpose{
+	1: fclient.CrossSigningKeyPurposeMaster,
+	2: fclient.CrossSigningKeyPurposeSelfSigning,
+	3: fclient.CrossSigningKeyPurposeUserSigning,
 }
 
 // Map of purpose -> public key
-type CrossSigningKeyMap map[gomatrixserverlib.CrossSigningKeyPurpose]gomatrixserverlib.Base64Bytes
+type CrossSigningKeyMap map[fclient.CrossSigningKeyPurpose]gomatrixserverlib.Base64Bytes
 
 // Map of user ID -> key ID -> signature
 type CrossSigningSigMap map[string]map[gomatrixserverlib.KeyID]gomatrixserverlib.Base64Bytes

--- a/userapi/userapi_test.go
+++ b/userapi/userapi_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/userapi/producers"
 	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 	"github.com/nats-io/nats.go"
 	"golang.org/x/crypto/bcrypt"
@@ -87,7 +88,7 @@ func MustMakeInternalAPI(t *testing.T, opts apiTestOpts, dbType test.DBType, pub
 		t.Fatalf("failed to create key DB: %s", err)
 	}
 
-	cfg.Global.SigningIdentity = gomatrixserverlib.SigningIdentity{
+	cfg.Global.SigningIdentity = fclient.SigningIdentity{
 		ServerName: sName,
 	}
 


### PR DESCRIPTION
Part of a series of refactors on GMSL.