### PR TITLE
Remove event building duplication & push to GMSL

### DIFF
--- a/clientapi/routing/createroom.go
+++ b/clientapi/routing/createroom.go
@@ -448,7 +448,7 @@ func createRoom(
 			builder.PrevEvents = []gomatrixserverlib.EventReference{builtEvents[i-1].EventReference()}
 		}
 		var ev *gomatrixserverlib.Event
-		ev, err = builder.BuildEvent(userDomain, &authEvents, evTime, roomVersion, cfg.Matrix.KeyID, cfg.Matrix.PrivateKey)
+		ev, err = builder.AddAuthEventsAndBuild(userDomain, &authEvents, evTime, roomVersion, cfg.Matrix.KeyID, cfg.Matrix.PrivateKey)
 		if err != nil {
 			util.GetLogger(ctx).WithError(err).Error("buildEvent failed")
 			return jsonerror.InternalServerError()

--- a/clientapi/routing/createroom.go
+++ b/clientapi/routing/createroom.go
@@ -448,7 +448,7 @@ func createRoom(
 			builder.PrevEvents = []gomatrixserverlib.EventReference{builtEvents[i-1].EventReference()}
 		}
 		var ev *gomatrixserverlib.Event
-		ev, err = buildEvent(&builder, userDomain, &authEvents, cfg, evTime, roomVersion)
+		ev, err = builder.BuildEvent(userDomain, &authEvents, evTime, roomVersion, cfg.Matrix.KeyID, cfg.Matrix.PrivateKey)
 		if err != nil {
 			util.GetLogger(ctx).WithError(err).Error("buildEvent failed")
 			return jsonerror.InternalServerError()
@@ -598,32 +598,4 @@ func createRoom(
 		Code: 200,
 		JSON: response,
 	}
-}
-
-// buildEvent fills out auth_events for the builder then builds the event
-func buildEvent(
-	builder *gomatrixserverlib.EventBuilder,
-	serverName gomatrixserverlib.ServerName,
-	provider gomatrixserverlib.AuthEventProvider,
-	cfg *config.ClientAPI,
-	evTime time.Time,
-	roomVersion gomatrixserverlib.RoomVersion,
-) (*gomatrixserverlib.Event, error) {
-	eventsNeeded, err := gomatrixserverlib.StateNeededForEventBuilder(builder)
-	if err != nil {
-		return nil, err
-	}
-	refs, err := eventsNeeded.AuthEventReferences(provider)
-	if err != nil {
-		return nil, err
-	}
-	builder.AuthEvents = refs
-	event, err := builder.Build(
-		evTime, serverName, cfg.Matrix.KeyID,
-		cfg.Matrix.PrivateKey, roomVersion,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("cannot build event %s : Builder failed to build. %w", builder.Type, err)
-	}
-	return event, nil
 }

--- a/roomserver/internal/api.go
+++ b/roomserver/internal/api.go
@@ -160,6 +160,7 @@ func (r *RoomserverInternalAPI) SetFederationAPI(fsAPI fsAPI.RoomserverFederatio
 		Cfg:     &r.Cfg.RoomServer,
 		DB:      r.DB,
 		FSAPI:   r.fsAPI,
+		RSAPI:   r,
 		Inputer: r.Inputer,
 	}
 	r.Publisher = &perform.Publisher{

--- a/roomserver/internal/perform/perform_upgrade.go
+++ b/roomserver/internal/perform/perform_upgrade.go
@@ -526,7 +526,7 @@ func (r *Upgrader) sendInitialEvents(ctx context.Context, evTime time.Time, user
 			builder.PrevEvents = []gomatrixserverlib.EventReference{builtEvents[i-1].EventReference()}
 		}
 		var event *gomatrixserverlib.Event
-		event, err = builder.BuildEvent(userDomain, &authEvents, evTime, gomatrixserverlib.RoomVersion(newVersion), r.Cfg.Matrix.KeyID, r.Cfg.Matrix.PrivateKey)
+		event, err = builder.AddAuthEventsAndBuild(userDomain, &authEvents, evTime, gomatrixserverlib.RoomVersion(newVersion), r.Cfg.Matrix.KeyID, r.Cfg.Matrix.PrivateKey)
 		if err != nil {
 			return &api.PerformError{
 				Msg: fmt.Sprintf("Failed to build new %q event: %s", builder.Type, err),

--- a/roomserver/internal/perform/perform_upgrade.go
+++ b/roomserver/internal/perform/perform_upgrade.go
@@ -526,7 +526,7 @@ func (r *Upgrader) sendInitialEvents(ctx context.Context, evTime time.Time, user
 			builder.PrevEvents = []gomatrixserverlib.EventReference{builtEvents[i-1].EventReference()}
 		}
 		var event *gomatrixserverlib.Event
-		event, err = r.buildEvent(&builder, userDomain, &authEvents, evTime, gomatrixserverlib.RoomVersion(newVersion))
+		event, err = builder.BuildEvent(userDomain, &authEvents, evTime, gomatrixserverlib.RoomVersion(newVersion), r.Cfg.Matrix.KeyID, r.Cfg.Matrix.PrivateKey)
 		if err != nil {
 			return &api.PerformError{
 				Msg: fmt.Sprintf("Failed to build new %q event: %s", builder.Type, err),
@@ -706,30 +706,4 @@ func (r *Upgrader) sendHeaderedEvent(
 	}
 
 	return nil
-}
-
-func (r *Upgrader) buildEvent(
-	builder *gomatrixserverlib.EventBuilder,
-	serverName gomatrixserverlib.ServerName,
-	provider gomatrixserverlib.AuthEventProvider,
-	evTime time.Time,
-	roomVersion gomatrixserverlib.RoomVersion,
-) (*gomatrixserverlib.Event, error) {
-	eventsNeeded, err := gomatrixserverlib.StateNeededForEventBuilder(builder)
-	if err != nil {
-		return nil, err
-	}
-	refs, err := eventsNeeded.AuthEventReferences(provider)
-	if err != nil {
-		return nil, err
-	}
-	builder.AuthEvents = refs
-	event, err := builder.Build(
-		evTime, serverName, r.Cfg.Matrix.KeyID,
-		r.Cfg.Matrix.PrivateKey, roomVersion,
-	)
-	if err != nil {
-		return nil, err
-	}
-	return event, nil
 }


### PR DESCRIPTION
Removes event building duplication and moves the funcionality into GMSL since all the sub-steps are already there.