### PR TITLE
Add some roomserver UTs

### DIFF
--- a/clientapi/routing/createroom.go
+++ b/clientapi/routing/createroom.go
@@ -48,7 +48,6 @@ type createRoomRequest struct {
 	CreationContent           json.RawMessage               `json:"creation_content"`
 	InitialState              []fledglingEvent              `json:"initial_state"`
 	RoomAliasName             string                        `json:"room_alias_name"`
-	GuestCanJoin              bool                          `json:"guest_can_join"`
 	RoomVersion               gomatrixserverlib.RoomVersion `json:"room_version"`
 	PowerLevelContentOverride json.RawMessage               `json:"power_level_content_override"`
 	IsDirect                  bool                          `json:"is_direct"`
@@ -253,16 +252,19 @@ func createRoom(
 		}
 	}
 
+	var guestsCanJoin bool
 	switch r.Preset {
 	case presetPrivateChat:
 		joinRuleContent.JoinRule = spec.Invite
 		historyVisibilityContent.HistoryVisibility = historyVisibilityShared
+		guestsCanJoin = true
 	case presetTrustedPrivateChat:
 		joinRuleContent.JoinRule = spec.Invite
 		historyVisibilityContent.HistoryVisibility = historyVisibilityShared
 		for _, invitee := range r.Invite {
 			powerLevelContent.Users[invitee] = 100
 		}
+		guestsCanJoin = true
 	case presetPublicChat:
 		joinRuleContent.JoinRule = spec.Public
 		historyVisibilityContent.HistoryVisibility = historyVisibilityShared
@@ -317,7 +319,7 @@ func createRoom(
 		}
 	}
 
-	if r.GuestCanJoin {
+	if guestsCanJoin {
 		guestAccessEvent = &fledglingEvent{
 			Type: spec.MRoomGuestAccess,
 			Content: eventutil.GuestAccessContent{

--- a/clientapi/routing/joinroom_test.go
+++ b/clientapi/routing/joinroom_test.go
@@ -66,7 +66,6 @@ func TestJoinRoomByIDOrAlias(t *testing.T) {
 			Preset:        presetPublicChat,
 			RoomAliasName: "alias",
 			Invite:        []string{bob.ID},
-			GuestCanJoin:  false,
 		}, aliceDev, &cfg.ClientAPI, userAPI, rsAPI, asAPI, time.Now())
 		crResp, ok := resp.JSON.(createRoomResponse)
 		if !ok {
@@ -75,13 +74,12 @@ func TestJoinRoomByIDOrAlias(t *testing.T) {
 
 		// create a room with guest access enabled and invite Charlie
 		resp = createRoom(ctx, createRoomRequest{
-			Name:         "testing",
-			IsDirect:     true,
-			Topic:        "testing",
-			Visibility:   "public",
-			Preset:       presetPublicChat,
-			Invite:       []string{charlie.ID},
-			GuestCanJoin: true,
+			Name:       "testing",
+			IsDirect:   true,
+			Topic:      "testing",
+			Visibility: "public",
+			Preset:     presetPublicChat,
+			Invite:     []string{charlie.ID},
 		}, aliceDev, &cfg.ClientAPI, userAPI, rsAPI, asAPI, time.Now())
 		crRespWithGuestAccess, ok := resp.JSON.(createRoomResponse)
 		if !ok {

--- a/clientapi/routing/profile.go
+++ b/clientapi/routing/profile.go
@@ -357,7 +357,7 @@ func buildMembershipEvents(
 		content.DisplayName = newProfile.DisplayName
 		content.AvatarURL = newProfile.AvatarURL
 
-		if err := builder.SetContent(content); err != nil {
+		if err = builder.SetContent(content); err != nil {
 			return nil, err
 		}
 

--- a/clientapi/routing/profile.go
+++ b/clientapi/routing/profile.go
@@ -338,9 +338,8 @@ func buildMembershipEvents(
 	evs := []*gomatrixserverlib.HeaderedEvent{}
 
 	for _, roomID := range roomIDs {
-		verReq := api.QueryRoomVersionForRoomRequest{RoomID: roomID}
-		verRes := api.QueryRoomVersionForRoomResponse{}
-		if err := rsAPI.QueryRoomVersionForRoom(ctx, &verReq, &verRes); err != nil {
+		roomVersion, err := rsAPI.QueryRoomVersionForRoom(ctx, roomID)
+		if err != nil {
 			return nil, err
 		}
 
@@ -372,7 +371,7 @@ func buildMembershipEvents(
 			return nil, err
 		}
 
-		evs = append(evs, event.Headered(verRes.RoomVersion))
+		evs = append(evs, event.Headered(roomVersion))
 	}
 
 	return evs, nil

--- a/clientapi/routing/sendevent.go
+++ b/clientapi/routing/sendevent.go
@@ -76,9 +76,8 @@ func SendEvent(
 	rsAPI api.ClientRoomserverAPI,
 	txnCache *transactions.Cache,
 ) util.JSONResponse {
-	verReq := api.QueryRoomVersionForRoomRequest{RoomID: roomID}
-	verRes := api.QueryRoomVersionForRoomResponse{}
-	if err := rsAPI.QueryRoomVersionForRoom(req.Context(), &verReq, &verRes); err != nil {
+	roomVersion, err := rsAPI.QueryRoomVersionForRoom(req.Context(), roomID)
+	if err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.UnsupportedRoomVersion(err.Error()),
@@ -185,7 +184,7 @@ func SendEvent(
 		req.Context(), rsAPI,
 		api.KindNew,
 		[]*gomatrixserverlib.HeaderedEvent{
-			e.Headered(verRes.RoomVersion),
+			e.Headered(roomVersion),
 		},
 		device.UserDomain(),
 		domain,
@@ -200,7 +199,7 @@ func SendEvent(
 	util.GetLogger(req.Context()).WithFields(logrus.Fields{
 		"event_id":     e.EventID(),
 		"room_id":      roomID,
-		"room_version": verRes.RoomVersion,
+		"room_version": roomVersion,
 	}).Info("Sent event to roomserver")
 
 	res := util.JSONResponse{

--- a/clientapi/routing/server_notices.go
+++ b/clientapi/routing/server_notices.go
@@ -157,7 +157,6 @@ func SendServerNotice(
 			Visibility:                "private",
 			Preset:                    presetPrivateChat,
 			CreationContent:           cc,
-			GuestCanJoin:              false,
 			RoomVersion:               roomVersion,
 			PowerLevelContentOverride: pl,
 		}

--- a/federationapi/routing/join.go
+++ b/federationapi/routing/join.go
@@ -42,9 +42,8 @@ func MakeJoin(
 	roomID, userID string,
 	remoteVersions []gomatrixserverlib.RoomVersion,
 ) util.JSONResponse {
-	verReq := api.QueryRoomVersionForRoomRequest{RoomID: roomID}
-	verRes := api.QueryRoomVersionForRoomResponse{}
-	if err := rsAPI.QueryRoomVersionForRoom(httpReq.Context(), &verReq, &verRes); err != nil {
+	roomVersion, err := rsAPI.QueryRoomVersionForRoom(httpReq.Context(), roomID)
+	if err != nil {
 		return util.JSONResponse{
 			Code: http.StatusInternalServerError,
 			JSON: jsonerror.InternalServerError(),
@@ -57,7 +56,7 @@ func MakeJoin(
 	// https://matrix.org/docs/spec/server_server/r0.1.3#get-matrix-federation-v1-make-join-roomid-userid
 	remoteSupportsVersion := false
 	for _, v := range remoteVersions {
-		if v == verRes.RoomVersion {
+		if v == roomVersion {
 			remoteSupportsVersion = true
 			break
 		}
@@ -66,7 +65,7 @@ func MakeJoin(
 	if !remoteSupportsVersion {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
-			JSON: jsonerror.IncompatibleRoomVersion(verRes.RoomVersion),
+			JSON: jsonerror.IncompatibleRoomVersion(roomVersion),
 		}
 	}
 
@@ -109,7 +108,7 @@ func MakeJoin(
 
 	// Check if the restricted join is allowed. If the room doesn't
 	// support restricted joins then this is effectively a no-op.
-	res, authorisedVia, err := checkRestrictedJoin(httpReq, rsAPI, verRes.RoomVersion, roomID, userID)
+	res, authorisedVia, err := checkRestrictedJoin(httpReq, rsAPI, roomVersion, roomID, userID)
 	if err != nil {
 		util.GetLogger(httpReq.Context()).WithError(err).Error("checkRestrictedJoin failed")
 		return jsonerror.InternalServerError()
@@ -144,7 +143,7 @@ func MakeJoin(
 	}
 
 	queryRes := api.QueryLatestEventsAndStateResponse{
-		RoomVersion: verRes.RoomVersion,
+		RoomVersion: roomVersion,
 	}
 	event, err := eventutil.QueryAndBuildEvent(httpReq.Context(), &builder, cfg.Matrix, identity, time.Now(), rsAPI, &queryRes)
 	if err == eventutil.ErrRoomNoExists {
@@ -180,7 +179,7 @@ func MakeJoin(
 		Code: http.StatusOK,
 		JSON: map[string]interface{}{
 			"event":        builder,
-			"room_version": verRes.RoomVersion,
+			"room_version": roomVersion,
 		},
 	}
 }
@@ -197,21 +196,20 @@ func SendJoin(
 	keys gomatrixserverlib.JSONVerifier,
 	roomID, eventID string,
 ) util.JSONResponse {
-	verReq := api.QueryRoomVersionForRoomRequest{RoomID: roomID}
-	verRes := api.QueryRoomVersionForRoomResponse{}
-	if err := rsAPI.QueryRoomVersionForRoom(httpReq.Context(), &verReq, &verRes); err != nil {
+	roomVersion, err := rsAPI.QueryRoomVersionForRoom(httpReq.Context(), roomID)
+	if err != nil {
 		util.GetLogger(httpReq.Context()).WithError(err).Error("rsAPI.QueryRoomVersionForRoom failed")
 		return util.JSONResponse{
 			Code: http.StatusInternalServerError,
 			JSON: jsonerror.InternalServerError(),
 		}
 	}
-	verImpl, err := gomatrixserverlib.GetRoomVersion(verRes.RoomVersion)
+	verImpl, err := gomatrixserverlib.GetRoomVersion(roomVersion)
 	if err != nil {
 		return util.JSONResponse{
 			Code: http.StatusInternalServerError,
 			JSON: jsonerror.UnsupportedRoomVersion(
-				fmt.Sprintf("QueryRoomVersionForRoom returned unknown room version: %s", verRes.RoomVersion),
+				fmt.Sprintf("QueryRoomVersionForRoom returned unknown room version: %s", roomVersion),
 			),
 		}
 	}

--- a/federationapi/routing/leave.go
+++ b/federationapi/routing/leave.go
@@ -140,21 +140,20 @@ func SendLeave(
 	keys gomatrixserverlib.JSONVerifier,
 	roomID, eventID string,
 ) util.JSONResponse {
-	verReq := api.QueryRoomVersionForRoomRequest{RoomID: roomID}
-	verRes := api.QueryRoomVersionForRoomResponse{}
-	if err := rsAPI.QueryRoomVersionForRoom(httpReq.Context(), &verReq, &verRes); err != nil {
+	roomVersion, err := rsAPI.QueryRoomVersionForRoom(httpReq.Context(), roomID)
+	if err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
 			JSON: jsonerror.UnsupportedRoomVersion(err.Error()),
 		}
 	}
 
-	verImpl, err := gomatrixserverlib.GetRoomVersion(verRes.RoomVersion)
+	verImpl, err := gomatrixserverlib.GetRoomVersion(roomVersion)
 	if err != nil {
 		return util.JSONResponse{
 			Code: http.StatusInternalServerError,
 			JSON: jsonerror.UnsupportedRoomVersion(
-				fmt.Sprintf("QueryRoomVersionForRoom returned unknown version: %s", verRes.RoomVersion),
+				fmt.Sprintf("QueryRoomVersionForRoom returned unknown version: %s", roomVersion),
 			),
 		}
 	}
@@ -313,7 +312,7 @@ func SendLeave(
 		InputRoomEvents: []api.InputRoomEvent{
 			{
 				Kind:          api.KindNew,
-				Event:         event.Headered(verRes.RoomVersion),
+				Event:         event.Headered(roomVersion),
 				SendAsServer:  string(cfg.Matrix.ServerName),
 				TransactionID: nil,
 			},

--- a/federationapi/routing/peek.go
+++ b/federationapi/routing/peek.go
@@ -35,10 +35,8 @@ func Peek(
 	remoteVersions []gomatrixserverlib.RoomVersion,
 ) util.JSONResponse {
 	// TODO: check if we're just refreshing an existing peek by querying the federationapi
-
-	verReq := api.QueryRoomVersionForRoomRequest{RoomID: roomID}
-	verRes := api.QueryRoomVersionForRoomResponse{}
-	if err := rsAPI.QueryRoomVersionForRoom(httpReq.Context(), &verReq, &verRes); err != nil {
+	roomVersion, err := rsAPI.QueryRoomVersionForRoom(httpReq.Context(), roomID)
+	if err != nil {
 		return util.JSONResponse{
 			Code: http.StatusInternalServerError,
 			JSON: jsonerror.InternalServerError(),
@@ -50,7 +48,7 @@ func Peek(
 	// the peek URL.
 	remoteSupportsVersion := false
 	for _, v := range remoteVersions {
-		if v == verRes.RoomVersion {
+		if v == roomVersion {
 			remoteSupportsVersion = true
 			break
 		}
@@ -59,7 +57,7 @@ func Peek(
 	if !remoteSupportsVersion {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
-			JSON: jsonerror.IncompatibleRoomVersion(verRes.RoomVersion),
+			JSON: jsonerror.IncompatibleRoomVersion(roomVersion),
 		}
 	}
 
@@ -69,7 +67,7 @@ func Peek(
 	renewalInterval := int64(60 * 60 * 1000 * 1000)
 
 	var response api.PerformInboundPeekResponse
-	err := rsAPI.PerformInboundPeek(
+	err = rsAPI.PerformInboundPeek(
 		httpReq.Context(),
 		&api.PerformInboundPeekRequest{
 			RoomID:          roomID,

--- a/internal/transactionrequest.go
+++ b/internal/transactionrequest.go
@@ -115,14 +115,13 @@ func (t *TxnReq) ProcessTransaction(ctx context.Context) (*fclient.RespSend, *ut
 		if v, ok := roomVersions[roomID]; ok {
 			return v
 		}
-		verReq := api.QueryRoomVersionForRoomRequest{RoomID: roomID}
-		verRes := api.QueryRoomVersionForRoomResponse{}
-		if err := t.rsAPI.QueryRoomVersionForRoom(ctx, &verReq, &verRes); err != nil {
-			util.GetLogger(ctx).WithError(err).Debug("Transaction: Failed to query room version for room", verReq.RoomID)
+		roomVersion, err := t.rsAPI.QueryRoomVersionForRoom(ctx, roomID)
+		if err != nil {
+			util.GetLogger(ctx).WithError(err).Debug("Transaction: Failed to query room version for room", roomID)
 			return ""
 		}
-		roomVersions[roomID] = verRes.RoomVersion
-		return verRes.RoomVersion
+		roomVersions[roomID] = roomVersion
+		return roomVersion
 	}
 
 	for _, pdu := range t.PDUs {

--- a/internal/transactionrequest_test.go
+++ b/internal/transactionrequest_test.go
@@ -72,14 +72,12 @@ type FakeRsAPI struct {
 
 func (r *FakeRsAPI) QueryRoomVersionForRoom(
 	ctx context.Context,
-	req *rsAPI.QueryRoomVersionForRoomRequest,
-	res *rsAPI.QueryRoomVersionForRoomResponse,
-) error {
+	roomID string,
+) (gomatrixserverlib.RoomVersion, error) {
 	if r.shouldFailQuery {
-		return fmt.Errorf("Failure")
+		return "", fmt.Errorf("Failure")
 	}
-	res.RoomVersion = gomatrixserverlib.RoomVersionV10
-	return nil
+	return gomatrixserverlib.RoomVersionV10, nil
 }
 
 func (r *FakeRsAPI) QueryServerBannedFromRoom(
@@ -722,11 +720,9 @@ func (t *testRoomserverAPI) QueryServerJoinedToRoom(
 // Asks for the room version for a given room.
 func (t *testRoomserverAPI) QueryRoomVersionForRoom(
 	ctx context.Context,
-	request *rsAPI.QueryRoomVersionForRoomRequest,
-	response *rsAPI.QueryRoomVersionForRoomResponse,
-) error {
-	response.RoomVersion = testRoomVersion
-	return nil
+	roomID string,
+) (gomatrixserverlib.RoomVersion, error) {
+	return testRoomVersion, nil
 }
 
 func (t *testRoomserverAPI) QueryServerBannedFromRoom(

--- a/roomserver/api/api.go
+++ b/roomserver/api/api.go
@@ -143,7 +143,7 @@ type ClientRoomserverAPI interface {
 	QueryStateAfterEvents(ctx context.Context, req *QueryStateAfterEventsRequest, res *QueryStateAfterEventsResponse) error
 	// QueryKnownUsers returns a list of users that we know about from our joined rooms.
 	QueryKnownUsers(ctx context.Context, req *QueryKnownUsersRequest, res *QueryKnownUsersResponse) error
-	QueryRoomVersionForRoom(ctx context.Context, req *QueryRoomVersionForRoomRequest, res *QueryRoomVersionForRoomResponse) error
+	QueryRoomVersionForRoom(ctx context.Context, roomID string) (gomatrixserverlib.RoomVersion, error)
 	QueryPublishedRooms(ctx context.Context, req *QueryPublishedRoomsRequest, res *QueryPublishedRoomsResponse) error
 
 	GetRoomIDForAlias(ctx context.Context, req *GetRoomIDForAliasRequest, res *GetRoomIDForAliasResponse) error
@@ -183,7 +183,7 @@ type FederationRoomserverAPI interface {
 	// QueryServerBannedFromRoom returns whether a server is banned from a room by server ACLs.
 	QueryServerBannedFromRoom(ctx context.Context, req *QueryServerBannedFromRoomRequest, res *QueryServerBannedFromRoomResponse) error
 	QueryMembershipsForRoom(ctx context.Context, req *QueryMembershipsForRoomRequest, res *QueryMembershipsForRoomResponse) error
-	QueryRoomVersionForRoom(ctx context.Context, req *QueryRoomVersionForRoomRequest, res *QueryRoomVersionForRoomResponse) error
+	QueryRoomVersionForRoom(ctx context.Context, roomID string) (gomatrixserverlib.RoomVersion, error)
 	GetRoomIDForAlias(ctx context.Context, req *GetRoomIDForAliasRequest, res *GetRoomIDForAliasResponse) error
 	// QueryEventsByID queries a list of events by event ID for one room. If no room is specified, it will try to determine
 	// which room to use by querying the first events roomID.

--- a/roomserver/auth/auth.go
+++ b/roomserver/auth/auth.go
@@ -26,6 +26,10 @@ func IsServerAllowed(
 	serverCurrentlyInRoom bool,
 	authEvents []*gomatrixserverlib.Event,
 ) bool {
+	// In practice should not happen, but avoids unneeded CPU cycles
+	if serverName == "" || len(authEvents) == 0 {
+		return false
+	}
 	historyVisibility := HistoryVisibilityForRoom(authEvents)
 
 	// 1. If the history_visibility was set to world_readable, allow.

--- a/roomserver/auth/auth_test.go
+++ b/roomserver/auth/auth_test.go
@@ -1,0 +1,85 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/matrix-org/dendrite/test"
+	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/gomatrixserverlib/spec"
+)
+
+func TestIsServerAllowed(t *testing.T) {
+	alice := test.NewUser(t)
+
+	tests := []struct {
+		name                  string
+		want                  bool
+		roomFunc              func() *test.Room
+		serverName            spec.ServerName
+		serverCurrentlyInRoom bool
+	}{
+		{
+			name:     "no servername specified",
+			roomFunc: func() *test.Room { return test.NewRoom(t, alice) },
+		},
+		{
+			name:       "no authEvents specified",
+			serverName: "test",
+			roomFunc:   func() *test.Room { return &test.Room{} },
+		},
+		{
+			name:       "default denied",
+			serverName: "test2",
+			roomFunc:   func() *test.Room { return test.NewRoom(t, alice) },
+		},
+		{
+			name:       "world readable room",
+			serverName: "test",
+			roomFunc: func() *test.Room {
+				return test.NewRoom(t, alice, test.RoomHistoryVisibility(gomatrixserverlib.HistoryVisibilityWorldReadable))
+			},
+			want: true,
+		},
+		{
+			name:       "allowed due to alice being joined",
+			serverName: "test",
+			roomFunc:   func() *test.Room { return test.NewRoom(t, alice) },
+			want:       true,
+		},
+		{
+			name:                  "allowed due to 'serverCurrentlyInRoom'",
+			serverName:            "test2",
+			roomFunc:              func() *test.Room { return test.NewRoom(t, alice) },
+			want:                  true,
+			serverCurrentlyInRoom: true,
+		},
+		{
+			name:       "allowed due to pending invite",
+			serverName: "test2",
+			roomFunc: func() *test.Room {
+				bob := test.User{ID: "@bob:test2"}
+				r := test.NewRoom(t, alice, test.RoomHistoryVisibility(gomatrixserverlib.HistoryVisibilityInvited))
+				r.CreateAndInsert(t, alice, spec.MRoomMember, map[string]interface{}{
+					"membership": spec.Invite,
+				}, test.WithStateKey(bob.ID))
+				return r
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.roomFunc == nil {
+				t.Fatalf("missing roomFunc")
+			}
+			var authEvents []*gomatrixserverlib.Event
+			for _, ev := range tt.roomFunc().Events() {
+				authEvents = append(authEvents, ev.Event)
+			}
+
+			if got := IsServerAllowed(tt.serverName, tt.serverCurrentlyInRoom, authEvents); got != tt.want {
+				t.Errorf("IsServerAllowed() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -478,7 +478,7 @@ func (r *Inputer) processRoomEvent(
 
 	// If guest_access changed and is not can_join, kick all guest users.
 	if event.Type() == spec.MRoomGuestAccess && gjson.GetBytes(event.Content(), "guest_access").Str != "can_join" {
-		if err = r.kickGuests(ctx, event, roomInfo); err != nil {
+		if err = r.kickGuests(ctx, event, roomInfo); err != nil && err != sql.ErrNoRows {
 			logrus.WithError(err).Error("failed to kick guest users on m.room.guest_access revocation")
 		}
 	}

--- a/roomserver/internal/perform/perform_upgrade.go
+++ b/roomserver/internal/perform/perform_upgrade.go
@@ -370,6 +370,10 @@ func (r *Upgrader) generateInitialEvents(ctx context.Context, oldRoom *api.Query
 				continue
 			}
 		}
+		// skip events that rely on a specific user being present
+		if event.Type() != spec.MRoomMember && !event.StateKeyEquals("") {
+			continue
+		}
 		state[gomatrixserverlib.StateKeyTuple{EventType: event.Type(), StateKey: *event.StateKey()}] = event
 	}
 

--- a/roomserver/internal/perform/perform_upgrade.go
+++ b/roomserver/internal/perform/perform_upgrade.go
@@ -319,9 +319,7 @@ func publishNewRoomAndUnpublishOldRoom(
 }
 
 func (r *Upgrader) validateRoomExists(ctx context.Context, roomID string) error {
-	verReq := api.QueryRoomVersionForRoomRequest{RoomID: roomID}
-	verRes := api.QueryRoomVersionForRoomResponse{}
-	if err := r.URSAPI.QueryRoomVersionForRoom(ctx, &verReq, &verRes); err != nil {
+	if _, err := r.URSAPI.QueryRoomVersionForRoom(ctx, roomID); err != nil {
 		return &api.PerformError{
 			Code: api.PerformErrorNoRoom,
 			Msg:  "Room does not exist",

--- a/roomserver/internal/perform/perform_upgrade.go
+++ b/roomserver/internal/perform/perform_upgrade.go
@@ -355,7 +355,7 @@ func (r *Upgrader) generateInitialEvents(ctx context.Context, oldRoom *api.Query
 			continue
 		}
 		if event.Type() == spec.MRoomMember && !event.StateKeyEquals(userID) {
-			// With the exception of bans and invites which we do want to copy, we
+			// With the exception of bans which we do want to copy, we
 			// should ignore membership events that aren't our own, as event auth will
 			// prevent us from being able to create membership events on behalf of other
 			// users anyway unless they are invites or bans.
@@ -365,13 +365,13 @@ func (r *Upgrader) generateInitialEvents(ctx context.Context, oldRoom *api.Query
 			}
 			switch membership {
 			case spec.Ban:
-			case spec.Invite:
 			default:
 				continue
 			}
 		}
 		// skip events that rely on a specific user being present
-		if event.Type() != spec.MRoomMember && !event.StateKeyEquals("") {
+		sKey := *event.StateKey()
+		if event.Type() != spec.MRoomMember && len(sKey) > 0 && sKey[:1] == "@" {
 			continue
 		}
 		state[gomatrixserverlib.StateKeyTuple{EventType: event.Type(), StateKey: *event.StateKey()}] = event

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -692,26 +692,20 @@ func GetAuthChain(
 }
 
 // QueryRoomVersionForRoom implements api.RoomserverInternalAPI
-func (r *Queryer) QueryRoomVersionForRoom(
-	ctx context.Context,
-	request *api.QueryRoomVersionForRoomRequest,
-	response *api.QueryRoomVersionForRoomResponse,
-) error {
-	if roomVersion, ok := r.Cache.GetRoomVersion(request.RoomID); ok {
-		response.RoomVersion = roomVersion
-		return nil
+func (r *Queryer) QueryRoomVersionForRoom(ctx context.Context, roomID string) (gomatrixserverlib.RoomVersion, error) {
+	if roomVersion, ok := r.Cache.GetRoomVersion(roomID); ok {
+		return roomVersion, nil
 	}
 
-	info, err := r.DB.RoomInfo(ctx, request.RoomID)
+	info, err := r.DB.RoomInfo(ctx, roomID)
 	if err != nil {
-		return err
+		return "", err
 	}
 	if info == nil {
-		return fmt.Errorf("QueryRoomVersionForRoom: missing room info for room %s", request.RoomID)
+		return "", fmt.Errorf("QueryRoomVersionForRoom: missing room info for room %s", roomID)
 	}
-	response.RoomVersion = info.RoomVersion
-	r.Cache.StoreRoomVersion(request.RoomID, response.RoomVersion)
-	return nil
+	r.Cache.StoreRoomVersion(roomID, info.RoomVersion)
+	return info.RoomVersion, nil
 }
 
 func (r *Queryer) QueryPublishedRooms(

--- a/setup/mscs/msc2836/msc2836.go
+++ b/setup/mscs/msc2836/msc2836.go
@@ -325,10 +325,8 @@ func (rc *reqCtx) fetchUnknownEvent(eventID, roomID string) *gomatrixserverlib.H
 	}
 	logger := util.GetLogger(rc.ctx).WithField("room_id", roomID)
 	// if they supplied a room_id, check the room exists.
-	var queryVerRes roomserver.QueryRoomVersionForRoomResponse
-	err := rc.rsAPI.QueryRoomVersionForRoom(rc.ctx, &roomserver.QueryRoomVersionForRoomRequest{
-		RoomID: roomID,
-	}, &queryVerRes)
+
+	roomVersion, err := rc.rsAPI.QueryRoomVersionForRoom(rc.ctx, roomID)
 	if err != nil {
 		logger.WithError(err).Warn("failed to query room version for room, does this room exist?")
 		return nil
@@ -367,7 +365,7 @@ func (rc *reqCtx) fetchUnknownEvent(eventID, roomID string) *gomatrixserverlib.H
 	// Inject the response into the roomserver to remember the event across multiple calls and to set
 	// unexplored flags correctly.
 	for _, srv := range serversToQuery {
-		res, err := rc.MSC2836EventRelationships(eventID, srv, queryVerRes.RoomVersion)
+		res, err := rc.MSC2836EventRelationships(eventID, srv, roomVersion)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
Adds tests for `QueryRestrictedJoinAllowed`, `IsServerAllowed` and `PerformRoomUpgrade`. Refactors the `QueryRoomVersionForRoom` method to accept a string and return a `gmsl.RoomVersion` instead of req/resp structs.
Adds some more caching for `GetStateEvent`

This should also fix #2912 by ignoring state events belonging to other users.