### PR TITLE
Remove gmsl.HeaderedEvent

### DIFF
--- a/appservice/consumers/roomserver.go
+++ b/appservice/consumers/roomserver.go
@@ -30,6 +30,7 @@ import (
 	"github.com/nats-io/nats.go"
 
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/dendrite/setup/jetstream"
 	"github.com/matrix-org/dendrite/setup/process"
@@ -104,7 +105,7 @@ func (s *OutputRoomEventConsumer) onMessage(
 	ctx context.Context, state *appserviceState, msgs []*nats.Msg,
 ) bool {
 	log.WithField("appservice", state.ID).Tracef("Appservice worker received %d message(s) from roomserver", len(msgs))
-	events := make([]*gomatrixserverlib.HeaderedEvent, 0, len(msgs))
+	events := make([]*types.HeaderedEvent, 0, len(msgs))
 	for _, msg := range msgs {
 		// Only handle events we care about
 		receivedType := api.OutputType(msg.Header.Get(jetstream.RoomEventType))
@@ -174,7 +175,7 @@ func (s *OutputRoomEventConsumer) onMessage(
 // endpoint. It will block for the backoff period if necessary.
 func (s *OutputRoomEventConsumer) sendEvents(
 	ctx context.Context, state *appserviceState,
-	events []*gomatrixserverlib.HeaderedEvent,
+	events []*types.HeaderedEvent,
 	txnID string,
 ) error {
 	// Create the transaction body.
@@ -231,7 +232,7 @@ func (s *appserviceState) backoffAndPause(err error) error {
 // event falls within one of a given application service's namespaces.
 //
 // TODO: This should be cached, see https://github.com/matrix-org/dendrite/issues/1682
-func (s *OutputRoomEventConsumer) appserviceIsInterestedInEvent(ctx context.Context, event *gomatrixserverlib.HeaderedEvent, appservice *config.ApplicationService) bool {
+func (s *OutputRoomEventConsumer) appserviceIsInterestedInEvent(ctx context.Context, event *types.HeaderedEvent, appservice *config.ApplicationService) bool {
 	switch {
 	case appservice.URL == "":
 		return false
@@ -269,7 +270,7 @@ func (s *OutputRoomEventConsumer) appserviceIsInterestedInEvent(ctx context.Cont
 
 // appserviceJoinedAtEvent returns a boolean depending on whether a given
 // appservice has membership at the time a given event was created.
-func (s *OutputRoomEventConsumer) appserviceJoinedAtEvent(ctx context.Context, event *gomatrixserverlib.HeaderedEvent, appservice *config.ApplicationService) bool {
+func (s *OutputRoomEventConsumer) appserviceJoinedAtEvent(ctx context.Context, event *types.HeaderedEvent, appservice *config.ApplicationService) bool {
 	// TODO: This is only checking the current room state, not the state at
 	// the event in question. Pretty sure this is what Synapse does too, but
 	// until we have a lighter way of checking the state before the event that

--- a/clientapi/routing/createroom.go
+++ b/clientapi/routing/createroom.go
@@ -24,6 +24,7 @@ import (
 
 	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"
 	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	roomserverVersion "github.com/matrix-org/dendrite/roomserver/version"
 	"github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib/fclient"
@@ -429,7 +430,7 @@ func createRoom(
 	// TODO: invite events
 	// TODO: 3pid invite events
 
-	var builtEvents []*gomatrixserverlib.HeaderedEvent
+	var builtEvents []*types.HeaderedEvent
 	authEvents := gomatrixserverlib.NewAuthEvents(nil)
 	for i, e := range eventsToMake {
 		depth := i + 1 // depth starts at 1
@@ -462,7 +463,7 @@ func createRoom(
 		}
 
 		// Add the event to the list of auth events
-		builtEvents = append(builtEvents, ev.Headered(roomVersion))
+		builtEvents = append(builtEvents, &types.HeaderedEvent{Event: ev})
 		err = authEvents.AddEvent(ev)
 		if err != nil {
 			util.GetLogger(ctx).WithError(err).Error("authEvents.AddEvent failed")
@@ -557,11 +558,11 @@ func createRoom(
 			)
 			// Send the invite event to the roomserver.
 			var inviteRes roomserverAPI.PerformInviteResponse
-			event := inviteEvent.Headered(roomVersion)
+			event := inviteEvent
 			if err := rsAPI.PerformInvite(ctx, &roomserverAPI.PerformInviteRequest{
 				Event:           event,
 				InviteRoomState: inviteStrippedState,
-				RoomVersion:     event.RoomVersion,
+				RoomVersion:     event.Version(),
 				SendAsServer:    string(userDomain),
 			}, &inviteRes); err != nil {
 				util.GetLogger(ctx).WithError(err).Error("PerformInvite failed")

--- a/clientapi/routing/membership.go
+++ b/clientapi/routing/membership.go
@@ -31,6 +31,7 @@ import (
 	"github.com/matrix-org/dendrite/internal/eventutil"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 
@@ -91,7 +92,7 @@ func sendMembership(ctx context.Context, profileAPI userapi.ClientUserAPI, devic
 	if err = roomserverAPI.SendEvents(
 		ctx, rsAPI,
 		roomserverAPI.KindNew,
-		[]*gomatrixserverlib.HeaderedEvent{event},
+		[]*types.HeaderedEvent{event},
 		device.UserDomain(),
 		serverName,
 		serverName,
@@ -268,7 +269,7 @@ func sendInvite(
 	if err := rsAPI.PerformInvite(ctx, &api.PerformInviteRequest{
 		Event:           event,
 		InviteRoomState: nil, // ask the roomserver to draw up invite room state for us
-		RoomVersion:     event.RoomVersion,
+		RoomVersion:     event.Version(),
 		SendAsServer:    string(device.UserDomain()),
 	}, &inviteRes); err != nil {
 		util.GetLogger(ctx).WithError(err).Error("PerformInvite failed")
@@ -294,7 +295,7 @@ func buildMembershipEvent(
 	membership, roomID string, isDirect bool,
 	cfg *config.ClientAPI, evTime time.Time,
 	rsAPI roomserverAPI.ClientRoomserverAPI, asAPI appserviceAPI.AppServiceInternalAPI,
-) (*gomatrixserverlib.HeaderedEvent, error) {
+) (*types.HeaderedEvent, error) {
 	profile, err := loadProfile(ctx, targetUserID, cfg, profileAPI, asAPI)
 	if err != nil {
 		return nil, err

--- a/clientapi/routing/profile.go
+++ b/clientapi/routing/profile.go
@@ -29,6 +29,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/internal/eventutil"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 
@@ -334,8 +335,8 @@ func buildMembershipEvents(
 	roomIDs []string,
 	newProfile authtypes.Profile, userID string, cfg *config.ClientAPI,
 	evTime time.Time, rsAPI api.ClientRoomserverAPI,
-) ([]*gomatrixserverlib.HeaderedEvent, error) {
-	evs := []*gomatrixserverlib.HeaderedEvent{}
+) ([]*types.HeaderedEvent, error) {
+	evs := []*types.HeaderedEvent{}
 
 	for _, roomID := range roomIDs {
 		verReq := api.QueryRoomVersionForRoomRequest{RoomID: roomID}
@@ -372,7 +373,7 @@ func buildMembershipEvents(
 			return nil, err
 		}
 
-		evs = append(evs, event.Headered(verRes.RoomVersion))
+		evs = append(evs, event)
 	}
 
 	return evs, nil

--- a/clientapi/routing/profile.go
+++ b/clientapi/routing/profile.go
@@ -339,11 +339,6 @@ func buildMembershipEvents(
 	evs := []*types.HeaderedEvent{}
 
 	for _, roomID := range roomIDs {
-		roomVersion, err := rsAPI.QueryRoomVersionForRoom(ctx, roomID)
-		if err != nil {
-			return nil, err
-		}
-
 		builder := gomatrixserverlib.EventBuilder{
 			Sender:   userID,
 			RoomID:   roomID,
@@ -358,7 +353,7 @@ func buildMembershipEvents(
 		content.DisplayName = newProfile.DisplayName
 		content.AvatarURL = newProfile.AvatarURL
 
-		if err = builder.SetContent(content); err != nil {
+		if err := builder.SetContent(content); err != nil {
 			return nil, err
 		}
 

--- a/clientapi/routing/redaction.go
+++ b/clientapi/routing/redaction.go
@@ -28,6 +28,7 @@ import (
 	"github.com/matrix-org/dendrite/internal/eventutil"
 	"github.com/matrix-org/dendrite/internal/transactions"
 	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 )
@@ -138,7 +139,7 @@ func SendRedaction(
 		}
 	}
 	domain := device.UserDomain()
-	if err = roomserverAPI.SendEvents(context.Background(), rsAPI, roomserverAPI.KindNew, []*gomatrixserverlib.HeaderedEvent{e}, device.UserDomain(), domain, domain, nil, false); err != nil {
+	if err = roomserverAPI.SendEvents(context.Background(), rsAPI, roomserverAPI.KindNew, []*types.HeaderedEvent{e}, device.UserDomain(), domain, domain, nil, false); err != nil {
 		util.GetLogger(req.Context()).WithError(err).Errorf("failed to SendEvents")
 		return jsonerror.InternalServerError()
 	}

--- a/clientapi/routing/sendevent.go
+++ b/clientapi/routing/sendevent.go
@@ -34,6 +34,7 @@ import (
 	"github.com/matrix-org/dendrite/internal/eventutil"
 	"github.com/matrix-org/dendrite/internal/transactions"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 )
@@ -184,8 +185,8 @@ func SendEvent(
 	if err := api.SendEvents(
 		req.Context(), rsAPI,
 		api.KindNew,
-		[]*gomatrixserverlib.HeaderedEvent{
-			e.Headered(verRes.RoomVersion),
+		[]*types.HeaderedEvent{
+			&types.HeaderedEvent{Event: e},
 		},
 		device.UserDomain(),
 		domain,

--- a/clientapi/routing/server_notices.go
+++ b/clientapi/routing/server_notices.go
@@ -22,12 +22,12 @@ import (
 	"time"
 
 	"github.com/matrix-org/gomatrix"
-	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/tokens"
 	"github.com/matrix-org/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/roomserver/version"
 
 	appserviceAPI "github.com/matrix-org/dendrite/appservice/api"
@@ -228,8 +228,8 @@ func SendServerNotice(
 	if err := api.SendEvents(
 		ctx, rsAPI,
 		api.KindNew,
-		[]*gomatrixserverlib.HeaderedEvent{
-			e.Headered(roomVersion),
+		[]*types.HeaderedEvent{
+			&types.HeaderedEvent{Event: e},
 		},
 		device.UserDomain(),
 		cfgClient.Matrix.ServerName,

--- a/clientapi/routing/state.go
+++ b/clientapi/routing/state.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/synctypes"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -266,7 +267,7 @@ func OnIncomingStateTypeRequest(
 		"state_at_event": !wantLatestState,
 	}).Info("Fetching state")
 
-	var event *gomatrixserverlib.HeaderedEvent
+	var event *types.HeaderedEvent
 	if wantLatestState {
 		// If we are happy to use the latest state, either because the user is
 		// still in the room, or because the room is world-readable, then just

--- a/clientapi/threepid/invites.go
+++ b/clientapi/threepid/invites.go
@@ -27,6 +27,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
 	"github.com/matrix-org/dendrite/internal/eventutil"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -367,8 +368,8 @@ func emit3PIDInviteEvent(
 	return api.SendEvents(
 		ctx, rsAPI,
 		api.KindNew,
-		[]*gomatrixserverlib.HeaderedEvent{
-			event.Headered(queryRes.RoomVersion),
+		[]*types.HeaderedEvent{
+			event,
 		},
 		device.UserDomain(),
 		cfg.Matrix.ServerName,

--- a/federationapi/api/api.go
+++ b/federationapi/api/api.go
@@ -11,6 +11,7 @@ import (
 	"github.com/matrix-org/gomatrixserverlib/spec"
 
 	"github.com/matrix-org/dendrite/federationapi/types"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 )
 
 // FederationInternalAPI is used to query information from the federation sender.
@@ -188,13 +189,13 @@ type PerformLeaveResponse struct {
 }
 
 type PerformInviteRequest struct {
-	RoomVersion     gomatrixserverlib.RoomVersion    `json:"room_version"`
-	Event           *gomatrixserverlib.HeaderedEvent `json:"event"`
-	InviteRoomState []fclient.InviteV2StrippedState  `json:"invite_room_state"`
+	RoomVersion     gomatrixserverlib.RoomVersion   `json:"room_version"`
+	Event           *rstypes.HeaderedEvent          `json:"event"`
+	InviteRoomState []fclient.InviteV2StrippedState `json:"invite_room_state"`
 }
 
 type PerformInviteResponse struct {
-	Event *gomatrixserverlib.HeaderedEvent `json:"event"`
+	Event *rstypes.HeaderedEvent `json:"event"`
 }
 
 // QueryJoinedHostServerNamesInRoomRequest is a request to QueryJoinedHostServerNames

--- a/federationapi/consumers/roomserver.go
+++ b/federationapi/consumers/roomserver.go
@@ -187,7 +187,12 @@ func (s *OutputRoomEventConsumer) processMessage(ore api.OutputNewRoomEvent, rew
 		addsStateEvents = append(addsStateEvents, eventsRes.Events...)
 	}
 
-	addsJoinedHosts, err := JoinedHostsFromEvents(gomatrixserverlib.UnwrapEventHeaders(addsStateEvents))
+	evs := make([]*gomatrixserverlib.Event, len(addsStateEvents))
+	for i := range evs {
+		evs[i] = addsStateEvents[i].Event
+	}
+
+	addsJoinedHosts, err := JoinedHostsFromEvents(evs)
 	if err != nil {
 		return err
 	}

--- a/federationapi/federationapi_test.go
+++ b/federationapi/federationapi_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/matrix-org/dendrite/federationapi/api"
 	"github.com/matrix-org/dendrite/federationapi/internal"
 	rsapi "github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/jetstream"
 	"github.com/matrix-org/dendrite/test"
 	"github.com/matrix-org/dendrite/test/testrig"
@@ -135,10 +136,10 @@ func (f *fedClient) SendJoin(ctx context.Context, origin, s spec.ServerName, eve
 	defer f.fedClientMutex.Unlock()
 	for _, r := range f.allowJoins {
 		if r.ID == event.RoomID() {
-			r.InsertEvent(f.t, event.Headered(r.Version))
+			r.InsertEvent(f.t, &types.HeaderedEvent{Event: event})
 			f.t.Logf("Join event: %v", event.EventID())
-			res.StateEvents = gomatrixserverlib.NewEventJSONsFromHeaderedEvents(r.CurrentState())
-			res.AuthEvents = gomatrixserverlib.NewEventJSONsFromHeaderedEvents(r.Events())
+			res.StateEvents = types.NewEventJSONsFromHeaderedEvents(r.CurrentState())
+			res.AuthEvents = types.NewEventJSONsFromHeaderedEvents(r.Events())
 		}
 	}
 	return
@@ -325,8 +326,7 @@ func TestRoomsV3URLEscapeDoNot404(t *testing.T) {
 		if err != nil {
 			t.Errorf("failed to parse event: %s", err)
 		}
-		he := ev.Headered(tc.roomVer)
-		invReq, err := fclient.NewInviteV2Request(he, nil)
+		invReq, err := fclient.NewInviteV2Request(ev, nil)
 		if err != nil {
 			t.Errorf("failed to create invite v2 request: %s", err)
 			continue

--- a/federationapi/internal/perform.go
+++ b/federationapi/internal/perform.go
@@ -18,6 +18,7 @@ import (
 	"github.com/matrix-org/dendrite/federationapi/consumers"
 	"github.com/matrix-org/dendrite/federationapi/statistics"
 	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/roomserver/version"
 )
 
@@ -302,7 +303,7 @@ func (r *FederationInternalAPI) performJoinUsingServer(
 		origin,
 		roomserverAPI.KindNew,
 		respState,
-		event.Headered(respMakeJoin.RoomVersion),
+		&types.HeaderedEvent{Event: event},
 		serverName,
 		nil,
 		false,
@@ -505,7 +506,7 @@ func (r *FederationInternalAPI) performOutboundPeekUsingServer(
 			StateEvents: gomatrixserverlib.NewEventJSONsFromEvents(stateEvents),
 			AuthEvents:  gomatrixserverlib.NewEventJSONsFromEvents(authEvents),
 		},
-		respPeek.LatestEvent.Headered(respPeek.RoomVersion),
+		&types.HeaderedEvent{Event: respPeek.LatestEvent},
 		serverName,
 		nil,
 		false,
@@ -652,7 +653,7 @@ func (r *FederationInternalAPI) PerformInvite(
 		"destination":  destination,
 	}).Info("Sending invite")
 
-	inviteReq, err := fclient.NewInviteV2Request(request.Event, request.InviteRoomState)
+	inviteReq, err := fclient.NewInviteV2Request(request.Event.Event, request.InviteRoomState)
 	if err != nil {
 		return fmt.Errorf("gomatrixserverlib.NewInviteV2Request: %w", err)
 	}
@@ -670,7 +671,7 @@ func (r *FederationInternalAPI) PerformInvite(
 	if err != nil {
 		return fmt.Errorf("r.federation.SendInviteV2 failed to decode event response: %w", err)
 	}
-	response.Event = inviteEvent.Headered(request.RoomVersion)
+	response.Event = &types.HeaderedEvent{Event: inviteEvent}
 	return nil
 }
 

--- a/federationapi/queue/destinationqueue.go
+++ b/federationapi/queue/destinationqueue.go
@@ -32,6 +32,7 @@ import (
 	"github.com/matrix-org/dendrite/federationapi/storage"
 	"github.com/matrix-org/dendrite/federationapi/storage/shared/receipt"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/process"
 )
 
@@ -71,7 +72,7 @@ type destinationQueue struct {
 // Send event adds the event to the pending queue for the destination.
 // If the queue is empty then it starts a background goroutine to
 // start sending events to that destination.
-func (oq *destinationQueue) sendEvent(event *gomatrixserverlib.HeaderedEvent, dbReceipt *receipt.Receipt) {
+func (oq *destinationQueue) sendEvent(event *types.HeaderedEvent, dbReceipt *receipt.Receipt) {
 	if event == nil {
 		logrus.Errorf("attempt to send nil PDU with destination %q", oq.destination)
 		return

--- a/federationapi/queue/queue.go
+++ b/federationapi/queue/queue.go
@@ -33,6 +33,7 @@ import (
 	"github.com/matrix-org/dendrite/federationapi/storage"
 	"github.com/matrix-org/dendrite/federationapi/storage/shared/receipt"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/process"
 )
 
@@ -140,7 +141,7 @@ func NewOutgoingQueues(
 
 type queuedPDU struct {
 	dbReceipt *receipt.Receipt
-	pdu       *gomatrixserverlib.HeaderedEvent
+	pdu       *types.HeaderedEvent
 }
 
 type queuedEDU struct {
@@ -187,7 +188,7 @@ func (oqs *OutgoingQueues) clearQueue(oq *destinationQueue) {
 
 // SendEvent sends an event to the destinations
 func (oqs *OutgoingQueues) SendEvent(
-	ev *gomatrixserverlib.HeaderedEvent, origin spec.ServerName,
+	ev *types.HeaderedEvent, origin spec.ServerName,
 	destinations []spec.ServerName,
 ) error {
 	if oqs.disabled {

--- a/federationapi/queue/queue_test.go
+++ b/federationapi/queue/queue_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/matrix-org/dendrite/federationapi/statistics"
 	"github.com/matrix-org/dendrite/federationapi/storage"
 	rsapi "github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/dendrite/setup/process"
 	"github.com/matrix-org/dendrite/test"
@@ -101,14 +102,14 @@ func (f *stubFederationClient) P2PSendTransactionToRelay(ctx context.Context, u 
 	return fclient.EmptyResp{}, result
 }
 
-func mustCreatePDU(t *testing.T) *gomatrixserverlib.HeaderedEvent {
+func mustCreatePDU(t *testing.T) *types.HeaderedEvent {
 	t.Helper()
 	content := `{"type":"m.room.message"}`
 	ev, err := gomatrixserverlib.MustGetRoomVersion(gomatrixserverlib.RoomVersionV10).NewEventFromTrustedJSON([]byte(content), false)
 	if err != nil {
 		t.Fatalf("failed to create event: %v", err)
 	}
-	return ev.Headered(gomatrixserverlib.RoomVersionV10)
+	return &types.HeaderedEvent{Event: ev}
 }
 
 func mustCreateEDU(t *testing.T) *gomatrixserverlib.EDU {

--- a/federationapi/routing/backfill.go
+++ b/federationapi/routing/backfill.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/fclient"
@@ -104,7 +105,7 @@ func Backfill(
 	// Filter any event that's not from the requested room out.
 	evs := make([]*gomatrixserverlib.Event, 0)
 
-	var ev *gomatrixserverlib.HeaderedEvent
+	var ev *types.HeaderedEvent
 	for _, ev = range res.Events {
 		if ev.RoomID() == roomID {
 			evs = append(evs, ev.Event)

--- a/federationapi/routing/eventauth.go
+++ b/federationapi/routing/eventauth.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/roomserver/api"
-	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 )
@@ -72,7 +72,7 @@ func GetEventAuth(
 	return util.JSONResponse{
 		Code: http.StatusOK,
 		JSON: fclient.RespEventAuth{
-			AuthEvents: gomatrixserverlib.NewEventJSONsFromHeaderedEvents(response.AuthChainEvents),
+			AuthEvents: types.NewEventJSONsFromHeaderedEvents(response.AuthChainEvents),
 		},
 	}
 }

--- a/federationapi/routing/invite.go
+++ b/federationapi/routing/invite.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/fclient"
@@ -196,11 +197,11 @@ func processInvite(
 	)
 
 	// Add the invite event to the roomserver.
-	inviteEvent := signedEvent.Headered(roomVer)
+	inviteEvent := &types.HeaderedEvent{Event: &signedEvent}
 	request := &api.PerformInviteRequest{
 		Event:           inviteEvent,
 		InviteRoomState: strippedState,
-		RoomVersion:     inviteEvent.RoomVersion,
+		RoomVersion:     inviteEvent.Version(),
 		SendAsServer:    string(api.DoNotSendToOtherServers),
 		TransactionID:   nil,
 	}

--- a/federationapi/routing/join.go
+++ b/federationapi/routing/join.go
@@ -30,6 +30,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/internal/eventutil"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 )
 
@@ -415,7 +416,7 @@ func SendJoin(
 			InputRoomEvents: []api.InputRoomEvent{
 				{
 					Kind:          api.KindNew,
-					Event:         signed.Headered(stateAndAuthChainResponse.RoomVersion),
+					Event:         &types.HeaderedEvent{Event: &signed},
 					SendAsServer:  string(cfg.Matrix.ServerName),
 					TransactionID: nil,
 				},
@@ -445,8 +446,8 @@ func SendJoin(
 	return util.JSONResponse{
 		Code: http.StatusOK,
 		JSON: fclient.RespSendJoin{
-			StateEvents: gomatrixserverlib.NewEventJSONsFromHeaderedEvents(stateAndAuthChainResponse.StateEvents),
-			AuthEvents:  gomatrixserverlib.NewEventJSONsFromHeaderedEvents(stateAndAuthChainResponse.AuthChainEvents),
+			StateEvents: types.NewEventJSONsFromHeaderedEvents(stateAndAuthChainResponse.StateEvents),
+			AuthEvents:  types.NewEventJSONsFromHeaderedEvents(stateAndAuthChainResponse.AuthChainEvents),
 			Origin:      cfg.Matrix.ServerName,
 			Event:       signed.JSON(),
 		},
@@ -521,7 +522,7 @@ func checkRestrictedJoin(
 	}
 }
 
-type eventsByDepth []*gomatrixserverlib.HeaderedEvent
+type eventsByDepth []*types.HeaderedEvent
 
 func (e eventsByDepth) Len() int {
 	return len(e)

--- a/federationapi/routing/leave.go
+++ b/federationapi/routing/leave.go
@@ -20,6 +20,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/internal/eventutil"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/fclient"
@@ -101,7 +102,7 @@ func MakeLeave(
 			return util.JSONResponse{
 				Code: http.StatusOK,
 				JSON: map[string]interface{}{
-					"room_version": event.RoomVersion,
+					"room_version": event.Version(),
 					"event":        state,
 				},
 			}
@@ -124,7 +125,7 @@ func MakeLeave(
 	return util.JSONResponse{
 		Code: http.StatusOK,
 		JSON: map[string]interface{}{
-			"room_version": event.RoomVersion,
+			"room_version": event.Version(),
 			"event":        builder,
 		},
 	}
@@ -313,7 +314,7 @@ func SendLeave(
 		InputRoomEvents: []api.InputRoomEvent{
 			{
 				Kind:          api.KindNew,
-				Event:         event.Headered(verRes.RoomVersion),
+				Event:         &types.HeaderedEvent{Event: event},
 				SendAsServer:  string(cfg.Matrix.ServerName),
 				TransactionID: nil,
 			},

--- a/federationapi/routing/missingevents.go
+++ b/federationapi/routing/missingevents.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/roomserver/api"
-	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 )
@@ -69,7 +69,7 @@ func GetMissingEvents(
 	eventsResponse.Events = filterEvents(eventsResponse.Events, roomID)
 
 	resp := fclient.RespMissingEvents{
-		Events: gomatrixserverlib.NewEventJSONsFromHeaderedEvents(eventsResponse.Events),
+		Events: types.NewEventJSONsFromHeaderedEvents(eventsResponse.Events),
 	}
 
 	return util.JSONResponse{
@@ -80,8 +80,8 @@ func GetMissingEvents(
 
 // filterEvents returns only those events with matching roomID
 func filterEvents(
-	events []*gomatrixserverlib.HeaderedEvent, roomID string,
-) []*gomatrixserverlib.HeaderedEvent {
+	events []*types.HeaderedEvent, roomID string,
+) []*types.HeaderedEvent {
 	ref := events[:0]
 	for _, ev := range events {
 		if ev.RoomID() == roomID {

--- a/federationapi/routing/peek.go
+++ b/federationapi/routing/peek.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/fclient"
@@ -89,10 +90,10 @@ func Peek(
 	}
 
 	respPeek := fclient.RespPeek{
-		StateEvents:     gomatrixserverlib.NewEventJSONsFromHeaderedEvents(response.StateEvents),
-		AuthEvents:      gomatrixserverlib.NewEventJSONsFromHeaderedEvents(response.AuthChainEvents),
+		StateEvents:     types.NewEventJSONsFromHeaderedEvents(response.StateEvents),
+		AuthEvents:      types.NewEventJSONsFromHeaderedEvents(response.AuthChainEvents),
 		RoomVersion:     response.RoomVersion,
-		LatestEvent:     response.LatestEvent.Unwrap(),
+		LatestEvent:     response.LatestEvent.Event,
 		RenewalInterval: renewalInterval,
 	}
 

--- a/federationapi/routing/state.go
+++ b/federationapi/routing/state.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/roomserver/api"
-	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/util"
 )
@@ -42,8 +42,8 @@ func GetState(
 	}
 
 	return util.JSONResponse{Code: http.StatusOK, JSON: &fclient.RespState{
-		AuthEvents:  gomatrixserverlib.NewEventJSONsFromHeaderedEvents(authChain),
-		StateEvents: gomatrixserverlib.NewEventJSONsFromHeaderedEvents(stateEvents),
+		AuthEvents:  types.NewEventJSONsFromHeaderedEvents(authChain),
+		StateEvents: types.NewEventJSONsFromHeaderedEvents(stateEvents),
 	}}
 }
 
@@ -101,7 +101,7 @@ func getState(
 	rsAPI api.FederationRoomserverAPI,
 	roomID string,
 	eventID string,
-) (stateEvents, authEvents []*gomatrixserverlib.HeaderedEvent, errRes *util.JSONResponse) {
+) (stateEvents, authEvents []*types.HeaderedEvent, errRes *util.JSONResponse) {
 	// If we don't think we belong to this room then don't waste the effort
 	// responding to expensive requests for it.
 	if err := ErrorIfLocalServerNotInRoom(ctx, rsAPI, roomID); err != nil {
@@ -157,7 +157,7 @@ func getState(
 	return response.StateEvents, response.AuthChainEvents, nil
 }
 
-func getIDsFromEvent(events []*gomatrixserverlib.HeaderedEvent) []string {
+func getIDsFromEvent(events []*types.HeaderedEvent) []string {
 	IDs := make([]string, len(events))
 	for i := range events {
 		IDs[i] = events[i].EventID()

--- a/federationapi/routing/threepid.go
+++ b/federationapi/routing/threepid.go
@@ -70,7 +70,7 @@ func CreateInvitesFrom3PIDInvites(
 
 	evs := []*types.HeaderedEvent{}
 	for _, inv := range body.Invites {
-		roomVersion, err := rsAPI.QueryRoomVersionForRoom(req.Context(), inv.RoomID)
+		_, err := rsAPI.QueryRoomVersionForRoom(req.Context(), inv.RoomID)
 		if err != nil {
 			return util.JSONResponse{
 				Code: http.StatusBadRequest,

--- a/federationapi/storage/interface.go
+++ b/federationapi/storage/interface.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/matrix-org/dendrite/federationapi/storage/shared/receipt"
 	"github.com/matrix-org/dendrite/federationapi/types"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 )
 
 type Database interface {
@@ -38,7 +39,7 @@ type Database interface {
 
 	StoreJSON(ctx context.Context, js string) (*receipt.Receipt, error)
 
-	GetPendingPDUs(ctx context.Context, serverName spec.ServerName, limit int) (pdus map[*receipt.Receipt]*gomatrixserverlib.HeaderedEvent, err error)
+	GetPendingPDUs(ctx context.Context, serverName spec.ServerName, limit int) (pdus map[*receipt.Receipt]*rstypes.HeaderedEvent, err error)
 	GetPendingEDUs(ctx context.Context, serverName spec.ServerName, limit int) (edus map[*receipt.Receipt]*gomatrixserverlib.EDU, err error)
 
 	AssociatePDUWithDestinations(ctx context.Context, destinations map[spec.ServerName]struct{}, dbReceipt *receipt.Receipt) error

--- a/federationapi/storage/shared/storage_pdus.go
+++ b/federationapi/storage/shared/storage_pdus.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 
 	"github.com/matrix-org/dendrite/federationapi/storage/shared/receipt"
-	"github.com/matrix-org/gomatrixserverlib"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 )
 
@@ -56,7 +56,7 @@ func (d *Database) GetPendingPDUs(
 	serverName spec.ServerName,
 	limit int,
 ) (
-	events map[*receipt.Receipt]*gomatrixserverlib.HeaderedEvent,
+	events map[*receipt.Receipt]*types.HeaderedEvent,
 	err error,
 ) {
 	// Strictly speaking this doesn't need to be using the writer
@@ -64,7 +64,7 @@ func (d *Database) GetPendingPDUs(
 	// a guarantee of transactional isolation, it's actually useful
 	// to know in SQLite mode that nothing else is trying to modify
 	// the database.
-	events = make(map[*receipt.Receipt]*gomatrixserverlib.HeaderedEvent)
+	events = make(map[*receipt.Receipt]*types.HeaderedEvent)
 	err = d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
 		nids, err := d.FederationQueuePDUs.SelectQueuePDUs(ctx, txn, serverName, limit)
 		if err != nil {
@@ -87,7 +87,7 @@ func (d *Database) GetPendingPDUs(
 		}
 
 		for nid, blob := range blobs {
-			var event gomatrixserverlib.HeaderedEvent
+			var event types.HeaderedEvent
 			if err := json.Unmarshal(blob, &event); err != nil {
 				return fmt.Errorf("json.Unmarshal: %w", err)
 			}

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/matrix-org/dugong v0.0.0-20210921133753-66e6b1c67e2e
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91
 	github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20230427083830-f2324ed2e085
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20230427113737-4a73af377afe
 	github.com/matrix-org/pinecone v0.11.1-0.20230210171230-8c3b24f2649a
 	github.com/matrix-org/util v0.0.0-20221111132719-399730281e66
 	github.com/mattn/go-sqlite3 v1.14.16

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/matrix-org/dugong v0.0.0-20210921133753-66e6b1c67e2e
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91
 	github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20230425114847-3f4aa39cdc54
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20230427083830-f2324ed2e085
 	github.com/matrix-org/pinecone v0.11.1-0.20230210171230-8c3b24f2649a
 	github.com/matrix-org/util v0.0.0-20221111132719-399730281e66
 	github.com/mattn/go-sqlite3 v1.14.16

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,6 @@
 module github.com/matrix-org/dendrite
 
+replace github.com/matrix-org/gomatrixserverlib => ../gomatrixserverlib
 require (
 	github.com/Arceliar/ironwood v0.0.0-20221025225125-45b4281814c2
 	github.com/Arceliar/phony v0.0.0-20210209235338-dde1a8dca979

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,5 @@
 module github.com/matrix-org/dendrite
 
-replace github.com/matrix-org/gomatrixserverlib => ../gomatrixserverlib
 require (
 	github.com/Arceliar/ironwood v0.0.0-20221025225125-45b4281814c2
 	github.com/Arceliar/phony v0.0.0-20210209235338-dde1a8dca979
@@ -23,7 +22,7 @@ require (
 	github.com/matrix-org/dugong v0.0.0-20210921133753-66e6b1c67e2e
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91
 	github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20230424155704-8daeaebaa0bc
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20230425114847-3f4aa39cdc54
 	github.com/matrix-org/pinecone v0.11.1-0.20230210171230-8c3b24f2649a
 	github.com/matrix-org/util v0.0.0-20221111132719-399730281e66
 	github.com/mattn/go-sqlite3 v1.14.16

--- a/go.sum
+++ b/go.sum
@@ -327,6 +327,8 @@ github.com/matrix-org/gomatrixserverlib v0.0.0-20230425114847-3f4aa39cdc54 h1:Fi
 github.com/matrix-org/gomatrixserverlib v0.0.0-20230425114847-3f4aa39cdc54/go.mod h1:7HTbSZe+CIdmeqVyFMekwD5dFU8khWQyngKATvd12FU=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20230427083830-f2324ed2e085 h1:QRj+06UWlwpZJFAa0AzxlWqRNVnh17vIgR141WSfu98=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20230427083830-f2324ed2e085/go.mod h1:7HTbSZe+CIdmeqVyFMekwD5dFU8khWQyngKATvd12FU=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20230427113737-4a73af377afe h1:+FeGaWZCDw7w3DGZhQW3n0amZ4iW5at/ocErlOFrO58=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20230427113737-4a73af377afe/go.mod h1:7HTbSZe+CIdmeqVyFMekwD5dFU8khWQyngKATvd12FU=
 github.com/matrix-org/pinecone v0.11.1-0.20230210171230-8c3b24f2649a h1:awrPDf9LEFySxTLKYBMCiObelNx/cBuv/wzllvCCH3A=
 github.com/matrix-org/pinecone v0.11.1-0.20230210171230-8c3b24f2649a/go.mod h1:HchJX9oKMXaT2xYFs0Ha/6Zs06mxLU8k6F1ODnrGkeQ=
 github.com/matrix-org/util v0.0.0-20221111132719-399730281e66 h1:6z4KxomXSIGWqhHcfzExgkH3Z3UkIXry4ibJS4Aqz2Y=

--- a/go.sum
+++ b/go.sum
@@ -325,6 +325,8 @@ github.com/matrix-org/gomatrixserverlib v0.0.0-20230424155704-8daeaebaa0bc h1:F7
 github.com/matrix-org/gomatrixserverlib v0.0.0-20230424155704-8daeaebaa0bc/go.mod h1:7HTbSZe+CIdmeqVyFMekwD5dFU8khWQyngKATvd12FU=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20230425114847-3f4aa39cdc54 h1:FiXd7w+dfX9/z0g1r//Xvhvk731mTyTJOWNBqqA6q9Q=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20230425114847-3f4aa39cdc54/go.mod h1:7HTbSZe+CIdmeqVyFMekwD5dFU8khWQyngKATvd12FU=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20230427083830-f2324ed2e085 h1:QRj+06UWlwpZJFAa0AzxlWqRNVnh17vIgR141WSfu98=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20230427083830-f2324ed2e085/go.mod h1:7HTbSZe+CIdmeqVyFMekwD5dFU8khWQyngKATvd12FU=
 github.com/matrix-org/pinecone v0.11.1-0.20230210171230-8c3b24f2649a h1:awrPDf9LEFySxTLKYBMCiObelNx/cBuv/wzllvCCH3A=
 github.com/matrix-org/pinecone v0.11.1-0.20230210171230-8c3b24f2649a/go.mod h1:HchJX9oKMXaT2xYFs0Ha/6Zs06mxLU8k6F1ODnrGkeQ=
 github.com/matrix-org/util v0.0.0-20221111132719-399730281e66 h1:6z4KxomXSIGWqhHcfzExgkH3Z3UkIXry4ibJS4Aqz2Y=

--- a/go.sum
+++ b/go.sum
@@ -323,6 +323,8 @@ github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530 h1:kHKxCOLcHH8
 github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530/go.mod h1:/gBX06Kw0exX1HrwmoBibFA98yBk/jxKpGVeyQbff+s=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20230424155704-8daeaebaa0bc h1:F73iHhpTZxWVO6qbyGZxd7Ch44v1gK6xNQZ7QVos/Es=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20230424155704-8daeaebaa0bc/go.mod h1:7HTbSZe+CIdmeqVyFMekwD5dFU8khWQyngKATvd12FU=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20230425114847-3f4aa39cdc54 h1:FiXd7w+dfX9/z0g1r//Xvhvk731mTyTJOWNBqqA6q9Q=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20230425114847-3f4aa39cdc54/go.mod h1:7HTbSZe+CIdmeqVyFMekwD5dFU8khWQyngKATvd12FU=
 github.com/matrix-org/pinecone v0.11.1-0.20230210171230-8c3b24f2649a h1:awrPDf9LEFySxTLKYBMCiObelNx/cBuv/wzllvCCH3A=
 github.com/matrix-org/pinecone v0.11.1-0.20230210171230-8c3b24f2649a/go.mod h1:HchJX9oKMXaT2xYFs0Ha/6Zs06mxLU8k6F1ODnrGkeQ=
 github.com/matrix-org/util v0.0.0-20221111132719-399730281e66 h1:6z4KxomXSIGWqhHcfzExgkH3Z3UkIXry4ibJS4Aqz2Y=

--- a/internal/caching/cache_federationevents.go
+++ b/internal/caching/cache_federationevents.go
@@ -1,14 +1,15 @@
 package caching
 
 import (
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
 // FederationCache contains the subset of functions needed for
 // a federation event cache.
 type FederationCache interface {
-	GetFederationQueuedPDU(eventNID int64) (event *gomatrixserverlib.HeaderedEvent, ok bool)
-	StoreFederationQueuedPDU(eventNID int64, event *gomatrixserverlib.HeaderedEvent)
+	GetFederationQueuedPDU(eventNID int64) (event *types.HeaderedEvent, ok bool)
+	StoreFederationQueuedPDU(eventNID int64, event *types.HeaderedEvent)
 	EvictFederationQueuedPDU(eventNID int64)
 
 	GetFederationQueuedEDU(eventNID int64) (event *gomatrixserverlib.EDU, ok bool)
@@ -16,11 +17,11 @@ type FederationCache interface {
 	EvictFederationQueuedEDU(eventNID int64)
 }
 
-func (c Caches) GetFederationQueuedPDU(eventNID int64) (*gomatrixserverlib.HeaderedEvent, bool) {
+func (c Caches) GetFederationQueuedPDU(eventNID int64) (*types.HeaderedEvent, bool) {
 	return c.FederationPDUs.Get(eventNID)
 }
 
-func (c Caches) StoreFederationQueuedPDU(eventNID int64, event *gomatrixserverlib.HeaderedEvent) {
+func (c Caches) StoreFederationQueuedPDU(eventNID int64, event *types.HeaderedEvent) {
 	c.FederationPDUs.Set(eventNID, event)
 }
 

--- a/internal/caching/caches.go
+++ b/internal/caching/caches.go
@@ -33,7 +33,7 @@ type Caches struct {
 	RoomServerStateKeyNIDs  Cache[string, types.EventStateKeyNID]                  // event state key -> eventStateKey NID
 	RoomServerEventTypeNIDs Cache[string, types.EventTypeNID]                      // eventType -> eventType NID
 	RoomServerEventTypes    Cache[types.EventTypeNID, string]                      // eventType NID -> eventType
-	FederationPDUs          Cache[int64, *gomatrixserverlib.HeaderedEvent]         // queue NID -> PDU
+	FederationPDUs          Cache[int64, *types.HeaderedEvent]         // queue NID -> PDU
 	FederationEDUs          Cache[int64, *gomatrixserverlib.EDU]                   // queue NID -> EDU
 	SpaceSummaryRooms       Cache[string, fclient.MSC2946SpacesResponse]           // room ID -> space response
 	LazyLoading             Cache[lazyLoadingCacheKey, string]                     // composite key -> event ID

--- a/internal/caching/caches.go
+++ b/internal/caching/caches.go
@@ -33,7 +33,7 @@ type Caches struct {
 	RoomServerStateKeyNIDs  Cache[string, types.EventStateKeyNID]                  // event state key -> eventStateKey NID
 	RoomServerEventTypeNIDs Cache[string, types.EventTypeNID]                      // eventType -> eventType NID
 	RoomServerEventTypes    Cache[types.EventTypeNID, string]                      // eventType NID -> eventType
-	FederationPDUs          Cache[int64, *types.HeaderedEvent]         // queue NID -> PDU
+	FederationPDUs          Cache[int64, *types.HeaderedEvent]                     // queue NID -> PDU
 	FederationEDUs          Cache[int64, *gomatrixserverlib.EDU]                   // queue NID -> EDU
 	SpaceSummaryRooms       Cache[string, fclient.MSC2946SpacesResponse]           // room ID -> space response
 	LazyLoading             Cache[lazyLoadingCacheKey, string]                     // composite key -> event ID

--- a/internal/caching/impl_ristretto.go
+++ b/internal/caching/impl_ristretto.go
@@ -131,8 +131,8 @@ func NewRistrettoCache(maxCost config.DataUnit, maxAge time.Duration, enableProm
 			Prefix: eventTypeNIDCache,
 			MaxAge: maxAge,
 		},
-		FederationPDUs: &RistrettoCostedCachePartition[int64, *gomatrixserverlib.HeaderedEvent]{ // queue NID -> PDU
-			&RistrettoCachePartition[int64, *gomatrixserverlib.HeaderedEvent]{
+		FederationPDUs: &RistrettoCostedCachePartition[int64, *types.HeaderedEvent]{ // queue NID -> PDU
+			&RistrettoCachePartition[int64, *types.HeaderedEvent]{
 				cache:   cache,
 				Prefix:  federationPDUsCache,
 				Mutable: true,

--- a/internal/eventutil/events.go
+++ b/internal/eventutil/events.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/gomatrixserverlib/spec"
@@ -43,7 +44,7 @@ func QueryAndBuildEvent(
 	builder *gomatrixserverlib.EventBuilder, cfg *config.Global,
 	identity *fclient.SigningIdentity, evTime time.Time,
 	rsAPI api.QueryLatestEventsAndStateAPI, queryRes *api.QueryLatestEventsAndStateResponse,
-) (*gomatrixserverlib.HeaderedEvent, error) {
+) (*types.HeaderedEvent, error) {
 	if queryRes == nil {
 		queryRes = &api.QueryLatestEventsAndStateResponse{}
 	}
@@ -63,7 +64,7 @@ func BuildEvent(
 	builder *gomatrixserverlib.EventBuilder, cfg *config.Global,
 	identity *fclient.SigningIdentity, evTime time.Time,
 	eventsNeeded *gomatrixserverlib.StateNeeded, queryRes *api.QueryLatestEventsAndStateResponse,
-) (*gomatrixserverlib.HeaderedEvent, error) {
+) (*types.HeaderedEvent, error) {
 	if err := addPrevEventsToEvent(builder, eventsNeeded, queryRes); err != nil {
 		return nil, err
 	}
@@ -76,7 +77,7 @@ func BuildEvent(
 		return nil, err
 	}
 
-	return event.Headered(queryRes.RoomVersion), nil
+	return &types.HeaderedEvent{Event: event}, nil
 }
 
 // queryRequiredEventsForBuilder queries the roomserver for auth/prev events needed for this builder.

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -21,17 +21,17 @@ import (
 )
 
 const (
-	// KindNewEventPersisted is a hook which is called with *gomatrixserverlib.HeaderedEvent
+	// KindNewEventPersisted is a hook which is called with *types.HeaderedEvent
 	// It is run when a new event is persisted in the roomserver.
 	// Usage:
 	//   hooks.Attach(hooks.KindNewEventPersisted, func(headeredEvent interface{}) { ... })
 	KindNewEventPersisted = "new_event_persisted"
-	// KindNewEventReceived is a hook which is called with *gomatrixserverlib.HeaderedEvent
+	// KindNewEventReceived is a hook which is called with *types.HeaderedEvent
 	// It is run before a new event is processed by the roomserver. This hook can be used
 	// to modify the event before it is persisted by adding data to `unsigned`.
 	// Usage:
 	//   hooks.Attach(hooks.KindNewEventReceived, func(headeredEvent interface{}) {
-	//     ev := headeredEvent.(*gomatrixserverlib.HeaderedEvent)
+	//     ev := headeredEvent.(*types.HeaderedEvent)
 	//     _ = ev.SetUnsignedField("key", "val")
 	//   })
 	KindNewEventReceived = "new_event_received"

--- a/internal/transactionrequest.go
+++ b/internal/transactionrequest.go
@@ -25,6 +25,7 @@ import (
 	"github.com/matrix-org/dendrite/federationapi/producers"
 	"github.com/matrix-org/dendrite/federationapi/types"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	syncTypes "github.com/matrix-org/dendrite/syncapi/types"
 	userAPI "github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -183,8 +184,8 @@ func (t *TxnReq) ProcessTransaction(ctx context.Context) (*fclient.RespSend, *ut
 			ctx,
 			t.rsAPI,
 			api.KindNew,
-			[]*gomatrixserverlib.HeaderedEvent{
-				event.Headered(roomVersion),
+			[]*rstypes.HeaderedEvent{
+				{Event: event},
 			},
 			t.Destination,
 			t.Origin,

--- a/internal/transactionrequest_test.go
+++ b/internal/transactionrequest_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/matrix-org/dendrite/federationapi/producers"
 	rsAPI "github.com/matrix-org/dendrite/roomserver/api"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/dendrite/setup/jetstream"
 	"github.com/matrix-org/dendrite/setup/process"
@@ -59,8 +60,8 @@ var (
 	}
 	testEvent       = []byte(`{"auth_events":["$x4MKEPRSF6OGlo0qpnsP3BfSmYX5HhVlykOsQH3ECyg","$BcEcbZnlFLB5rxSNSZNBn6fO3jU/TKAJ79wfKyCQLiU"],"content":{"body":"Test Message"},"depth":3917,"hashes":{"sha256":"cNAWtlHIegrji0mMA6x1rhpYCccY8W1NsWZqSpJFhjs"},"origin":"localhost","origin_server_ts":0,"prev_events":["$4GDB0bVjkWwS3G4noUZCq5oLWzpBYpwzdMcf7gj24CI"],"room_id":"!roomid:localhost","sender":"@userid:localhost","signatures":{"localhost":{"ed25519:auto":"NKym6Kcy3u9mGUr21Hjfe3h7DfDilDhN5PqztT0QZ4NTZ+8Y7owseLolQVXp+TvNjecvzdDywsXXVvGiuQiWAQ"}},"type":"m.room.message"}`)
 	testRoomVersion = gomatrixserverlib.RoomVersionV1
-	testEvents      = []*gomatrixserverlib.HeaderedEvent{}
-	testStateEvents = make(map[gomatrixserverlib.StateKeyTuple]*gomatrixserverlib.HeaderedEvent)
+	testEvents      = []*rstypes.HeaderedEvent{}
+	testStateEvents = make(map[gomatrixserverlib.StateKeyTuple]*rstypes.HeaderedEvent)
 )
 
 type FakeRsAPI struct {
@@ -637,7 +638,7 @@ func init() {
 		if err != nil {
 			panic("cannot load test data: " + err.Error())
 		}
-		h := e.Headered(testRoomVersion)
+		h := &rstypes.HeaderedEvent{Event: e}
 		testEvents = append(testEvents, h)
 		if e.StateKey() != nil {
 			testStateEvents[gomatrixserverlib.StateKeyTuple{
@@ -781,7 +782,7 @@ NextPDU:
 	}
 }
 
-func assertInputRoomEvents(t *testing.T, got []rsAPI.InputRoomEvent, want []*gomatrixserverlib.HeaderedEvent) {
+func assertInputRoomEvents(t *testing.T, got []rsAPI.InputRoomEvent, want []*rstypes.HeaderedEvent) {
 	for _, g := range got {
 		fmt.Println("GOT ", g.Event.EventID())
 	}
@@ -805,7 +806,7 @@ func TestBasicTransaction(t *testing.T) {
 	}
 	txn := mustCreateTransaction(rsAPI, pdus)
 	mustProcessTransaction(t, txn, nil)
-	assertInputRoomEvents(t, rsAPI.inputRoomEvents, []*gomatrixserverlib.HeaderedEvent{testEvents[len(testEvents)-1]})
+	assertInputRoomEvents(t, rsAPI.inputRoomEvents, []*rstypes.HeaderedEvent{testEvents[len(testEvents)-1]})
 }
 
 // The purpose of this test is to check that if the event received fails auth checks the event is still sent to the roomserver
@@ -818,5 +819,5 @@ func TestTransactionFailAuthChecks(t *testing.T) {
 	txn := mustCreateTransaction(rsAPI, pdus)
 	mustProcessTransaction(t, txn, []string{})
 	// expect message to be sent to the roomserver
-	assertInputRoomEvents(t, rsAPI.inputRoomEvents, []*gomatrixserverlib.HeaderedEvent{testEvents[len(testEvents)-1]})
+	assertInputRoomEvents(t, rsAPI.inputRoomEvents, []*rstypes.HeaderedEvent{testEvents[len(testEvents)-1]})
 }

--- a/roomserver/acls/acls.go
+++ b/roomserver/acls/acls.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/sirupsen/logrus"
@@ -34,7 +35,7 @@ type ServerACLDatabase interface {
 	// GetStateEvent returns the state event of a given type for a given room with a given state key
 	// If no event could be found, returns nil
 	// If there was an issue during the retrieval, returns an error
-	GetStateEvent(ctx context.Context, roomID, evType, stateKey string) (*gomatrixserverlib.HeaderedEvent, error)
+	GetStateEvent(ctx context.Context, roomID, evType, stateKey string) (*types.HeaderedEvent, error)
 }
 
 type ServerACLs struct {

--- a/roomserver/api/api.go
+++ b/roomserver/api/api.go
@@ -102,7 +102,7 @@ type SyncRoomserverAPI interface {
 	) error
 
 	// QueryMembershipAtEvent queries the memberships at the given events.
-	// Returns a map from eventID to a slice of gomatrixserverlib.HeaderedEvent.
+	// Returns a map from eventID to a slice of types.HeaderedEvent.
 	QueryMembershipAtEvent(
 		ctx context.Context,
 		request *QueryMembershipAtEventRequest,

--- a/roomserver/api/input.go
+++ b/roomserver/api/input.go
@@ -18,6 +18,7 @@ package api
 import (
 	"fmt"
 
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 )
@@ -67,7 +68,7 @@ type InputRoomEvent struct {
 	// This controls how the event is processed.
 	Kind Kind `json:"kind"`
 	// The event JSON for the event to add.
-	Event *gomatrixserverlib.HeaderedEvent `json:"event"`
+	Event *types.HeaderedEvent `json:"event"`
 	// Which server told us about this event.
 	Origin spec.ServerName `json:"origin"`
 	// Whether the state is supplied as a list of event IDs or whether it

--- a/roomserver/api/output.go
+++ b/roomserver/api/output.go
@@ -15,6 +15,7 @@
 package api
 
 import (
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 )
@@ -107,7 +108,7 @@ const (
 // prev_events.
 type OutputNewRoomEvent struct {
 	// The Event.
-	Event *gomatrixserverlib.HeaderedEvent `json:"event"`
+	Event *types.HeaderedEvent `json:"event"`
 	// Does the event completely rewrite the room state? If so, then AddsStateEventIDs
 	// will contain the entire room state.
 	RewritesState bool `json:"rewrites_state,omitempty"`
@@ -170,8 +171,8 @@ type OutputNewRoomEvent struct {
 	HistoryVisibility gomatrixserverlib.HistoryVisibility `json:"history_visibility"`
 }
 
-func (o *OutputNewRoomEvent) NeededStateEventIDs() ([]*gomatrixserverlib.HeaderedEvent, []string) {
-	addsStateEvents := make([]*gomatrixserverlib.HeaderedEvent, 0, 1)
+func (o *OutputNewRoomEvent) NeededStateEventIDs() ([]*types.HeaderedEvent, []string) {
+	addsStateEvents := make([]*types.HeaderedEvent, 0, 1)
 	missingEventIDs := make([]string, 0, len(o.AddsStateEventIDs))
 	for _, eventID := range o.AddsStateEventIDs {
 		if eventID != o.Event.EventID() {
@@ -194,7 +195,7 @@ func (o *OutputNewRoomEvent) NeededStateEventIDs() ([]*gomatrixserverlib.Headere
 // should build their current room state up from OutputNewRoomEvents only.
 type OutputOldRoomEvent struct {
 	// The Event.
-	Event             *gomatrixserverlib.HeaderedEvent    `json:"event"`
+	Event             *types.HeaderedEvent                `json:"event"`
 	HistoryVisibility gomatrixserverlib.HistoryVisibility `json:"history_visibility"`
 }
 
@@ -205,7 +206,7 @@ type OutputNewInviteEvent struct {
 	// The room version of the invited room.
 	RoomVersion gomatrixserverlib.RoomVersion `json:"room_version"`
 	// The "m.room.member" invite event.
-	Event *gomatrixserverlib.HeaderedEvent `json:"event"`
+	Event *types.HeaderedEvent `json:"event"`
 }
 
 // An OutputRetireInviteEvent is written whenever an existing invite is no longer
@@ -232,7 +233,7 @@ type OutputRedactedEvent struct {
 	// The event ID that was redacted
 	RedactedEventID string
 	// The value of `unsigned.redacted_because` - the redaction event itself
-	RedactedBecause *gomatrixserverlib.HeaderedEvent
+	RedactedBecause *types.HeaderedEvent
 }
 
 // An OutputNewPeek is written whenever a user starts peeking into a room

--- a/roomserver/api/perform.go
+++ b/roomserver/api/perform.go
@@ -11,6 +11,7 @@ import (
 	"github.com/matrix-org/util"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
+	"github.com/matrix-org/dendrite/roomserver/types"
 )
 
 type PerformErrorCode int
@@ -105,11 +106,11 @@ type PerformLeaveResponse struct {
 }
 
 type PerformInviteRequest struct {
-	RoomVersion     gomatrixserverlib.RoomVersion    `json:"room_version"`
-	Event           *gomatrixserverlib.HeaderedEvent `json:"event"`
-	InviteRoomState []fclient.InviteV2StrippedState  `json:"invite_room_state"`
-	SendAsServer    string                           `json:"send_as_server"`
-	TransactionID   *TransactionID                   `json:"transaction_id"`
+	RoomVersion     gomatrixserverlib.RoomVersion   `json:"room_version"`
+	Event           *types.HeaderedEvent            `json:"event"`
+	InviteRoomState []fclient.InviteV2StrippedState `json:"invite_room_state"`
+	SendAsServer    string                          `json:"send_as_server"`
+	TransactionID   *TransactionID                  `json:"transaction_id"`
 }
 
 type PerformInviteResponse struct {
@@ -168,7 +169,7 @@ func (r *PerformBackfillRequest) PrevEventIDs() []string {
 // PerformBackfillResponse is a response to PerformBackfill.
 type PerformBackfillResponse struct {
 	// Missing events, arbritrary order.
-	Events            []*gomatrixserverlib.HeaderedEvent  `json:"events"`
+	Events            []*types.HeaderedEvent              `json:"events"`
 	HistoryVisibility gomatrixserverlib.HistoryVisibility `json:"history_visibility"`
 }
 
@@ -200,10 +201,10 @@ type PerformInboundPeekResponse struct {
 	RoomVersion gomatrixserverlib.RoomVersion `json:"room_version"`
 	// The current state and auth chain events.
 	// The lists will be in an arbitrary order.
-	StateEvents     []*gomatrixserverlib.HeaderedEvent `json:"state_events"`
-	AuthChainEvents []*gomatrixserverlib.HeaderedEvent `json:"auth_chain_events"`
+	StateEvents     []*types.HeaderedEvent `json:"state_events"`
+	AuthChainEvents []*types.HeaderedEvent `json:"auth_chain_events"`
 	// The event at which this state was captured
-	LatestEvent *gomatrixserverlib.HeaderedEvent `json:"latest_event"`
+	LatestEvent *types.HeaderedEvent `json:"latest_event"`
 }
 
 // PerformForgetRequest is a request to PerformForget

--- a/roomserver/api/query.go
+++ b/roomserver/api/query.go
@@ -25,6 +25,7 @@ import (
 	"github.com/matrix-org/gomatrixserverlib/spec"
 
 	"github.com/matrix-org/dendrite/clientapi/auth/authtypes"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/synctypes"
 )
 
@@ -53,7 +54,7 @@ type QueryLatestEventsAndStateResponse struct {
 	// This list will be in an arbitrary order.
 	// These are used to set the auth_events when sending an event.
 	// These are used to check whether the event is allowed.
-	StateEvents []*gomatrixserverlib.HeaderedEvent `json:"state_events"`
+	StateEvents []*types.HeaderedEvent `json:"state_events"`
 	// The depth of the latest events.
 	// This is one greater than the maximum depth of the latest events.
 	// This is used to set the depth when sending an event.
@@ -83,7 +84,7 @@ type QueryStateAfterEventsResponse struct {
 	PrevEventsExist bool `json:"prev_events_exist"`
 	// The state events requested.
 	// This list will be in an arbitrary order.
-	StateEvents []*gomatrixserverlib.HeaderedEvent `json:"state_events"`
+	StateEvents []*types.HeaderedEvent `json:"state_events"`
 }
 
 // QueryEventsByIDRequest is a request to QueryEventsByID
@@ -104,7 +105,7 @@ type QueryEventsByIDResponse struct {
 	// fails to read it from the database then it will fail
 	// the entire request.
 	// This list will be in an arbitrary order.
-	Events []*gomatrixserverlib.HeaderedEvent `json:"events"`
+	Events []*types.HeaderedEvent `json:"events"`
 }
 
 // QueryMembershipForUserRequest is a request to QueryMembership
@@ -202,7 +203,7 @@ type QueryMissingEventsRequest struct {
 // QueryMissingEventsResponse is a response to QueryMissingEvents
 type QueryMissingEventsResponse struct {
 	// Missing events, arbritrary order.
-	Events []*gomatrixserverlib.HeaderedEvent `json:"events"`
+	Events []*types.HeaderedEvent `json:"events"`
 }
 
 // QueryStateAndAuthChainRequest is a request to QueryStateAndAuthChain
@@ -236,8 +237,8 @@ type QueryStateAndAuthChainResponse struct {
 	StateKnown      bool `json:"state_known"`
 	// The state and auth chain events that were requested.
 	// The lists will be in an arbitrary order.
-	StateEvents     []*gomatrixserverlib.HeaderedEvent `json:"state_events"`
-	AuthChainEvents []*gomatrixserverlib.HeaderedEvent `json:"auth_chain_events"`
+	StateEvents     []*types.HeaderedEvent `json:"state_events"`
+	AuthChainEvents []*types.HeaderedEvent `json:"auth_chain_events"`
 	// True if the queried event was rejected earlier.
 	IsRejected bool `json:"is_rejected"`
 }
@@ -269,7 +270,7 @@ type QueryAuthChainRequest struct {
 }
 
 type QueryAuthChainResponse struct {
-	AuthChain []*gomatrixserverlib.HeaderedEvent
+	AuthChain []*types.HeaderedEvent
 }
 
 type QuerySharedUsersRequest struct {
@@ -327,7 +328,7 @@ type QueryCurrentStateRequest struct {
 }
 
 type QueryCurrentStateResponse struct {
-	StateEvents map[gomatrixserverlib.StateKeyTuple]*gomatrixserverlib.HeaderedEvent
+	StateEvents map[gomatrixserverlib.StateKeyTuple]*types.HeaderedEvent
 }
 
 type QueryKnownUsersRequest struct {
@@ -404,7 +405,7 @@ func (r *QueryBulkStateContentResponse) UnmarshalJSON(data []byte) error {
 
 // MarshalJSON stringifies the StateKeyTuple keys so they can be sent over the wire in HTTP API mode.
 func (r *QueryCurrentStateResponse) MarshalJSON() ([]byte, error) {
-	se := make(map[string]*gomatrixserverlib.HeaderedEvent, len(r.StateEvents))
+	se := make(map[string]*types.HeaderedEvent, len(r.StateEvents))
 	for k, v := range r.StateEvents {
 		// use 0x1F (unit separator) as the delimiter between type/state key,
 		se[fmt.Sprintf("%s\x1F%s", k.EventType, k.StateKey)] = v
@@ -413,12 +414,12 @@ func (r *QueryCurrentStateResponse) MarshalJSON() ([]byte, error) {
 }
 
 func (r *QueryCurrentStateResponse) UnmarshalJSON(data []byte) error {
-	res := make(map[string]*gomatrixserverlib.HeaderedEvent)
+	res := make(map[string]*types.HeaderedEvent)
 	err := json.Unmarshal(data, &res)
 	if err != nil {
 		return err
 	}
-	r.StateEvents = make(map[gomatrixserverlib.StateKeyTuple]*gomatrixserverlib.HeaderedEvent, len(res))
+	r.StateEvents = make(map[gomatrixserverlib.StateKeyTuple]*types.HeaderedEvent, len(res))
 	for k, v := range res {
 		fields := strings.Split(k, "\x1F")
 		r.StateEvents[gomatrixserverlib.StateKeyTuple{
@@ -442,7 +443,7 @@ type QueryMembershipAtEventResponse struct {
 	// Membership is a map from eventID to membership event. Events that
 	// do not have known state will return a nil event, resulting in a "leave" membership
 	// when calculating history visibility.
-	Membership map[string]*gomatrixserverlib.HeaderedEvent `json:"membership"`
+	Membership map[string]*types.HeaderedEvent `json:"membership"`
 }
 
 // QueryLeftUsersRequest is a request to calculate users that we (the server) don't share a

--- a/roomserver/api/wrapper.go
+++ b/roomserver/api/wrapper.go
@@ -17,6 +17,7 @@ package api
 import (
 	"context"
 
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/gomatrixserverlib/spec"
@@ -27,7 +28,7 @@ import (
 // SendEvents to the roomserver The events are written with KindNew.
 func SendEvents(
 	ctx context.Context, rsAPI InputRoomEventsAPI,
-	kind Kind, events []*gomatrixserverlib.HeaderedEvent,
+	kind Kind, events []*types.HeaderedEvent,
 	virtualHost, origin spec.ServerName,
 	sendAsServer spec.ServerName, txnID *TransactionID,
 	async bool,
@@ -51,10 +52,10 @@ func SendEvents(
 func SendEventWithState(
 	ctx context.Context, rsAPI InputRoomEventsAPI,
 	virtualHost spec.ServerName, kind Kind,
-	state gomatrixserverlib.StateResponse, event *gomatrixserverlib.HeaderedEvent,
+	state gomatrixserverlib.StateResponse, event *types.HeaderedEvent,
 	origin spec.ServerName, haveEventIDs map[string]bool, async bool,
 ) error {
-	outliers := gomatrixserverlib.LineariseStateResponse(event.RoomVersion, state)
+	outliers := gomatrixserverlib.LineariseStateResponse(event.Version(), state)
 	ires := make([]InputRoomEvent, 0, len(outliers))
 	for _, outlier := range outliers {
 		if haveEventIDs[outlier.EventID()] {
@@ -62,12 +63,12 @@ func SendEventWithState(
 		}
 		ires = append(ires, InputRoomEvent{
 			Kind:   KindOutlier,
-			Event:  outlier.Headered(event.RoomVersion),
+			Event:  &types.HeaderedEvent{Event: outlier},
 			Origin: origin,
 		})
 	}
 
-	stateEvents := state.GetStateEvents().UntrustedEvents(event.RoomVersion)
+	stateEvents := state.GetStateEvents().UntrustedEvents(event.Version())
 	stateEventIDs := make([]string, len(stateEvents))
 	for i := range stateEvents {
 		stateEventIDs[i] = stateEvents[i].EventID()
@@ -110,7 +111,7 @@ func SendInputRoomEvents(
 }
 
 // GetEvent returns the event or nil, even on errors.
-func GetEvent(ctx context.Context, rsAPI QueryEventsAPI, roomID, eventID string) *gomatrixserverlib.HeaderedEvent {
+func GetEvent(ctx context.Context, rsAPI QueryEventsAPI, roomID, eventID string) *types.HeaderedEvent {
 	var res QueryEventsByIDResponse
 	err := rsAPI.QueryEventsByID(ctx, &QueryEventsByIDRequest{
 		RoomID:   roomID,
@@ -127,7 +128,7 @@ func GetEvent(ctx context.Context, rsAPI QueryEventsAPI, roomID, eventID string)
 }
 
 // GetStateEvent returns the current state event in the room or nil.
-func GetStateEvent(ctx context.Context, rsAPI QueryEventsAPI, roomID string, tuple gomatrixserverlib.StateKeyTuple) *gomatrixserverlib.HeaderedEvent {
+func GetStateEvent(ctx context.Context, rsAPI QueryEventsAPI, roomID string, tuple gomatrixserverlib.StateKeyTuple) *types.HeaderedEvent {
 	var res QueryCurrentStateResponse
 	err := rsAPI.QueryCurrentState(ctx, &QueryCurrentStateRequest{
 		RoomID:      roomID,

--- a/roomserver/internal/alias.go
+++ b/roomserver/internal/alias.go
@@ -25,6 +25,7 @@ import (
 	"github.com/matrix-org/dendrite/internal/eventutil"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/roomserver/internal/helpers"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/tidwall/gjson"
@@ -140,7 +141,7 @@ func (r *RoomserverInternalAPI) RemoveRoomAlias(
 	}
 
 	if creatorID != request.UserID {
-		var plEvent *gomatrixserverlib.HeaderedEvent
+		var plEvent *types.HeaderedEvent
 		var pls *gomatrixserverlib.PowerLevelContent
 
 		plEvent, err = r.DB.GetStateEvent(ctx, roomID, spec.MRoomPowerLevels, "")
@@ -212,7 +213,7 @@ func (r *RoomserverInternalAPI) RemoveRoomAlias(
 				return err
 			}
 
-			err = api.SendEvents(ctx, r, api.KindNew, []*gomatrixserverlib.HeaderedEvent{newEvent}, virtualHost, r.ServerName, r.ServerName, nil, false)
+			err = api.SendEvents(ctx, r, api.KindNew, []*types.HeaderedEvent{newEvent}, virtualHost, r.ServerName, r.ServerName, nil, false)
 			if err != nil {
 				return err
 			}

--- a/roomserver/internal/helpers/auth.go
+++ b/roomserver/internal/helpers/auth.go
@@ -34,7 +34,7 @@ func CheckForSoftFail(
 	ctx context.Context,
 	db storage.RoomDatabase,
 	roomInfo *types.RoomInfo,
-	event *gomatrixserverlib.HeaderedEvent,
+	event *types.HeaderedEvent,
 	stateEventIDs []string,
 ) (bool, error) {
 	rewritesState := len(stateEventIDs) > 1
@@ -65,7 +65,7 @@ func CheckForSoftFail(
 	}
 
 	// Work out which of the state events we actually need.
-	stateNeeded := gomatrixserverlib.StateNeededForAuth([]*gomatrixserverlib.Event{event.Unwrap()})
+	stateNeeded := gomatrixserverlib.StateNeededForAuth([]*gomatrixserverlib.Event{event.Event})
 
 	// Load the actual auth events from the database.
 	authEvents, err := loadAuthEvents(ctx, db, roomInfo, stateNeeded, authStateEntries)
@@ -87,7 +87,7 @@ func CheckAuthEvents(
 	ctx context.Context,
 	db storage.RoomDatabase,
 	roomInfo *types.RoomInfo,
-	event *gomatrixserverlib.HeaderedEvent,
+	event *types.HeaderedEvent,
 	authEventIDs []string,
 ) ([]types.EventNID, error) {
 	// Grab the numeric IDs for the supplied auth state events from the database.
@@ -98,7 +98,7 @@ func CheckAuthEvents(
 	authStateEntries = types.DeduplicateStateEntries(authStateEntries)
 
 	// Work out which of the state events we actually need.
-	stateNeeded := gomatrixserverlib.StateNeededForAuth([]*gomatrixserverlib.Event{event.Unwrap()})
+	stateNeeded := gomatrixserverlib.StateNeededForAuth([]*gomatrixserverlib.Event{event.Event})
 
 	// Load the actual auth events from the database.
 	authEvents, err := loadAuthEvents(ctx, db, roomInfo, stateNeeded, authStateEntries)

--- a/roomserver/internal/helpers/helpers.go
+++ b/roomserver/internal/helpers/helpers.go
@@ -45,7 +45,7 @@ func UpdateToInviteMembership(
 		updates = append(updates, api.OutputEvent{
 			Type: api.OutputTypeNewInviteEvent,
 			NewInviteEvent: &api.OutputNewInviteEvent{
-				Event:       add.Headered(roomVersion),
+				Event:       &types.HeaderedEvent{Event: add.Event},
 				RoomVersion: roomVersion,
 			},
 		})
@@ -479,7 +479,7 @@ func QueryLatestEventsAndState(
 	}
 
 	for _, event := range stateEvents {
-		response.StateEvents = append(response.StateEvents, event.Headered(roomInfo.RoomVersion))
+		response.StateEvents = append(response.StateEvents, &types.HeaderedEvent{Event: event})
 	}
 
 	return nil

--- a/roomserver/internal/helpers/helpers_test.go
+++ b/roomserver/internal/helpers/helpers_test.go
@@ -41,7 +41,7 @@ func TestIsInvitePendingWithoutNID(t *testing.T) {
 		var authNIDs []types.EventNID
 		for _, x := range room.Events() {
 
-			roomInfo, err := db.GetOrCreateRoomInfo(context.Background(), x.Unwrap())
+			roomInfo, err := db.GetOrCreateRoomInfo(context.Background(), x.Event)
 			assert.NoError(t, err)
 			assert.NotNil(t, roomInfo)
 

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -567,7 +567,7 @@ func (r *Inputer) processStateBefore(
 			rejectionErr = fmt.Errorf("prev events of %q are not known", event.EventID())
 			return
 		default:
-			stateBeforeEvent := make([]*gomatrixserverlib.Event, len(stateBeforeRes.StateEvents))
+			stateBeforeEvent = make([]*gomatrixserverlib.Event, len(stateBeforeRes.StateEvents))
 			for i := range stateBeforeRes.StateEvents {
 				stateBeforeEvent[i] = stateBeforeRes.StateEvents[i].Event
 			}
@@ -578,6 +578,7 @@ func (r *Inputer) processStateBefore(
 	// Check whether the event is allowed or not.
 	stateBeforeAuth := gomatrixserverlib.NewAuthEvents(stateBeforeEvent)
 	if rejectionErr = gomatrixserverlib.Allowed(event, &stateBeforeAuth); rejectionErr != nil {
+		rejectionErr = fmt.Errorf("Allowed() failed for stateBeforeEvent: %w", rejectionErr)
 		return
 	}
 	// Work out what the history visibility was at the time of the

--- a/roomserver/internal/input/input_latest_events.go
+++ b/roomserver/internal/input/input_latest_events.go
@@ -393,7 +393,7 @@ func (u *latestEventsUpdater) makeOutputNewRoomEvent() (*api.OutputEvent, error)
 	}
 
 	ore := api.OutputNewRoomEvent{
-		Event:             u.event.Headered(u.roomInfo.RoomVersion),
+		Event:             &types.HeaderedEvent{Event: u.event},
 		RewritesState:     u.rewritesState,
 		LastSentEventID:   u.lastEventIDSent,
 		LatestEventIDs:    latestEventIDs,

--- a/roomserver/internal/input/input_missing.go
+++ b/roomserver/internal/input/input_missing.go
@@ -106,7 +106,7 @@ func (t *missingStateReq) processEventWithMissingState(
 		for _, newEvent := range newEvents {
 			err = t.inputer.processRoomEvent(ctx, t.virtualHost, &api.InputRoomEvent{
 				Kind:         api.KindOld,
-				Event:        newEvent.Headered(roomVersion),
+				Event:        &types.HeaderedEvent{Event: newEvent},
 				Origin:       t.origin,
 				SendAsServer: api.DoNotSendToOtherServers,
 			})
@@ -155,7 +155,7 @@ func (t *missingStateReq) processEventWithMissingState(
 			}
 			outlierRoomEvents = append(outlierRoomEvents, api.InputRoomEvent{
 				Kind:   api.KindOutlier,
-				Event:  outlier.Headered(roomVersion),
+				Event:  &types.HeaderedEvent{Event: outlier},
 				Origin: t.origin,
 			})
 		}
@@ -185,7 +185,7 @@ func (t *missingStateReq) processEventWithMissingState(
 
 	err = t.inputer.processRoomEvent(ctx, t.virtualHost, &api.InputRoomEvent{
 		Kind:          api.KindOld,
-		Event:         backwardsExtremity.Headered(roomVersion),
+		Event:         &types.HeaderedEvent{Event: backwardsExtremity},
 		Origin:        t.origin,
 		HasState:      true,
 		StateEventIDs: stateIDs,
@@ -204,7 +204,7 @@ func (t *missingStateReq) processEventWithMissingState(
 	for _, newEvent := range newEvents {
 		err = t.inputer.processRoomEvent(ctx, t.virtualHost, &api.InputRoomEvent{
 			Kind:         api.KindOld,
-			Event:        newEvent.Headered(roomVersion),
+			Event:        &types.HeaderedEvent{Event: newEvent},
 			Origin:       t.origin,
 			SendAsServer: api.DoNotSendToOtherServers,
 		})

--- a/roomserver/internal/input/input_test.go
+++ b/roomserver/internal/input/input_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/matrix-org/dendrite/roomserver"
 	"github.com/matrix-org/dendrite/roomserver/api"
 	"github.com/matrix-org/dendrite/roomserver/internal/input"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/jetstream"
 	"github.com/matrix-org/dendrite/test"
 	"github.com/matrix-org/dendrite/test/testrig"
@@ -44,7 +45,7 @@ func TestSingleTransactionOnInput(t *testing.T) {
 		}
 		in := api.InputRoomEvent{
 			Kind:  api.KindOutlier, // don't panic if we generate an output event
-			Event: event.Headered(gomatrixserverlib.RoomVersionV6),
+			Event: &types.HeaderedEvent{Event: event},
 		}
 
 		inputter := &input.Inputer{

--- a/roomserver/internal/perform/perform_admin.go
+++ b/roomserver/internal/perform/perform_admin.go
@@ -26,6 +26,7 @@ import (
 	"github.com/matrix-org/dendrite/roomserver/internal/input"
 	"github.com/matrix-org/dendrite/roomserver/internal/query"
 	"github.com/matrix-org/dendrite/roomserver/storage"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
@@ -346,15 +347,15 @@ func (r *Admin) PerformAdminDownloadState(
 		}
 	}
 
-	authEvents := make([]*gomatrixserverlib.HeaderedEvent, 0, len(authEventMap))
-	stateEvents := make([]*gomatrixserverlib.HeaderedEvent, 0, len(stateEventMap))
+	authEvents := make([]*types.HeaderedEvent, 0, len(authEventMap))
+	stateEvents := make([]*types.HeaderedEvent, 0, len(stateEventMap))
 	stateIDs := make([]string, 0, len(stateEventMap))
 
 	for _, authEvent := range authEventMap {
-		authEvents = append(authEvents, authEvent.Headered(roomInfo.RoomVersion))
+		authEvents = append(authEvents, &types.HeaderedEvent{Event: authEvent})
 	}
 	for _, stateEvent := range stateEventMap {
-		stateEvents = append(stateEvents, stateEvent.Headered(roomInfo.RoomVersion))
+		stateEvents = append(stateEvents, &types.HeaderedEvent{Event: stateEvent})
 		stateIDs = append(stateIDs, stateEvent.EventID())
 	}
 

--- a/roomserver/internal/perform/perform_inbound_peek.go
+++ b/roomserver/internal/perform/perform_inbound_peek.go
@@ -76,7 +76,7 @@ func (r *InboundPeeker) PerformInboundPeek(
 		sortedLatestEvents,
 		gomatrixserverlib.TopologicalOrderByPrevEvents,
 	)
-	response.LatestEvent = sortedLatestEvents[0].Headered(info.RoomVersion)
+	response.LatestEvent = &types.HeaderedEvent{Event: sortedLatestEvents[0]}
 
 	// XXX: do we actually need to do a state resolution here?
 	roomState := state.NewStateResolution(r.DB, info)
@@ -106,11 +106,11 @@ func (r *InboundPeeker) PerformInboundPeek(
 	}
 
 	for _, event := range stateEvents {
-		response.StateEvents = append(response.StateEvents, event.Headered(info.RoomVersion))
+		response.StateEvents = append(response.StateEvents, &types.HeaderedEvent{Event: event})
 	}
 
 	for _, event := range authEvents {
-		response.AuthChainEvents = append(response.AuthChainEvents, event.Headered(info.RoomVersion))
+		response.AuthChainEvents = append(response.AuthChainEvents, &types.HeaderedEvent{Event: event})
 	}
 
 	err = r.Inputer.OutputProducer.ProduceRoomEvents(request.RoomID, []api.OutputEvent{

--- a/roomserver/internal/perform/perform_invite.go
+++ b/roomserver/internal/perform/perform_invite.go
@@ -119,8 +119,8 @@ func (r *Inviter) PerformInvite(
 		}
 		outputUpdates, err = helpers.UpdateToInviteMembership(updater, &types.Event{
 			EventNID: 0,
-			Event:    event.Unwrap(),
-		}, outputUpdates, req.Event.RoomVersion)
+			Event:    event.Event,
+		}, outputUpdates, req.Event.Version())
 		if err != nil {
 			return nil, fmt.Errorf("updateToInviteMembership: %w", err)
 		}
@@ -300,7 +300,7 @@ func buildInviteStrippedState(
 	inviteState := []fclient.InviteV2StrippedState{
 		fclient.NewInviteV2StrippedState(input.Event.Event),
 	}
-	stateEvents = append(stateEvents, types.Event{Event: input.Event.Unwrap()})
+	stateEvents = append(stateEvents, types.Event{Event: input.Event.Event})
 	for _, event := range stateEvents {
 		inviteState = append(inviteState, fclient.NewInviteV2StrippedState(event.Event))
 	}

--- a/roomserver/internal/perform/perform_join.go
+++ b/roomserver/internal/perform/perform_join.go
@@ -36,6 +36,7 @@ import (
 	"github.com/matrix-org/dendrite/roomserver/internal/input"
 	"github.com/matrix-org/dendrite/roomserver/internal/query"
 	"github.com/matrix-org/dendrite/roomserver/storage"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 )
 
@@ -273,7 +274,7 @@ func (r *Joiner) performJoinRoomByID(
 
 	// If a guest is trying to join a room, check that the room has a m.room.guest_access event
 	if req.IsGuest {
-		var guestAccessEvent *gomatrixserverlib.HeaderedEvent
+		var guestAccessEvent *types.HeaderedEvent
 		guestAccess := "forbidden"
 		guestAccessEvent, err = r.DB.GetStateEvent(ctx, req.RoomIDOrAlias, spec.MRoomGuestAccess, "")
 		if (err != nil && !errors.Is(err, sql.ErrNoRows)) || guestAccessEvent == nil {
@@ -334,7 +335,7 @@ func (r *Joiner) performJoinRoomByID(
 				InputRoomEvents: []rsAPI.InputRoomEvent{
 					{
 						Kind:         rsAPI.KindNew,
-						Event:        event.Headered(buildRes.RoomVersion),
+						Event:        event,
 						SendAsServer: string(userDomain),
 					},
 				},

--- a/roomserver/internal/perform/perform_leave.go
+++ b/roomserver/internal/perform/perform_leave.go
@@ -196,7 +196,7 @@ func (r *Leaver) performLeaveRoomByID(
 		InputRoomEvents: []api.InputRoomEvent{
 			{
 				Kind:         api.KindNew,
-				Event:        event.Headered(buildRes.RoomVersion),
+				Event:        event,
 				Origin:       senderDomain,
 				SendAsServer: string(senderDomain),
 			},

--- a/roomserver/internal/perform/perform_upgrade.go
+++ b/roomserver/internal/perform/perform_upgrade.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/matrix-org/dendrite/internal/eventutil"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
@@ -349,8 +350,8 @@ func (r *Upgrader) userIsAuthorized(ctx context.Context, userID, roomID string,
 }
 
 // nolint:gocyclo
-func (r *Upgrader) generateInitialEvents(ctx context.Context, oldRoom *api.QueryLatestEventsAndStateResponse, userID, roomID, newVersion string, tombstoneEvent *gomatrixserverlib.HeaderedEvent) ([]fledglingEvent, *api.PerformError) {
-	state := make(map[gomatrixserverlib.StateKeyTuple]*gomatrixserverlib.HeaderedEvent, len(oldRoom.StateEvents))
+func (r *Upgrader) generateInitialEvents(ctx context.Context, oldRoom *api.QueryLatestEventsAndStateResponse, userID, roomID, newVersion string, tombstoneEvent *types.HeaderedEvent) ([]fledglingEvent, *api.PerformError) {
+	state := make(map[gomatrixserverlib.StateKeyTuple]*types.HeaderedEvent, len(oldRoom.StateEvents))
 	for _, event := range oldRoom.StateEvents {
 		if event.StateKey() == nil {
 			// This shouldn't ever happen, but better to be safe than sorry.
@@ -505,7 +506,7 @@ func (r *Upgrader) generateInitialEvents(ctx context.Context, oldRoom *api.Query
 
 func (r *Upgrader) sendInitialEvents(ctx context.Context, evTime time.Time, userID string, userDomain spec.ServerName, newRoomID, newVersion string, eventsToMake []fledglingEvent) *api.PerformError {
 	var err error
-	var builtEvents []*gomatrixserverlib.HeaderedEvent
+	var builtEvents []*types.HeaderedEvent
 	authEvents := gomatrixserverlib.NewAuthEvents(nil)
 	for i, e := range eventsToMake {
 		depth := i + 1 // depth starts at 1
@@ -541,7 +542,7 @@ func (r *Upgrader) sendInitialEvents(ctx context.Context, evTime time.Time, user
 		}
 
 		// Add the event to the list of auth events
-		builtEvents = append(builtEvents, event.Headered(gomatrixserverlib.RoomVersion(newVersion)))
+		builtEvents = append(builtEvents, &types.HeaderedEvent{Event: event})
 		err = authEvents.AddEvent(event)
 		if err != nil {
 			return &api.PerformError{
@@ -571,7 +572,7 @@ func (r *Upgrader) makeTombstoneEvent(
 	ctx context.Context,
 	evTime time.Time,
 	userID, roomID, newRoomID string,
-) (*gomatrixserverlib.HeaderedEvent, *api.PerformError) {
+) (*types.HeaderedEvent, *api.PerformError) {
 	content := map[string]interface{}{
 		"body":             "This room has been replaced",
 		"replacement_room": newRoomID,
@@ -583,7 +584,7 @@ func (r *Upgrader) makeTombstoneEvent(
 	return r.makeHeaderedEvent(ctx, evTime, userID, roomID, event)
 }
 
-func (r *Upgrader) makeHeaderedEvent(ctx context.Context, evTime time.Time, userID, roomID string, event fledglingEvent) (*gomatrixserverlib.HeaderedEvent, *api.PerformError) {
+func (r *Upgrader) makeHeaderedEvent(ctx context.Context, evTime time.Time, userID, roomID string, event fledglingEvent) (*types.HeaderedEvent, *api.PerformError) {
 	builder := gomatrixserverlib.EventBuilder{
 		Sender:   userID,
 		RoomID:   roomID,
@@ -690,7 +691,7 @@ func createTemporaryPowerLevels(powerLevelContent *gomatrixserverlib.PowerLevelC
 func (r *Upgrader) sendHeaderedEvent(
 	ctx context.Context,
 	serverName spec.ServerName,
-	headeredEvent *gomatrixserverlib.HeaderedEvent,
+	headeredEvent *types.HeaderedEvent,
 	sendAsServer string,
 ) *api.PerformError {
 	var inputs []api.InputRoomEvent

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -521,10 +521,6 @@ func (r *Queryer) QueryMissingEvents(
 	response.Events = make([]*types.HeaderedEvent, 0, len(loadedEvents)-len(eventsToFilter))
 	for _, event := range loadedEvents {
 		if !eventsToFilter[event.EventID()] {
-			_, verr := r.roomVersion(event.RoomID())
-			if verr != nil {
-				return verr
-			}
 			if _, ok := redactEventIDs[event.EventID()]; ok {
 				event.Redact()
 			}

--- a/roomserver/internal/query/query.go
+++ b/roomserver/internal/query/query.go
@@ -128,7 +128,7 @@ func (r *Queryer) QueryStateAfterEvents(
 	}
 
 	for _, event := range stateEvents {
-		response.StateEvents = append(response.StateEvents, event.Headered(info.RoomVersion))
+		response.StateEvents = append(response.StateEvents, &types.HeaderedEvent{Event: event})
 	}
 
 	return nil
@@ -173,7 +173,7 @@ func (r *Queryer) QueryEventsByID(
 	}
 
 	for _, event := range events {
-		response.Events = append(response.Events, event.Headered(roomInfo.RoomVersion))
+		response.Events = append(response.Events, &types.HeaderedEvent{Event: event.Event})
 	}
 
 	return nil
@@ -231,7 +231,7 @@ func (r *Queryer) QueryMembershipAtEvent(
 	request *api.QueryMembershipAtEventRequest,
 	response *api.QueryMembershipAtEventResponse,
 ) error {
-	response.Membership = make(map[string]*gomatrixserverlib.HeaderedEvent)
+	response.Membership = make(map[string]*types.HeaderedEvent)
 
 	info, err := r.DB.RoomInfo(ctx, request.RoomID)
 	if err != nil {
@@ -259,7 +259,7 @@ func (r *Queryer) QueryMembershipAtEvent(
 		return err
 	}
 
-	response.Membership = make(map[string]*gomatrixserverlib.HeaderedEvent)
+	response.Membership = make(map[string]*types.HeaderedEvent)
 	stateEntries, err := helpers.MembershipAtEvent(ctx, r.DB, nil, request.EventIDs, stateKeyNIDs[request.UserID])
 	if err != nil {
 		return fmt.Errorf("unable to get state before event: %w", err)
@@ -307,7 +307,7 @@ func (r *Queryer) QueryMembershipAtEvent(
 		for i := range memberships {
 			ev := memberships[i]
 			if ev.Type() == spec.MRoomMember && ev.StateKeyEquals(request.UserID) {
-				response.Membership[eventID] = ev.Event.Headered(info.RoomVersion)
+				response.Membership[eventID] = &types.HeaderedEvent{Event: ev.Event}
 			}
 		}
 	}
@@ -518,17 +518,17 @@ func (r *Queryer) QueryMissingEvents(
 		return err
 	}
 
-	response.Events = make([]*gomatrixserverlib.HeaderedEvent, 0, len(loadedEvents)-len(eventsToFilter))
+	response.Events = make([]*types.HeaderedEvent, 0, len(loadedEvents)-len(eventsToFilter))
 	for _, event := range loadedEvents {
 		if !eventsToFilter[event.EventID()] {
-			roomVersion, verr := r.roomVersion(event.RoomID())
+			_, verr := r.roomVersion(event.RoomID())
 			if verr != nil {
 				return verr
 			}
 			if _, ok := redactEventIDs[event.EventID()]; ok {
 				event.Redact()
 			}
-			response.Events = append(response.Events, event.Headered(roomVersion))
+			response.Events = append(response.Events, &types.HeaderedEvent{Event: event})
 		}
 	}
 
@@ -561,7 +561,7 @@ func (r *Queryer) QueryStateAndAuthChain(
 			return err
 		}
 		for _, event := range authEvents {
-			response.AuthChainEvents = append(response.AuthChainEvents, event.Headered(info.RoomVersion))
+			response.AuthChainEvents = append(response.AuthChainEvents, &types.HeaderedEvent{Event: event})
 		}
 		return nil
 	}
@@ -597,11 +597,11 @@ func (r *Queryer) QueryStateAndAuthChain(
 	}
 
 	for _, event := range stateEvents {
-		response.StateEvents = append(response.StateEvents, event.Headered(info.RoomVersion))
+		response.StateEvents = append(response.StateEvents, &types.HeaderedEvent{Event: event})
 	}
 
 	for _, event := range authEvents {
-		response.AuthChainEvents = append(response.AuthChainEvents, event.Headered(info.RoomVersion))
+		response.AuthChainEvents = append(response.AuthChainEvents, &types.HeaderedEvent{Event: event})
 	}
 
 	return err
@@ -748,7 +748,7 @@ func (r *Queryer) QueryPublishedRooms(
 }
 
 func (r *Queryer) QueryCurrentState(ctx context.Context, req *api.QueryCurrentStateRequest, res *api.QueryCurrentStateResponse) error {
-	res.StateEvents = make(map[gomatrixserverlib.StateKeyTuple]*gomatrixserverlib.HeaderedEvent)
+	res.StateEvents = make(map[gomatrixserverlib.StateKeyTuple]*types.HeaderedEvent)
 	for _, tuple := range req.StateTuples {
 		if tuple.StateKey == "*" && req.AllowWildcards {
 			events, err := r.DB.GetStateEventsWithEventType(ctx, req.RoomID, tuple.EventType)
@@ -865,9 +865,9 @@ func (r *Queryer) QueryAuthChain(ctx context.Context, req *api.QueryAuthChainReq
 	if err != nil {
 		return err
 	}
-	hchain := make([]*gomatrixserverlib.HeaderedEvent, len(chain))
+	hchain := make([]*types.HeaderedEvent, len(chain))
 	for i := range chain {
-		hchain[i] = chain[i].Headered(chain[i].Version())
+		hchain[i] = &types.HeaderedEvent{Event: chain[i]}
 	}
 	res.AuthChain = hchain
 	return nil

--- a/roomserver/producers/roomevent.go
+++ b/roomserver/producers/roomevent.go
@@ -74,7 +74,7 @@ func (r *RoomEventProducer) ProduceRoomEvents(roomID string, updates []api.Outpu
 			}
 
 			if eventType == "m.room.server_acl" && update.NewRoomEvent.Event.StateKeyEquals("") {
-				ev := update.NewRoomEvent.Event.Unwrap()
+				ev := update.NewRoomEvent.Event.Event
 				defer r.ACLs.OnServerACLUpdate(ev)
 			}
 		}

--- a/roomserver/roomserver_test.go
+++ b/roomserver/roomserver_test.go
@@ -136,7 +136,7 @@ func testKickUsers(t *testing.T, rsAPI api.RoomserverInternalAPI, usrAPI userAPI
 
 	// revoke guest access
 	revokeEvent := room.CreateAndInsert(t, alice, spec.MRoomGuestAccess, map[string]string{"guest_access": "forbidden"}, test.WithStateKey(""))
-	if err := api.SendEvents(ctx, rsAPI, api.KindNew, []*gomatrixserverlib.HeaderedEvent{revokeEvent}, "test", "test", "test", nil, false); err != nil {
+	if err := api.SendEvents(ctx, rsAPI, api.KindNew, []*types.HeaderedEvent{revokeEvent}, "test", "test", "test", nil, false); err != nil {
 		t.Errorf("failed to send events: %v", err)
 	}
 
@@ -401,7 +401,7 @@ type fledglingEvent struct {
 	PrevEvents []interface{}
 }
 
-func mustCreateEvent(t *testing.T, ev fledglingEvent) (result *gomatrixserverlib.HeaderedEvent) {
+func mustCreateEvent(t *testing.T, ev fledglingEvent) (result *types.HeaderedEvent) {
 	t.Helper()
 	roomVer := gomatrixserverlib.RoomVersionV9
 	seed := make([]byte, ed25519.SeedSize) // zero seed
@@ -423,7 +423,7 @@ func mustCreateEvent(t *testing.T, ev fledglingEvent) (result *gomatrixserverlib
 	if err != nil {
 		t.Fatalf("mustCreateEvent: failed to sign event: %s", err)
 	}
-	h := signedEvent.Headered(roomVer)
+	h := &types.HeaderedEvent{Event: signedEvent}
 	return h
 }
 
@@ -451,7 +451,7 @@ func TestRedaction(t *testing.T) {
 					Depth:      redactedEvent.Depth() + 1,
 					PrevEvents: []interface{}{redactedEvent.EventID()},
 				})
-				room.InsertEvent(t, builderEv.Headered(gomatrixserverlib.RoomVersionV9))
+				room.InsertEvent(t, builderEv)
 			},
 		},
 		{
@@ -468,7 +468,7 @@ func TestRedaction(t *testing.T) {
 					Depth:      redactedEvent.Depth() + 1,
 					PrevEvents: []interface{}{redactedEvent.EventID()},
 				})
-				room.InsertEvent(t, builderEv.Headered(gomatrixserverlib.RoomVersionV9))
+				room.InsertEvent(t, builderEv)
 			},
 		},
 		{
@@ -485,7 +485,7 @@ func TestRedaction(t *testing.T) {
 					Depth:      redactedEvent.Depth() + 1,
 					PrevEvents: []interface{}{redactedEvent.EventID()},
 				})
-				room.InsertEvent(t, builderEv.Headered(gomatrixserverlib.RoomVersionV9))
+				room.InsertEvent(t, builderEv)
 			},
 		},
 		{
@@ -501,7 +501,7 @@ func TestRedaction(t *testing.T) {
 					Depth:      redactedEvent.Depth() + 1,
 					PrevEvents: []interface{}{redactedEvent.EventID()},
 				})
-				room.InsertEvent(t, builderEv.Headered(gomatrixserverlib.RoomVersionV9))
+				room.InsertEvent(t, builderEv)
 			},
 		},
 	}

--- a/roomserver/storage/interface.go
+++ b/roomserver/storage/interface.go
@@ -151,8 +151,8 @@ type Database interface {
 	// GetStateEvent returns the state event of a given type for a given room with a given state key
 	// If no event could be found, returns nil
 	// If there was an issue during the retrieval, returns an error
-	GetStateEvent(ctx context.Context, roomID, evType, stateKey string) (*gomatrixserverlib.HeaderedEvent, error)
-	GetStateEventsWithEventType(ctx context.Context, roomID, evType string) ([]*gomatrixserverlib.HeaderedEvent, error)
+	GetStateEvent(ctx context.Context, roomID, evType, stateKey string) (*types.HeaderedEvent, error)
+	GetStateEventsWithEventType(ctx context.Context, roomID, evType string) ([]*types.HeaderedEvent, error)
 	// GetRoomsByMembership returns a list of room IDs matching the provided membership and user ID (as state_key).
 	GetRoomsByMembership(ctx context.Context, userID, membership string) ([]string, error)
 	// GetBulkStateContent returns all state events which match a given room ID and a given state key tuple. Both must be satisfied for a match.
@@ -181,7 +181,7 @@ type Database interface {
 	// a membership of "leave" when calculating history visibility.
 	GetMembershipForHistoryVisibility(
 		ctx context.Context, userNID types.EventStateKeyNID, info *types.RoomInfo, eventIDs ...string,
-	) (map[string]*gomatrixserverlib.HeaderedEvent, error)
+	) (map[string]*types.HeaderedEvent, error)
 	GetOrCreateRoomInfo(ctx context.Context, event *gomatrixserverlib.Event) (*types.RoomInfo, error)
 	GetOrCreateEventTypeNID(ctx context.Context, eventType string) (eventTypeNID types.EventTypeNID, err error)
 	GetOrCreateEventStateKeyNID(ctx context.Context, eventStateKey *string) (types.EventStateKeyNID, error)
@@ -210,7 +210,7 @@ type RoomDatabase interface {
 	GetOrCreateRoomInfo(ctx context.Context, event *gomatrixserverlib.Event) (*types.RoomInfo, error)
 	GetOrCreateEventTypeNID(ctx context.Context, eventType string) (eventTypeNID types.EventTypeNID, err error)
 	GetOrCreateEventStateKeyNID(ctx context.Context, eventStateKey *string) (types.EventStateKeyNID, error)
-	GetStateEvent(ctx context.Context, roomID, evType, stateKey string) (*gomatrixserverlib.HeaderedEvent, error)
+	GetStateEvent(ctx context.Context, roomID, evType, stateKey string) (*types.HeaderedEvent, error)
 }
 
 type EventDatabase interface {

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -1207,7 +1207,7 @@ func (d *Database) GetStateEvent(ctx context.Context, roomID, evType, stateKey s
 		if e.EventTypeNID == eventTypeNID && e.EventStateKeyNID == stateKeyNID {
 			cachedEvent, ok := d.Cache.GetRoomServerEvent(e.EventNID)
 			if ok {
-				return cachedEvent.Headered(roomInfo.RoomVersion), nil
+				return &types.HeaderedEvent{Event: cachedEvent}, nil
 			}
 			data, err := d.EventJSONTable.BulkSelectEventJSON(ctx, nil, []types.EventNID{e.EventNID})
 			if err != nil {

--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -63,7 +63,7 @@ func (d *Database) SupportsConcurrentRoomInputs() bool {
 
 func (d *Database) GetMembershipForHistoryVisibility(
 	ctx context.Context, userNID types.EventStateKeyNID, roomInfo *types.RoomInfo, eventIDs ...string,
-) (map[string]*gomatrixserverlib.HeaderedEvent, error) {
+) (map[string]*types.HeaderedEvent, error) {
 	return d.StateSnapshotTable.BulkSelectMembershipForHistoryVisibility(ctx, nil, userNID, roomInfo, eventIDs...)
 }
 
@@ -1152,7 +1152,7 @@ func (d *Database) GetHistoryVisibilityState(ctx context.Context, roomInfo *type
 // GetStateEvent returns the current state event of a given type for a given room with a given state key
 // If no event could be found, returns nil
 // If there was an issue during the retrieval, returns an error
-func (d *Database) GetStateEvent(ctx context.Context, roomID, evType, stateKey string) (*gomatrixserverlib.HeaderedEvent, error) {
+func (d *Database) GetStateEvent(ctx context.Context, roomID, evType, stateKey string) (*types.HeaderedEvent, error) {
 	roomInfo, err := d.roomInfo(ctx, nil, roomID)
 	if err != nil {
 		return nil, err
@@ -1212,7 +1212,7 @@ func (d *Database) GetStateEvent(ctx context.Context, roomID, evType, stateKey s
 			if err != nil {
 				return nil, err
 			}
-			return ev.Headered(roomInfo.RoomVersion), nil
+			return &types.HeaderedEvent{Event: ev}, nil
 		}
 	}
 
@@ -1221,7 +1221,7 @@ func (d *Database) GetStateEvent(ctx context.Context, roomID, evType, stateKey s
 
 // Same as GetStateEvent but returns all matching state events with this event type. Returns no error
 // if there are no events with this event type.
-func (d *Database) GetStateEventsWithEventType(ctx context.Context, roomID, evType string) ([]*gomatrixserverlib.HeaderedEvent, error) {
+func (d *Database) GetStateEventsWithEventType(ctx context.Context, roomID, evType string) ([]*types.HeaderedEvent, error) {
 	roomInfo, err := d.roomInfo(ctx, nil, roomID)
 	if err != nil {
 		return nil, err
@@ -1267,13 +1267,13 @@ func (d *Database) GetStateEventsWithEventType(ctx context.Context, roomID, evTy
 	if err != nil {
 		return nil, err
 	}
-	var result []*gomatrixserverlib.HeaderedEvent
+	var result []*types.HeaderedEvent
 	for _, pair := range eventPairs {
 		ev, err := verImpl.NewEventFromTrustedJSONWithEventID(eventIDs[pair.EventNID], pair.EventJSON, false)
 		if err != nil {
 			return nil, err
 		}
-		result = append(result, ev.Headered(roomInfo.RoomVersion))
+		result = append(result, &types.HeaderedEvent{Event: ev})
 	}
 
 	return result, nil
@@ -1401,7 +1401,7 @@ func (d *Database) GetBulkStateContent(ctx context.Context, roomIDs []string, tu
 			EventType:    ev.Type(),
 			RoomID:       ev.RoomID(),
 			StateKey:     *ev.StateKey(),
-			ContentValue: tables.ExtractContentValue(ev.Headered(roomVer)),
+			ContentValue: tables.ExtractContentValue(&types.HeaderedEvent{Event: ev}),
 		}
 	}
 

--- a/roomserver/storage/sqlite3/state_snapshot_table.go
+++ b/roomserver/storage/sqlite3/state_snapshot_table.go
@@ -26,7 +26,6 @@ import (
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/roomserver/storage/tables"
 	"github.com/matrix-org/dendrite/roomserver/types"
-	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 )
 
@@ -153,7 +152,7 @@ func (s *stateSnapshotStatements) BulkSelectStateForHistoryVisibility(
 	return nil, tables.OptimisationNotSupportedError
 }
 
-func (s *stateSnapshotStatements) BulkSelectMembershipForHistoryVisibility(ctx context.Context, txn *sql.Tx, userNID types.EventStateKeyNID, roomInfo *types.RoomInfo, eventIDs ...string) (map[string]*gomatrixserverlib.HeaderedEvent, error) {
+func (s *stateSnapshotStatements) BulkSelectMembershipForHistoryVisibility(ctx context.Context, txn *sql.Tx, userNID types.EventStateKeyNID, roomInfo *types.RoomInfo, eventIDs ...string) (map[string]*types.HeaderedEvent, error) {
 	return nil, tables.OptimisationNotSupportedError
 }
 

--- a/roomserver/storage/tables/interface.go
+++ b/roomserver/storage/tables/interface.go
@@ -95,7 +95,7 @@ type StateSnapshot interface {
 
 	BulkSelectMembershipForHistoryVisibility(
 		ctx context.Context, txn *sql.Tx, userNID types.EventStateKeyNID, roomInfo *types.RoomInfo, eventIDs ...string,
-	) (map[string]*gomatrixserverlib.HeaderedEvent, error)
+	) (map[string]*types.HeaderedEvent, error)
 }
 
 type StateBlock interface {
@@ -196,7 +196,7 @@ type StrippedEvent struct {
 // ExtractContentValue from the given state event. For example, given an m.room.name event with:
 // content: { name: "Foo" }
 // this returns "Foo".
-func ExtractContentValue(ev *gomatrixserverlib.HeaderedEvent) string {
+func ExtractContentValue(ev *types.HeaderedEvent) string {
 	content := ev.Content()
 	key := ""
 	switch ev.Type() {

--- a/roomserver/types/headered_event.go
+++ b/roomserver/types/headered_event.go
@@ -1,3 +1,17 @@
+// Copyright 2023 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package types
 
 import (

--- a/roomserver/types/headered_event.go
+++ b/roomserver/types/headered_event.go
@@ -1,0 +1,33 @@
+package types
+
+import (
+	"github.com/matrix-org/gomatrixserverlib"
+)
+
+// HeaderedEvent is an Event which serialises to the headered form, which includes
+// _room_version and _event_id fields.
+type HeaderedEvent struct {
+	*gomatrixserverlib.Event
+	Visibility gomatrixserverlib.HistoryVisibility
+}
+
+func (h *HeaderedEvent) MarshalJSON() ([]byte, error) {
+	return h.Event.ToHeaderedJSON()
+}
+
+func (j *HeaderedEvent) UnmarshalJSON(data []byte) error {
+	ev, err := gomatrixserverlib.NewEventFromHeaderedJSON(data, false)
+	if err != nil {
+		return err
+	}
+	j.Event = ev
+	return nil
+}
+
+func NewEventJSONsFromHeaderedEvents(hes []*HeaderedEvent) gomatrixserverlib.EventJSONs {
+	result := make(gomatrixserverlib.EventJSONs, len(hes))
+	for i := range hes {
+		result[i] = hes[i].JSON()
+	}
+	return result
+}

--- a/setup/mscs/msc2836/msc2836_test.go
+++ b/setup/mscs/msc2836/msc2836_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/matrix-org/dendrite/internal/httputil"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	roomserver "github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/dendrite/setup/mscs/msc2836"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
@@ -171,7 +172,7 @@ func TestMSC2836(t *testing.T) {
 			bob:     {roomID},
 			charlie: {roomID},
 		},
-		events: map[string]*gomatrixserverlib.HeaderedEvent{
+		events: map[string]*types.HeaderedEvent{
 			eventA.EventID(): eventA,
 			eventB.EventID(): eventB,
 			eventC.EventID(): eventC,
@@ -182,7 +183,7 @@ func TestMSC2836(t *testing.T) {
 			eventH.EventID(): eventH,
 		},
 	}
-	router := injectEvents(t, nopUserAPI, nopRsAPI, []*gomatrixserverlib.HeaderedEvent{
+	router := injectEvents(t, nopUserAPI, nopRsAPI, []*types.HeaderedEvent{
 		eventA, eventB, eventC, eventD, eventE, eventF, eventG, eventH,
 	})
 	cancel := runServer(t, router)
@@ -521,7 +522,7 @@ type testRoomserverAPI struct {
 	// We'll override the functions we care about.
 	roomserver.RoomserverInternalAPI
 	userToJoinedRooms map[string][]string
-	events            map[string]*gomatrixserverlib.HeaderedEvent
+	events            map[string]*types.HeaderedEvent
 }
 
 func (r *testRoomserverAPI) QueryEventsByID(ctx context.Context, req *roomserver.QueryEventsByIDRequest, res *roomserver.QueryEventsByIDResponse) error {
@@ -547,7 +548,7 @@ func (r *testRoomserverAPI) QueryMembershipForUser(ctx context.Context, req *roo
 	return nil
 }
 
-func injectEvents(t *testing.T, userAPI userapi.UserInternalAPI, rsAPI roomserver.RoomserverInternalAPI, events []*gomatrixserverlib.HeaderedEvent) *mux.Router {
+func injectEvents(t *testing.T, userAPI userapi.UserInternalAPI, rsAPI roomserver.RoomserverInternalAPI, events []*types.HeaderedEvent) *mux.Router {
 	t.Helper()
 	cfg := &config.Dendrite{}
 	cfg.Defaults(config.DefaultOpts{
@@ -579,7 +580,7 @@ type fledglingEvent struct {
 	RoomID   string
 }
 
-func mustCreateEvent(t *testing.T, ev fledglingEvent) (result *gomatrixserverlib.HeaderedEvent) {
+func mustCreateEvent(t *testing.T, ev fledglingEvent) (result *types.HeaderedEvent) {
 	t.Helper()
 	roomVer := gomatrixserverlib.RoomVersionV6
 	seed := make([]byte, ed25519.SeedSize) // zero seed
@@ -601,6 +602,6 @@ func mustCreateEvent(t *testing.T, ev fledglingEvent) (result *gomatrixserverlib
 	if err != nil {
 		t.Fatalf("mustCreateEvent: failed to sign event: %s", err)
 	}
-	h := signedEvent.Headered(roomVer)
+	h := &types.HeaderedEvent{Event: signedEvent}
 	return h
 }

--- a/setup/mscs/msc2836/storage.go
+++ b/setup/mscs/msc2836/storage.go
@@ -8,8 +8,8 @@ import (
 	"encoding/json"
 
 	"github.com/matrix-org/dendrite/internal/sqlutil"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
-	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/matrix-org/util"
 )
@@ -23,7 +23,7 @@ type eventInfo struct {
 type Database interface {
 	// StoreRelation stores the parent->child and child->parent relationship for later querying.
 	// Also stores the event metadata e.g timestamp
-	StoreRelation(ctx context.Context, ev *gomatrixserverlib.HeaderedEvent) error
+	StoreRelation(ctx context.Context, ev *types.HeaderedEvent) error
 	// ChildrenForParent returns the events who have the given `eventID` as an m.relationship with the
 	// provided `relType`. The returned slice is sorted by origin_server_ts according to whether
 	// `recentFirst` is true or false.
@@ -35,7 +35,7 @@ type Database interface {
 	// UpdateChildMetadata persists the children_count and children_hash from this event if and only if
 	// the count is greater than what was previously there. If the count is updated, the event will be
 	// updated to be unexplored.
-	UpdateChildMetadata(ctx context.Context, ev *gomatrixserverlib.HeaderedEvent) error
+	UpdateChildMetadata(ctx context.Context, ev *types.HeaderedEvent) error
 	// ChildMetadata returns the children_count and children_hash for the event ID in question.
 	// Also returns the `explored` flag, which is set to true when MarkChildrenExplored is called and is set
 	// back to `false` when a larger count is inserted via UpdateChildMetadata.
@@ -222,7 +222,7 @@ func newSQLiteDatabase(conMan sqlutil.Connections, dbOpts *config.DatabaseOption
 	return &d, nil
 }
 
-func (p *DB) StoreRelation(ctx context.Context, ev *gomatrixserverlib.HeaderedEvent) error {
+func (p *DB) StoreRelation(ctx context.Context, ev *types.HeaderedEvent) error {
 	parent, child, relType := parentChildEventIDs(ev)
 	if parent == "" || child == "" {
 		return nil
@@ -244,7 +244,7 @@ func (p *DB) StoreRelation(ctx context.Context, ev *gomatrixserverlib.HeaderedEv
 	})
 }
 
-func (p *DB) UpdateChildMetadata(ctx context.Context, ev *gomatrixserverlib.HeaderedEvent) error {
+func (p *DB) UpdateChildMetadata(ctx context.Context, ev *types.HeaderedEvent) error {
 	eventCount, eventHash := extractChildMetadata(ev)
 	if eventCount == 0 {
 		return nil // nothing to update with
@@ -315,7 +315,7 @@ func (p *DB) ParentForChild(ctx context.Context, eventID, relType string) (*even
 	return &ei, nil
 }
 
-func parentChildEventIDs(ev *gomatrixserverlib.HeaderedEvent) (parent, child, relType string) {
+func parentChildEventIDs(ev *types.HeaderedEvent) (parent, child, relType string) {
 	if ev == nil {
 		return
 	}
@@ -334,7 +334,7 @@ func parentChildEventIDs(ev *gomatrixserverlib.HeaderedEvent) (parent, child, re
 	return body.Relationship.EventID, ev.EventID(), body.Relationship.RelType
 }
 
-func roomIDAndServers(ev *gomatrixserverlib.HeaderedEvent) (roomID string, servers []string) {
+func roomIDAndServers(ev *types.HeaderedEvent) (roomID string, servers []string) {
 	servers = []string{}
 	if ev == nil {
 		return
@@ -349,7 +349,7 @@ func roomIDAndServers(ev *gomatrixserverlib.HeaderedEvent) (roomID string, serve
 	return body.RoomID, body.Servers
 }
 
-func extractChildMetadata(ev *gomatrixserverlib.HeaderedEvent) (count int, hash []byte) {
+func extractChildMetadata(ev *types.HeaderedEvent) (count int, hash []byte) {
 	unsigned := struct {
 		Counts map[string]int   `json:"children"`
 		Hash   spec.Base64Bytes `json:"children_hash"`

--- a/setup/mscs/msc2946/msc2946.go
+++ b/setup/mscs/msc2946/msc2946.go
@@ -33,6 +33,7 @@ import (
 	"github.com/matrix-org/dendrite/internal/caching"
 	"github.com/matrix-org/dendrite/internal/httputil"
 	roomserver "github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib"
@@ -388,7 +389,7 @@ func (w *walker) walk() util.JSONResponse {
 	}
 }
 
-func (w *walker) stateEvent(roomID, evType, stateKey string) *gomatrixserverlib.HeaderedEvent {
+func (w *walker) stateEvent(roomID, evType, stateKey string) *types.HeaderedEvent {
 	var queryRes roomserver.QueryCurrentStateResponse
 	tuple := gomatrixserverlib.StateKeyTuple{
 		EventType: evType,
@@ -636,7 +637,7 @@ func (w *walker) authorisedUser(roomID, parentRoomID string) (authed bool, isJoi
 	return false, false
 }
 
-func (w *walker) restrictedJoinRuleAllowedRooms(joinRuleEv *gomatrixserverlib.HeaderedEvent, allowType string) (allows []string) {
+func (w *walker) restrictedJoinRuleAllowedRooms(joinRuleEv *types.HeaderedEvent, allowType string) (allows []string) {
 	rule, _ := joinRuleEv.JoinRule()
 	if rule != spec.Restricted {
 		return nil

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"github.com/getsentry/sentry-go"
-	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/nats-io/nats.go"
 	"github.com/sirupsen/logrus"
@@ -31,6 +30,7 @@ import (
 	"github.com/matrix-org/dendrite/internal/fulltext"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/dendrite/setup/jetstream"
 	"github.com/matrix-org/dendrite/setup/process"
@@ -318,7 +318,7 @@ func (s *OutputRoomEventConsumer) onOldRoomEvent(
 	pduPos, err := s.db.WriteEvent(
 		ctx,
 		ev,
-		[]*gomatrixserverlib.HeaderedEvent{},
+		[]*rstypes.HeaderedEvent{},
 		[]string{},           // adds no state
 		[]string{},           // removes no state
 		nil,                  // no transaction
@@ -362,7 +362,7 @@ func (s *OutputRoomEventConsumer) onOldRoomEvent(
 	return nil
 }
 
-func (s *OutputRoomEventConsumer) notifyJoinedPeeks(ctx context.Context, ev *gomatrixserverlib.HeaderedEvent, sp types.StreamPosition) (types.StreamPosition, error) {
+func (s *OutputRoomEventConsumer) notifyJoinedPeeks(ctx context.Context, ev *rstypes.HeaderedEvent, sp types.StreamPosition) (types.StreamPosition, error) {
 	if ev.Type() != spec.MRoomMember {
 		return sp, nil
 	}
@@ -496,7 +496,7 @@ func (s *OutputRoomEventConsumer) onPurgeRoom(
 	}
 }
 
-func (s *OutputRoomEventConsumer) updateStateEvent(event *gomatrixserverlib.HeaderedEvent) (*gomatrixserverlib.HeaderedEvent, error) {
+func (s *OutputRoomEventConsumer) updateStateEvent(event *rstypes.HeaderedEvent) (*rstypes.HeaderedEvent, error) {
 	if event.StateKey() == nil {
 		return event, nil
 	}
@@ -531,7 +531,7 @@ func (s *OutputRoomEventConsumer) updateStateEvent(event *gomatrixserverlib.Head
 	return event, err
 }
 
-func (s *OutputRoomEventConsumer) writeFTS(ev *gomatrixserverlib.HeaderedEvent, pduPosition types.StreamPosition) error {
+func (s *OutputRoomEventConsumer) writeFTS(ev *rstypes.HeaderedEvent, pduPosition types.StreamPosition) error {
 	if !s.cfg.Fulltext.Enabled {
 		return nil
 	}

--- a/syncapi/internal/history_visibility.go
+++ b/syncapi/internal/history_visibility.go
@@ -26,6 +26,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/storage"
 )
 
@@ -98,16 +99,16 @@ func (ev eventVisibility) allowed() (allowed bool) {
 	}
 }
 
-// ApplyHistoryVisibilityFilter applies the room history visibility filter on gomatrixserverlib.HeaderedEvents.
+// ApplyHistoryVisibilityFilter applies the room history visibility filter on types.HeaderedEvents.
 // Returns the filtered events and an error, if any.
 func ApplyHistoryVisibilityFilter(
 	ctx context.Context,
 	syncDB storage.DatabaseTransaction,
 	rsAPI api.SyncRoomserverAPI,
-	events []*gomatrixserverlib.HeaderedEvent,
+	events []*types.HeaderedEvent,
 	alwaysIncludeEventIDs map[string]struct{},
 	userID, endpoint string,
-) ([]*gomatrixserverlib.HeaderedEvent, error) {
+) ([]*types.HeaderedEvent, error) {
 	if len(events) == 0 {
 		return events, nil
 	}
@@ -120,7 +121,7 @@ func ApplyHistoryVisibilityFilter(
 	}
 
 	// Get the mapping from eventID -> eventVisibility
-	eventsFiltered := make([]*gomatrixserverlib.HeaderedEvent, 0, len(events))
+	eventsFiltered := make([]*types.HeaderedEvent, 0, len(events))
 	visibilities := visibilityForEvents(ctx, rsAPI, events, userID, events[0].RoomID())
 	for _, ev := range events {
 		evVis := visibilities[ev.EventID()]
@@ -170,7 +171,7 @@ func ApplyHistoryVisibilityFilter(
 func visibilityForEvents(
 	ctx context.Context,
 	rsAPI api.SyncRoomserverAPI,
-	events []*gomatrixserverlib.HeaderedEvent,
+	events []*types.HeaderedEvent,
 	userID, roomID string,
 ) map[string]eventVisibility {
 	eventIDs := make([]string, len(events))

--- a/syncapi/notifier/notifier.go
+++ b/syncapi/notifier/notifier.go
@@ -20,9 +20,9 @@ import (
 	"time"
 
 	"github.com/matrix-org/dendrite/internal/sqlutil"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/storage"
 	"github.com/matrix-org/dendrite/syncapi/types"
-	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	log "github.com/sirupsen/logrus"
 )
@@ -87,7 +87,7 @@ func (n *Notifier) SetCurrentPosition(currPos types.StreamingToken) {
 // Typically a consumer supplies a posUpdate with the latest sync position for the
 // event type it handles, leaving other fields as 0.
 func (n *Notifier) OnNewEvent(
-	ev *gomatrixserverlib.HeaderedEvent, roomID string, userIDs []string,
+	ev *rstypes.HeaderedEvent, roomID string, userIDs []string,
 	posUpdate types.StreamingToken,
 ) {
 	// update the current position then notify relevant /sync streams.

--- a/syncapi/notifier/notifier_test.go
+++ b/syncapi/notifier/notifier_test.go
@@ -22,16 +22,16 @@ import (
 	"testing"
 	"time"
 
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/types"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
-	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 )
 
 var (
-	randomMessageEvent  gomatrixserverlib.HeaderedEvent
-	aliceInviteBobEvent gomatrixserverlib.HeaderedEvent
-	bobLeaveEvent       gomatrixserverlib.HeaderedEvent
+	randomMessageEvent  rstypes.HeaderedEvent
+	aliceInviteBobEvent rstypes.HeaderedEvent
+	bobLeaveEvent       rstypes.HeaderedEvent
 	syncPositionVeryOld = types.StreamingToken{PDUPosition: 5}
 	syncPositionBefore  = types.StreamingToken{PDUPosition: 11}
 	syncPositionAfter   = types.StreamingToken{PDUPosition: 12}

--- a/syncapi/routing/context.go
+++ b/syncapi/routing/context.go
@@ -27,12 +27,12 @@ import (
 	"github.com/matrix-org/dendrite/internal/caching"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	roomserver "github.com/matrix-org/dendrite/roomserver/api"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/internal"
 	"github.com/matrix-org/dendrite/syncapi/storage"
 	"github.com/matrix-org/dendrite/syncapi/synctypes"
 	"github.com/matrix-org/dendrite/syncapi/types"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
-	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/matrix-org/util"
 	"github.com/sirupsen/logrus"
@@ -122,7 +122,7 @@ func Context(
 
 	// verify the user is allowed to see the context for this room/event
 	startTime := time.Now()
-	filteredEvents, err := internal.ApplyHistoryVisibilityFilter(ctx, snapshot, rsAPI, []*gomatrixserverlib.HeaderedEvent{&requestedEvent}, nil, device.UserID, "context")
+	filteredEvents, err := internal.ApplyHistoryVisibilityFilter(ctx, snapshot, rsAPI, []*rstypes.HeaderedEvent{&requestedEvent}, nil, device.UserID, "context")
 	if err != nil {
 		logrus.WithError(err).Error("unable to apply history visibility filter")
 		return jsonerror.InternalServerError()
@@ -212,9 +212,9 @@ func Context(
 // and an error, if any.
 func applyHistoryVisibilityOnContextEvents(
 	ctx context.Context, snapshot storage.DatabaseTransaction, rsAPI roomserver.SyncRoomserverAPI,
-	eventsBefore, eventsAfter []*gomatrixserverlib.HeaderedEvent,
+	eventsBefore, eventsAfter []*rstypes.HeaderedEvent,
 	userID string,
-) (filteredBefore, filteredAfter []*gomatrixserverlib.HeaderedEvent, err error) {
+) (filteredBefore, filteredAfter []*rstypes.HeaderedEvent, err error) {
 	eventIDsBefore := make(map[string]struct{}, len(eventsBefore))
 	eventIDsAfter := make(map[string]struct{}, len(eventsAfter))
 
@@ -245,7 +245,7 @@ func applyHistoryVisibilityOnContextEvents(
 	return filteredBefore, filteredAfter, nil
 }
 
-func getStartEnd(ctx context.Context, snapshot storage.DatabaseTransaction, startEvents, endEvents []*gomatrixserverlib.HeaderedEvent) (start, end types.TopologyToken, err error) {
+func getStartEnd(ctx context.Context, snapshot storage.DatabaseTransaction, startEvents, endEvents []*rstypes.HeaderedEvent) (start, end types.TopologyToken, err error) {
 	if len(startEvents) > 0 {
 		start, err = snapshot.EventPositionInTopology(ctx, startEvents[0].EventID())
 		if err != nil {
@@ -265,7 +265,7 @@ func applyLazyLoadMembers(
 	roomID string,
 	events []synctypes.ClientEvent,
 	lazyLoadCache caching.LazyLoadCache,
-) ([]*gomatrixserverlib.HeaderedEvent, error) {
+) ([]*rstypes.HeaderedEvent, error) {
 	eventSenders := make(map[string]struct{})
 	// get members who actually send an event
 	for _, e := range events {

--- a/syncapi/routing/relations.go
+++ b/syncapi/routing/relations.go
@@ -18,13 +18,13 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/util"
 	"github.com/sirupsen/logrus"
 
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/internal"
 	"github.com/matrix-org/dendrite/syncapi/storage"
 	"github.com/matrix-org/dendrite/syncapi/synctypes"
@@ -96,7 +96,7 @@ func Relations(
 		return util.ErrorResponse(err)
 	}
 
-	headeredEvents := make([]*gomatrixserverlib.HeaderedEvent, 0, len(events))
+	headeredEvents := make([]*rstypes.HeaderedEvent, 0, len(events))
 	for _, event := range events {
 		headeredEvents = append(headeredEvents, event.HeaderedEvent)
 	}

--- a/syncapi/routing/search.go
+++ b/syncapi/routing/search.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/blevesearch/bleve/v2/search"
-	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/matrix-org/util"
 	"github.com/sirupsen/logrus"
@@ -32,6 +31,7 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/jsonerror"
 	"github.com/matrix-org/dendrite/internal/fulltext"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/storage"
 	"github.com/matrix-org/dendrite/syncapi/synctypes"
 	"github.com/matrix-org/dendrite/userapi/api"
@@ -263,10 +263,10 @@ func Search(req *http.Request, device *api.Device, syncDB storage.Database, fts 
 func contextEvents(
 	ctx context.Context,
 	snapshot storage.DatabaseTransaction,
-	event *gomatrixserverlib.HeaderedEvent,
+	event *types.HeaderedEvent,
 	roomFilter *synctypes.RoomEventFilter,
 	searchReq SearchRequest,
-) ([]*gomatrixserverlib.HeaderedEvent, []*gomatrixserverlib.HeaderedEvent, error) {
+) ([]*types.HeaderedEvent, []*types.HeaderedEvent, error) {
 	id, _, err := snapshot.SelectContextEvent(ctx, event.RoomID(), event.EventID())
 	if err != nil {
 		logrus.WithError(err).Error("failed to query context event")

--- a/syncapi/routing/search_test.go
+++ b/syncapi/routing/search_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/matrix-org/dendrite/internal/fulltext"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/storage"
 	"github.com/matrix-org/dendrite/syncapi/synctypes"
 	"github.com/matrix-org/dendrite/syncapi/types"
@@ -215,7 +216,7 @@ func TestSearch(t *testing.T) {
 		// store the events in the database
 		var sp types.StreamPosition
 		for _, x := range room.Events() {
-			var stateEvents []*gomatrixserverlib.HeaderedEvent
+			var stateEvents []*rstypes.HeaderedEvent
 			var stateEventIDs []string
 			if x.Type() == spec.MRoomMember {
 				stateEvents = append(stateEvents, x)

--- a/syncapi/storage/postgres/current_room_state_table.go
+++ b/syncapi/storage/postgres/current_room_state_table.go
@@ -24,6 +24,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/storage/postgres/deltas"
 	"github.com/matrix-org/dendrite/syncapi/storage/tables"
 	"github.com/matrix-org/dendrite/syncapi/synctypes"
@@ -274,7 +275,7 @@ func (s *currentRoomStateStatements) SelectCurrentState(
 	ctx context.Context, txn *sql.Tx, roomID string,
 	stateFilter *synctypes.StateFilter,
 	excludeEventIDs []string,
-) ([]*gomatrixserverlib.HeaderedEvent, error) {
+) ([]*rstypes.HeaderedEvent, error) {
 	stmt := sqlutil.TxStmt(txn, s.selectCurrentStateStmt)
 	senders, notSenders := getSendersStateFilterFilter(stateFilter)
 	// We're going to query members later, so remove them from this request
@@ -320,7 +321,7 @@ func (s *currentRoomStateStatements) DeleteRoomStateForRoom(
 
 func (s *currentRoomStateStatements) UpsertRoomState(
 	ctx context.Context, txn *sql.Tx,
-	event *gomatrixserverlib.HeaderedEvent, membership *string, addedAt types.StreamPosition,
+	event *rstypes.HeaderedEvent, membership *string, addedAt types.StreamPosition,
 ) error {
 	// Parse content as JSON and search for an "url" key
 	containsURL := false
@@ -378,8 +379,8 @@ func currentRoomStateRowsToStreamEvents(rows *sql.Rows) ([]types.StreamEvent, er
 			return nil, err
 		}
 		// TODO: Handle redacted events
-		var ev gomatrixserverlib.HeaderedEvent
-		if err := ev.UnmarshalJSONWithEventID(eventBytes, eventID); err != nil {
+		var ev rstypes.HeaderedEvent
+		if err := json.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, err
 		}
 
@@ -394,8 +395,8 @@ func currentRoomStateRowsToStreamEvents(rows *sql.Rows) ([]types.StreamEvent, er
 	return events, nil
 }
 
-func rowsToEvents(rows *sql.Rows) ([]*gomatrixserverlib.HeaderedEvent, error) {
-	result := []*gomatrixserverlib.HeaderedEvent{}
+func rowsToEvents(rows *sql.Rows) ([]*rstypes.HeaderedEvent, error) {
+	result := []*rstypes.HeaderedEvent{}
 	for rows.Next() {
 		var eventID string
 		var eventBytes []byte
@@ -403,8 +404,8 @@ func rowsToEvents(rows *sql.Rows) ([]*gomatrixserverlib.HeaderedEvent, error) {
 			return nil, err
 		}
 		// TODO: Handle redacted events
-		var ev gomatrixserverlib.HeaderedEvent
-		if err := ev.UnmarshalJSONWithEventID(eventBytes, eventID); err != nil {
+		var ev rstypes.HeaderedEvent
+		if err := json.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, err
 		}
 		result = append(result, &ev)
@@ -414,7 +415,7 @@ func rowsToEvents(rows *sql.Rows) ([]*gomatrixserverlib.HeaderedEvent, error) {
 
 func (s *currentRoomStateStatements) SelectStateEvent(
 	ctx context.Context, txn *sql.Tx, roomID, evType, stateKey string,
-) (*gomatrixserverlib.HeaderedEvent, error) {
+) (*rstypes.HeaderedEvent, error) {
 	stmt := sqlutil.TxStmt(txn, s.selectStateEventStmt)
 	var res []byte
 	err := stmt.QueryRowContext(ctx, roomID, evType, stateKey).Scan(&res)
@@ -424,7 +425,7 @@ func (s *currentRoomStateStatements) SelectStateEvent(
 	if err != nil {
 		return nil, err
 	}
-	var ev gomatrixserverlib.HeaderedEvent
+	var ev rstypes.HeaderedEvent
 	if err = json.Unmarshal(res, &ev); err != nil {
 		return nil, err
 	}

--- a/syncapi/storage/postgres/deltas/2022061412000000_history_visibility_column.go
+++ b/syncapi/storage/postgres/deltas/2022061412000000_history_visibility_column.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
@@ -79,7 +80,7 @@ func currentHistoryVisibilities(ctx context.Context, tx *sql.Tx) (map[string]gom
 	defer rows.Close() // nolint: errcheck
 	var eventBytes []byte
 	var roomID string
-	var event gomatrixserverlib.HeaderedEvent
+	var event types.HeaderedEvent
 	var hisVis gomatrixserverlib.HistoryVisibility
 	historyVisibilities := make(map[string]gomatrixserverlib.HistoryVisibility)
 	for rows.Next() {

--- a/syncapi/storage/postgres/invites_table.go
+++ b/syncapi/storage/postgres/invites_table.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/storage/tables"
 	"github.com/matrix-org/dendrite/syncapi/types"
-	"github.com/matrix-org/gomatrixserverlib"
 )
 
 const inviteEventsSchema = `
@@ -89,7 +89,7 @@ func NewPostgresInvitesTable(db *sql.DB) (tables.Invites, error) {
 }
 
 func (s *inviteEventsStatements) InsertInviteEvent(
-	ctx context.Context, txn *sql.Tx, inviteEvent *gomatrixserverlib.HeaderedEvent,
+	ctx context.Context, txn *sql.Tx, inviteEvent *rstypes.HeaderedEvent,
 ) (streamPos types.StreamPosition, err error) {
 	var headeredJSON []byte
 	headeredJSON, err = json.Marshal(inviteEvent)
@@ -119,7 +119,7 @@ func (s *inviteEventsStatements) DeleteInviteEvent(
 // active invites for the target user ID in the supplied range.
 func (s *inviteEventsStatements) SelectInviteEventsInRange(
 	ctx context.Context, txn *sql.Tx, targetUserID string, r types.Range,
-) (map[string]*gomatrixserverlib.HeaderedEvent, map[string]*gomatrixserverlib.HeaderedEvent, types.StreamPosition, error) {
+) (map[string]*rstypes.HeaderedEvent, map[string]*rstypes.HeaderedEvent, types.StreamPosition, error) {
 	var lastPos types.StreamPosition
 	stmt := sqlutil.TxStmt(txn, s.selectInviteEventsInRangeStmt)
 	rows, err := stmt.QueryContext(ctx, targetUserID, r.Low(), r.High())
@@ -127,8 +127,8 @@ func (s *inviteEventsStatements) SelectInviteEventsInRange(
 		return nil, nil, lastPos, err
 	}
 	defer internal.CloseAndLogIfError(ctx, rows, "selectInviteEventsInRange: rows.close() failed")
-	result := map[string]*gomatrixserverlib.HeaderedEvent{}
-	retired := map[string]*gomatrixserverlib.HeaderedEvent{}
+	result := map[string]*rstypes.HeaderedEvent{}
+	retired := map[string]*rstypes.HeaderedEvent{}
 	for rows.Next() {
 		var (
 			id        types.StreamPosition
@@ -151,7 +151,7 @@ func (s *inviteEventsStatements) SelectInviteEventsInRange(
 			continue
 		}
 
-		var event *gomatrixserverlib.HeaderedEvent
+		var event *rstypes.HeaderedEvent
 		if err := json.Unmarshal(eventJSON, &event); err != nil {
 			return nil, nil, lastPos, err
 		}

--- a/syncapi/storage/postgres/memberships_table.go
+++ b/syncapi/storage/postgres/memberships_table.go
@@ -19,9 +19,8 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/matrix-org/gomatrixserverlib"
-
 	"github.com/matrix-org/dendrite/internal/sqlutil"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/storage/tables"
 	"github.com/matrix-org/dendrite/syncapi/types"
 )
@@ -100,7 +99,7 @@ func NewPostgresMembershipsTable(db *sql.DB) (tables.Memberships, error) {
 }
 
 func (s *membershipsStatements) UpsertMembership(
-	ctx context.Context, txn *sql.Tx, event *gomatrixserverlib.HeaderedEvent,
+	ctx context.Context, txn *sql.Tx, event *rstypes.HeaderedEvent,
 	streamPos, topologicalPos types.StreamPosition,
 ) error {
 	membership, err := event.Membership()

--- a/syncapi/storage/postgres/output_room_events_table.go
+++ b/syncapi/storage/postgres/output_room_events_table.go
@@ -26,6 +26,7 @@ import (
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/storage/postgres/deltas"
 	"github.com/matrix-org/dendrite/syncapi/storage/tables"
 	"github.com/matrix-org/dendrite/syncapi/synctypes"
@@ -264,7 +265,7 @@ func NewPostgresEventsTable(db *sql.DB) (tables.Events, error) {
 	}.Prepare(db)
 }
 
-func (s *outputRoomEventsStatements) UpdateEventJSON(ctx context.Context, txn *sql.Tx, event *gomatrixserverlib.HeaderedEvent) error {
+func (s *outputRoomEventsStatements) UpdateEventJSON(ctx context.Context, txn *sql.Tx, event *rstypes.HeaderedEvent) error {
 	headeredJSON, err := json.Marshal(event)
 	if err != nil {
 		return err
@@ -329,8 +330,8 @@ func (s *outputRoomEventsStatements) SelectStateInRange(
 		}
 
 		// TODO: Handle redacted events
-		var ev gomatrixserverlib.HeaderedEvent
-		if err := ev.UnmarshalJSONWithEventID(eventBytes, eventID); err != nil {
+		var ev rstypes.HeaderedEvent
+		if err := json.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, nil, err
 		}
 		needSet := stateNeeded[ev.RoomID()]
@@ -375,7 +376,7 @@ func (s *outputRoomEventsStatements) SelectMaxEventID(
 // of the inserted event.
 func (s *outputRoomEventsStatements) InsertEvent(
 	ctx context.Context, txn *sql.Tx,
-	event *gomatrixserverlib.HeaderedEvent, addState, removeState []string,
+	event *rstypes.HeaderedEvent, addState, removeState []string,
 	transactionID *api.TransactionID, excludeFromSync bool, historyVisibility gomatrixserverlib.HistoryVisibility,
 ) (streamPos types.StreamPosition, err error) {
 	var txnID *string
@@ -465,8 +466,8 @@ func (s *outputRoomEventsStatements) SelectRecentEvents(
 			return nil, err
 		}
 		// TODO: Handle redacted events
-		var ev gomatrixserverlib.HeaderedEvent
-		if err := ev.UnmarshalJSONWithEventID(eventBytes, eventID); err != nil {
+		var ev rstypes.HeaderedEvent
+		if err := json.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, err
 		}
 
@@ -577,7 +578,7 @@ func (s *outputRoomEventsStatements) DeleteEventsForRoom(
 	return err
 }
 
-func (s *outputRoomEventsStatements) SelectContextEvent(ctx context.Context, txn *sql.Tx, roomID, eventID string) (id int, evt gomatrixserverlib.HeaderedEvent, err error) {
+func (s *outputRoomEventsStatements) SelectContextEvent(ctx context.Context, txn *sql.Tx, roomID, eventID string) (id int, evt rstypes.HeaderedEvent, err error) {
 	row := sqlutil.TxStmt(txn, s.selectContextEventStmt).QueryRowContext(ctx, roomID, eventID)
 
 	var eventAsString string
@@ -595,7 +596,7 @@ func (s *outputRoomEventsStatements) SelectContextEvent(ctx context.Context, txn
 
 func (s *outputRoomEventsStatements) SelectContextBeforeEvent(
 	ctx context.Context, txn *sql.Tx, id int, roomID string, filter *synctypes.RoomEventFilter,
-) (evts []*gomatrixserverlib.HeaderedEvent, err error) {
+) (evts []*rstypes.HeaderedEvent, err error) {
 	senders, notSenders := getSendersRoomEventFilter(filter)
 	rows, err := sqlutil.TxStmt(txn, s.selectContextBeforeEventStmt).QueryContext(
 		ctx, roomID, id, filter.Limit,
@@ -612,7 +613,7 @@ func (s *outputRoomEventsStatements) SelectContextBeforeEvent(
 	for rows.Next() {
 		var (
 			eventBytes        []byte
-			evt               *gomatrixserverlib.HeaderedEvent
+			evt               *rstypes.HeaderedEvent
 			historyVisibility gomatrixserverlib.HistoryVisibility
 		)
 		if err = rows.Scan(&eventBytes, &historyVisibility); err != nil {
@@ -630,7 +631,7 @@ func (s *outputRoomEventsStatements) SelectContextBeforeEvent(
 
 func (s *outputRoomEventsStatements) SelectContextAfterEvent(
 	ctx context.Context, txn *sql.Tx, id int, roomID string, filter *synctypes.RoomEventFilter,
-) (lastID int, evts []*gomatrixserverlib.HeaderedEvent, err error) {
+) (lastID int, evts []*rstypes.HeaderedEvent, err error) {
 	senders, notSenders := getSendersRoomEventFilter(filter)
 	rows, err := sqlutil.TxStmt(txn, s.selectContextAfterEventStmt).QueryContext(
 		ctx, roomID, id, filter.Limit,
@@ -647,7 +648,7 @@ func (s *outputRoomEventsStatements) SelectContextAfterEvent(
 	for rows.Next() {
 		var (
 			eventBytes        []byte
-			evt               *gomatrixserverlib.HeaderedEvent
+			evt               *rstypes.HeaderedEvent
 			historyVisibility gomatrixserverlib.HistoryVisibility
 		)
 		if err = rows.Scan(&lastID, &eventBytes, &historyVisibility); err != nil {
@@ -680,8 +681,8 @@ func rowsToStreamEvents(rows *sql.Rows) ([]types.StreamEvent, error) {
 			return nil, err
 		}
 		// TODO: Handle redacted events
-		var ev gomatrixserverlib.HeaderedEvent
-		if err := ev.UnmarshalJSONWithEventID(eventBytes, eventID); err != nil {
+		var ev rstypes.HeaderedEvent
+		if err := json.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, err
 		}
 
@@ -709,7 +710,7 @@ func (s *outputRoomEventsStatements) PurgeEvents(
 	return err
 }
 
-func (s *outputRoomEventsStatements) ReIndex(ctx context.Context, txn *sql.Tx, limit, afterID int64, types []string) (map[int64]gomatrixserverlib.HeaderedEvent, error) {
+func (s *outputRoomEventsStatements) ReIndex(ctx context.Context, txn *sql.Tx, limit, afterID int64, types []string) (map[int64]rstypes.HeaderedEvent, error) {
 	rows, err := sqlutil.TxStmt(txn, s.selectSearchStmt).QueryContext(ctx, afterID, pq.StringArray(types), limit)
 	if err != nil {
 		return nil, err
@@ -718,14 +719,14 @@ func (s *outputRoomEventsStatements) ReIndex(ctx context.Context, txn *sql.Tx, l
 
 	var eventID string
 	var id int64
-	result := make(map[int64]gomatrixserverlib.HeaderedEvent)
+	result := make(map[int64]rstypes.HeaderedEvent)
 	for rows.Next() {
-		var ev gomatrixserverlib.HeaderedEvent
+		var ev rstypes.HeaderedEvent
 		var eventBytes []byte
 		if err = rows.Scan(&id, &eventID, &eventBytes); err != nil {
 			return nil, err
 		}
-		if err = ev.UnmarshalJSONWithEventID(eventBytes, eventID); err != nil {
+		if err = json.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, err
 		}
 		result[id] = ev

--- a/syncapi/storage/postgres/output_room_events_topology_table.go
+++ b/syncapi/storage/postgres/output_room_events_topology_table.go
@@ -18,10 +18,9 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/matrix-org/gomatrixserverlib"
-
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/storage/tables"
 	"github.com/matrix-org/dendrite/syncapi/types"
 )
@@ -105,7 +104,7 @@ func NewPostgresTopologyTable(db *sql.DB) (tables.Topology, error) {
 // InsertEventInTopology inserts the given event in the room's topology, based
 // on the event's depth.
 func (s *outputRoomEventsTopologyStatements) InsertEventInTopology(
-	ctx context.Context, txn *sql.Tx, event *gomatrixserverlib.HeaderedEvent, pos types.StreamPosition,
+	ctx context.Context, txn *sql.Tx, event *rstypes.HeaderedEvent, pos types.StreamPosition,
 ) (topoPos types.StreamPosition, err error) {
 	err = sqlutil.TxStmt(txn, s.insertEventInTopologyStmt).QueryRowContext(
 		ctx, event.EventID(), event.Depth(), event.RoomID(), pos,

--- a/syncapi/storage/shared/storage_consumer.go
+++ b/syncapi/storage/shared/storage_consumer.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/tidwall/gjson"
 
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 
@@ -90,7 +91,7 @@ func (d *Database) NewDatabaseTransaction(ctx context.Context) (*DatabaseTransac
 	}, nil
 }
 
-func (d *Database) Events(ctx context.Context, eventIDs []string) ([]*gomatrixserverlib.HeaderedEvent, error) {
+func (d *Database) Events(ctx context.Context, eventIDs []string) ([]*rstypes.HeaderedEvent, error) {
 	streamEvents, err := d.OutputEvents.SelectEvents(ctx, nil, eventIDs, nil, false)
 	if err != nil {
 		return nil, err
@@ -105,7 +106,7 @@ func (d *Database) Events(ctx context.Context, eventIDs []string) ([]*gomatrixse
 // If the invite was successfully stored this returns the stream ID it was stored at.
 // Returns an error if there was a problem communicating with the database.
 func (d *Database) AddInviteEvent(
-	ctx context.Context, inviteEvent *gomatrixserverlib.HeaderedEvent,
+	ctx context.Context, inviteEvent *rstypes.HeaderedEvent,
 ) (sp types.StreamPosition, err error) {
 	_ = d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
 		sp, err = d.Invites.InsertInviteEvent(ctx, txn, inviteEvent)
@@ -189,8 +190,8 @@ func (d *Database) UpsertAccountData(
 	return
 }
 
-func (d *Database) StreamEventsToEvents(device *userapi.Device, in []types.StreamEvent) []*gomatrixserverlib.HeaderedEvent {
-	out := make([]*gomatrixserverlib.HeaderedEvent, len(in))
+func (d *Database) StreamEventsToEvents(device *userapi.Device, in []types.StreamEvent) []*rstypes.HeaderedEvent {
+	out := make([]*rstypes.HeaderedEvent, len(in))
 	for i := 0; i < len(in); i++ {
 		out[i] = in[i].HeaderedEvent
 		if device != nil && in[i].TransactionID != nil {
@@ -213,7 +214,7 @@ func (d *Database) StreamEventsToEvents(device *userapi.Device, in []types.Strea
 // the events listed in the event's 'prev_events'. This function also updates the backwards extremities table
 // to account for the fact that the given event is no longer a backwards extremity, but may be marked as such.
 // This function should always be called within a sqlutil.Writer for safety in SQLite.
-func (d *Database) handleBackwardExtremities(ctx context.Context, txn *sql.Tx, ev *gomatrixserverlib.HeaderedEvent) error {
+func (d *Database) handleBackwardExtremities(ctx context.Context, txn *sql.Tx, ev *rstypes.HeaderedEvent) error {
 	if err := d.BackwardExtremities.DeleteBackwardExtremity(ctx, txn, ev.RoomID(), ev.EventID()); err != nil {
 		return err
 	}
@@ -246,8 +247,8 @@ func (d *Database) handleBackwardExtremities(ctx context.Context, txn *sql.Tx, e
 
 func (d *Database) WriteEvent(
 	ctx context.Context,
-	ev *gomatrixserverlib.HeaderedEvent,
-	addStateEvents []*gomatrixserverlib.HeaderedEvent,
+	ev *rstypes.HeaderedEvent,
+	addStateEvents []*rstypes.HeaderedEvent,
 	addStateEventIDs, removeStateEventIDs []string,
 	transactionID *api.TransactionID, excludeFromSync bool,
 	historyVisibility gomatrixserverlib.HistoryVisibility,
@@ -288,7 +289,7 @@ func (d *Database) WriteEvent(
 func (d *Database) updateRoomState(
 	ctx context.Context, txn *sql.Tx,
 	removedEventIDs []string,
-	addedEvents []*gomatrixserverlib.HeaderedEvent,
+	addedEvents []*rstypes.HeaderedEvent,
 	pduPosition types.StreamPosition,
 	topoPosition types.StreamPosition,
 ) error {
@@ -342,7 +343,7 @@ func (d *Database) PutFilter(
 	return filterID, err
 }
 
-func (d *Database) RedactEvent(ctx context.Context, redactedEventID string, redactedBecause *gomatrixserverlib.HeaderedEvent) error {
+func (d *Database) RedactEvent(ctx context.Context, redactedEventID string, redactedBecause *rstypes.HeaderedEvent) error {
 	redactedEvents, err := d.Events(ctx, []string{redactedEventID})
 	if err != nil {
 		return err
@@ -351,13 +352,13 @@ func (d *Database) RedactEvent(ctx context.Context, redactedEventID string, reda
 		logrus.WithField("event_id", redactedEventID).WithField("redaction_event", redactedBecause.EventID()).Warnf("missing redacted event for redaction")
 		return nil
 	}
-	eventToRedact := redactedEvents[0].Unwrap()
-	redactionEvent := redactedBecause.Unwrap()
+	eventToRedact := redactedEvents[0].Event
+	redactionEvent := redactedBecause.Event
 	if err = eventutil.RedactEvent(redactionEvent, eventToRedact); err != nil {
 		return err
 	}
 
-	newEvent := eventToRedact.Headered(redactedBecause.RoomVersion)
+	newEvent := &rstypes.HeaderedEvent{Event: eventToRedact}
 	err = d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
 		return d.OutputEvents.UpdateEventJSON(ctx, txn, newEvent)
 	})
@@ -521,14 +522,14 @@ func (d *Database) UpsertRoomUnreadNotificationCounts(ctx context.Context, userI
 	return
 }
 
-func (d *Database) SelectContextEvent(ctx context.Context, roomID, eventID string) (int, gomatrixserverlib.HeaderedEvent, error) {
+func (d *Database) SelectContextEvent(ctx context.Context, roomID, eventID string) (int, rstypes.HeaderedEvent, error) {
 	return d.OutputEvents.SelectContextEvent(ctx, nil, roomID, eventID)
 }
 
-func (d *Database) SelectContextBeforeEvent(ctx context.Context, id int, roomID string, filter *synctypes.RoomEventFilter) ([]*gomatrixserverlib.HeaderedEvent, error) {
+func (d *Database) SelectContextBeforeEvent(ctx context.Context, id int, roomID string, filter *synctypes.RoomEventFilter) ([]*rstypes.HeaderedEvent, error) {
 	return d.OutputEvents.SelectContextBeforeEvent(ctx, nil, id, roomID, filter)
 }
-func (d *Database) SelectContextAfterEvent(ctx context.Context, id int, roomID string, filter *synctypes.RoomEventFilter) (int, []*gomatrixserverlib.HeaderedEvent, error) {
+func (d *Database) SelectContextAfterEvent(ctx context.Context, id int, roomID string, filter *synctypes.RoomEventFilter) (int, []*rstypes.HeaderedEvent, error) {
 	return d.OutputEvents.SelectContextAfterEvent(ctx, nil, id, roomID, filter)
 }
 
@@ -560,7 +561,7 @@ func (d *Database) SelectMembershipForUser(ctx context.Context, roomID, userID s
 	return d.Memberships.SelectMembershipForUser(ctx, nil, roomID, userID, pos)
 }
 
-func (d *Database) ReIndex(ctx context.Context, limit, afterID int64) (map[int64]gomatrixserverlib.HeaderedEvent, error) {
+func (d *Database) ReIndex(ctx context.Context, limit, afterID int64) (map[int64]rstypes.HeaderedEvent, error) {
 	return d.OutputEvents.ReIndex(ctx, nil, limit, afterID, []string{
 		spec.MRoomName,
 		spec.MRoomTopic,
@@ -568,7 +569,7 @@ func (d *Database) ReIndex(ctx context.Context, limit, afterID int64) (map[int64
 	})
 }
 
-func (d *Database) UpdateRelations(ctx context.Context, event *gomatrixserverlib.HeaderedEvent) error {
+func (d *Database) UpdateRelations(ctx context.Context, event *rstypes.HeaderedEvent) error {
 	// No need to unmarshal if the event is a redaction
 	if event.Type() == spec.MRoomRedaction {
 		return nil

--- a/syncapi/storage/shared/storage_sync.go
+++ b/syncapi/storage/shared/storage_sync.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/dendrite/internal/eventutil"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/synctypes"
 	"github.com/matrix-org/dendrite/syncapi/types"
 	userapi "github.com/matrix-org/dendrite/userapi/api"
@@ -84,7 +84,7 @@ func (d *DatabaseTransaction) MaxStreamPositionForNotificationData(ctx context.C
 	return types.StreamPosition(id), nil
 }
 
-func (d *DatabaseTransaction) CurrentState(ctx context.Context, roomID string, stateFilterPart *synctypes.StateFilter, excludeEventIDs []string) ([]*gomatrixserverlib.HeaderedEvent, error) {
+func (d *DatabaseTransaction) CurrentState(ctx context.Context, roomID string, stateFilterPart *synctypes.StateFilter, excludeEventIDs []string) ([]*rstypes.HeaderedEvent, error) {
 	return d.CurrentRoomState.SelectCurrentState(ctx, d.txn, roomID, stateFilterPart, excludeEventIDs)
 }
 
@@ -161,7 +161,7 @@ func (d *DatabaseTransaction) PositionInTopology(ctx context.Context, eventID st
 	return d.Topology.SelectPositionInTopology(ctx, d.txn, eventID)
 }
 
-func (d *DatabaseTransaction) InviteEventsInRange(ctx context.Context, targetUserID string, r types.Range) (map[string]*gomatrixserverlib.HeaderedEvent, map[string]*gomatrixserverlib.HeaderedEvent, types.StreamPosition, error) {
+func (d *DatabaseTransaction) InviteEventsInRange(ctx context.Context, targetUserID string, r types.Range) (map[string]*rstypes.HeaderedEvent, map[string]*rstypes.HeaderedEvent, types.StreamPosition, error) {
 	return d.Invites.SelectInviteEventsInRange(ctx, d.txn, targetUserID, r)
 }
 
@@ -178,7 +178,7 @@ func (d *DatabaseTransaction) RoomReceiptsAfter(ctx context.Context, roomIDs []s
 // If an event is not found in the database then it will be omitted from the list.
 // Returns an error if there was a problem talking with the database.
 // Does not include any transaction IDs in the returned events.
-func (d *DatabaseTransaction) Events(ctx context.Context, eventIDs []string) ([]*gomatrixserverlib.HeaderedEvent, error) {
+func (d *DatabaseTransaction) Events(ctx context.Context, eventIDs []string) ([]*rstypes.HeaderedEvent, error) {
 	streamEvents, err := d.OutputEvents.SelectEvents(ctx, d.txn, eventIDs, nil, false)
 	if err != nil {
 		return nil, err
@@ -207,13 +207,13 @@ func (d *DatabaseTransaction) SharedUsers(ctx context.Context, userID string, ot
 
 func (d *DatabaseTransaction) GetStateEvent(
 	ctx context.Context, roomID, evType, stateKey string,
-) (*gomatrixserverlib.HeaderedEvent, error) {
+) (*rstypes.HeaderedEvent, error) {
 	return d.CurrentRoomState.SelectStateEvent(ctx, d.txn, roomID, evType, stateKey)
 }
 
 func (d *DatabaseTransaction) GetStateEventsForRoom(
 	ctx context.Context, roomID string, stateFilter *synctypes.StateFilter,
-) (stateEvents []*gomatrixserverlib.HeaderedEvent, err error) {
+) (stateEvents []*rstypes.HeaderedEvent, err error) {
 	stateEvents, err = d.CurrentRoomState.SelectCurrentState(ctx, d.txn, roomID, stateFilter, nil)
 	return
 }
@@ -302,7 +302,7 @@ func (d *DatabaseTransaction) StreamToTopologicalPosition(
 // oldest event in the room's topology.
 func (d *DatabaseTransaction) GetBackwardTopologyPos(
 	ctx context.Context,
-	events []*gomatrixserverlib.HeaderedEvent,
+	events []*rstypes.HeaderedEvent,
 ) (types.TopologyToken, error) {
 	zeroToken := types.TopologyToken{}
 	if len(events) == 0 {

--- a/syncapi/storage/sqlite3/deltas/2022061412000000_history_visibility_column.go
+++ b/syncapi/storage/sqlite3/deltas/2022061412000000_history_visibility_column.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib"
 )
 
@@ -91,7 +92,7 @@ func currentHistoryVisibilities(ctx context.Context, tx *sql.Tx) (map[string]gom
 	defer rows.Close() // nolint: errcheck
 	var eventBytes []byte
 	var roomID string
-	var event gomatrixserverlib.HeaderedEvent
+	var event types.HeaderedEvent
 	var hisVis gomatrixserverlib.HistoryVisibility
 	historyVisibilities := make(map[string]gomatrixserverlib.HistoryVisibility)
 	for rows.Next() {

--- a/syncapi/storage/sqlite3/invites_table.go
+++ b/syncapi/storage/sqlite3/invites_table.go
@@ -22,9 +22,9 @@ import (
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/internal/sqlutil"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/storage/tables"
 	"github.com/matrix-org/dendrite/syncapi/types"
-	"github.com/matrix-org/gomatrixserverlib"
 )
 
 const inviteEventsSchema = `
@@ -89,7 +89,7 @@ func NewSqliteInvitesTable(db *sql.DB, streamID *StreamIDStatements) (tables.Inv
 }
 
 func (s *inviteEventsStatements) InsertInviteEvent(
-	ctx context.Context, txn *sql.Tx, inviteEvent *gomatrixserverlib.HeaderedEvent,
+	ctx context.Context, txn *sql.Tx, inviteEvent *rstypes.HeaderedEvent,
 ) (streamPos types.StreamPosition, err error) {
 	streamPos, err = s.streamIDStatements.nextInviteID(ctx, txn)
 	if err != nil {
@@ -130,7 +130,7 @@ func (s *inviteEventsStatements) DeleteInviteEvent(
 // active invites for the target user ID in the supplied range.
 func (s *inviteEventsStatements) SelectInviteEventsInRange(
 	ctx context.Context, txn *sql.Tx, targetUserID string, r types.Range,
-) (map[string]*gomatrixserverlib.HeaderedEvent, map[string]*gomatrixserverlib.HeaderedEvent, types.StreamPosition, error) {
+) (map[string]*rstypes.HeaderedEvent, map[string]*rstypes.HeaderedEvent, types.StreamPosition, error) {
 	var lastPos types.StreamPosition
 	stmt := sqlutil.TxStmt(txn, s.selectInviteEventsInRangeStmt)
 	rows, err := stmt.QueryContext(ctx, targetUserID, r.Low(), r.High())
@@ -138,8 +138,8 @@ func (s *inviteEventsStatements) SelectInviteEventsInRange(
 		return nil, nil, lastPos, err
 	}
 	defer internal.CloseAndLogIfError(ctx, rows, "selectInviteEventsInRange: rows.close() failed")
-	result := map[string]*gomatrixserverlib.HeaderedEvent{}
-	retired := map[string]*gomatrixserverlib.HeaderedEvent{}
+	result := map[string]*rstypes.HeaderedEvent{}
+	retired := map[string]*rstypes.HeaderedEvent{}
 	for rows.Next() {
 		var (
 			id        types.StreamPosition
@@ -162,7 +162,7 @@ func (s *inviteEventsStatements) SelectInviteEventsInRange(
 			continue
 		}
 
-		var event *gomatrixserverlib.HeaderedEvent
+		var event *rstypes.HeaderedEvent
 		if err := json.Unmarshal(eventJSON, &event); err != nil {
 			return nil, nil, lastPos, err
 		}

--- a/syncapi/storage/sqlite3/memberships_table.go
+++ b/syncapi/storage/sqlite3/memberships_table.go
@@ -19,9 +19,8 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/matrix-org/gomatrixserverlib"
-
 	"github.com/matrix-org/dendrite/internal/sqlutil"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/storage/tables"
 	"github.com/matrix-org/dendrite/syncapi/types"
 )
@@ -103,7 +102,7 @@ func NewSqliteMembershipsTable(db *sql.DB) (tables.Memberships, error) {
 }
 
 func (s *membershipsStatements) UpsertMembership(
-	ctx context.Context, txn *sql.Tx, event *gomatrixserverlib.HeaderedEvent,
+	ctx context.Context, txn *sql.Tx, event *rstypes.HeaderedEvent,
 	streamPos, topologicalPos types.StreamPosition,
 ) error {
 	membership, err := event.Membership()

--- a/syncapi/storage/sqlite3/output_room_events_table.go
+++ b/syncapi/storage/sqlite3/output_room_events_table.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/matrix-org/dendrite/internal"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/storage/sqlite3/deltas"
 	"github.com/matrix-org/dendrite/syncapi/storage/tables"
 	"github.com/matrix-org/dendrite/syncapi/synctypes"
@@ -166,7 +167,7 @@ func NewSqliteEventsTable(db *sql.DB, streamID *StreamIDStatements) (tables.Even
 	}.Prepare(db)
 }
 
-func (s *outputRoomEventsStatements) UpdateEventJSON(ctx context.Context, txn *sql.Tx, event *gomatrixserverlib.HeaderedEvent) error {
+func (s *outputRoomEventsStatements) UpdateEventJSON(ctx context.Context, txn *sql.Tx, event *rstypes.HeaderedEvent) error {
 	headeredJSON, err := json.Marshal(event)
 	if err != nil {
 		return err
@@ -249,8 +250,8 @@ func (s *outputRoomEventsStatements) SelectStateInRange(
 		}
 
 		// TODO: Handle redacted events
-		var ev gomatrixserverlib.HeaderedEvent
-		if err := ev.UnmarshalJSONWithEventID(eventBytes, eventID); err != nil {
+		var ev rstypes.HeaderedEvent
+		if err := json.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, nil, err
 		}
 		needSet := stateNeeded[ev.RoomID()]
@@ -296,7 +297,7 @@ func (s *outputRoomEventsStatements) SelectMaxEventID(
 // of the inserted event.
 func (s *outputRoomEventsStatements) InsertEvent(
 	ctx context.Context, txn *sql.Tx,
-	event *gomatrixserverlib.HeaderedEvent, addState, removeState []string,
+	event *rstypes.HeaderedEvent, addState, removeState []string,
 	transactionID *api.TransactionID, excludeFromSync bool, historyVisibility gomatrixserverlib.HistoryVisibility,
 ) (types.StreamPosition, error) {
 	var txnID *string
@@ -498,8 +499,8 @@ func rowsToStreamEvents(rows *sql.Rows) ([]types.StreamEvent, error) {
 			return nil, err
 		}
 		// TODO: Handle redacted events
-		var ev gomatrixserverlib.HeaderedEvent
-		if err := ev.UnmarshalJSONWithEventID(eventBytes, eventID); err != nil {
+		var ev rstypes.HeaderedEvent
+		if err := json.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, err
 		}
 
@@ -523,7 +524,7 @@ func rowsToStreamEvents(rows *sql.Rows) ([]types.StreamEvent, error) {
 }
 func (s *outputRoomEventsStatements) SelectContextEvent(
 	ctx context.Context, txn *sql.Tx, roomID, eventID string,
-) (id int, evt gomatrixserverlib.HeaderedEvent, err error) {
+) (id int, evt rstypes.HeaderedEvent, err error) {
 	row := sqlutil.TxStmt(txn, s.selectContextEventStmt).QueryRowContext(ctx, roomID, eventID)
 	var eventAsString string
 	var historyVisibility gomatrixserverlib.HistoryVisibility
@@ -540,7 +541,7 @@ func (s *outputRoomEventsStatements) SelectContextEvent(
 
 func (s *outputRoomEventsStatements) SelectContextBeforeEvent(
 	ctx context.Context, txn *sql.Tx, id int, roomID string, filter *synctypes.RoomEventFilter,
-) (evts []*gomatrixserverlib.HeaderedEvent, err error) {
+) (evts []*rstypes.HeaderedEvent, err error) {
 	stmt, params, err := prepareWithFilters(
 		s.db, txn, selectContextBeforeEventSQL,
 		[]interface{}{
@@ -564,7 +565,7 @@ func (s *outputRoomEventsStatements) SelectContextBeforeEvent(
 	for rows.Next() {
 		var (
 			eventBytes        []byte
-			evt               *gomatrixserverlib.HeaderedEvent
+			evt               *rstypes.HeaderedEvent
 			historyVisibility gomatrixserverlib.HistoryVisibility
 		)
 		if err = rows.Scan(&eventBytes, &historyVisibility); err != nil {
@@ -582,7 +583,7 @@ func (s *outputRoomEventsStatements) SelectContextBeforeEvent(
 
 func (s *outputRoomEventsStatements) SelectContextAfterEvent(
 	ctx context.Context, txn *sql.Tx, id int, roomID string, filter *synctypes.RoomEventFilter,
-) (lastID int, evts []*gomatrixserverlib.HeaderedEvent, err error) {
+) (lastID int, evts []*rstypes.HeaderedEvent, err error) {
 	stmt, params, err := prepareWithFilters(
 		s.db, txn, selectContextAfterEventSQL,
 		[]interface{}{
@@ -606,7 +607,7 @@ func (s *outputRoomEventsStatements) SelectContextAfterEvent(
 	for rows.Next() {
 		var (
 			eventBytes        []byte
-			evt               *gomatrixserverlib.HeaderedEvent
+			evt               *rstypes.HeaderedEvent
 			historyVisibility gomatrixserverlib.HistoryVisibility
 		)
 		if err = rows.Scan(&lastID, &eventBytes, &historyVisibility); err != nil {
@@ -642,7 +643,7 @@ func (s *outputRoomEventsStatements) PurgeEvents(
 	return err
 }
 
-func (s *outputRoomEventsStatements) ReIndex(ctx context.Context, txn *sql.Tx, limit, afterID int64, types []string) (map[int64]gomatrixserverlib.HeaderedEvent, error) {
+func (s *outputRoomEventsStatements) ReIndex(ctx context.Context, txn *sql.Tx, limit, afterID int64, types []string) (map[int64]rstypes.HeaderedEvent, error) {
 	params := make([]interface{}, len(types)+1)
 	params[0] = afterID
 	for i := range types {
@@ -664,14 +665,14 @@ func (s *outputRoomEventsStatements) ReIndex(ctx context.Context, txn *sql.Tx, l
 
 	var eventID string
 	var id int64
-	result := make(map[int64]gomatrixserverlib.HeaderedEvent)
+	result := make(map[int64]rstypes.HeaderedEvent)
 	for rows.Next() {
-		var ev gomatrixserverlib.HeaderedEvent
+		var ev rstypes.HeaderedEvent
 		var eventBytes []byte
 		if err = rows.Scan(&id, &eventID, &eventBytes); err != nil {
 			return nil, err
 		}
-		if err = ev.UnmarshalJSONWithEventID(eventBytes, eventID); err != nil {
+		if err = json.Unmarshal(eventBytes, &ev); err != nil {
 			return nil, err
 		}
 		result[id] = ev

--- a/syncapi/storage/sqlite3/output_room_events_topology_table.go
+++ b/syncapi/storage/sqlite3/output_room_events_topology_table.go
@@ -18,9 +18,8 @@ import (
 	"context"
 	"database/sql"
 
-	"github.com/matrix-org/gomatrixserverlib"
-
 	"github.com/matrix-org/dendrite/internal/sqlutil"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/storage/tables"
 	"github.com/matrix-org/dendrite/syncapi/types"
 )
@@ -104,7 +103,7 @@ func NewSqliteTopologyTable(db *sql.DB) (tables.Topology, error) {
 // insertEventInTopology inserts the given event in the room's topology, based
 // on the event's depth.
 func (s *outputRoomEventsTopologyStatements) InsertEventInTopology(
-	ctx context.Context, txn *sql.Tx, event *gomatrixserverlib.HeaderedEvent, pos types.StreamPosition,
+	ctx context.Context, txn *sql.Tx, event *rstypes.HeaderedEvent, pos types.StreamPosition,
 ) (types.StreamPosition, error) {
 	_, err := sqlutil.TxStmt(txn, s.insertEventInTopologyStmt).ExecContext(
 		ctx, event.EventID(), event.Depth(), event.RoomID(), pos,

--- a/syncapi/storage/tables/interface.go
+++ b/syncapi/storage/tables/interface.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/matrix-org/dendrite/internal/eventutil"
 	"github.com/matrix-org/dendrite/roomserver/api"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/synctypes"
 	"github.com/matrix-org/dendrite/syncapi/types"
 )
@@ -35,11 +36,11 @@ type AccountData interface {
 }
 
 type Invites interface {
-	InsertInviteEvent(ctx context.Context, txn *sql.Tx, inviteEvent *gomatrixserverlib.HeaderedEvent) (streamPos types.StreamPosition, err error)
+	InsertInviteEvent(ctx context.Context, txn *sql.Tx, inviteEvent *rstypes.HeaderedEvent) (streamPos types.StreamPosition, err error)
 	DeleteInviteEvent(ctx context.Context, txn *sql.Tx, inviteEventID string) (types.StreamPosition, error)
 	// SelectInviteEventsInRange returns a map of room ID to invite events. If multiple invite/retired invites exist in the given range, return the latest value
 	// for the room.
-	SelectInviteEventsInRange(ctx context.Context, txn *sql.Tx, targetUserID string, r types.Range) (invites map[string]*gomatrixserverlib.HeaderedEvent, retired map[string]*gomatrixserverlib.HeaderedEvent, maxID types.StreamPosition, err error)
+	SelectInviteEventsInRange(ctx context.Context, txn *sql.Tx, targetUserID string, r types.Range) (invites map[string]*rstypes.HeaderedEvent, retired map[string]*rstypes.HeaderedEvent, maxID types.StreamPosition, err error)
 	SelectMaxInviteID(ctx context.Context, txn *sql.Tx) (id int64, err error)
 	PurgeInvites(ctx context.Context, txn *sql.Tx, roomID string) error
 }
@@ -59,7 +60,7 @@ type Events interface {
 	SelectMaxEventID(ctx context.Context, txn *sql.Tx) (id int64, err error)
 	InsertEvent(
 		ctx context.Context, txn *sql.Tx,
-		event *gomatrixserverlib.HeaderedEvent,
+		event *rstypes.HeaderedEvent,
 		addState, removeState []string,
 		transactionID *api.TransactionID,
 		excludeFromSync bool,
@@ -70,16 +71,16 @@ type Events interface {
 	// Returns up to `limit` events. Returns `limited=true` if there are more events in this range but we hit the `limit`.
 	SelectRecentEvents(ctx context.Context, txn *sql.Tx, roomIDs []string, r types.Range, eventFilter *synctypes.RoomEventFilter, chronologicalOrder bool, onlySyncEvents bool) (map[string]types.RecentEvents, error)
 	SelectEvents(ctx context.Context, txn *sql.Tx, eventIDs []string, filter *synctypes.RoomEventFilter, preserveOrder bool) ([]types.StreamEvent, error)
-	UpdateEventJSON(ctx context.Context, txn *sql.Tx, event *gomatrixserverlib.HeaderedEvent) error
+	UpdateEventJSON(ctx context.Context, txn *sql.Tx, event *rstypes.HeaderedEvent) error
 	// DeleteEventsForRoom removes all event information for a room. This should only be done when removing the room entirely.
 	DeleteEventsForRoom(ctx context.Context, txn *sql.Tx, roomID string) (err error)
 
-	SelectContextEvent(ctx context.Context, txn *sql.Tx, roomID, eventID string) (int, gomatrixserverlib.HeaderedEvent, error)
-	SelectContextBeforeEvent(ctx context.Context, txn *sql.Tx, id int, roomID string, filter *synctypes.RoomEventFilter) ([]*gomatrixserverlib.HeaderedEvent, error)
-	SelectContextAfterEvent(ctx context.Context, txn *sql.Tx, id int, roomID string, filter *synctypes.RoomEventFilter) (int, []*gomatrixserverlib.HeaderedEvent, error)
+	SelectContextEvent(ctx context.Context, txn *sql.Tx, roomID, eventID string) (int, rstypes.HeaderedEvent, error)
+	SelectContextBeforeEvent(ctx context.Context, txn *sql.Tx, id int, roomID string, filter *synctypes.RoomEventFilter) ([]*rstypes.HeaderedEvent, error)
+	SelectContextAfterEvent(ctx context.Context, txn *sql.Tx, id int, roomID string, filter *synctypes.RoomEventFilter) (int, []*rstypes.HeaderedEvent, error)
 
 	PurgeEvents(ctx context.Context, txn *sql.Tx, roomID string) error
-	ReIndex(ctx context.Context, txn *sql.Tx, limit, offset int64, types []string) (map[int64]gomatrixserverlib.HeaderedEvent, error)
+	ReIndex(ctx context.Context, txn *sql.Tx, limit, offset int64, types []string) (map[int64]rstypes.HeaderedEvent, error)
 }
 
 // Topology keeps track of the depths and stream positions for all events.
@@ -87,7 +88,7 @@ type Events interface {
 type Topology interface {
 	// InsertEventInTopology inserts the given event in the room's topology, based on the event's depth.
 	// `pos` is the stream position of this event in the events table, and is used to order events which have the same depth.
-	InsertEventInTopology(ctx context.Context, txn *sql.Tx, event *gomatrixserverlib.HeaderedEvent, pos types.StreamPosition) (topoPos types.StreamPosition, err error)
+	InsertEventInTopology(ctx context.Context, txn *sql.Tx, event *rstypes.HeaderedEvent, pos types.StreamPosition) (topoPos types.StreamPosition, err error)
 	// SelectEventIDsInRange selects the IDs of events whose depths are within a given range in a given room's topological order.
 	// Events with `minDepth` are *exclusive*, as is the event which has exactly `minDepth`,`maxStreamPos`.
 	// `maxStreamPos` is only used when events have the same depth as `maxDepth`, which results in events less than `maxStreamPos` being returned.
@@ -101,13 +102,13 @@ type Topology interface {
 }
 
 type CurrentRoomState interface {
-	SelectStateEvent(ctx context.Context, txn *sql.Tx, roomID, evType, stateKey string) (*gomatrixserverlib.HeaderedEvent, error)
+	SelectStateEvent(ctx context.Context, txn *sql.Tx, roomID, evType, stateKey string) (*rstypes.HeaderedEvent, error)
 	SelectEventsWithEventIDs(ctx context.Context, txn *sql.Tx, eventIDs []string) ([]types.StreamEvent, error)
-	UpsertRoomState(ctx context.Context, txn *sql.Tx, event *gomatrixserverlib.HeaderedEvent, membership *string, addedAt types.StreamPosition) error
+	UpsertRoomState(ctx context.Context, txn *sql.Tx, event *rstypes.HeaderedEvent, membership *string, addedAt types.StreamPosition) error
 	DeleteRoomStateByEventID(ctx context.Context, txn *sql.Tx, eventID string) error
 	DeleteRoomStateForRoom(ctx context.Context, txn *sql.Tx, roomID string) error
 	// SelectCurrentState returns all the current state events for the given room.
-	SelectCurrentState(ctx context.Context, txn *sql.Tx, roomID string, stateFilter *synctypes.StateFilter, excludeEventIDs []string) ([]*gomatrixserverlib.HeaderedEvent, error)
+	SelectCurrentState(ctx context.Context, txn *sql.Tx, roomID string, stateFilter *synctypes.StateFilter, excludeEventIDs []string) ([]*rstypes.HeaderedEvent, error)
 	// SelectRoomIDsWithMembership returns the list of room IDs which have the given user in the given membership state.
 	SelectRoomIDsWithMembership(ctx context.Context, txn *sql.Tx, userID string, membership string) ([]string, error)
 	// SelectRoomIDsWithAnyMembership returns a map of all memberships for the given user.
@@ -191,7 +192,7 @@ type Receipts interface {
 }
 
 type Memberships interface {
-	UpsertMembership(ctx context.Context, txn *sql.Tx, event *gomatrixserverlib.HeaderedEvent, streamPos, topologicalPos types.StreamPosition) error
+	UpsertMembership(ctx context.Context, txn *sql.Tx, event *rstypes.HeaderedEvent, streamPos, topologicalPos types.StreamPosition) error
 	SelectMembershipCount(ctx context.Context, txn *sql.Tx, roomID, membership string, pos types.StreamPosition) (count int, err error)
 	SelectMembershipForUser(ctx context.Context, txn *sql.Tx, roomID, userID string, pos int64) (membership string, topologicalPos int, err error)
 	PurgeMemberships(ctx context.Context, txn *sql.Tx, roomID string) error

--- a/syncapi/storage/tables/memberships_test.go
+++ b/syncapi/storage/tables/memberships_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 
 	"github.com/matrix-org/dendrite/internal/sqlutil"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/dendrite/syncapi/storage/postgres"
 	"github.com/matrix-org/dendrite/syncapi/storage/sqlite3"
@@ -47,7 +47,7 @@ func TestMembershipsTable(t *testing.T) {
 	room := test.NewRoom(t, alice)
 
 	// Create users
-	var userEvents []*gomatrixserverlib.HeaderedEvent
+	var userEvents []*rstypes.HeaderedEvent
 	users := []string{alice.ID}
 	for _, x := range room.CurrentState() {
 		if x.StateKeyEquals(alice.ID) {
@@ -114,7 +114,7 @@ func testMembershipCount(t *testing.T, ctx context.Context, table tables.Members
 	})
 }
 
-func testUpsert(t *testing.T, ctx context.Context, table tables.Memberships, membershipEvent *gomatrixserverlib.HeaderedEvent, user *test.User, room *test.Room) {
+func testUpsert(t *testing.T, ctx context.Context, table tables.Memberships, membershipEvent *rstypes.HeaderedEvent, user *test.User, room *test.Room) {
 	t.Run("upserting works as expected", func(t *testing.T) {
 		if err := table.UpsertMembership(ctx, nil, membershipEvent, 1, 1); err != nil {
 			t.Fatalf("failed to upsert membership: %s", err)

--- a/syncapi/streams/stream_pdu.go
+++ b/syncapi/streams/stream_pdu.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/matrix-org/dendrite/internal/caching"
 	roomserverAPI "github.com/matrix-org/dendrite/roomserver/api"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/internal"
 	"github.com/matrix-org/dendrite/syncapi/storage"
 	"github.com/matrix-org/dendrite/syncapi/synctypes"
@@ -273,10 +274,14 @@ func (p *PDUStreamProvider) addRoomDeltaToResponse(
 	recentStreamEvents := dbEvents[delta.RoomID].Events
 	limited := dbEvents[delta.RoomID].Limited
 
-	recentEvents := gomatrixserverlib.HeaderedReverseTopologicalOrdering(
-		snapshot.StreamEventsToEvents(device, recentStreamEvents),
+	recEvents := gomatrixserverlib.HeaderedReverseTopologicalOrdering(
+		toEvents(snapshot.StreamEventsToEvents(device, recentStreamEvents)),
 		gomatrixserverlib.TopologicalOrderByPrevEvents,
 	)
+	recentEvents := make([]*rstypes.HeaderedEvent, len(recEvents))
+	for i := range recEvents {
+		recentEvents[i] = &rstypes.HeaderedEvent{Event: recEvents[i]}
+	}
 
 	// If we didn't return any events at all then don't bother doing anything else.
 	if len(recentEvents) == 0 && len(delta.StateEvents) == 0 {
@@ -341,10 +346,14 @@ func (p *PDUStreamProvider) addRoomDeltaToResponse(
 	// Now that we've filtered the timeline, work out which state events are still
 	// left. Anything that appears in the filtered timeline will be removed from the
 	// "state" section and kept in "timeline".
-	delta.StateEvents = gomatrixserverlib.HeaderedReverseTopologicalOrdering(
-		removeDuplicates(delta.StateEvents, events),
+	sEvents := gomatrixserverlib.HeaderedReverseTopologicalOrdering(
+		toEvents(removeDuplicates(delta.StateEvents, events)),
 		gomatrixserverlib.TopologicalOrderByAuthEvents,
 	)
+	delta.StateEvents = make([]*rstypes.HeaderedEvent, len(sEvents))
+	for i := range sEvents {
+		delta.StateEvents[i] = &rstypes.HeaderedEvent{Event: sEvents[i]}
+	}
 
 	if len(delta.StateEvents) > 0 {
 		if last := delta.StateEvents[len(delta.StateEvents)-1]; last != nil {
@@ -407,8 +416,8 @@ func applyHistoryVisibilityFilter(
 	snapshot storage.DatabaseTransaction,
 	rsAPI roomserverAPI.SyncRoomserverAPI,
 	roomID, userID string,
-	recentEvents []*gomatrixserverlib.HeaderedEvent,
-) ([]*gomatrixserverlib.HeaderedEvent, error) {
+	recentEvents []*rstypes.HeaderedEvent,
+) ([]*rstypes.HeaderedEvent, error) {
 	// We need to make sure we always include the latest state events, if they are in the timeline.
 	alwaysIncludeIDs := make(map[string]struct{})
 	var stateTypes []string
@@ -555,8 +564,8 @@ func (p *PDUStreamProvider) lazyLoadMembers(
 	ctx context.Context, snapshot storage.DatabaseTransaction, roomID string,
 	incremental, limited bool, stateFilter *synctypes.StateFilter,
 	device *userapi.Device,
-	timelineEvents, stateEvents []*gomatrixserverlib.HeaderedEvent,
-) ([]*gomatrixserverlib.HeaderedEvent, error) {
+	timelineEvents, stateEvents []*rstypes.HeaderedEvent,
+) ([]*rstypes.HeaderedEvent, error) {
 	if len(timelineEvents) == 0 {
 		return stateEvents, nil
 	}
@@ -573,7 +582,7 @@ func (p *PDUStreamProvider) lazyLoadMembers(
 		}
 	}
 	// Preallocate with the same amount, even if it will end up with fewer values
-	newStateEvents := make([]*gomatrixserverlib.HeaderedEvent, 0, len(stateEvents))
+	newStateEvents := make([]*rstypes.HeaderedEvent, 0, len(stateEvents))
 	// Remove existing membership events we don't care about, e.g. users not in the timeline.events
 	for _, event := range stateEvents {
 		if event.Type() == spec.MRoomMember && event.StateKey() != nil {
@@ -633,7 +642,7 @@ func (p *PDUStreamProvider) addIgnoredUsersToFilter(ctx context.Context, snapsho
 	return nil
 }
 
-func removeDuplicates(stateEvents, recentEvents []*gomatrixserverlib.HeaderedEvent) []*gomatrixserverlib.HeaderedEvent {
+func removeDuplicates(stateEvents, recentEvents []*rstypes.HeaderedEvent) []*rstypes.HeaderedEvent {
 	for _, recentEv := range recentEvents {
 		if recentEv.StateKey() == nil {
 			continue // not a state event
@@ -653,4 +662,12 @@ func removeDuplicates(stateEvents, recentEvents []*gomatrixserverlib.HeaderedEve
 		}
 	}
 	return stateEvents
+}
+
+func toEvents(events []*rstypes.HeaderedEvent) []*gomatrixserverlib.Event {
+	result := make([]*gomatrixserverlib.Event, len(events))
+	for i := range events {
+		result[i] = events[i].Event
+	}
+	return result
 }

--- a/syncapi/syncapi_test.go
+++ b/syncapi/syncapi_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/tidwall/gjson"
 
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/routing"
 	"github.com/matrix-org/dendrite/syncapi/storage"
 	"github.com/matrix-org/dendrite/syncapi/synctypes"
@@ -490,7 +491,7 @@ func testHistoryVisibility(t *testing.T, dbType test.DBType) {
 				afterJoinBody := fmt.Sprintf("After join in a %s room", tc.historyVisibility)
 				msgEv := room.CreateAndInsert(t, alice, "m.room.message", map[string]interface{}{"body": afterJoinBody})
 
-				eventsToSend = append([]*gomatrixserverlib.HeaderedEvent{}, inviteEv, afterInviteEv, joinEv, msgEv)
+				eventsToSend = append([]*rstypes.HeaderedEvent{}, inviteEv, afterInviteEv, joinEv, msgEv)
 
 				if err := api.SendEvents(ctx, rsAPI, api.KindNew, eventsToSend, "test", "test", "test", nil, false); err != nil {
 					t.Fatalf("failed to send events: %v", err)
@@ -523,7 +524,7 @@ func testHistoryVisibility(t *testing.T, dbType test.DBType) {
 	}
 }
 
-func verifyEventVisible(t *testing.T, wantVisible bool, wantVisibleEvent *gomatrixserverlib.HeaderedEvent, chunk []synctypes.ClientEvent) {
+func verifyEventVisible(t *testing.T, wantVisible bool, wantVisibleEvent *rstypes.HeaderedEvent, chunk []synctypes.ClientEvent) {
 	t.Helper()
 	if wantVisible {
 		for _, ev := range chunk {
@@ -1228,7 +1229,7 @@ func syncUntil(t *testing.T,
 	}
 }
 
-func toNATSMsgs(t *testing.T, cfg *config.Dendrite, input ...*gomatrixserverlib.HeaderedEvent) []*nats.Msg {
+func toNATSMsgs(t *testing.T, cfg *config.Dendrite, input ...*rstypes.HeaderedEvent) []*nats.Msg {
 	result := make([]*nats.Msg, len(input))
 	for i, ev := range input {
 		var addsStateIDs []string

--- a/syncapi/synctypes/clientevent.go
+++ b/syncapi/synctypes/clientevent.go
@@ -16,6 +16,7 @@
 package synctypes
 
 import (
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 )
@@ -56,7 +57,7 @@ func ToClientEvents(serverEvs []*gomatrixserverlib.Event, format ClientEventForm
 }
 
 // HeaderedToClientEvents converts headered server events to client events.
-func HeaderedToClientEvents(serverEvs []*gomatrixserverlib.HeaderedEvent, format ClientEventFormat) []ClientEvent {
+func HeaderedToClientEvents(serverEvs []*types.HeaderedEvent, format ClientEventFormat) []ClientEvent {
 	evs := make([]ClientEvent, 0, len(serverEvs))
 	for _, se := range serverEvs {
 		if se == nil {
@@ -86,6 +87,6 @@ func ToClientEvent(se *gomatrixserverlib.Event, format ClientEventFormat) Client
 }
 
 // HeaderedToClientEvent converts a single headered server event to a client event.
-func HeaderedToClientEvent(se *gomatrixserverlib.HeaderedEvent, format ClientEventFormat) ClientEvent {
+func HeaderedToClientEvent(se *types.HeaderedEvent, format ClientEventFormat) ClientEvent {
 	return ToClientEvent(se.Event, format)
 }

--- a/syncapi/types/types.go
+++ b/syncapi/types/types.go
@@ -26,6 +26,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	"github.com/matrix-org/dendrite/roomserver/api"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/synctypes"
 )
 
@@ -38,7 +39,7 @@ var (
 
 type StateDelta struct {
 	RoomID      string
-	StateEvents []*gomatrixserverlib.HeaderedEvent
+	StateEvents []*types.HeaderedEvent
 	NewlyJoined bool
 	Membership  string
 	// The PDU stream position of the latest membership event for this user, if applicable.
@@ -59,7 +60,7 @@ func NewStreamPositionFromString(s string) (StreamPosition, error) {
 
 // StreamEvent is the same as gomatrixserverlib.Event but also has the PDU stream position for this event.
 type StreamEvent struct {
-	*gomatrixserverlib.HeaderedEvent
+	*types.HeaderedEvent
 	StreamPosition  StreamPosition
 	TransactionID   *api.TransactionID
 	ExcludeFromSync bool
@@ -538,7 +539,7 @@ type InviteResponse struct {
 }
 
 // NewInviteResponse creates an empty response with initialised arrays.
-func NewInviteResponse(event *gomatrixserverlib.HeaderedEvent) *InviteResponse {
+func NewInviteResponse(event *types.HeaderedEvent) *InviteResponse {
 	res := InviteResponse{}
 	res.InviteState.Events = []json.RawMessage{}
 
@@ -551,7 +552,7 @@ func NewInviteResponse(event *gomatrixserverlib.HeaderedEvent) *InviteResponse {
 
 	// Then we'll see if we can create a partial of the invite event itself.
 	// This is needed for clients to work out *who* sent the invite.
-	inviteEvent := synctypes.ToClientEvent(event.Unwrap(), synctypes.FormatSync)
+	inviteEvent := synctypes.ToClientEvent(event.Event, synctypes.FormatSync)
 	inviteEvent.Unsigned = nil
 	if ev, err := json.Marshal(inviteEvent); err == nil {
 		res.InviteState.Events = append(res.InviteState.Events, ev)

--- a/syncapi/types/types_test.go
+++ b/syncapi/types/types_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/syncapi/synctypes"
 	"github.com/matrix-org/gomatrixserverlib"
 )
@@ -55,7 +56,7 @@ func TestNewInviteResponse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res := NewInviteResponse(ev.Headered(gomatrixserverlib.RoomVersionV5))
+	res := NewInviteResponse(&types.HeaderedEvent{Event: ev})
 	j, err := json.Marshal(res)
 	if err != nil {
 		t.Fatal(err)

--- a/test/event.go
+++ b/test/event.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 )
@@ -79,15 +80,15 @@ func WithOrigin(origin spec.ServerName) eventModifier {
 }
 
 // Reverse a list of events
-func Reversed(in []*gomatrixserverlib.HeaderedEvent) []*gomatrixserverlib.HeaderedEvent {
-	out := make([]*gomatrixserverlib.HeaderedEvent, len(in))
+func Reversed(in []*types.HeaderedEvent) []*types.HeaderedEvent {
+	out := make([]*types.HeaderedEvent, len(in))
 	for i := 0; i < len(in); i++ {
 		out[i] = in[len(in)-i-1]
 	}
 	return out
 }
 
-func AssertEventIDsEqual(t *testing.T, gotEventIDs []string, wants []*gomatrixserverlib.HeaderedEvent) {
+func AssertEventIDsEqual(t *testing.T, gotEventIDs []string, wants []*types.HeaderedEvent) {
 	t.Helper()
 	if len(gotEventIDs) != len(wants) {
 		t.Errorf("length mismatch: got %d events, want %d", len(gotEventIDs), len(wants))
@@ -102,7 +103,7 @@ func AssertEventIDsEqual(t *testing.T, gotEventIDs []string, wants []*gomatrixse
 	}
 }
 
-func AssertEventsEqual(t *testing.T, gots, wants []*gomatrixserverlib.HeaderedEvent) {
+func AssertEventsEqual(t *testing.T, gots, wants []*types.HeaderedEvent) {
 	t.Helper()
 	if len(gots) != len(wants) {
 		t.Fatalf("length mismatch: got %d events, want %d", len(gots), len(wants))

--- a/test/memory_federation_db.go
+++ b/test/memory_federation_db.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/matrix-org/dendrite/federationapi/storage/shared/receipt"
 	"github.com/matrix-org/dendrite/federationapi/types"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 )
@@ -36,7 +37,7 @@ type InMemoryFederationDatabase struct {
 	pendingEDUServers  map[spec.ServerName]struct{}
 	blacklistedServers map[spec.ServerName]struct{}
 	assumedOffline     map[spec.ServerName]struct{}
-	pendingPDUs        map[*receipt.Receipt]*gomatrixserverlib.HeaderedEvent
+	pendingPDUs        map[*receipt.Receipt]*rstypes.HeaderedEvent
 	pendingEDUs        map[*receipt.Receipt]*gomatrixserverlib.EDU
 	associatedPDUs     map[spec.ServerName]map[*receipt.Receipt]struct{}
 	associatedEDUs     map[spec.ServerName]map[*receipt.Receipt]struct{}
@@ -49,7 +50,7 @@ func NewInMemoryFederationDatabase() *InMemoryFederationDatabase {
 		pendingEDUServers:  make(map[spec.ServerName]struct{}),
 		blacklistedServers: make(map[spec.ServerName]struct{}),
 		assumedOffline:     make(map[spec.ServerName]struct{}),
-		pendingPDUs:        make(map[*receipt.Receipt]*gomatrixserverlib.HeaderedEvent),
+		pendingPDUs:        make(map[*receipt.Receipt]*rstypes.HeaderedEvent),
 		pendingEDUs:        make(map[*receipt.Receipt]*gomatrixserverlib.EDU),
 		associatedPDUs:     make(map[spec.ServerName]map[*receipt.Receipt]struct{}),
 		associatedEDUs:     make(map[spec.ServerName]map[*receipt.Receipt]struct{}),
@@ -64,7 +65,7 @@ func (d *InMemoryFederationDatabase) StoreJSON(
 	d.dbMutex.Lock()
 	defer d.dbMutex.Unlock()
 
-	var event gomatrixserverlib.HeaderedEvent
+	var event rstypes.HeaderedEvent
 	if err := json.Unmarshal([]byte(js), &event); err == nil {
 		nidMutex.Lock()
 		defer nidMutex.Unlock()
@@ -91,12 +92,12 @@ func (d *InMemoryFederationDatabase) GetPendingPDUs(
 	ctx context.Context,
 	serverName spec.ServerName,
 	limit int,
-) (pdus map[*receipt.Receipt]*gomatrixserverlib.HeaderedEvent, err error) {
+) (pdus map[*receipt.Receipt]*rstypes.HeaderedEvent, err error) {
 	d.dbMutex.Lock()
 	defer d.dbMutex.Unlock()
 
 	pduCount := 0
-	pdus = make(map[*receipt.Receipt]*gomatrixserverlib.HeaderedEvent)
+	pdus = make(map[*receipt.Receipt]*rstypes.HeaderedEvent)
 	if receipts, ok := d.associatedPDUs[serverName]; ok {
 		for dbReceipt := range receipts {
 			if event, ok := d.pendingPDUs[dbReceipt]; ok {

--- a/test/room.go
+++ b/test/room.go
@@ -25,6 +25,7 @@ import (
 	"github.com/matrix-org/gomatrixserverlib/spec"
 
 	"github.com/matrix-org/dendrite/internal/eventutil"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 )
 
 type Preset int
@@ -47,8 +48,8 @@ type Room struct {
 	creator      *User
 
 	authEvents   gomatrixserverlib.AuthEvents
-	currentState map[string]*gomatrixserverlib.HeaderedEvent
-	events       []*gomatrixserverlib.HeaderedEvent
+	currentState map[string]*rstypes.HeaderedEvent
+	events       []*rstypes.HeaderedEvent
 }
 
 // Create a new test room. Automatically creates the initial create events.
@@ -64,7 +65,7 @@ func NewRoom(t *testing.T, creator *User, modifiers ...roomModifier) *Room {
 		authEvents:   gomatrixserverlib.NewAuthEvents(nil),
 		preset:       PresetPublicChat,
 		Version:      gomatrixserverlib.RoomVersionV9,
-		currentState: make(map[string]*gomatrixserverlib.HeaderedEvent),
+		currentState: make(map[string]*rstypes.HeaderedEvent),
 		visibility:   gomatrixserverlib.HistoryVisibilityShared,
 	}
 	for _, m := range modifiers {
@@ -130,7 +131,7 @@ func (r *Room) insertCreateEvents(t *testing.T) {
 }
 
 // Create an event in this room but do not insert it. Does not modify the room in any way (depth, fwd extremities, etc) so is thread-safe.
-func (r *Room) CreateEvent(t *testing.T, creator *User, eventType string, content interface{}, mods ...eventModifier) *gomatrixserverlib.HeaderedEvent {
+func (r *Room) CreateEvent(t *testing.T, creator *User, eventType string, content interface{}, mods ...eventModifier) *rstypes.HeaderedEvent {
 	t.Helper()
 	depth := 1 + len(r.events) // depth starts at 1
 
@@ -203,18 +204,18 @@ func (r *Room) CreateEvent(t *testing.T, creator *User, eventType string, conten
 	if err = gomatrixserverlib.Allowed(ev, &r.authEvents); err != nil {
 		t.Fatalf("CreateEvent[%s]: failed to verify event was allowed: %s", eventType, err)
 	}
-	headeredEvent := ev.Headered(r.Version)
+	headeredEvent := &rstypes.HeaderedEvent{Event: ev}
 	headeredEvent.Visibility = r.visibility
 	return headeredEvent
 }
 
 // Add a new event to this room DAG. Not thread-safe.
-func (r *Room) InsertEvent(t *testing.T, he *gomatrixserverlib.HeaderedEvent) {
+func (r *Room) InsertEvent(t *testing.T, he *rstypes.HeaderedEvent) {
 	t.Helper()
 	// Add the event to the list of auth/state events
 	r.events = append(r.events, he)
 	if he.StateKey() != nil {
-		err := r.authEvents.AddEvent(he.Unwrap())
+		err := r.authEvents.AddEvent(he.Event)
 		if err != nil {
 			t.Fatalf("InsertEvent: failed to add event to auth events: %s", err)
 		}
@@ -222,12 +223,12 @@ func (r *Room) InsertEvent(t *testing.T, he *gomatrixserverlib.HeaderedEvent) {
 	}
 }
 
-func (r *Room) Events() []*gomatrixserverlib.HeaderedEvent {
+func (r *Room) Events() []*rstypes.HeaderedEvent {
 	return r.events
 }
 
-func (r *Room) CurrentState() []*gomatrixserverlib.HeaderedEvent {
-	events := make([]*gomatrixserverlib.HeaderedEvent, len(r.currentState))
+func (r *Room) CurrentState() []*rstypes.HeaderedEvent {
+	events := make([]*rstypes.HeaderedEvent, len(r.currentState))
 	i := 0
 	for _, e := range r.currentState {
 		events[i] = e
@@ -236,7 +237,7 @@ func (r *Room) CurrentState() []*gomatrixserverlib.HeaderedEvent {
 	return events
 }
 
-func (r *Room) CreateAndInsert(t *testing.T, creator *User, eventType string, content interface{}, mods ...eventModifier) *gomatrixserverlib.HeaderedEvent {
+func (r *Room) CreateAndInsert(t *testing.T, creator *User, eventType string, content interface{}, mods ...eventModifier) *rstypes.HeaderedEvent {
 	t.Helper()
 	he := r.CreateEvent(t, creator, eventType, content, mods...)
 	r.InsertEvent(t, he)

--- a/userapi/consumers/roomserver.go
+++ b/userapi/consumers/roomserver.go
@@ -21,6 +21,7 @@ import (
 	"github.com/matrix-org/dendrite/internal/pushgateway"
 	"github.com/matrix-org/dendrite/internal/pushrules"
 	rsapi "github.com/matrix-org/dendrite/roomserver/api"
+	rstypes "github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/dendrite/setup/config"
 	"github.com/matrix-org/dendrite/setup/jetstream"
 	"github.com/matrix-org/dendrite/setup/process"
@@ -292,7 +293,7 @@ func (s *OutputRoomEventConsumer) copyTags(ctx context.Context, oldRoomID, newRo
 	return s.db.SaveAccountData(ctx, localpart, serverName, newRoomID, "m.tag", tag)
 }
 
-func (s *OutputRoomEventConsumer) processMessage(ctx context.Context, event *gomatrixserverlib.HeaderedEvent, streamPos uint64) error {
+func (s *OutputRoomEventConsumer) processMessage(ctx context.Context, event *rstypes.HeaderedEvent, streamPos uint64) error {
 	members, roomSize, err := s.localRoomMembers(ctx, event.RoomID())
 	if err != nil {
 		return fmt.Errorf("s.localRoomMembers: %w", err)
@@ -436,7 +437,7 @@ func (s *OutputRoomEventConsumer) localRoomMembers(ctx context.Context, roomID s
 // looks it up in roomserver. If there is no name,
 // m.room.canonical_alias is consulted. Returns an empty string if the
 // room has no name.
-func (s *OutputRoomEventConsumer) roomName(ctx context.Context, event *gomatrixserverlib.HeaderedEvent) (string, error) {
+func (s *OutputRoomEventConsumer) roomName(ctx context.Context, event *rstypes.HeaderedEvent) (string, error) {
 	if event.Type() == spec.MRoomName {
 		name, err := unmarshalRoomName(event)
 		if err != nil {
@@ -485,7 +486,7 @@ var (
 	roomNameTuple       = gomatrixserverlib.StateKeyTuple{EventType: spec.MRoomName}
 )
 
-func unmarshalRoomName(event *gomatrixserverlib.HeaderedEvent) (string, error) {
+func unmarshalRoomName(event *rstypes.HeaderedEvent) (string, error) {
 	var nc eventutil.NameContent
 	if err := json.Unmarshal(event.Content(), &nc); err != nil {
 		return "", fmt.Errorf("unmarshaling NameContent: %w", err)
@@ -494,7 +495,7 @@ func unmarshalRoomName(event *gomatrixserverlib.HeaderedEvent) (string, error) {
 	return nc.Name, nil
 }
 
-func unmarshalCanonicalAlias(event *gomatrixserverlib.HeaderedEvent) (string, error) {
+func unmarshalCanonicalAlias(event *rstypes.HeaderedEvent) (string, error) {
 	var cac eventutil.CanonicalAliasContent
 	if err := json.Unmarshal(event.Content(), &cac); err != nil {
 		return "", fmt.Errorf("unmarshaling CanonicalAliasContent: %w", err)
@@ -504,7 +505,7 @@ func unmarshalCanonicalAlias(event *gomatrixserverlib.HeaderedEvent) (string, er
 }
 
 // notifyLocal finds the right push actions for a local user, given an event.
-func (s *OutputRoomEventConsumer) notifyLocal(ctx context.Context, event *gomatrixserverlib.HeaderedEvent, mem *localMembership, roomSize int, roomName string, streamPos uint64) error {
+func (s *OutputRoomEventConsumer) notifyLocal(ctx context.Context, event *rstypes.HeaderedEvent, mem *localMembership, roomSize int, roomName string, streamPos uint64) error {
 	actions, err := s.evaluatePushRules(ctx, event, mem, roomSize)
 	if err != nil {
 		return fmt.Errorf("s.evaluatePushRules: %w", err)
@@ -613,7 +614,7 @@ func (s *OutputRoomEventConsumer) notifyLocal(ctx context.Context, event *gomatr
 
 // evaluatePushRules fetches and evaluates the push rules of a local
 // user. Returns actions (including dont_notify).
-func (s *OutputRoomEventConsumer) evaluatePushRules(ctx context.Context, event *gomatrixserverlib.HeaderedEvent, mem *localMembership, roomSize int) ([]*pushrules.Action, error) {
+func (s *OutputRoomEventConsumer) evaluatePushRules(ctx context.Context, event *rstypes.HeaderedEvent, mem *localMembership, roomSize int) ([]*pushrules.Action, error) {
 	if event.Sender() == mem.UserID {
 		// SPEC: Homeservers MUST NOT notify the Push Gateway for
 		// events that the user has sent themselves.
@@ -732,7 +733,7 @@ func (s *OutputRoomEventConsumer) localPushDevices(ctx context.Context, localpar
 }
 
 // notifyHTTP performs a notificatation to a Push Gateway.
-func (s *OutputRoomEventConsumer) notifyHTTP(ctx context.Context, event *gomatrixserverlib.HeaderedEvent, url, format string, devices []*pushgateway.Device, localpart, roomName string, userNumUnreadNotifs int) ([]*pushgateway.Device, error) {
+func (s *OutputRoomEventConsumer) notifyHTTP(ctx context.Context, event *rstypes.HeaderedEvent, url, format string, devices []*pushgateway.Device, localpart, roomName string, userNumUnreadNotifs int) ([]*pushgateway.Device, error) {
 	logger := log.WithFields(log.Fields{
 		"event_id":    event.EventID(),
 		"url":         url,

--- a/userapi/consumers/roomserver_test.go
+++ b/userapi/consumers/roomserver_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/matrix-org/dendrite/internal/sqlutil"
+	"github.com/matrix-org/dendrite/roomserver/types"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/stretchr/testify/assert"
@@ -34,13 +35,13 @@ func mustCreateDatabase(t *testing.T, dbType test.DBType) (storage.UserDatabase,
 	}
 }
 
-func mustCreateEvent(t *testing.T, content string) *gomatrixserverlib.HeaderedEvent {
+func mustCreateEvent(t *testing.T, content string) *types.HeaderedEvent {
 	t.Helper()
 	ev, err := gomatrixserverlib.MustGetRoomVersion(gomatrixserverlib.RoomVersionV10).NewEventFromTrustedJSON([]byte(content), false)
 	if err != nil {
 		t.Fatalf("failed to create event: %v", err)
 	}
-	return ev.Headered(gomatrixserverlib.RoomVersionV10)
+	return &types.HeaderedEvent{Event: ev}
 }
 
 func Test_evaluatePushRules(t *testing.T) {


### PR DESCRIPTION
Replaced with types.HeaderedEvent _for now_. In reality we want to move them all to gmsl.Event and only use HeaderedEvent when we _need_ to bundle the version/event ID with the event (seriailsation boundaries, and even then only when we don't have the room version).

Requires https://github.com/matrix-org/gomatrixserverlib/pull/373