### PR TITLE
Use PDU not *Event in HeaderedEvent

### DIFF
--- a/appservice/consumers/roomserver.go
+++ b/appservice/consumers/roomserver.go
@@ -190,7 +190,7 @@ func (s *OutputRoomEventConsumer) sendEvents(
 
 	// If txnID is not defined, generate one from the events.
 	if txnID == "" {
-		txnID = fmt.Sprintf("%d_%d", events[0].Event.OriginServerTS(), len(transaction))
+		txnID = fmt.Sprintf("%d_%d", events[0].PDU.OriginServerTS(), len(transaction))
 	}
 
 	// Send the transaction to the appservice.

--- a/clientapi/routing/aliases.go
+++ b/clientapi/routing/aliases.go
@@ -15,6 +15,7 @@
 package routing
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -48,11 +49,12 @@ func GetAliases(
 	visibility := gomatrixserverlib.HistoryVisibilityInvited
 	if historyVisEvent, ok := stateRes.StateEvents[stateTuple]; ok {
 		var err error
-		visibility, err = historyVisEvent.HistoryVisibility()
-		if err != nil {
+		var content gomatrixserverlib.HistoryVisibilityContent
+		if err = json.Unmarshal(historyVisEvent.Content(), &content); err != nil {
 			util.GetLogger(req.Context()).WithError(err).Error("historyVisEvent.HistoryVisibility failed")
 			return util.ErrorResponse(fmt.Errorf("historyVisEvent.HistoryVisibility: %w", err))
 		}
+		visibility = content.HistoryVisibility
 	}
 	if visibility != spec.WorldReadable {
 		queryReq := api.QueryMembershipForUserRequest{

--- a/clientapi/routing/createroom.go
+++ b/clientapi/routing/createroom.go
@@ -465,7 +465,7 @@ func createRoom(
 		}
 
 		// Add the event to the list of auth events
-		builtEvents = append(builtEvents, &types.HeaderedEvent{Event: ev})
+		builtEvents = append(builtEvents, &types.HeaderedEvent{PDU: ev})
 		err = authEvents.AddEvent(ev)
 		if err != nil {
 			util.GetLogger(ctx).WithError(err).Error("authEvents.AddEvent failed")
@@ -535,7 +535,7 @@ func createRoom(
 			case spec.MRoomMember:
 				fallthrough
 			case spec.MRoomJoinRules:
-				ev := event.Event
+				ev := event.PDU
 				globalStrippedState = append(
 					globalStrippedState,
 					fclient.NewInviteV2StrippedState(ev),
@@ -556,7 +556,7 @@ func createRoom(
 			}
 			inviteStrippedState := append(
 				globalStrippedState,
-				fclient.NewInviteV2StrippedState(inviteEvent.Event),
+				fclient.NewInviteV2StrippedState(inviteEvent.PDU),
 			)
 			// Send the invite event to the roomserver.
 			var inviteRes roomserverAPI.PerformInviteResponse

--- a/clientapi/routing/directory.go
+++ b/clientapi/routing/directory.go
@@ -291,7 +291,7 @@ func SetVisibility(
 	}
 
 	// NOTSPEC: Check if the user's power is greater than power required to change m.room.canonical_alias event
-	power, _ := gomatrixserverlib.NewPowerLevelContentFromEvent(queryEventsRes.StateEvents[0].Event)
+	power, _ := gomatrixserverlib.NewPowerLevelContentFromEvent(queryEventsRes.StateEvents[0].PDU)
 	if power.UserLevel(dev.UserID) < power.EventLevel(spec.MRoomCanonicalAlias, true) {
 		return util.JSONResponse{
 			Code: http.StatusForbidden,

--- a/clientapi/routing/sendevent.go
+++ b/clientapi/routing/sendevent.go
@@ -185,7 +185,7 @@ func SendEvent(
 		req.Context(), rsAPI,
 		api.KindNew,
 		[]*types.HeaderedEvent{
-			&types.HeaderedEvent{Event: e},
+			&types.HeaderedEvent{PDU: e},
 		},
 		device.UserDomain(),
 		domain,
@@ -259,7 +259,7 @@ func generateSendEvent(
 	cfg *config.ClientAPI,
 	rsAPI api.ClientRoomserverAPI,
 	evTime time.Time,
-) (*gomatrixserverlib.Event, *util.JSONResponse) {
+) (gomatrixserverlib.PDU, *util.JSONResponse) {
 	// parse the incoming http request
 	userID := device.UserID
 
@@ -313,12 +313,12 @@ func generateSendEvent(
 	}
 
 	// check to see if this user can perform this operation
-	stateEvents := make([]*gomatrixserverlib.Event, len(queryRes.StateEvents))
+	stateEvents := make([]gomatrixserverlib.PDU, len(queryRes.StateEvents))
 	for i := range queryRes.StateEvents {
-		stateEvents[i] = queryRes.StateEvents[i].Event
+		stateEvents[i] = queryRes.StateEvents[i].PDU
 	}
 	provider := gomatrixserverlib.NewAuthEvents(gomatrixserverlib.ToPDUs(stateEvents))
-	if err = gomatrixserverlib.Allowed(e.Event, &provider); err != nil {
+	if err = gomatrixserverlib.Allowed(e.PDU, &provider); err != nil {
 		return nil, &util.JSONResponse{
 			Code: http.StatusForbidden,
 			JSON: jsonerror.Forbidden(err.Error()), // TODO: Is this error string comprehensible to the client?
@@ -343,5 +343,5 @@ func generateSendEvent(
 		}
 	}
 
-	return e.Event, nil
+	return e.PDU, nil
 }

--- a/clientapi/routing/server_notices.go
+++ b/clientapi/routing/server_notices.go
@@ -228,7 +228,7 @@ func SendServerNotice(
 		ctx, rsAPI,
 		api.KindNew,
 		[]*types.HeaderedEvent{
-			&types.HeaderedEvent{Event: e},
+			&types.HeaderedEvent{PDU: e},
 		},
 		device.UserDomain(),
 		cfgClient.Matrix.ServerName,

--- a/cmd/resolve-state/main.go
+++ b/cmd/resolve-state/main.go
@@ -96,9 +96,9 @@ func main() {
 			panic(err)
 		}
 
-		events := make(map[types.EventNID]*gomatrixserverlib.Event, len(eventEntries))
+		events := make(map[types.EventNID]gomatrixserverlib.PDU, len(eventEntries))
 		for _, entry := range eventEntries {
-			events[entry.EventNID] = entry.Event
+			events[entry.EventNID] = entry.PDU
 		}
 
 		if len(removed) > 0 {
@@ -155,9 +155,9 @@ func main() {
 	}
 
 	authEventIDMap := make(map[string]struct{})
-	events := make([]*gomatrixserverlib.Event, len(eventEntries))
+	events := make([]gomatrixserverlib.PDU, len(eventEntries))
 	for i := range eventEntries {
-		events[i] = eventEntries[i].Event
+		events[i] = eventEntries[i].PDU
 		for _, authEventID := range eventEntries[i].AuthEventIDs() {
 			authEventIDMap[authEventID] = struct{}{}
 		}
@@ -174,17 +174,15 @@ func main() {
 		panic(err)
 	}
 
-	authEvents := make([]*gomatrixserverlib.Event, len(authEventEntries))
+	authEvents := make([]gomatrixserverlib.PDU, len(authEventEntries))
 	for i := range authEventEntries {
-		authEvents[i] = authEventEntries[i].Event
+		authEvents[i] = authEventEntries[i].PDU
 	}
 
 	fmt.Println("Resolving state")
 	var resolved Events
 	resolved, err = gomatrixserverlib.ResolveConflicts(
-		gomatrixserverlib.RoomVersion(*roomVersion),
-		gomatrixserverlib.ToPDUs(events),
-		gomatrixserverlib.ToPDUs(authEvents),
+		gomatrixserverlib.RoomVersion(*roomVersion), events, authEvents,
 	)
 	if err != nil {
 		panic(err)

--- a/federationapi/consumers/roomserver.go
+++ b/federationapi/consumers/roomserver.go
@@ -187,9 +187,9 @@ func (s *OutputRoomEventConsumer) processMessage(ore api.OutputNewRoomEvent, rew
 		addsStateEvents = append(addsStateEvents, eventsRes.Events...)
 	}
 
-	evs := make([]*gomatrixserverlib.Event, len(addsStateEvents))
+	evs := make([]gomatrixserverlib.PDU, len(addsStateEvents))
 	for i := range evs {
-		evs[i] = addsStateEvents[i].Event
+		evs[i] = addsStateEvents[i].PDU
 	}
 
 	addsJoinedHosts, err := JoinedHostsFromEvents(evs)
@@ -340,7 +340,7 @@ func (s *OutputRoomEventConsumer) joinedHostsAtEvent(
 		ore.AddsStateEventIDs, ore.RemovesStateEventIDs,
 		ore.StateBeforeAddsEventIDs, ore.StateBeforeRemovesEventIDs,
 	)
-	combinedAddsEvents, err := s.lookupStateEvents(combinedAdds, ore.Event.Event)
+	combinedAddsEvents, err := s.lookupStateEvents(combinedAdds, ore.Event.PDU)
 	if err != nil {
 		return nil, err
 	}
@@ -374,7 +374,7 @@ func (s *OutputRoomEventConsumer) joinedHostsAtEvent(
 	}
 
 	// handle peeking hosts
-	inboundPeeks, err := s.db.GetInboundPeeks(s.ctx, ore.Event.Event.RoomID())
+	inboundPeeks, err := s.db.GetInboundPeeks(s.ctx, ore.Event.PDU.RoomID())
 	if err != nil {
 		return nil, err
 	}
@@ -394,7 +394,7 @@ func (s *OutputRoomEventConsumer) joinedHostsAtEvent(
 // JoinedHostsFromEvents turns a list of state events into a list of joined hosts.
 // This errors if one of the events was invalid.
 // It should be impossible for an invalid event to get this far in the pipeline.
-func JoinedHostsFromEvents(evs []*gomatrixserverlib.Event) ([]types.JoinedHost, error) {
+func JoinedHostsFromEvents(evs []gomatrixserverlib.PDU) ([]types.JoinedHost, error) {
 	var joinedHosts []types.JoinedHost
 	for _, ev := range evs {
 		if ev.Type() != "m.room.member" || ev.StateKey() == nil {
@@ -459,8 +459,8 @@ func combineDeltas(adds1, removes1, adds2, removes2 []string) (adds, removes []s
 
 // lookupStateEvents looks up the state events that are added by a new event.
 func (s *OutputRoomEventConsumer) lookupStateEvents(
-	addsStateEventIDs []string, event *gomatrixserverlib.Event,
-) ([]*gomatrixserverlib.Event, error) {
+	addsStateEventIDs []string, event gomatrixserverlib.PDU,
+) ([]gomatrixserverlib.PDU, error) {
 	// Fast path if there aren't any new state events.
 	if len(addsStateEventIDs) == 0 {
 		return nil, nil
@@ -468,11 +468,11 @@ func (s *OutputRoomEventConsumer) lookupStateEvents(
 
 	// Fast path if the only state event added is the event itself.
 	if len(addsStateEventIDs) == 1 && addsStateEventIDs[0] == event.EventID() {
-		return []*gomatrixserverlib.Event{event}, nil
+		return []gomatrixserverlib.PDU{event}, nil
 	}
 
 	missing := addsStateEventIDs
-	var result []*gomatrixserverlib.Event
+	var result []gomatrixserverlib.PDU
 
 	// Check if event itself is being added.
 	for _, eventID := range missing {
@@ -497,7 +497,7 @@ func (s *OutputRoomEventConsumer) lookupStateEvents(
 	}
 
 	for _, headeredEvent := range eventResp.Events {
-		result = append(result, headeredEvent.Event)
+		result = append(result, headeredEvent.PDU)
 	}
 
 	missing = missingEventsFrom(result, addsStateEventIDs)
@@ -511,7 +511,7 @@ func (s *OutputRoomEventConsumer) lookupStateEvents(
 	return result, nil
 }
 
-func missingEventsFrom(events []*gomatrixserverlib.Event, required []string) []string {
+func missingEventsFrom(events []gomatrixserverlib.PDU, required []string) []string {
 	have := map[string]bool{}
 	for _, event := range events {
 		have[event.EventID()] = true

--- a/federationapi/federationapi_test.go
+++ b/federationapi/federationapi_test.go
@@ -133,12 +133,12 @@ func (f *fedClient) MakeJoin(ctx context.Context, origin, s spec.ServerName, roo
 	}
 	return
 }
-func (f *fedClient) SendJoin(ctx context.Context, origin, s spec.ServerName, event *gomatrixserverlib.Event) (res fclient.RespSendJoin, err error) {
+func (f *fedClient) SendJoin(ctx context.Context, origin, s spec.ServerName, event gomatrixserverlib.PDU) (res fclient.RespSendJoin, err error) {
 	f.fedClientMutex.Lock()
 	defer f.fedClientMutex.Unlock()
 	for _, r := range f.allowJoins {
 		if r.ID == event.RoomID() {
-			r.InsertEvent(f.t, &types.HeaderedEvent{Event: event})
+			r.InsertEvent(f.t, &types.HeaderedEvent{PDU: event})
 			f.t.Logf("Join event: %v", event.EventID())
 			res.StateEvents = types.NewEventJSONsFromHeaderedEvents(r.CurrentState())
 			res.AuthEvents = types.NewEventJSONsFromHeaderedEvents(r.Events())

--- a/federationapi/internal/federationclient.go
+++ b/federationapi/internal/federationclient.go
@@ -27,7 +27,7 @@ func (a *FederationInternalAPI) MakeJoin(
 }
 
 func (a *FederationInternalAPI) SendJoin(
-	ctx context.Context, origin, s spec.ServerName, event *gomatrixserverlib.Event,
+	ctx context.Context, origin, s spec.ServerName, event gomatrixserverlib.PDU,
 ) (res gomatrixserverlib.SendJoinResponse, err error) {
 	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
 	defer cancel()

--- a/federationapi/internal/perform.go
+++ b/federationapi/internal/perform.go
@@ -204,7 +204,7 @@ func (r *FederationInternalAPI) performJoinUsingServer(
 		user.Domain(),
 		roomserverAPI.KindNew,
 		response.StateSnapshot,
-		&types.HeaderedEvent{Event: response.JoinEvent},
+		&types.HeaderedEvent{PDU: response.JoinEvent},
 		serverName,
 		nil,
 		false,
@@ -389,7 +389,7 @@ func (r *FederationInternalAPI) performOutboundPeekUsingServer(
 			StateEvents: gomatrixserverlib.NewEventJSONsFromEvents(stateEvents),
 			AuthEvents:  gomatrixserverlib.NewEventJSONsFromEvents(authEvents),
 		},
-		&types.HeaderedEvent{Event: respPeek.LatestEvent},
+		&types.HeaderedEvent{PDU: respPeek.LatestEvent},
 		serverName,
 		nil,
 		false,
@@ -536,7 +536,7 @@ func (r *FederationInternalAPI) PerformInvite(
 		"destination":  destination,
 	}).Info("Sending invite")
 
-	inviteReq, err := fclient.NewInviteV2Request(request.Event.Event, request.InviteRoomState)
+	inviteReq, err := fclient.NewInviteV2Request(request.Event.PDU, request.InviteRoomState)
 	if err != nil {
 		return fmt.Errorf("gomatrixserverlib.NewInviteV2Request: %w", err)
 	}
@@ -554,7 +554,7 @@ func (r *FederationInternalAPI) PerformInvite(
 	if err != nil {
 		return fmt.Errorf("r.federation.SendInviteV2 failed to decode event response: %w", err)
 	}
-	response.Event = &types.HeaderedEvent{Event: inviteEvent}
+	response.Event = &types.HeaderedEvent{PDU: inviteEvent}
 	return nil
 }
 
@@ -603,7 +603,7 @@ func (r *FederationInternalAPI) MarkServersAlive(destinations []spec.ServerName)
 	}
 }
 
-func checkEventsContainCreateEvent(events []*gomatrixserverlib.Event) error {
+func checkEventsContainCreateEvent(events []gomatrixserverlib.PDU) error {
 	// sanity check we have a create event and it has a known room version
 	for _, ev := range events {
 		if ev.Type() == spec.MRoomCreate && ev.StateKeyEquals("") {

--- a/federationapi/queue/queue_test.go
+++ b/federationapi/queue/queue_test.go
@@ -109,7 +109,7 @@ func mustCreatePDU(t *testing.T) *types.HeaderedEvent {
 	if err != nil {
 		t.Fatalf("failed to create event: %v", err)
 	}
-	return &types.HeaderedEvent{Event: ev}
+	return &types.HeaderedEvent{PDU: ev}
 }
 
 func mustCreateEDU(t *testing.T) *gomatrixserverlib.EDU {

--- a/federationapi/routing/backfill.go
+++ b/federationapi/routing/backfill.go
@@ -103,18 +103,18 @@ func Backfill(
 	}
 
 	// Filter any event that's not from the requested room out.
-	evs := make([]*gomatrixserverlib.Event, 0)
+	evs := make([]gomatrixserverlib.PDU, 0)
 
 	var ev *types.HeaderedEvent
 	for _, ev = range res.Events {
 		if ev.RoomID() == roomID {
-			evs = append(evs, ev.Event)
+			evs = append(evs, ev.PDU)
 		}
 	}
 
 	eventJSONs := []json.RawMessage{}
 	for _, e := range gomatrixserverlib.ReverseTopologicalOrdering(
-		gomatrixserverlib.ToPDUs(evs),
+		evs,
 		gomatrixserverlib.TopologicalOrderByPrevEvents,
 	) {
 		eventJSONs = append(eventJSONs, e.JSON())

--- a/federationapi/routing/events.go
+++ b/federationapi/routing/events.go
@@ -80,7 +80,7 @@ func allowedToSeeEvent(
 }
 
 // fetchEvent fetches the event without auth checks. Returns an error if the event cannot be found.
-func fetchEvent(ctx context.Context, rsAPI api.FederationRoomserverAPI, roomID, eventID string) (*gomatrixserverlib.Event, *util.JSONResponse) {
+func fetchEvent(ctx context.Context, rsAPI api.FederationRoomserverAPI, roomID, eventID string) (gomatrixserverlib.PDU, *util.JSONResponse) {
 	var eventsResponse api.QueryEventsByIDResponse
 	err := rsAPI.QueryEventsByID(
 		ctx,
@@ -99,5 +99,5 @@ func fetchEvent(ctx context.Context, rsAPI api.FederationRoomserverAPI, roomID, 
 		}
 	}
 
-	return eventsResponse.Events[0].Event, nil
+	return eventsResponse.Events[0].PDU, nil
 }

--- a/federationapi/routing/invite.go
+++ b/federationapi/routing/invite.go
@@ -106,7 +106,7 @@ func InviteV1(
 func processInvite(
 	ctx context.Context,
 	isInviteV2 bool,
-	event *gomatrixserverlib.Event,
+	event gomatrixserverlib.PDU,
 	roomVer gomatrixserverlib.RoomVersion,
 	strippedState []fclient.InviteV2StrippedState,
 	roomID string,
@@ -197,7 +197,7 @@ func processInvite(
 	)
 
 	// Add the invite event to the roomserver.
-	inviteEvent := &types.HeaderedEvent{Event: &signedEvent}
+	inviteEvent := &types.HeaderedEvent{PDU: signedEvent}
 	request := &api.PerformInviteRequest{
 		Event:           inviteEvent,
 		InviteRoomState: strippedState,

--- a/federationapi/routing/join.go
+++ b/federationapi/routing/join.go
@@ -163,13 +163,13 @@ func MakeJoin(
 	}
 
 	// Check that the join is allowed or not
-	stateEvents := make([]*gomatrixserverlib.Event, len(queryRes.StateEvents))
+	stateEvents := make([]gomatrixserverlib.PDU, len(queryRes.StateEvents))
 	for i := range queryRes.StateEvents {
-		stateEvents[i] = queryRes.StateEvents[i].Event
+		stateEvents[i] = queryRes.StateEvents[i].PDU
 	}
 
-	provider := gomatrixserverlib.NewAuthEvents(gomatrixserverlib.ToPDUs(stateEvents))
-	if err = gomatrixserverlib.Allowed(event.Event, &provider); err != nil {
+	provider := gomatrixserverlib.NewAuthEvents(stateEvents)
+	if err = gomatrixserverlib.Allowed(event.PDU, &provider); err != nil {
 		return util.JSONResponse{
 			Code: http.StatusForbidden,
 			JSON: jsonerror.Forbidden(err.Error()),
@@ -414,7 +414,7 @@ func SendJoin(
 			InputRoomEvents: []api.InputRoomEvent{
 				{
 					Kind:          api.KindNew,
-					Event:         &types.HeaderedEvent{Event: &signed},
+					Event:         &types.HeaderedEvent{PDU: signed},
 					SendAsServer:  string(cfg.Matrix.ServerName),
 					TransactionID: nil,
 				},

--- a/federationapi/routing/leave.go
+++ b/federationapi/routing/leave.go
@@ -110,12 +110,12 @@ func MakeLeave(
 	}
 
 	// Check that the leave is allowed or not
-	stateEvents := make([]*gomatrixserverlib.Event, len(queryRes.StateEvents))
+	stateEvents := make([]gomatrixserverlib.PDU, len(queryRes.StateEvents))
 	for i := range queryRes.StateEvents {
-		stateEvents[i] = queryRes.StateEvents[i].Event
+		stateEvents[i] = queryRes.StateEvents[i].PDU
 	}
-	provider := gomatrixserverlib.NewAuthEvents(gomatrixserverlib.ToPDUs(stateEvents))
-	if err = gomatrixserverlib.Allowed(event.Event, &provider); err != nil {
+	provider := gomatrixserverlib.NewAuthEvents(stateEvents)
+	if err = gomatrixserverlib.Allowed(event, &provider); err != nil {
 		return util.JSONResponse{
 			Code: http.StatusForbidden,
 			JSON: jsonerror.Forbidden(err.Error()),
@@ -313,7 +313,7 @@ func SendLeave(
 		InputRoomEvents: []api.InputRoomEvent{
 			{
 				Kind:          api.KindNew,
-				Event:         &types.HeaderedEvent{Event: event},
+				Event:         &types.HeaderedEvent{PDU: event},
 				SendAsServer:  string(cfg.Matrix.ServerName),
 				TransactionID: nil,
 			},

--- a/federationapi/routing/peek.go
+++ b/federationapi/routing/peek.go
@@ -91,7 +91,7 @@ func Peek(
 		StateEvents:     types.NewEventJSONsFromHeaderedEvents(response.StateEvents),
 		AuthEvents:      types.NewEventJSONsFromHeaderedEvents(response.AuthChainEvents),
 		RoomVersion:     response.RoomVersion,
-		LatestEvent:     response.LatestEvent.Event,
+		LatestEvent:     response.LatestEvent.PDU,
 		RenewalInterval: renewalInterval,
 	}
 

--- a/federationapi/routing/threepid.go
+++ b/federationapi/routing/threepid.go
@@ -86,7 +86,7 @@ func CreateInvitesFrom3PIDInvites(
 			return jsonerror.InternalServerError()
 		}
 		if event != nil {
-			evs = append(evs, &types.HeaderedEvent{Event: event})
+			evs = append(evs, &types.HeaderedEvent{PDU: event})
 		}
 	}
 
@@ -210,7 +210,7 @@ func ExchangeThirdPartyInvite(
 		httpReq.Context(), rsAPI,
 		api.KindNew,
 		[]*types.HeaderedEvent{
-			{Event: inviteEvent},
+			{PDU: inviteEvent},
 		},
 		request.Destination(),
 		request.Origin(),
@@ -325,7 +325,7 @@ func buildMembershipEvent(
 	authEvents := gomatrixserverlib.NewAuthEvents(nil)
 
 	for i := range queryRes.StateEvents {
-		err = authEvents.AddEvent(queryRes.StateEvents[i].Event)
+		err = authEvents.AddEvent(queryRes.StateEvents[i].PDU)
 		if err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/matrix-org/dugong v0.0.0-20210921133753-66e6b1c67e2e
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91
 	github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20230428142634-a4fa967eac17
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20230502101247-782aebf83205
 	github.com/matrix-org/pinecone v0.11.1-0.20230210171230-8c3b24f2649a
 	github.com/matrix-org/util v0.0.0-20221111132719-399730281e66
 	github.com/mattn/go-sqlite3 v1.14.16

--- a/go.sum
+++ b/go.sum
@@ -327,6 +327,8 @@ github.com/matrix-org/gomatrixserverlib v0.0.0-20230428003202-267b4e79f138 h1:zq
 github.com/matrix-org/gomatrixserverlib v0.0.0-20230428003202-267b4e79f138/go.mod h1:7HTbSZe+CIdmeqVyFMekwD5dFU8khWQyngKATvd12FU=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20230428142634-a4fa967eac17 h1:So8d7SZZdKB7+vWFXwmAQ3C+tUkkegMlcGk8n60w2og=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20230428142634-a4fa967eac17/go.mod h1:7HTbSZe+CIdmeqVyFMekwD5dFU8khWQyngKATvd12FU=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20230502101247-782aebf83205 h1:foJFr0V1uZC0oJ3ooenScGtLViq7Hx3rioe1Hf0lnhY=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20230502101247-782aebf83205/go.mod h1:7HTbSZe+CIdmeqVyFMekwD5dFU8khWQyngKATvd12FU=
 github.com/matrix-org/pinecone v0.11.1-0.20230210171230-8c3b24f2649a h1:awrPDf9LEFySxTLKYBMCiObelNx/cBuv/wzllvCCH3A=
 github.com/matrix-org/pinecone v0.11.1-0.20230210171230-8c3b24f2649a/go.mod h1:HchJX9oKMXaT2xYFs0Ha/6Zs06mxLU8k6F1ODnrGkeQ=
 github.com/matrix-org/util v0.0.0-20221111132719-399730281e66 h1:6z4KxomXSIGWqhHcfzExgkH3Z3UkIXry4ibJS4Aqz2Y=

--- a/internal/eventutil/events.go
+++ b/internal/eventutil/events.go
@@ -77,7 +77,7 @@ func BuildEvent(
 		return nil, err
 	}
 
-	return &types.HeaderedEvent{Event: event}, nil
+	return &types.HeaderedEvent{PDU: event}, nil
 }
 
 // queryRequiredEventsForBuilder queries the roomserver for auth/prev events needed for this builder.
@@ -124,7 +124,7 @@ func addPrevEventsToEvent(
 	authEvents := gomatrixserverlib.NewAuthEvents(nil)
 
 	for i := range queryRes.StateEvents {
-		err = authEvents.AddEvent(queryRes.StateEvents[i].Event)
+		err = authEvents.AddEvent(queryRes.StateEvents[i].PDU)
 		if err != nil {
 			return fmt.Errorf("authEvents.AddEvent: %w", err)
 		}
@@ -175,7 +175,7 @@ func truncateAuthAndPrevEvents(auth, prev []gomatrixserverlib.EventReference) (
 
 // RedactEvent redacts the given event and sets the unsigned field appropriately. This should be used by
 // downstream components to the roomserver when an OutputTypeRedactedEvent occurs.
-func RedactEvent(redactionEvent, redactedEvent *gomatrixserverlib.Event) error {
+func RedactEvent(redactionEvent, redactedEvent gomatrixserverlib.PDU) error {
 	// sanity check
 	if redactionEvent.Type() != spec.MRoomRedaction {
 		return fmt.Errorf("RedactEvent: redactionEvent isn't a redaction event, is '%s'", redactionEvent.Type())

--- a/internal/transactionrequest.go
+++ b/internal/transactionrequest.go
@@ -184,7 +184,7 @@ func (t *TxnReq) ProcessTransaction(ctx context.Context) (*fclient.RespSend, *ut
 			t.rsAPI,
 			api.KindNew,
 			[]*rstypes.HeaderedEvent{
-				{Event: event},
+				{PDU: event},
 			},
 			t.Destination,
 			t.Origin,

--- a/internal/transactionrequest_test.go
+++ b/internal/transactionrequest_test.go
@@ -636,7 +636,7 @@ func init() {
 		if err != nil {
 			panic("cannot load test data: " + err.Error())
 		}
-		h := &rstypes.HeaderedEvent{Event: e}
+		h := &rstypes.HeaderedEvent{PDU: e}
 		testEvents = append(testEvents, h)
 		if e.StateKey() != nil {
 			testStateEvents[gomatrixserverlib.StateKeyTuple{

--- a/roomserver/acls/acls.go
+++ b/roomserver/acls/acls.go
@@ -63,7 +63,7 @@ func NewServerACLs(db ServerACLDatabase) *ServerACLs {
 			continue
 		}
 		if state != nil {
-			acls.OnServerACLUpdate(state.Event)
+			acls.OnServerACLUpdate(state.PDU)
 		}
 	}
 	return acls
@@ -88,7 +88,7 @@ func compileACLRegex(orig string) (*regexp.Regexp, error) {
 	return regexp.Compile(escaped)
 }
 
-func (s *ServerACLs) OnServerACLUpdate(state *gomatrixserverlib.Event) {
+func (s *ServerACLs) OnServerACLUpdate(state gomatrixserverlib.PDU) {
 	acls := &serverACL{}
 	if err := json.Unmarshal(state.Content(), &acls.ServerACL); err != nil {
 		logrus.WithError(err).Errorf("Failed to unmarshal state content for server ACLs")

--- a/roomserver/api/wrapper.go
+++ b/roomserver/api/wrapper.go
@@ -64,7 +64,7 @@ func SendEventWithState(
 		}
 		ires = append(ires, InputRoomEvent{
 			Kind:   KindOutlier,
-			Event:  &types.HeaderedEvent{Event: outlier},
+			Event:  &types.HeaderedEvent{PDU: outlier},
 			Origin: origin,
 		})
 	}

--- a/roomserver/auth/auth.go
+++ b/roomserver/auth/auth.go
@@ -24,7 +24,7 @@ import (
 func IsServerAllowed(
 	serverName spec.ServerName,
 	serverCurrentlyInRoom bool,
-	authEvents []*gomatrixserverlib.Event,
+	authEvents []gomatrixserverlib.PDU,
 ) bool {
 	// In practice should not happen, but avoids unneeded CPU cycles
 	if serverName == "" || len(authEvents) == 0 {
@@ -55,7 +55,7 @@ func IsServerAllowed(
 	return false
 }
 
-func HistoryVisibilityForRoom(authEvents []*gomatrixserverlib.Event) gomatrixserverlib.HistoryVisibility {
+func HistoryVisibilityForRoom(authEvents []gomatrixserverlib.PDU) gomatrixserverlib.HistoryVisibility {
 	// https://matrix.org/docs/spec/client_server/r0.6.0#id87
 	// By default if no history_visibility is set, or if the value is not understood, the visibility is assumed to be shared.
 	visibility := gomatrixserverlib.HistoryVisibilityShared
@@ -70,7 +70,7 @@ func HistoryVisibilityForRoom(authEvents []*gomatrixserverlib.Event) gomatrixser
 	return visibility
 }
 
-func IsAnyUserOnServerWithMembership(serverName spec.ServerName, authEvents []*gomatrixserverlib.Event, wantMembership string) bool {
+func IsAnyUserOnServerWithMembership(serverName spec.ServerName, authEvents []gomatrixserverlib.PDU, wantMembership string) bool {
 	for _, ev := range authEvents {
 		if ev.Type() != spec.MRoomMember {
 			continue

--- a/roomserver/auth/auth_test.go
+++ b/roomserver/auth/auth_test.go
@@ -72,9 +72,9 @@ func TestIsServerAllowed(t *testing.T) {
 			if tt.roomFunc == nil {
 				t.Fatalf("missing roomFunc")
 			}
-			var authEvents []*gomatrixserverlib.Event
+			var authEvents []gomatrixserverlib.PDU
 			for _, ev := range tt.roomFunc().Events() {
-				authEvents = append(authEvents, ev.Event)
+				authEvents = append(authEvents, ev.PDU)
 			}
 
 			if got := IsServerAllowed(tt.serverName, tt.serverCurrentlyInRoom, authEvents); got != tt.want {

--- a/roomserver/internal/helpers/auth.go
+++ b/roomserver/internal/helpers/auth.go
@@ -66,7 +66,7 @@ func CheckForSoftFail(
 
 	// Work out which of the state events we actually need.
 	stateNeeded := gomatrixserverlib.StateNeededForAuth(
-		gomatrixserverlib.ToPDUs([]*gomatrixserverlib.Event{event.Event}),
+		[]gomatrixserverlib.PDU{event.PDU},
 	)
 
 	// Load the actual auth events from the database.
@@ -76,7 +76,7 @@ func CheckForSoftFail(
 	}
 
 	// Check if the event is allowed.
-	if err = gomatrixserverlib.Allowed(event.Event, &authEvents); err != nil {
+	if err = gomatrixserverlib.Allowed(event.PDU, &authEvents); err != nil {
 		// return true, nil
 		return true, err
 	}
@@ -100,7 +100,7 @@ func CheckAuthEvents(
 	authStateEntries = types.DeduplicateStateEntries(authStateEntries)
 
 	// Work out which of the state events we actually need.
-	stateNeeded := gomatrixserverlib.StateNeededForAuth([]gomatrixserverlib.PDU{event.Event})
+	stateNeeded := gomatrixserverlib.StateNeededForAuth([]gomatrixserverlib.PDU{event.PDU})
 
 	// Load the actual auth events from the database.
 	authEvents, err := loadAuthEvents(ctx, db, roomInfo, stateNeeded, authStateEntries)
@@ -109,7 +109,7 @@ func CheckAuthEvents(
 	}
 
 	// Check if the event is allowed.
-	if err = gomatrixserverlib.Allowed(event.Event, &authEvents); err != nil {
+	if err = gomatrixserverlib.Allowed(event.PDU, &authEvents); err != nil {
 		return nil, err
 	}
 
@@ -170,7 +170,7 @@ func (ae *authEvents) lookupEventWithEmptyStateKey(typeNID types.EventTypeNID) g
 	if !ok {
 		return nil
 	}
-	return event.Event
+	return event.PDU
 }
 
 func (ae *authEvents) lookupEvent(typeNID types.EventTypeNID, stateKey string) gomatrixserverlib.PDU {
@@ -189,7 +189,7 @@ func (ae *authEvents) lookupEvent(typeNID types.EventTypeNID, stateKey string) g
 	if !ok {
 		return nil
 	}
-	return event.Event
+	return event.PDU
 }
 
 // loadAuthEvents loads the events needed for authentication from the supplied room state.

--- a/roomserver/internal/helpers/helpers.go
+++ b/roomserver/internal/helpers/helpers.go
@@ -45,7 +45,7 @@ func UpdateToInviteMembership(
 		updates = append(updates, api.OutputEvent{
 			Type: api.OutputTypeNewInviteEvent,
 			NewInviteEvent: &api.OutputNewInviteEvent{
-				Event:       &types.HeaderedEvent{Event: add.Event},
+				Event:       &types.HeaderedEvent{PDU: add.PDU},
 				RoomVersion: roomVersion,
 			},
 		})
@@ -90,9 +90,9 @@ func IsServerCurrentlyInRoom(ctx context.Context, db storage.Database, serverNam
 	if err != nil {
 		return false, err
 	}
-	gmslEvents := make([]*gomatrixserverlib.Event, len(events))
+	gmslEvents := make([]gomatrixserverlib.PDU, len(events))
 	for i := range events {
-		gmslEvents[i] = events[i].Event
+		gmslEvents[i] = events[i].PDU
 	}
 	return auth.IsAnyUserOnServerWithMembership(serverName, gmslEvents, spec.Join), nil
 }
@@ -234,22 +234,22 @@ func MembershipAtEvent(ctx context.Context, db storage.RoomDatabase, info *types
 
 func LoadEvents(
 	ctx context.Context, db storage.RoomDatabase, roomInfo *types.RoomInfo, eventNIDs []types.EventNID,
-) ([]*gomatrixserverlib.Event, error) {
+) ([]gomatrixserverlib.PDU, error) {
 	stateEvents, err := db.Events(ctx, roomInfo, eventNIDs)
 	if err != nil {
 		return nil, err
 	}
 
-	result := make([]*gomatrixserverlib.Event, len(stateEvents))
+	result := make([]gomatrixserverlib.PDU, len(stateEvents))
 	for i := range stateEvents {
-		result[i] = stateEvents[i].Event
+		result[i] = stateEvents[i].PDU
 	}
 	return result, nil
 }
 
 func LoadStateEvents(
 	ctx context.Context, db storage.RoomDatabase, roomInfo *types.RoomInfo, stateEntries []types.StateEntry,
-) ([]*gomatrixserverlib.Event, error) {
+) ([]gomatrixserverlib.PDU, error) {
 	eventNIDs := make([]types.EventNID, len(stateEntries))
 	for i := range stateEntries {
 		eventNIDs[i] = stateEntries[i].EventNID
@@ -287,7 +287,7 @@ func CheckServerAllowedToSeeEvent(
 
 func slowGetHistoryVisibilityState(
 	ctx context.Context, db storage.Database, info *types.RoomInfo, eventID string, serverName spec.ServerName,
-) ([]*gomatrixserverlib.Event, error) {
+) ([]gomatrixserverlib.PDU, error) {
 	roomState := state.NewStateResolution(db, info)
 	stateEntries, err := roomState.LoadStateAtEvent(ctx, eventID)
 	if err != nil {
@@ -479,7 +479,7 @@ func QueryLatestEventsAndState(
 	}
 
 	for _, event := range stateEvents {
-		response.StateEvents = append(response.StateEvents, &types.HeaderedEvent{Event: event})
+		response.StateEvents = append(response.StateEvents, &types.HeaderedEvent{PDU: event})
 	}
 
 	return nil

--- a/roomserver/internal/helpers/helpers_test.go
+++ b/roomserver/internal/helpers/helpers_test.go
@@ -41,7 +41,7 @@ func TestIsInvitePendingWithoutNID(t *testing.T) {
 		var authNIDs []types.EventNID
 		for _, x := range room.Events() {
 
-			roomInfo, err := db.GetOrCreateRoomInfo(context.Background(), x.Event)
+			roomInfo, err := db.GetOrCreateRoomInfo(context.Background(), x.PDU)
 			assert.NoError(t, err)
 			assert.NotNil(t, roomInfo)
 
@@ -52,7 +52,7 @@ func TestIsInvitePendingWithoutNID(t *testing.T) {
 			eventStateKeyNID, err := db.GetOrCreateEventStateKeyNID(context.Background(), x.StateKey())
 			assert.NoError(t, err)
 
-			evNID, _, err := db.StoreEvent(context.Background(), x.Event, roomInfo, eventTypeNID, eventStateKeyNID, authNIDs, false)
+			evNID, _, err := db.StoreEvent(context.Background(), x.PDU, roomInfo, eventTypeNID, eventStateKeyNID, authNIDs, false)
 			assert.NoError(t, err)
 			authNIDs = append(authNIDs, evNID)
 		}

--- a/roomserver/internal/input/input_events_test.go
+++ b/roomserver/internal/input/input_events_test.go
@@ -18,21 +18,21 @@ func Test_EventAuth(t *testing.T) {
 	room2 := test.NewRoom(t, alice, test.RoomPreset(test.PresetPublicChat))
 
 	authEventIDs := make([]string, 0, 4)
-	authEvents := []*gomatrixserverlib.Event{}
+	authEvents := []gomatrixserverlib.PDU{}
 
 	// Add the legal auth events from room2
 	for _, x := range room2.Events() {
 		if x.Type() == spec.MRoomCreate {
 			authEventIDs = append(authEventIDs, x.EventID())
-			authEvents = append(authEvents, x.Event)
+			authEvents = append(authEvents, x.PDU)
 		}
 		if x.Type() == spec.MRoomPowerLevels {
 			authEventIDs = append(authEventIDs, x.EventID())
-			authEvents = append(authEvents, x.Event)
+			authEvents = append(authEvents, x.PDU)
 		}
 		if x.Type() == spec.MRoomJoinRules {
 			authEventIDs = append(authEventIDs, x.EventID())
-			authEvents = append(authEvents, x.Event)
+			authEvents = append(authEvents, x.PDU)
 		}
 	}
 
@@ -40,7 +40,7 @@ func Test_EventAuth(t *testing.T) {
 	for _, x := range room1.Events() {
 		if x.Type() == spec.MRoomMember {
 			authEventIDs = append(authEventIDs, x.EventID())
-			authEvents = append(authEvents, x.Event)
+			authEvents = append(authEvents, x.PDU)
 		}
 	}
 
@@ -58,7 +58,7 @@ func Test_EventAuth(t *testing.T) {
 	}
 
 	// Finally check that the event is NOT allowed
-	if err := gomatrixserverlib.Allowed(ev.Event, &allower); err == nil {
+	if err := gomatrixserverlib.Allowed(ev.PDU, &allower); err == nil {
 		t.Fatalf("event should not be allowed, but it was")
 	}
 }

--- a/roomserver/internal/input/input_latest_events.go
+++ b/roomserver/internal/input/input_latest_events.go
@@ -53,7 +53,7 @@ func (r *Inputer) updateLatestEvents(
 	ctx context.Context,
 	roomInfo *types.RoomInfo,
 	stateAtEvent types.StateAtEvent,
-	event *gomatrixserverlib.Event,
+	event gomatrixserverlib.PDU,
 	sendAsServer string,
 	transactionID *api.TransactionID,
 	rewritesState bool,
@@ -101,7 +101,7 @@ type latestEventsUpdater struct {
 	updater       *shared.RoomUpdater
 	roomInfo      *types.RoomInfo
 	stateAtEvent  types.StateAtEvent
-	event         *gomatrixserverlib.Event
+	event         gomatrixserverlib.PDU
 	transactionID *api.TransactionID
 	rewritesState bool
 	// Which server to send this event as.
@@ -326,7 +326,7 @@ func (u *latestEventsUpdater) latestState() error {
 // true if the new event is included in those extremites, false otherwise.
 func (u *latestEventsUpdater) calculateLatest(
 	oldLatest []types.StateAtEventAndReference,
-	newEvent *gomatrixserverlib.Event,
+	newEvent gomatrixserverlib.PDU,
 	newStateAndRef types.StateAtEventAndReference,
 ) (bool, error) {
 	trace, _ := internal.StartRegion(u.ctx, "calculateLatest")
@@ -393,7 +393,7 @@ func (u *latestEventsUpdater) makeOutputNewRoomEvent() (*api.OutputEvent, error)
 	}
 
 	ore := api.OutputNewRoomEvent{
-		Event:             &types.HeaderedEvent{Event: u.event},
+		Event:             &types.HeaderedEvent{PDU: u.event},
 		RewritesState:     u.rewritesState,
 		LastSentEventID:   u.lastEventIDSent,
 		LatestEventIDs:    latestEventIDs,

--- a/roomserver/internal/input/input_missing.go
+++ b/roomserver/internal/input/input_missing.go
@@ -22,19 +22,19 @@ import (
 )
 
 type parsedRespState struct {
-	AuthEvents  []*gomatrixserverlib.Event
-	StateEvents []*gomatrixserverlib.Event
+	AuthEvents  []gomatrixserverlib.PDU
+	StateEvents []gomatrixserverlib.PDU
 }
 
 func (p *parsedRespState) Events() []gomatrixserverlib.PDU {
-	eventsByID := make(map[string]*gomatrixserverlib.Event, len(p.AuthEvents)+len(p.StateEvents))
+	eventsByID := make(map[string]gomatrixserverlib.PDU, len(p.AuthEvents)+len(p.StateEvents))
 	for i, event := range p.AuthEvents {
 		eventsByID[event.EventID()] = p.AuthEvents[i]
 	}
 	for i, event := range p.StateEvents {
 		eventsByID[event.EventID()] = p.StateEvents[i]
 	}
-	allEvents := make([]*gomatrixserverlib.Event, 0, len(eventsByID))
+	allEvents := make([]gomatrixserverlib.PDU, 0, len(eventsByID))
 	for _, event := range eventsByID {
 		allEvents = append(allEvents, event)
 	}
@@ -55,7 +55,7 @@ type missingStateReq struct {
 	servers         []spec.ServerName
 	hadEvents       map[string]bool
 	hadEventsMutex  sync.Mutex
-	haveEvents      map[string]*gomatrixserverlib.Event
+	haveEvents      map[string]gomatrixserverlib.PDU
 	haveEventsMutex sync.Mutex
 }
 
@@ -63,7 +63,7 @@ type missingStateReq struct {
 // request, as called from processRoomEvent.
 // nolint:gocyclo
 func (t *missingStateReq) processEventWithMissingState(
-	ctx context.Context, e *gomatrixserverlib.Event, roomVersion gomatrixserverlib.RoomVersion,
+	ctx context.Context, e gomatrixserverlib.PDU, roomVersion gomatrixserverlib.RoomVersion,
 ) (*parsedRespState, error) {
 	trace, ctx := internal.StartRegion(ctx, "processEventWithMissingState")
 	defer trace.EndRegion()
@@ -107,7 +107,7 @@ func (t *missingStateReq) processEventWithMissingState(
 		for _, newEvent := range newEvents {
 			err = t.inputer.processRoomEvent(ctx, t.virtualHost, &api.InputRoomEvent{
 				Kind:         api.KindOld,
-				Event:        &types.HeaderedEvent{Event: newEvent},
+				Event:        &types.HeaderedEvent{PDU: newEvent},
 				Origin:       t.origin,
 				SendAsServer: api.DoNotSendToOtherServers,
 			})
@@ -156,7 +156,7 @@ func (t *missingStateReq) processEventWithMissingState(
 			}
 			outlierRoomEvents = append(outlierRoomEvents, api.InputRoomEvent{
 				Kind:   api.KindOutlier,
-				Event:  &types.HeaderedEvent{Event: outlier.(*gomatrixserverlib.Event)},
+				Event:  &types.HeaderedEvent{PDU: outlier},
 				Origin: t.origin,
 			})
 		}
@@ -186,7 +186,7 @@ func (t *missingStateReq) processEventWithMissingState(
 
 	err = t.inputer.processRoomEvent(ctx, t.virtualHost, &api.InputRoomEvent{
 		Kind:          api.KindOld,
-		Event:         &types.HeaderedEvent{Event: backwardsExtremity},
+		Event:         &types.HeaderedEvent{PDU: backwardsExtremity},
 		Origin:        t.origin,
 		HasState:      true,
 		StateEventIDs: stateIDs,
@@ -205,7 +205,7 @@ func (t *missingStateReq) processEventWithMissingState(
 	for _, newEvent := range newEvents {
 		err = t.inputer.processRoomEvent(ctx, t.virtualHost, &api.InputRoomEvent{
 			Kind:         api.KindOld,
-			Event:        &types.HeaderedEvent{Event: newEvent},
+			Event:        &types.HeaderedEvent{PDU: newEvent},
 			Origin:       t.origin,
 			SendAsServer: api.DoNotSendToOtherServers,
 		})
@@ -243,7 +243,7 @@ func (t *missingStateReq) processEventWithMissingState(
 	return resolvedState, nil
 }
 
-func (t *missingStateReq) lookupResolvedStateBeforeEvent(ctx context.Context, e *gomatrixserverlib.Event, roomVersion gomatrixserverlib.RoomVersion) (*parsedRespState, error) {
+func (t *missingStateReq) lookupResolvedStateBeforeEvent(ctx context.Context, e gomatrixserverlib.PDU, roomVersion gomatrixserverlib.RoomVersion) (*parsedRespState, error) {
 	trace, ctx := internal.StartRegion(ctx, "lookupResolvedStateBeforeEvent")
 	defer trace.EndRegion()
 
@@ -368,7 +368,7 @@ func (t *missingStateReq) lookupStateAfterEvent(ctx context.Context, roomVersion
 	return respState, false, nil
 }
 
-func (t *missingStateReq) cacheAndReturn(ev *gomatrixserverlib.Event) *gomatrixserverlib.Event {
+func (t *missingStateReq) cacheAndReturn(ev gomatrixserverlib.PDU) gomatrixserverlib.PDU {
 	t.haveEventsMutex.Lock()
 	defer t.haveEventsMutex.Unlock()
 	if cached, exists := t.haveEvents[ev.EventID()]; exists {
@@ -403,11 +403,11 @@ func (t *missingStateReq) lookupStateAfterEventLocally(ctx context.Context, even
 		t.log.WithError(err).Warnf("failed to load state events locally")
 		return nil
 	}
-	res.StateEvents = make([]*gomatrixserverlib.Event, 0, len(stateEvents))
+	res.StateEvents = make([]gomatrixserverlib.PDU, 0, len(stateEvents))
 	for _, ev := range stateEvents {
 		// set the event from the haveEvents cache - this means we will share pointers with other prev_event branches for this
 		// processEvent request, which is better for memory.
-		res.StateEvents = append(res.StateEvents, t.cacheAndReturn(ev.Event))
+		res.StateEvents = append(res.StateEvents, t.cacheAndReturn(ev.PDU))
 		t.hadEvent(ev.EventID())
 	}
 
@@ -415,7 +415,7 @@ func (t *missingStateReq) lookupStateAfterEventLocally(ctx context.Context, even
 	stateEvents, stateEventNIDs, stateEntries, stateAtEvents = nil, nil, nil, nil // nolint:ineffassign
 
 	missingAuthEvents := map[string]bool{}
-	res.AuthEvents = make([]*gomatrixserverlib.Event, 0, len(stateEvents)*3)
+	res.AuthEvents = make([]gomatrixserverlib.PDU, 0, len(stateEvents)*3)
 	for _, ev := range stateEvents {
 		t.haveEventsMutex.Lock()
 		for _, ae := range ev.AuthEventIDs() {
@@ -440,7 +440,7 @@ func (t *missingStateReq) lookupStateAfterEventLocally(ctx context.Context, even
 			return nil
 		}
 		for i, ev := range events {
-			res.AuthEvents = append(res.AuthEvents, t.cacheAndReturn(events[i].Event))
+			res.AuthEvents = append(res.AuthEvents, t.cacheAndReturn(events[i].PDU))
 			t.hadEvent(ev.EventID())
 		}
 	}
@@ -459,12 +459,12 @@ func (t *missingStateReq) lookupStateBeforeEvent(ctx context.Context, roomVersio
 	return t.lookupMissingStateViaStateIDs(ctx, roomID, eventID, roomVersion)
 }
 
-func (t *missingStateReq) resolveStatesAndCheck(ctx context.Context, roomVersion gomatrixserverlib.RoomVersion, states []*parsedRespState, backwardsExtremity *gomatrixserverlib.Event) (*parsedRespState, error) {
+func (t *missingStateReq) resolveStatesAndCheck(ctx context.Context, roomVersion gomatrixserverlib.RoomVersion, states []*parsedRespState, backwardsExtremity gomatrixserverlib.PDU) (*parsedRespState, error) {
 	trace, ctx := internal.StartRegion(ctx, "resolveStatesAndCheck")
 	defer trace.EndRegion()
 
-	var authEventList []*gomatrixserverlib.Event
-	var stateEventList []*gomatrixserverlib.Event
+	var authEventList []gomatrixserverlib.PDU
+	var stateEventList []gomatrixserverlib.PDU
 	for _, state := range states {
 		authEventList = append(authEventList, state.AuthEvents...)
 		stateEventList = append(stateEventList, state.StateEvents...)
@@ -485,7 +485,7 @@ retryAllowedState:
 			case verifySigError:
 				return &parsedRespState{
 					AuthEvents:  authEventList,
-					StateEvents: gomatrixserverlib.TempCastToEvents(resolvedStateEvents),
+					StateEvents: resolvedStateEvents,
 				}, nil
 			case nil:
 				// do nothing
@@ -501,13 +501,13 @@ retryAllowedState:
 	}
 	return &parsedRespState{
 		AuthEvents:  authEventList,
-		StateEvents: gomatrixserverlib.TempCastToEvents(resolvedStateEvents),
+		StateEvents: resolvedStateEvents,
 	}, nil
 }
 
 // get missing events for `e`. If `isGapFilled`=true then `newEvents` contains all the events to inject,
 // without `e`. If `isGapFilled=false` then `newEvents` contains the response to /get_missing_events
-func (t *missingStateReq) getMissingEvents(ctx context.Context, e *gomatrixserverlib.Event, roomVersion gomatrixserverlib.RoomVersion) (newEvents []*gomatrixserverlib.Event, isGapFilled, prevStateKnown bool, err error) {
+func (t *missingStateReq) getMissingEvents(ctx context.Context, e gomatrixserverlib.PDU, roomVersion gomatrixserverlib.RoomVersion) (newEvents []*gomatrixserverlib.Event, isGapFilled, prevStateKnown bool, err error) {
 	trace, ctx := internal.StartRegion(ctx, "getMissingEvents")
 	defer trace.EndRegion()
 
@@ -560,7 +560,7 @@ func (t *missingStateReq) getMissingEvents(ctx context.Context, e *gomatrixserve
 
 	// Make sure events from the missingResp are using the cache - missing events
 	// will be added and duplicates will be removed.
-	missingEvents := make([]*gomatrixserverlib.Event, 0, len(missingResp.Events))
+	missingEvents := make([]gomatrixserverlib.PDU, 0, len(missingResp.Events))
 	for _, ev := range missingResp.Events.UntrustedEvents(roomVersion) {
 		if err = gomatrixserverlib.VerifyEventSignatures(ctx, ev, t.keys); err != nil {
 			continue
@@ -618,7 +618,7 @@ Event:
 	return newEvents, true, t.isPrevStateKnown(ctx, e), nil
 }
 
-func (t *missingStateReq) isPrevStateKnown(ctx context.Context, e *gomatrixserverlib.Event) bool {
+func (t *missingStateReq) isPrevStateKnown(ctx context.Context, e gomatrixserverlib.PDU) bool {
 	expected := len(e.PrevEventIDs())
 	state, err := t.db.StateAtEventIDs(ctx, e.PrevEventIDs())
 	if err != nil || len(state) != expected {
@@ -707,7 +707,7 @@ func (t *missingStateReq) lookupMissingStateViaStateIDs(ctx context.Context, roo
 	}
 
 	for i, ev := range events {
-		events[i].Event = t.cacheAndReturn(events[i].Event)
+		events[i].PDU = t.cacheAndReturn(events[i].PDU)
 		t.hadEvent(ev.EventID())
 		evID := events[i].EventID()
 		if missing[evID] {
@@ -839,7 +839,7 @@ func (t *missingStateReq) createRespStateFromStateIDs(
 	return &respState, nil
 }
 
-func (t *missingStateReq) lookupEvent(ctx context.Context, roomVersion gomatrixserverlib.RoomVersion, _, missingEventID string, localFirst bool) (*gomatrixserverlib.Event, error) {
+func (t *missingStateReq) lookupEvent(ctx context.Context, roomVersion gomatrixserverlib.RoomVersion, _, missingEventID string, localFirst bool) (gomatrixserverlib.PDU, error) {
 	trace, ctx := internal.StartRegion(ctx, "lookupEvent")
 	defer trace.EndRegion()
 
@@ -854,7 +854,7 @@ func (t *missingStateReq) lookupEvent(ctx context.Context, roomVersion gomatrixs
 		if err != nil {
 			t.log.Warnf("Failed to query roomserver for missing event %s: %s - falling back to remote", missingEventID, err)
 		} else if len(events) == 1 {
-			return events[0].Event, nil
+			return events[0].PDU, nil
 		}
 	}
 	var event *gomatrixserverlib.Event
@@ -894,7 +894,7 @@ func (t *missingStateReq) lookupEvent(ctx context.Context, roomVersion gomatrixs
 	return t.cacheAndReturn(event), nil
 }
 
-func checkAllowedByState(e *gomatrixserverlib.Event, stateEvents []gomatrixserverlib.PDU) error {
+func checkAllowedByState(e gomatrixserverlib.PDU, stateEvents []gomatrixserverlib.PDU) error {
 	authUsingState := gomatrixserverlib.NewAuthEvents(nil)
 	for i := range stateEvents {
 		err := authUsingState.AddEvent(stateEvents[i])

--- a/roomserver/internal/input/input_test.go
+++ b/roomserver/internal/input/input_test.go
@@ -45,7 +45,7 @@ func TestSingleTransactionOnInput(t *testing.T) {
 		}
 		in := api.InputRoomEvent{
 			Kind:  api.KindOutlier, // don't panic if we generate an output event
-			Event: &types.HeaderedEvent{Event: event},
+			Event: &types.HeaderedEvent{PDU: event},
 		}
 
 		inputter := &input.Inputer{

--- a/roomserver/internal/perform/perform_admin.go
+++ b/roomserver/internal/perform/perform_admin.go
@@ -320,8 +320,8 @@ func (r *Admin) PerformAdminDownloadState(
 		return nil
 	}
 
-	authEventMap := map[string]*gomatrixserverlib.Event{}
-	stateEventMap := map[string]*gomatrixserverlib.Event{}
+	authEventMap := map[string]gomatrixserverlib.PDU{}
+	stateEventMap := map[string]gomatrixserverlib.PDU{}
 
 	for _, fwdExtremity := range fwdExtremities {
 		var state gomatrixserverlib.StateResponse
@@ -352,10 +352,10 @@ func (r *Admin) PerformAdminDownloadState(
 	stateIDs := make([]string, 0, len(stateEventMap))
 
 	for _, authEvent := range authEventMap {
-		authEvents = append(authEvents, &types.HeaderedEvent{Event: authEvent})
+		authEvents = append(authEvents, &types.HeaderedEvent{PDU: authEvent})
 	}
 	for _, stateEvent := range stateEventMap {
-		stateEvents = append(stateEvents, &types.HeaderedEvent{Event: stateEvent})
+		stateEvents = append(stateEvents, &types.HeaderedEvent{PDU: stateEvent})
 		stateIDs = append(stateIDs, stateEvent.EventID())
 	}
 

--- a/roomserver/internal/perform/perform_inbound_peek.go
+++ b/roomserver/internal/perform/perform_inbound_peek.go
@@ -56,7 +56,7 @@ func (r *InboundPeeker) PerformInboundPeek(
 	response.RoomExists = true
 	response.RoomVersion = info.RoomVersion
 
-	var stateEvents []*gomatrixserverlib.Event
+	var stateEvents []gomatrixserverlib.PDU
 
 	var currentStateSnapshotNID types.StateSnapshotNID
 	latestEventRefs, currentStateSnapshotNID, _, err :=
@@ -70,13 +70,13 @@ func (r *InboundPeeker) PerformInboundPeek(
 	}
 	var sortedLatestEvents []gomatrixserverlib.PDU
 	for _, ev := range latestEvents {
-		sortedLatestEvents = append(sortedLatestEvents, ev.Event)
+		sortedLatestEvents = append(sortedLatestEvents, ev.PDU)
 	}
 	sortedLatestEvents = gomatrixserverlib.ReverseTopologicalOrdering(
 		sortedLatestEvents,
 		gomatrixserverlib.TopologicalOrderByPrevEvents,
 	)
-	response.LatestEvent = &types.HeaderedEvent{Event: sortedLatestEvents[0].(*gomatrixserverlib.Event)}
+	response.LatestEvent = &types.HeaderedEvent{PDU: sortedLatestEvents[0]}
 
 	// XXX: do we actually need to do a state resolution here?
 	roomState := state.NewStateResolution(r.DB, info)
@@ -106,11 +106,11 @@ func (r *InboundPeeker) PerformInboundPeek(
 	}
 
 	for _, event := range stateEvents {
-		response.StateEvents = append(response.StateEvents, &types.HeaderedEvent{Event: event})
+		response.StateEvents = append(response.StateEvents, &types.HeaderedEvent{PDU: event})
 	}
 
 	for _, event := range authEvents {
-		response.AuthChainEvents = append(response.AuthChainEvents, &types.HeaderedEvent{Event: event})
+		response.AuthChainEvents = append(response.AuthChainEvents, &types.HeaderedEvent{PDU: event})
 	}
 
 	err = r.Inputer.OutputProducer.ProduceRoomEvents(request.RoomID, []api.OutputEvent{

--- a/roomserver/internal/perform/perform_invite.go
+++ b/roomserver/internal/perform/perform_invite.go
@@ -119,7 +119,7 @@ func (r *Inviter) PerformInvite(
 		}
 		outputUpdates, err = helpers.UpdateToInviteMembership(updater, &types.Event{
 			EventNID: 0,
-			Event:    event.Event,
+			PDU:      event.PDU,
 		}, outputUpdates, req.Event.Version())
 		if err != nil {
 			return nil, fmt.Errorf("updateToInviteMembership: %w", err)
@@ -298,11 +298,11 @@ func buildInviteStrippedState(
 		return nil, err
 	}
 	inviteState := []fclient.InviteV2StrippedState{
-		fclient.NewInviteV2StrippedState(input.Event.Event),
+		fclient.NewInviteV2StrippedState(input.Event.PDU),
 	}
-	stateEvents = append(stateEvents, types.Event{Event: input.Event.Event})
+	stateEvents = append(stateEvents, types.Event{PDU: input.Event.PDU})
 	for _, event := range stateEvents {
-		inviteState = append(inviteState, fclient.NewInviteV2StrippedState(event.Event))
+		inviteState = append(inviteState, fclient.NewInviteV2StrippedState(event.PDU))
 	}
 	return inviteState, nil
 }

--- a/roomserver/internal/perform/perform_upgrade.go
+++ b/roomserver/internal/perform/perform_upgrade.go
@@ -544,7 +544,7 @@ func (r *Upgrader) sendInitialEvents(ctx context.Context, evTime time.Time, user
 		}
 
 		// Add the event to the list of auth events
-		builtEvents = append(builtEvents, &types.HeaderedEvent{Event: event})
+		builtEvents = append(builtEvents, &types.HeaderedEvent{PDU: event})
 		err = authEvents.AddEvent(event)
 		if err != nil {
 			return &api.PerformError{
@@ -638,12 +638,12 @@ func (r *Upgrader) makeHeaderedEvent(ctx context.Context, evTime time.Time, user
 		}
 	}
 	// check to see if this user can perform this operation
-	stateEvents := make([]*gomatrixserverlib.Event, len(queryRes.StateEvents))
+	stateEvents := make([]gomatrixserverlib.PDU, len(queryRes.StateEvents))
 	for i := range queryRes.StateEvents {
-		stateEvents[i] = queryRes.StateEvents[i].Event
+		stateEvents[i] = queryRes.StateEvents[i].PDU
 	}
-	provider := gomatrixserverlib.NewAuthEvents(gomatrixserverlib.ToPDUs(stateEvents))
-	if err = gomatrixserverlib.Allowed(headeredEvent.Event, &provider); err != nil {
+	provider := gomatrixserverlib.NewAuthEvents(stateEvents)
+	if err = gomatrixserverlib.Allowed(headeredEvent.PDU, &provider); err != nil {
 		return nil, &api.PerformError{
 			Code: api.PerformErrorNotAllowed,
 			Msg:  fmt.Sprintf("Failed to auth new %q event: %s", builder.Type, err), // TODO: Is this error string comprehensible to the client?

--- a/roomserver/internal/query/query_test.go
+++ b/roomserver/internal/query/query_test.go
@@ -84,7 +84,7 @@ func (db *getEventDB) EventsFromIDs(ctx context.Context, roomInfo *types.RoomInf
 	for _, evID := range eventIDs {
 		res = append(res, types.Event{
 			EventNID: 0,
-			Event:    db.eventMap[evID],
+			PDU:      db.eventMap[evID],
 		})
 	}
 

--- a/roomserver/producers/roomevent.go
+++ b/roomserver/producers/roomevent.go
@@ -74,7 +74,7 @@ func (r *RoomEventProducer) ProduceRoomEvents(roomID string, updates []api.Outpu
 			}
 
 			if eventType == "m.room.server_acl" && update.NewRoomEvent.Event.StateKeyEquals("") {
-				ev := update.NewRoomEvent.Event.Event
+				ev := update.NewRoomEvent.Event.PDU
 				defer r.ACLs.OnServerACLUpdate(ev)
 			}
 		}

--- a/roomserver/roomserver_test.go
+++ b/roomserver/roomserver_test.go
@@ -426,7 +426,7 @@ func mustCreateEvent(t *testing.T, ev fledglingEvent) (result *types.HeaderedEve
 	if err != nil {
 		t.Fatalf("mustCreateEvent: failed to sign event: %s", err)
 	}
-	h := &types.HeaderedEvent{Event: signedEvent}
+	h := &types.HeaderedEvent{PDU: signedEvent}
 	return h
 }
 
@@ -539,7 +539,7 @@ func TestRedaction(t *testing.T) {
 				}
 
 				for _, ev := range room.Events() {
-					roomInfo, err = db.GetOrCreateRoomInfo(ctx, ev.Event)
+					roomInfo, err = db.GetOrCreateRoomInfo(ctx, ev.PDU)
 					assert.NoError(t, err)
 					assert.NotNil(t, roomInfo)
 					evTypeNID, err := db.GetOrCreateEventTypeNID(ctx, ev.Type())
@@ -548,7 +548,7 @@ func TestRedaction(t *testing.T) {
 					stateKeyNID, err := db.GetOrCreateEventStateKeyNID(ctx, ev.StateKey())
 					assert.NoError(t, err)
 
-					eventNID, stateAtEvent, err := db.StoreEvent(ctx, ev.Event, roomInfo, evTypeNID, stateKeyNID, authEvents, false)
+					eventNID, stateAtEvent, err := db.StoreEvent(ctx, ev.PDU, roomInfo, evTypeNID, stateKeyNID, authEvents, false)
 					assert.NoError(t, err)
 					if ev.StateKey() != nil {
 						authEvents = append(authEvents, eventNID)
@@ -556,7 +556,7 @@ func TestRedaction(t *testing.T) {
 
 					// Calculate the snapshotNID etc.
 					plResolver := state.NewStateResolution(db, roomInfo)
-					stateAtEvent.BeforeStateSnapshotNID, err = plResolver.CalculateAndStoreStateBeforeEvent(ctx, ev.Event, false)
+					stateAtEvent.BeforeStateSnapshotNID, err = plResolver.CalculateAndStoreStateBeforeEvent(ctx, ev.PDU, false)
 					assert.NoError(t, err)
 
 					// Update the room
@@ -567,7 +567,7 @@ func TestRedaction(t *testing.T) {
 					err = updater.Commit()
 					assert.NoError(t, err)
 
-					_, redactedEvent, err := db.MaybeRedactEvent(ctx, roomInfo, eventNID, ev.Event, &plResolver)
+					_, redactedEvent, err := db.MaybeRedactEvent(ctx, roomInfo, eventNID, ev.PDU, &plResolver)
 					assert.NoError(t, err)
 					if redactedEvent != nil {
 						assert.Equal(t, ev.Redacts(), redactedEvent.EventID())

--- a/roomserver/storage/interface.go
+++ b/roomserver/storage/interface.go
@@ -41,7 +41,7 @@ type Database interface {
 	) (types.StateSnapshotNID, error)
 
 	MissingAuthPrevEvents(
-		ctx context.Context, e *gomatrixserverlib.Event,
+		ctx context.Context, e gomatrixserverlib.PDU,
 	) (missingAuth, missingPrev []string, err error)
 
 	// Look up the state of a room at each event for a list of string event IDs.
@@ -171,7 +171,7 @@ type Database interface {
 	// ForgetRoom sets a flag in the membership table, that the user wishes to forget a specific room
 	ForgetRoom(ctx context.Context, userID, roomID string, forget bool) error
 
-	GetHistoryVisibilityState(ctx context.Context, roomInfo *types.RoomInfo, eventID string, domain string) ([]*gomatrixserverlib.Event, error)
+	GetHistoryVisibilityState(ctx context.Context, roomInfo *types.RoomInfo, eventID string, domain string) ([]gomatrixserverlib.PDU, error)
 	GetLeftUsers(ctx context.Context, userIDs []string) ([]string, error)
 	PurgeRoom(ctx context.Context, roomID string) error
 	UpgradeRoom(ctx context.Context, oldRoomID, newRoomID, eventSender string) error
@@ -186,8 +186,8 @@ type Database interface {
 	GetOrCreateEventTypeNID(ctx context.Context, eventType string) (eventTypeNID types.EventTypeNID, err error)
 	GetOrCreateEventStateKeyNID(ctx context.Context, eventStateKey *string) (types.EventStateKeyNID, error)
 	MaybeRedactEvent(
-		ctx context.Context, roomInfo *types.RoomInfo, eventNID types.EventNID, event *gomatrixserverlib.Event, plResolver state.PowerLevelResolver,
-	) (*gomatrixserverlib.Event, *gomatrixserverlib.Event, error)
+		ctx context.Context, roomInfo *types.RoomInfo, eventNID types.EventNID, event gomatrixserverlib.PDU, plResolver state.PowerLevelResolver,
+	) (gomatrixserverlib.PDU, gomatrixserverlib.PDU, error)
 }
 
 type RoomDatabase interface {
@@ -197,7 +197,7 @@ type RoomDatabase interface {
 	RoomInfoByNID(ctx context.Context, roomNID types.RoomNID) (*types.RoomInfo, error)
 	// IsEventRejected returns true if the event is known and rejected.
 	IsEventRejected(ctx context.Context, roomNID types.RoomNID, eventID string) (rejected bool, err error)
-	MissingAuthPrevEvents(ctx context.Context, e *gomatrixserverlib.Event) (missingAuth, missingPrev []string, err error)
+	MissingAuthPrevEvents(ctx context.Context, e gomatrixserverlib.PDU) (missingAuth, missingPrev []string, err error)
 	UpgradeRoom(ctx context.Context, oldRoomID, newRoomID, eventSender string) error
 	GetRoomUpdater(ctx context.Context, roomInfo *types.RoomInfo) (*shared.RoomUpdater, error)
 	GetMembershipEventNIDsForRoom(ctx context.Context, roomNID types.RoomNID, joinOnly bool, localOnly bool) ([]types.EventNID, error)
@@ -228,7 +228,7 @@ type EventDatabase interface {
 	// MaybeRedactEvent returns the redaction event and the redacted event if this call resulted in a redaction, else an error
 	// (nil if there was nothing to do)
 	MaybeRedactEvent(
-		ctx context.Context, roomInfo *types.RoomInfo, eventNID types.EventNID, event *gomatrixserverlib.Event, plResolver state.PowerLevelResolver,
-	) (*gomatrixserverlib.Event, *gomatrixserverlib.Event, error)
+		ctx context.Context, roomInfo *types.RoomInfo, eventNID types.EventNID, event gomatrixserverlib.PDU, plResolver state.PowerLevelResolver,
+	) (gomatrixserverlib.PDU, gomatrixserverlib.PDU, error)
 	StoreEvent(ctx context.Context, event gomatrixserverlib.PDU, roomInfo *types.RoomInfo, eventTypeNID types.EventTypeNID, eventStateKeyNID types.EventStateKeyNID, authEventNIDs []types.EventNID, isRejected bool) (types.EventNID, types.StateAtEvent, error)
 }

--- a/roomserver/storage/postgres/state_snapshot_table.go
+++ b/roomserver/storage/postgres/state_snapshot_table.go
@@ -242,7 +242,7 @@ func (s *stateSnapshotStatements) BulkSelectMembershipForHistoryVisibility(
 			// not fatal
 			continue
 		}
-		he := &types.HeaderedEvent{Event: event}
+		he := &types.HeaderedEvent{PDU: event}
 		result[eventID] = he
 		knownEvents[membershipEventID] = he
 	}

--- a/roomserver/types/types.go
+++ b/roomserver/types/types.go
@@ -228,7 +228,7 @@ func (s StateAtEventAndReferences) EventIDs() string {
 // It is when performing bulk event lookup in the database.
 type Event struct {
 	EventNID EventNID
-	*gomatrixserverlib.Event
+	gomatrixserverlib.PDU
 }
 
 const (

--- a/setup/mscs/msc2836/msc2836.go
+++ b/setup/mscs/msc2836/msc2836.go
@@ -89,8 +89,8 @@ type EventRelationshipResponse struct {
 
 type MSC2836EventRelationshipsResponse struct {
 	fclient.MSC2836EventRelationshipsResponse
-	ParsedEvents    []*gomatrixserverlib.Event
-	ParsedAuthChain []*gomatrixserverlib.Event
+	ParsedEvents    []gomatrixserverlib.PDU
+	ParsedAuthChain []gomatrixserverlib.PDU
 }
 
 func toClientResponse(res *MSC2836EventRelationshipsResponse) *EventRelationshipResponse {
@@ -306,11 +306,11 @@ func (rc *reqCtx) process() (*MSC2836EventRelationshipsResponse, *util.JSONRespo
 		)
 		returnEvents = append(returnEvents, events...)
 	}
-	res.ParsedEvents = make([]*gomatrixserverlib.Event, len(returnEvents))
+	res.ParsedEvents = make([]gomatrixserverlib.PDU, len(returnEvents))
 	for i, ev := range returnEvents {
 		// for each event, extract the children_count | hash and add it as unsigned data.
 		rc.addChildMetadata(ev)
-		res.ParsedEvents[i] = ev.Event
+		res.ParsedEvents[i] = ev.PDU
 	}
 	res.Limited = remaining == 0 || walkLimited
 	return &res, nil
@@ -373,7 +373,7 @@ func (rc *reqCtx) fetchUnknownEvent(eventID, roomID string) *types.HeaderedEvent
 		rc.injectResponseToRoomserver(res)
 		for _, ev := range res.ParsedEvents {
 			if ev.EventID() == eventID {
-				return &types.HeaderedEvent{Event: ev}
+				return &types.HeaderedEvent{PDU: ev}
 			}
 		}
 	}
@@ -603,7 +603,7 @@ func (rc *reqCtx) lookForEvent(eventID string) *types.HeaderedEvent {
 			rc.injectResponseToRoomserver(queryRes)
 			for _, ev := range queryRes.ParsedEvents {
 				if ev.EventID() == eventID && rc.req.RoomID == ev.RoomID() {
-					return &types.HeaderedEvent{Event: ev}
+					return &types.HeaderedEvent{PDU: ev}
 				}
 			}
 		}
@@ -665,7 +665,7 @@ func (rc *reqCtx) injectResponseToRoomserver(res *MSC2836EventRelationshipsRespo
 	for _, outlier := range append(eventsInOrder, messageEvents...) {
 		ires = append(ires, roomserver.InputRoomEvent{
 			Kind:  roomserver.KindOutlier,
-			Event: &types.HeaderedEvent{Event: outlier.(*gomatrixserverlib.Event)},
+			Event: &types.HeaderedEvent{PDU: outlier},
 		})
 	}
 	// we've got the data by this point so use a background context

--- a/setup/mscs/msc2836/msc2836_test.go
+++ b/setup/mscs/msc2836/msc2836_test.go
@@ -602,6 +602,6 @@ func mustCreateEvent(t *testing.T, ev fledglingEvent) (result *types.HeaderedEve
 	if err != nil {
 		t.Fatalf("mustCreateEvent: failed to sign event: %s", err)
 	}
-	h := &types.HeaderedEvent{Event: signedEvent}
+	h := &types.HeaderedEvent{PDU: signedEvent}
 	return h
 }

--- a/setup/mscs/msc2946/msc2946.go
+++ b/setup/mscs/msc2946/msc2946.go
@@ -693,7 +693,7 @@ func (w *walker) childReferences(roomID string) ([]fclient.MSC2946StrippedEvent,
 		// else we'll incorrectly walk redacted events (as the link
 		// is in the state_key)
 		if content.Get("via").Exists() {
-			strip := stripped(ev.Event)
+			strip := stripped(ev.PDU)
 			if strip == nil {
 				continue
 			}
@@ -723,7 +723,7 @@ func (s set) isSet(val string) bool {
 	return ok
 }
 
-func stripped(ev *gomatrixserverlib.Event) *fclient.MSC2946StrippedEvent {
+func stripped(ev gomatrixserverlib.PDU) *fclient.MSC2946StrippedEvent {
 	if ev.StateKey() == nil {
 		return nil
 	}

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -526,7 +526,7 @@ func (s *OutputRoomEventConsumer) updateStateEvent(event *rstypes.HeaderedEvent)
 		PrevSender:    prevEvent.Sender(),
 	}
 
-	event.Event, err = event.SetUnsigned(prev)
+	event.PDU, err = event.SetUnsigned(prev)
 	succeeded = true
 	return event, err
 }

--- a/syncapi/routing/relations.go
+++ b/syncapi/routing/relations.go
@@ -113,7 +113,7 @@ func Relations(
 	for _, event := range filteredEvents {
 		res.Chunk = append(
 			res.Chunk,
-			synctypes.ToClientEvent(event.Event, synctypes.FormatAll),
+			synctypes.ToClientEvent(event.PDU, synctypes.FormatAll),
 		)
 	}
 

--- a/syncapi/storage/shared/storage_consumer.go
+++ b/syncapi/storage/shared/storage_consumer.go
@@ -352,13 +352,13 @@ func (d *Database) RedactEvent(ctx context.Context, redactedEventID string, reda
 		logrus.WithField("event_id", redactedEventID).WithField("redaction_event", redactedBecause.EventID()).Warnf("missing redacted event for redaction")
 		return nil
 	}
-	eventToRedact := redactedEvents[0].Event
-	redactionEvent := redactedBecause.Event
+	eventToRedact := redactedEvents[0].PDU
+	redactionEvent := redactedBecause.PDU
 	if err = eventutil.RedactEvent(redactionEvent, eventToRedact); err != nil {
 		return err
 	}
 
-	newEvent := &rstypes.HeaderedEvent{Event: eventToRedact}
+	newEvent := &rstypes.HeaderedEvent{PDU: eventToRedact}
 	err = d.Writer.Do(d.DB, nil, func(txn *sql.Tx) error {
 		return d.OutputEvents.UpdateEventJSON(ctx, txn, newEvent)
 	})
@@ -493,7 +493,7 @@ func (d *Database) CleanSendToDeviceUpdates(
 
 // getMembershipFromEvent returns the value of content.membership iff the event is a state event
 // with type 'm.room.member' and state_key of userID. Otherwise, an empty string is returned.
-func getMembershipFromEvent(ev *gomatrixserverlib.Event, userID string) (string, string) {
+func getMembershipFromEvent(ev gomatrixserverlib.PDU, userID string) (string, string) {
 	if ev.Type() != "m.room.member" || !ev.StateKeyEquals(userID) {
 		return "", ""
 	}

--- a/syncapi/storage/shared/storage_sync.go
+++ b/syncapi/storage/shared/storage_sync.go
@@ -429,7 +429,7 @@ func (d *DatabaseTransaction) GetStateDeltas(
 		for _, ev := range stateStreamEvents {
 			// Look for our membership in the state events and skip over any
 			// membership events that are not related to us.
-			membership, prevMembership := getMembershipFromEvent(ev.Event, userID)
+			membership, prevMembership := getMembershipFromEvent(ev.PDU, userID)
 			if membership == "" {
 				continue
 			}
@@ -555,7 +555,7 @@ func (d *DatabaseTransaction) GetStateDeltasForFullStateSync(
 
 	for roomID, stateStreamEvents := range state {
 		for _, ev := range stateStreamEvents {
-			if membership, _ := getMembershipFromEvent(ev.Event, userID); membership != "" {
+			if membership, _ := getMembershipFromEvent(ev.PDU, userID); membership != "" {
 				if membership != spec.Join { // We've already added full state for all joined rooms above.
 					deltas[roomID] = types.StateDelta{
 						Membership:    membership,

--- a/syncapi/types/types.go
+++ b/syncapi/types/types.go
@@ -552,7 +552,7 @@ func NewInviteResponse(event *types.HeaderedEvent) *InviteResponse {
 
 	// Then we'll see if we can create a partial of the invite event itself.
 	// This is needed for clients to work out *who* sent the invite.
-	inviteEvent := synctypes.ToClientEvent(event.Event, synctypes.FormatSync)
+	inviteEvent := synctypes.ToClientEvent(event.PDU, synctypes.FormatSync)
 	inviteEvent.Unsigned = nil
 	if ev, err := json.Marshal(inviteEvent); err == nil {
 		res.InviteState.Events = append(res.InviteState.Events, ev)

--- a/syncapi/types/types_test.go
+++ b/syncapi/types/types_test.go
@@ -56,7 +56,7 @@ func TestNewInviteResponse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	res := NewInviteResponse(&types.HeaderedEvent{Event: ev})
+	res := NewInviteResponse(&types.HeaderedEvent{PDU: ev})
 	j, err := json.Marshal(res)
 	if err != nil {
 		t.Fatal(err)

--- a/test/room.go
+++ b/test/room.go
@@ -204,7 +204,7 @@ func (r *Room) CreateEvent(t *testing.T, creator *User, eventType string, conten
 	if err = gomatrixserverlib.Allowed(ev, &r.authEvents); err != nil {
 		t.Fatalf("CreateEvent[%s]: failed to verify event was allowed: %s", eventType, err)
 	}
-	headeredEvent := &rstypes.HeaderedEvent{Event: ev}
+	headeredEvent := &rstypes.HeaderedEvent{PDU: ev}
 	headeredEvent.Visibility = r.visibility
 	return headeredEvent
 }
@@ -215,7 +215,7 @@ func (r *Room) InsertEvent(t *testing.T, he *rstypes.HeaderedEvent) {
 	// Add the event to the list of auth/state events
 	r.events = append(r.events, he)
 	if he.StateKey() != nil {
-		err := r.authEvents.AddEvent(he.Event)
+		err := r.authEvents.AddEvent(he.PDU)
 		if err != nil {
 			t.Fatalf("InsertEvent: failed to add event to auth events: %s", err)
 		}

--- a/userapi/consumers/roomserver.go
+++ b/userapi/consumers/roomserver.go
@@ -650,7 +650,7 @@ func (s *OutputRoomEventConsumer) evaluatePushRules(ctx context.Context, event *
 		roomSize: roomSize,
 	}
 	eval := pushrules.NewRuleSetEvaluator(ec, &ruleSets.Global)
-	rule, err := eval.MatchEvent(event.Event)
+	rule, err := eval.MatchEvent(event.PDU)
 	if err != nil {
 		return nil, err
 	}
@@ -698,7 +698,7 @@ func (rse *ruleSetEvalContext) HasPowerLevel(userID, levelKey string) (bool, err
 			continue
 		}
 
-		plc, err := gomatrixserverlib.NewPowerLevelContentFromEvent(ev.Event)
+		plc, err := gomatrixserverlib.NewPowerLevelContentFromEvent(ev.PDU)
 		if err != nil {
 			return false, err
 		}

--- a/userapi/consumers/roomserver_test.go
+++ b/userapi/consumers/roomserver_test.go
@@ -41,7 +41,7 @@ func mustCreateEvent(t *testing.T, content string) *types.HeaderedEvent {
 	if err != nil {
 		t.Fatalf("failed to create event: %v", err)
 	}
-	return &types.HeaderedEvent{Event: ev}
+	return &types.HeaderedEvent{PDU: ev}
 }
 
 func Test_evaluatePushRules(t *testing.T) {


### PR DESCRIPTION
Requires https://github.com/matrix-org/gomatrixserverlib/pull/376

This has numerous upsides:
 - Less type casting to `*Event` is required.
 - Making Dendrite work with `PDU` interfaces means we can swap out Event impls more easily.
 - Tests which represent weird event shapes are easier to write.

Part of a series of refactors on GMSL.