### PR TITLE
Use ProtoEvent where needed instead of EventBuilder

### DIFF
--- a/clientapi/routing/membership.go
+++ b/clientapi/routing/membership.go
@@ -313,7 +313,7 @@ func buildMembershipEvent(
 		return nil, err
 	}
 
-	builder := gomatrixserverlib.EventBuilder{
+	proto := gomatrixserverlib.ProtoEvent{
 		Sender:   device.UserID,
 		RoomID:   roomID,
 		Type:     "m.room.member",
@@ -328,7 +328,7 @@ func buildMembershipEvent(
 		IsDirect:    isDirect,
 	}
 
-	if err = builder.SetContent(content); err != nil {
+	if err = proto.SetContent(content); err != nil {
 		return nil, err
 	}
 
@@ -337,7 +337,7 @@ func buildMembershipEvent(
 		return nil, err
 	}
 
-	return eventutil.QueryAndBuildEvent(ctx, &builder, cfg.Matrix, identity, evTime, rsAPI, nil)
+	return eventutil.QueryAndBuildEvent(ctx, &proto, cfg.Matrix, identity, evTime, rsAPI, nil)
 }
 
 // loadProfile lookups the profile of a given user from the database and returns

--- a/clientapi/routing/profile.go
+++ b/clientapi/routing/profile.go
@@ -339,7 +339,7 @@ func buildMembershipEvents(
 	evs := []*types.HeaderedEvent{}
 
 	for _, roomID := range roomIDs {
-		builder := gomatrixserverlib.EventBuilder{
+		proto := gomatrixserverlib.ProtoEvent{
 			Sender:   userID,
 			RoomID:   roomID,
 			Type:     "m.room.member",
@@ -353,7 +353,7 @@ func buildMembershipEvents(
 		content.DisplayName = newProfile.DisplayName
 		content.AvatarURL = newProfile.AvatarURL
 
-		if err := builder.SetContent(content); err != nil {
+		if err := proto.SetContent(content); err != nil {
 			return nil, err
 		}
 
@@ -362,7 +362,7 @@ func buildMembershipEvents(
 			return nil, err
 		}
 
-		event, err := eventutil.QueryAndBuildEvent(ctx, &builder, cfg.Matrix, identity, evTime, rsAPI, nil)
+		event, err := eventutil.QueryAndBuildEvent(ctx, &proto, cfg.Matrix, identity, evTime, rsAPI, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/clientapi/routing/redaction.go
+++ b/clientapi/routing/redaction.go
@@ -113,15 +113,15 @@ func SendRedaction(
 	}
 
 	// create the new event and set all the fields we can
-	builder := gomatrixserverlib.EventBuilder{
+	proto := gomatrixserverlib.ProtoEvent{
 		Sender:  device.UserID,
 		RoomID:  roomID,
 		Type:    spec.MRoomRedaction,
 		Redacts: eventID,
 	}
-	err := builder.SetContent(r)
+	err := proto.SetContent(r)
 	if err != nil {
-		util.GetLogger(req.Context()).WithError(err).Error("builder.SetContent failed")
+		util.GetLogger(req.Context()).WithError(err).Error("proto.SetContent failed")
 		return jsonerror.InternalServerError()
 	}
 
@@ -131,7 +131,7 @@ func SendRedaction(
 	}
 
 	var queryRes roomserverAPI.QueryLatestEventsAndStateResponse
-	e, err := eventutil.QueryAndBuildEvent(req.Context(), &builder, cfg.Matrix, identity, time.Now(), rsAPI, &queryRes)
+	e, err := eventutil.QueryAndBuildEvent(req.Context(), &proto, cfg.Matrix, identity, time.Now(), rsAPI, &queryRes)
 	if err == eventutil.ErrRoomNoExists {
 		return util.JSONResponse{
 			Code: http.StatusNotFound,

--- a/clientapi/routing/sendevent.go
+++ b/clientapi/routing/sendevent.go
@@ -264,15 +264,15 @@ func generateSendEvent(
 	userID := device.UserID
 
 	// create the new event and set all the fields we can
-	builder := gomatrixserverlib.EventBuilder{
+	proto := gomatrixserverlib.ProtoEvent{
 		Sender:   userID,
 		RoomID:   roomID,
 		Type:     eventType,
 		StateKey: stateKey,
 	}
-	err := builder.SetContent(r)
+	err := proto.SetContent(r)
 	if err != nil {
-		util.GetLogger(ctx).WithError(err).Error("builder.SetContent failed")
+		util.GetLogger(ctx).WithError(err).Error("proto.SetContent failed")
 		resErr := jsonerror.InternalServerError()
 		return nil, &resErr
 	}
@@ -284,7 +284,7 @@ func generateSendEvent(
 	}
 
 	var queryRes api.QueryLatestEventsAndStateResponse
-	e, err := eventutil.QueryAndBuildEvent(ctx, &builder, cfg.Matrix, identity, evTime, rsAPI, &queryRes)
+	e, err := eventutil.QueryAndBuildEvent(ctx, &proto, cfg.Matrix, identity, evTime, rsAPI, &queryRes)
 	if err == eventutil.ErrRoomNoExists {
 		return nil, &util.JSONResponse{
 			Code: http.StatusNotFound,

--- a/clientapi/threepid/invites.go
+++ b/clientapi/threepid/invites.go
@@ -335,7 +335,7 @@ func emit3PIDInviteEvent(
 	rsAPI api.ClientRoomserverAPI,
 	evTime time.Time,
 ) error {
-	builder := &gomatrixserverlib.EventBuilder{
+	proto := &gomatrixserverlib.ProtoEvent{
 		Sender:   device.UserID,
 		RoomID:   roomID,
 		Type:     "m.room.third_party_invite",
@@ -350,7 +350,7 @@ func emit3PIDInviteEvent(
 		PublicKeys:     res.PublicKeys,
 	}
 
-	if err := builder.SetContent(content); err != nil {
+	if err := proto.SetContent(content); err != nil {
 		return err
 	}
 
@@ -360,7 +360,7 @@ func emit3PIDInviteEvent(
 	}
 
 	queryRes := api.QueryLatestEventsAndStateResponse{}
-	event, err := eventutil.QueryAndBuildEvent(ctx, builder, cfg.Matrix, identity, evTime, rsAPI, &queryRes)
+	event, err := eventutil.QueryAndBuildEvent(ctx, proto, cfg.Matrix, identity, evTime, rsAPI, &queryRes)
 	if err != nil {
 		return err
 	}

--- a/federationapi/federationapi_test.go
+++ b/federationapi/federationapi_test.go
@@ -113,7 +113,7 @@ func (f *fedClient) MakeJoin(ctx context.Context, origin, s spec.ServerName, roo
 	for _, r := range f.allowJoins {
 		if r.ID == roomID {
 			res.RoomVersion = r.Version
-			res.JoinEvent = gomatrixserverlib.EventBuilder{
+			res.JoinEvent = gomatrixserverlib.ProtoEvent{
 				Sender:     userID,
 				RoomID:     roomID,
 				Type:       "m.room.member",
@@ -122,7 +122,7 @@ func (f *fedClient) MakeJoin(ctx context.Context, origin, s spec.ServerName, roo
 				PrevEvents: r.ForwardExtremities(),
 			}
 			var needed gomatrixserverlib.StateNeeded
-			needed, err = gomatrixserverlib.StateNeededForEventBuilder(&res.JoinEvent)
+			needed, err = gomatrixserverlib.StateNeededForProtoEvent(&res.JoinEvent)
 			if err != nil {
 				f.t.Errorf("StateNeededForEventBuilder: %v", err)
 				return

--- a/federationapi/routing/join.go
+++ b/federationapi/routing/join.go
@@ -118,7 +118,7 @@ func MakeJoin(
 	}
 
 	// Try building an event for the server
-	builder := gomatrixserverlib.EventBuilder{
+	proto := gomatrixserverlib.ProtoEvent{
 		Sender:   userID,
 		RoomID:   roomID,
 		Type:     "m.room.member",
@@ -128,7 +128,7 @@ func MakeJoin(
 		Membership:    spec.Join,
 		AuthorisedVia: authorisedVia,
 	}
-	if err = builder.SetContent(content); err != nil {
+	if err = proto.SetContent(content); err != nil {
 		util.GetLogger(httpReq.Context()).WithError(err).Error("builder.SetContent failed")
 		return jsonerror.InternalServerError()
 	}
@@ -146,7 +146,7 @@ func MakeJoin(
 	queryRes := api.QueryLatestEventsAndStateResponse{
 		RoomVersion: roomVersion,
 	}
-	event, err := eventutil.QueryAndBuildEvent(httpReq.Context(), &builder, cfg.Matrix, identity, time.Now(), rsAPI, &queryRes)
+	event, err := eventutil.QueryAndBuildEvent(httpReq.Context(), &proto, cfg.Matrix, identity, time.Now(), rsAPI, &queryRes)
 	if err == eventutil.ErrRoomNoExists {
 		return util.JSONResponse{
 			Code: http.StatusNotFound,
@@ -179,7 +179,7 @@ func MakeJoin(
 	return util.JSONResponse{
 		Code: http.StatusOK,
 		JSON: map[string]interface{}{
-			"event":        builder,
+			"event":        proto,
 			"room_version": roomVersion,
 		},
 	}

--- a/federationapi/routing/leave.go
+++ b/federationapi/routing/leave.go
@@ -52,15 +52,15 @@ func MakeLeave(
 	}
 
 	// Try building an event for the server
-	builder := gomatrixserverlib.EventBuilder{
+	proto := gomatrixserverlib.ProtoEvent{
 		Sender:   userID,
 		RoomID:   roomID,
 		Type:     "m.room.member",
 		StateKey: &userID,
 	}
-	err = builder.SetContent(map[string]interface{}{"membership": spec.Leave})
+	err = proto.SetContent(map[string]interface{}{"membership": spec.Leave})
 	if err != nil {
-		util.GetLogger(httpReq.Context()).WithError(err).Error("builder.SetContent failed")
+		util.GetLogger(httpReq.Context()).WithError(err).Error("proto.SetContent failed")
 		return jsonerror.InternalServerError()
 	}
 
@@ -75,7 +75,7 @@ func MakeLeave(
 	}
 
 	var queryRes api.QueryLatestEventsAndStateResponse
-	event, err := eventutil.QueryAndBuildEvent(httpReq.Context(), &builder, cfg.Matrix, identity, time.Now(), rsAPI, &queryRes)
+	event, err := eventutil.QueryAndBuildEvent(httpReq.Context(), &proto, cfg.Matrix, identity, time.Now(), rsAPI, &queryRes)
 	if err == eventutil.ErrRoomNoExists {
 		return util.JSONResponse{
 			Code: http.StatusNotFound,
@@ -126,7 +126,7 @@ func MakeLeave(
 		Code: http.StatusOK,
 		JSON: map[string]interface{}{
 			"room_version": event.Version(),
-			"event":        builder,
+			"event":        proto,
 		},
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/matrix-org/dugong v0.0.0-20210921133753-66e6b1c67e2e
 	github.com/matrix-org/go-sqlite3-js v0.0.0-20220419092513-28aa791a1c91
 	github.com/matrix-org/gomatrix v0.0.0-20220926102614-ceba4d9f7530
-	github.com/matrix-org/gomatrixserverlib v0.0.0-20230503081352-9e29bff996eb
+	github.com/matrix-org/gomatrixserverlib v0.0.0-20230504085954-69034410deb1
 	github.com/matrix-org/pinecone v0.11.1-0.20230210171230-8c3b24f2649a
 	github.com/matrix-org/util v0.0.0-20221111132719-399730281e66
 	github.com/mattn/go-sqlite3 v1.14.16

--- a/go.sum
+++ b/go.sum
@@ -333,6 +333,8 @@ github.com/matrix-org/gomatrixserverlib v0.0.0-20230502133856-ad26780a085c h1:5x
 github.com/matrix-org/gomatrixserverlib v0.0.0-20230502133856-ad26780a085c/go.mod h1:7HTbSZe+CIdmeqVyFMekwD5dFU8khWQyngKATvd12FU=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20230503081352-9e29bff996eb h1:qg9iR39ctvB7A4hBcddjxmHQO/t3y4mpQnpmEc3xvNI=
 github.com/matrix-org/gomatrixserverlib v0.0.0-20230503081352-9e29bff996eb/go.mod h1:7HTbSZe+CIdmeqVyFMekwD5dFU8khWQyngKATvd12FU=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20230504085954-69034410deb1 h1:K0wM4rUNdqzWVQ54am8IeQn1q6f03sTNvhUW+ZaK1Zs=
+github.com/matrix-org/gomatrixserverlib v0.0.0-20230504085954-69034410deb1/go.mod h1:7HTbSZe+CIdmeqVyFMekwD5dFU8khWQyngKATvd12FU=
 github.com/matrix-org/pinecone v0.11.1-0.20230210171230-8c3b24f2649a h1:awrPDf9LEFySxTLKYBMCiObelNx/cBuv/wzllvCCH3A=
 github.com/matrix-org/pinecone v0.11.1-0.20230210171230-8c3b24f2649a/go.mod h1:HchJX9oKMXaT2xYFs0Ha/6Zs06mxLU8k6F1ODnrGkeQ=
 github.com/matrix-org/util v0.0.0-20221111132719-399730281e66 h1:6z4KxomXSIGWqhHcfzExgkH3Z3UkIXry4ibJS4Aqz2Y=

--- a/roomserver/internal/alias.go
+++ b/roomserver/internal/alias.go
@@ -187,7 +187,7 @@ func (r *RoomserverInternalAPI) RemoveRoomAlias(
 				return err
 			}
 
-			builder := &gomatrixserverlib.EventBuilder{
+			proto := &gomatrixserverlib.ProtoEvent{
 				Sender:   sender,
 				RoomID:   ev.RoomID(),
 				Type:     ev.Type(),
@@ -195,7 +195,7 @@ func (r *RoomserverInternalAPI) RemoveRoomAlias(
 				Content:  res,
 			}
 
-			eventsNeeded, err := gomatrixserverlib.StateNeededForEventBuilder(builder)
+			eventsNeeded, err := gomatrixserverlib.StateNeededForProtoEvent(proto)
 			if err != nil {
 				return fmt.Errorf("gomatrixserverlib.StateNeededForEventBuilder: %w", err)
 			}
@@ -208,7 +208,7 @@ func (r *RoomserverInternalAPI) RemoveRoomAlias(
 				return err
 			}
 
-			newEvent, err := eventutil.BuildEvent(ctx, builder, &r.Cfg.Global, identity, time.Now(), &eventsNeeded, stateRes)
+			newEvent, err := eventutil.BuildEvent(ctx, proto, &r.Cfg.Global, identity, time.Now(), &eventsNeeded, stateRes)
 			if err != nil {
 				return err
 			}

--- a/roomserver/internal/input/input_events.go
+++ b/roomserver/internal/input/input_events.go
@@ -852,7 +852,7 @@ func (r *Inputer) kickGuests(ctx context.Context, event gomatrixserverlib.PDU, r
 		memberContent.Membership = spec.Leave
 
 		stateKey := *memberEvent.StateKey()
-		fledglingEvent := &gomatrixserverlib.EventBuilder{
+		fledglingEvent := &gomatrixserverlib.ProtoEvent{
 			RoomID:     event.RoomID(),
 			Type:       spec.MRoomMember,
 			StateKey:   &stateKey,
@@ -864,7 +864,7 @@ func (r *Inputer) kickGuests(ctx context.Context, event gomatrixserverlib.PDU, r
 			return err
 		}
 
-		eventsNeeded, err := gomatrixserverlib.StateNeededForEventBuilder(fledglingEvent)
+		eventsNeeded, err := gomatrixserverlib.StateNeededForProtoEvent(fledglingEvent)
 		if err != nil {
 			return err
 		}

--- a/roomserver/internal/perform/perform_admin.go
+++ b/roomserver/internal/perform/perform_admin.go
@@ -92,7 +92,7 @@ func (r *Admin) PerformAdminEvacuateRoom(
 		memberContent.Membership = spec.Leave
 
 		stateKey := *memberEvent.StateKey()
-		fledglingEvent := &gomatrixserverlib.EventBuilder{
+		fledglingEvent := &gomatrixserverlib.ProtoEvent{
 			RoomID:     roomID,
 			Type:       spec.MRoomMember,
 			StateKey:   &stateKey,
@@ -109,7 +109,7 @@ func (r *Admin) PerformAdminEvacuateRoom(
 			return nil, err
 		}
 
-		eventsNeeded, err = gomatrixserverlib.StateNeededForEventBuilder(fledglingEvent)
+		eventsNeeded, err = gomatrixserverlib.StateNeededForProtoEvent(fledglingEvent)
 		if err != nil {
 			return nil, err
 		}
@@ -283,16 +283,16 @@ func (r *Admin) PerformAdminDownloadState(
 		stateIDs = append(stateIDs, stateEvent.EventID())
 	}
 
-	builder := &gomatrixserverlib.EventBuilder{
+	proto := &gomatrixserverlib.ProtoEvent{
 		Type:    "org.matrix.dendrite.state_download",
 		Sender:  userID,
 		RoomID:  roomID,
 		Content: spec.RawJSON("{}"),
 	}
 
-	eventsNeeded, err := gomatrixserverlib.StateNeededForEventBuilder(builder)
+	eventsNeeded, err := gomatrixserverlib.StateNeededForProtoEvent(proto)
 	if err != nil {
-		return fmt.Errorf("gomatrixserverlib.StateNeededForEventBuilder: %w", err)
+		return fmt.Errorf("gomatrixserverlib.StateNeededForProtoEvent: %w", err)
 	}
 
 	queryRes := &api.QueryLatestEventsAndStateResponse{
@@ -308,7 +308,7 @@ func (r *Admin) PerformAdminDownloadState(
 		return err
 	}
 
-	ev, err := eventutil.BuildEvent(ctx, builder, r.Cfg.Matrix, identity, time.Now(), &eventsNeeded, queryRes)
+	ev, err := eventutil.BuildEvent(ctx, proto, r.Cfg.Matrix, identity, time.Now(), &eventsNeeded, queryRes)
 	if err != nil {
 		return fmt.Errorf("eventutil.BuildEvent: %w", err)
 	}

--- a/roomserver/internal/perform/perform_join.go
+++ b/roomserver/internal/perform/perform_join.go
@@ -180,14 +180,14 @@ func (r *Joiner) performJoinRoomByID(
 	if err != nil {
 		return "", "", rsAPI.ErrInvalidID{Err: fmt.Errorf("user ID %q is invalid: %w", userID, err)}
 	}
-	eb := gomatrixserverlib.EventBuilder{
+	proto := gomatrixserverlib.ProtoEvent{
 		Type:     spec.MRoomMember,
 		Sender:   userID,
 		StateKey: &userID,
 		RoomID:   req.RoomIDOrAlias,
 		Redacts:  "",
 	}
-	if err = eb.SetUnsigned(struct{}{}); err != nil {
+	if err = proto.SetUnsigned(struct{}{}); err != nil {
 		return "", "", fmt.Errorf("eb.SetUnsigned: %w", err)
 	}
 
@@ -203,7 +203,7 @@ func (r *Joiner) performJoinRoomByID(
 	} else if authorisedVia != "" {
 		req.Content["join_authorised_via_users_server"] = authorisedVia
 	}
-	if err = eb.SetContent(req.Content); err != nil {
+	if err = proto.SetContent(req.Content); err != nil {
 		return "", "", fmt.Errorf("eb.SetContent: %w", err)
 	}
 
@@ -284,7 +284,7 @@ func (r *Joiner) performJoinRoomByID(
 	if err != nil {
 		return "", "", fmt.Errorf("error joining local room: %q", err)
 	}
-	event, err := eventutil.QueryAndBuildEvent(ctx, &eb, r.Cfg.Matrix, identity, time.Now(), r.RSAPI, &buildRes)
+	event, err := eventutil.QueryAndBuildEvent(ctx, &proto, r.Cfg.Matrix, identity, time.Now(), r.RSAPI, &buildRes)
 
 	switch err {
 	case nil:

--- a/roomserver/internal/perform/perform_leave.go
+++ b/roomserver/internal/perform/perform_leave.go
@@ -154,24 +154,24 @@ func (r *Leaver) performLeaveRoomByID(
 
 	// Prepare the template for the leave event.
 	userID := req.UserID
-	eb := gomatrixserverlib.EventBuilder{
+	proto := gomatrixserverlib.ProtoEvent{
 		Type:     spec.MRoomMember,
 		Sender:   userID,
 		StateKey: &userID,
 		RoomID:   req.RoomID,
 		Redacts:  "",
 	}
-	if err = eb.SetContent(map[string]interface{}{"membership": "leave"}); err != nil {
+	if err = proto.SetContent(map[string]interface{}{"membership": "leave"}); err != nil {
 		return nil, fmt.Errorf("eb.SetContent: %w", err)
 	}
-	if err = eb.SetUnsigned(struct{}{}); err != nil {
+	if err = proto.SetUnsigned(struct{}{}); err != nil {
 		return nil, fmt.Errorf("eb.SetUnsigned: %w", err)
 	}
 
 	// Get the sender domain.
-	_, senderDomain, serr := r.Cfg.Matrix.SplitLocalID('@', eb.Sender)
+	_, senderDomain, serr := r.Cfg.Matrix.SplitLocalID('@', proto.Sender)
 	if serr != nil {
-		return nil, fmt.Errorf("sender %q is invalid", eb.Sender)
+		return nil, fmt.Errorf("sender %q is invalid", proto.Sender)
 	}
 
 	// We know that the user is in the room at this point so let's build
@@ -184,7 +184,7 @@ func (r *Leaver) performLeaveRoomByID(
 	if err != nil {
 		return nil, fmt.Errorf("SigningIdentityFor: %w", err)
 	}
-	event, err := eventutil.QueryAndBuildEvent(ctx, &eb, r.Cfg.Matrix, identity, time.Now(), r.RSAPI, &buildRes)
+	event, err := eventutil.QueryAndBuildEvent(ctx, &proto, r.Cfg.Matrix, identity, time.Now(), r.RSAPI, &buildRes)
 	if err != nil {
 		return nil, fmt.Errorf("eventutil.QueryAndBuildEvent: %w", err)
 	}

--- a/roomserver/internal/perform/perform_upgrade.go
+++ b/roomserver/internal/perform/perform_upgrade.go
@@ -474,7 +474,8 @@ func (r *Upgrader) sendInitialEvents(ctx context.Context, evTime time.Time, user
 			proto.PrevEvents = []gomatrixserverlib.EventReference{builtEvents[i-1].EventReference()}
 		}
 
-		verImpl, err := gomatrixserverlib.GetRoomVersion(newVersion)
+		var verImpl gomatrixserverlib.IRoomVersion
+		verImpl, err = gomatrixserverlib.GetRoomVersion(newVersion)
 		if err != nil {
 			return err
 		}

--- a/roomserver/roomserver_test.go
+++ b/roomserver/roomserver_test.go
@@ -404,7 +404,7 @@ func mustCreateEvent(t *testing.T, ev fledglingEvent) (result *types.HeaderedEve
 	roomVer := gomatrixserverlib.RoomVersionV9
 	seed := make([]byte, ed25519.SeedSize) // zero seed
 	key := ed25519.NewKeyFromSeed(seed)
-	eb := gomatrixserverlib.EventBuilder{
+	eb := gomatrixserverlib.MustGetRoomVersion(roomVer).NewEventBuilderFromProtoEvent(&gomatrixserverlib.ProtoEvent{
 		Sender:     ev.Sender,
 		Type:       ev.Type,
 		StateKey:   ev.StateKey,
@@ -412,12 +412,13 @@ func mustCreateEvent(t *testing.T, ev fledglingEvent) (result *types.HeaderedEve
 		Redacts:    ev.Redacts,
 		Depth:      ev.Depth,
 		PrevEvents: ev.PrevEvents,
-	}
+	})
 	err := eb.SetContent(map[string]interface{}{})
 	if err != nil {
 		t.Fatalf("mustCreateEvent: failed to marshal event content %v", err)
 	}
-	signedEvent, err := eb.Build(time.Now(), "localhost", "ed25519:test", key, roomVer)
+
+	signedEvent, err := eb.Build(time.Now(), "localhost", "ed25519:test", key)
 	if err != nil {
 		t.Fatalf("mustCreateEvent: failed to sign event: %s", err)
 	}

--- a/setup/mscs/msc2836/msc2836_test.go
+++ b/setup/mscs/msc2836/msc2836_test.go
@@ -585,20 +585,20 @@ func mustCreateEvent(t *testing.T, ev fledglingEvent) (result *types.HeaderedEve
 	roomVer := gomatrixserverlib.RoomVersionV6
 	seed := make([]byte, ed25519.SeedSize) // zero seed
 	key := ed25519.NewKeyFromSeed(seed)
-	eb := gomatrixserverlib.EventBuilder{
+	eb := gomatrixserverlib.MustGetRoomVersion(roomVer).NewEventBuilderFromProtoEvent(&gomatrixserverlib.ProtoEvent{
 		Sender:   ev.Sender,
 		Depth:    999,
 		Type:     ev.Type,
 		StateKey: ev.StateKey,
 		RoomID:   ev.RoomID,
-	}
+	})
 	err := eb.SetContent(ev.Content)
 	if err != nil {
 		t.Fatalf("mustCreateEvent: failed to marshal event content %+v", ev.Content)
 	}
 	// make sure the origin_server_ts changes so we can test recency
 	time.Sleep(1 * time.Millisecond)
-	signedEvent, err := eb.Build(time.Now(), spec.ServerName("localhost"), "ed25519:test", key, roomVer)
+	signedEvent, err := eb.Build(time.Now(), spec.ServerName("localhost"), "ed25519:test", key)
 	if err != nil {
 		t.Fatalf("mustCreateEvent: failed to sign event: %s", err)
 	}


### PR DESCRIPTION
They are fundamentally different concepts, so should be represented as such. Proto events are exchanged in /make_xxx calls over federation, and made as "fledgling" events in /createRoom and general event sending. *Building* events is a reasonably complex VERSION SPECIFIC process which needs amongst other things, auth event providers, prev events, signing keys, etc.

Requires https://github.com/matrix-org/gomatrixserverlib/pull/379