### PR TITLE
Revamp furl to be more useful

### DIFF
--- a/cmd/furl/main.go
+++ b/cmd/furl/main.go
@@ -147,7 +147,8 @@ func main() {
 		if err != nil {
 			panic(err)
 		}
-		signedBytes, err := gomatrixserverlib.SignJSON(string(a.Origin), a.MatrixKeyID, a.MatrixKey, serverKeyBytes)
+		var signedBytes []byte
+		signedBytes, err = gomatrixserverlib.SignJSON(string(a.Origin), a.MatrixKeyID, a.MatrixKey, serverKeyBytes)
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/furl/main.go
+++ b/cmd/furl/main.go
@@ -142,7 +142,8 @@ func main() {
 				},
 			},
 		}
-		serverKeyBytes, err := json.Marshal(serverKey)
+		var serverKeyBytes []byte
+		serverKeyBytes, err = json.Marshal(serverKey)
 		if err != nil {
 			panic(err)
 		}
@@ -198,7 +199,7 @@ func main() {
 	)
 	if a.Data != nil {
 		var jsonData interface{}
-		if err := json.Unmarshal(a.Data, &jsonData); err != nil {
+		if err = json.Unmarshal(a.Data, &jsonData); err != nil {
 			fmt.Printf("Supplied data is not valid json: %s\n", err)
 			os.Exit(1)
 		}

--- a/cmd/furl/main.go
+++ b/cmd/furl/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"crypto/ed25519"
@@ -9,99 +8,194 @@ import (
 	"encoding/pem"
 	"flag"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
+	"strings"
+	"time"
 
+	"github.com/matrix-org/dendrite/test"
+	"github.com/matrix-org/gomatrix"
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 )
 
-var requestFrom = flag.String("from", "", "the server name that the request should originate from")
-var requestKey = flag.String("key", "matrix_key.pem", "the private key to use when signing the request")
-var requestPost = flag.Bool("post", false, "send a POST request instead of GET (pipe input into stdin or type followed by Ctrl-D)")
+var (
+	flagSkipVerify bool   //  -k, --insecure           Allow insecure server connections
+	flagMethod     string //  -X, --request <method>   Specify request method to use
+	flagData       string // -d, --data <data>        HTTP POST data
+
+	flagMatrixKey string
+	flagOrigin    string
+)
+
+func init() {
+	flag.BoolVar(&flagSkipVerify, "insecure", false, "Allow insecure server connections")
+	flag.BoolVar(&flagSkipVerify, "k", false, "Allow insecure server connections")
+
+	flag.StringVar(&flagMethod, "X", "GET", "Specify HTTP request method to use")
+	flag.StringVar(&flagMethod, "request", "GET", "Specify HTTP request method to use")
+
+	flag.StringVar(&flagData, "d", "", "HTTP JSON body data. If you start the data with the letter @, the rest should be a filename.")
+	flag.StringVar(&flagData, "data", "", "HTTP JSON body data. If you start the data with the letter @, the rest should be a filename.")
+
+	flag.StringVar(&flagMatrixKey, "M", "matrix_key.pem", "The private key to use when signing the request")
+	flag.StringVar(&flagMatrixKey, "key", "matrix_key.pem", "The private key to use when signing the request")
+
+	flag.StringVar(&flagOrigin, "O", "", "The server name that the request should originate from. The remote server will use this to request server keys. There MUST be a TLS listener at the .well-known address for this server name, i.e it needs to be pointing to a real homeserver. If blank, furl will self-host this on a random high numbered port, but only if the target is localhost. Use $PORT in request URLs/bodies to substitute the port number in.")
+	flag.StringVar(&flagOrigin, "origin", "", "The server name that the request should originate from. The remote server will use this to request server keys. There MUST be a TLS listener at the .well-known address for this server name, i.e it needs to be pointing to a real homeserver. If blank, furl will self-host this on a random high numbered port, but only if the target is localhost. Use $PORT in request URLs/bodies to substitute the port number in.")
+}
+
+type args struct {
+	SkipVerify  bool
+	Method      string
+	Data        []byte
+	MatrixKey   ed25519.PrivateKey
+	MatrixKeyID gomatrixserverlib.KeyID
+	Origin      spec.ServerName
+	SelfHostKey bool
+	TargetURL   *url.URL
+}
+
+func processArgs() (*args, error) {
+	if len(flag.Arg(0)) == 0 {
+		return nil, fmt.Errorf("furl [-k] [-X GET|PUT|POST|DELETE] [-d @filename|{\"inline\":\"json\"}] [-M matrix_key.pem] [-O localhost] https://federation-server.url/_matrix/.../")
+	}
+	targetURL, err := url.Parse(flag.Arg(0))
+	if err != nil {
+		return nil, fmt.Errorf("invalid url: %s", err)
+	}
+
+	// load .pem file
+	data, err := os.ReadFile(flagMatrixKey)
+	if err != nil {
+		return nil, err
+	}
+	keyBlock, _ := pem.Decode(data)
+	if keyBlock == nil {
+		return nil, fmt.Errorf("invalid pem file: %s", flagMatrixKey)
+	}
+	if keyBlock.Type != "MATRIX PRIVATE KEY" {
+		return nil, fmt.Errorf("pem file bad block type, want MATRIX PRIVATE KEY got %s", keyBlock.Type)
+	}
+	_, privateKey, err := ed25519.GenerateKey(bytes.NewReader(keyBlock.Bytes))
+	if err != nil {
+		return nil, err
+	}
+
+	var a args
+	a.MatrixKey = privateKey
+	a.MatrixKeyID = gomatrixserverlib.KeyID(keyBlock.Headers["Key-ID"])
+
+	a.SkipVerify = flagSkipVerify
+	a.Method = strings.ToUpper(flagMethod)
+	a.Origin = spec.ServerName(flagOrigin)
+	a.TargetURL = targetURL
+	a.SelfHostKey = a.Origin == "" && a.TargetURL.Hostname() == "localhost"
+
+	// load data
+	isFile := strings.HasPrefix(flagData, "@")
+	if isFile {
+		a.Data, err = os.ReadFile(flagData[1:])
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file '%s': %s", flagData[1:], err)
+		}
+	} else if len(flagData) > 0 {
+		a.Data = []byte(flagData)
+	}
+
+	return &a, nil
+}
 
 func main() {
 	flag.Parse()
-
-	if requestFrom == nil || *requestFrom == "" {
-		fmt.Println("expecting: furl -from origin.com [-key matrix_key.pem] https://path/to/url")
-		fmt.Println("supported flags:")
+	a, err := processArgs()
+	if err != nil {
+		fmt.Println(err.Error())
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
 
-	data, err := os.ReadFile(*requestKey)
-	if err != nil {
-		panic(err)
-	}
+	if a.SelfHostKey {
+		fmt.Printf("Self-hosting key...")
+		apiURL, cancel := test.ListenAndServe(tt{}, http.DefaultServeMux, true)
+		defer cancel()
+		parsedURL, _ := url.Parse(apiURL)
+		a.Origin = spec.ServerName(parsedURL.Host)
+		fmt.Printf(" OK on %s\n", a.Origin)
 
-	var privateKey ed25519.PrivateKey
-	keyBlock, _ := pem.Decode(data)
-	if keyBlock == nil {
-		panic("keyBlock is nil")
-	}
-	if keyBlock.Type == "MATRIX PRIVATE KEY" {
-		_, privateKey, err = ed25519.GenerateKey(bytes.NewReader(keyBlock.Bytes))
+		// handle the request when it comes in
+		pubKey := a.MatrixKey.Public().(ed25519.PublicKey)
+		serverKey := gomatrixserverlib.ServerKeyFields{
+			ServerName:   a.Origin,
+			ValidUntilTS: spec.AsTimestamp(time.Now().Add(2 * time.Minute)),
+			VerifyKeys: map[gomatrixserverlib.KeyID]gomatrixserverlib.VerifyKey{
+				a.MatrixKeyID: {
+					Key: spec.Base64Bytes(pubKey),
+				},
+			},
+		}
+		serverKeyBytes, err := json.Marshal(serverKey)
 		if err != nil {
 			panic(err)
 		}
-	} else {
-		panic("unexpected key block")
+		signedBytes, err := gomatrixserverlib.SignJSON(string(a.Origin), a.MatrixKeyID, a.MatrixKey, serverKeyBytes)
+		if err != nil {
+			panic(err)
+		}
+		resp := map[string]interface{}{
+			"server_keys": []json.RawMessage{signedBytes},
+		}
+		respBytes, err := json.Marshal(resp)
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf("Will return %s\n", string(respBytes))
+		http.HandleFunc("/_matrix/key/v2/query", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "POST" {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write(respBytes)
+		})
+
+		// replace anything with $PORT
+		port := parsedURL.Port()
+		a.TargetURL, err = url.Parse(strings.ReplaceAll(a.TargetURL.String(), "$PORT", port))
+		if err != nil {
+			panic(err)
+		}
 	}
 
-	serverName := spec.ServerName(*requestFrom)
 	client := fclient.NewFederationClient(
 		[]*fclient.SigningIdentity{
 			{
-				ServerName: serverName,
-				KeyID:      gomatrixserverlib.KeyID(keyBlock.Headers["Key-ID"]),
-				PrivateKey: privateKey,
+				ServerName: a.Origin,
+				KeyID:      a.MatrixKeyID,
+				PrivateKey: a.MatrixKey,
 			},
-		},
+		}, fclient.WithSkipVerify(a.SkipVerify),
 	)
-
-	u, err := url.Parse(flag.Arg(0))
-	if err != nil {
-		panic(err)
-	}
-
-	var bodyObj interface{}
-	var bodyBytes []byte
-	method := "GET"
-	if *requestPost {
-		method = "POST"
-		fmt.Println("Waiting for JSON input. Press Enter followed by Ctrl-D when done...")
-
-		scan := bufio.NewScanner(os.Stdin)
-		for scan.Scan() {
-			bytes := scan.Bytes()
-			bodyBytes = append(bodyBytes, bytes...)
-		}
-		fmt.Println("Done!")
-		if err = json.Unmarshal(bodyBytes, &bodyObj); err != nil {
-			panic(err)
-		}
-	}
 
 	req := fclient.NewFederationRequest(
-		method,
-		serverName,
-		spec.ServerName(u.Host),
-		u.RequestURI(),
+		a.Method,
+		a.Origin,
+		spec.ServerName(a.TargetURL.Host),
+		a.TargetURL.RequestURI(),
 	)
-
-	if *requestPost {
-		if err = req.SetContent(bodyObj); err != nil {
-			panic(err)
+	if a.Data != nil {
+		var jsonData interface{}
+		if err := json.Unmarshal(a.Data, &jsonData); err != nil {
+			fmt.Printf("Supplied data is not valid json: %s\n", err)
+			os.Exit(1)
+		}
+		if err = req.SetContent(jsonData); err != nil {
+			panic(err) // should be impossible as we just checked it was valid JSON
 		}
 	}
-
-	if err = req.Sign(
-		spec.ServerName(*requestFrom),
-		gomatrixserverlib.KeyID(keyBlock.Headers["Key-ID"]),
-		privateKey,
-	); err != nil {
+	if err = req.Sign(a.Origin, a.MatrixKeyID, a.MatrixKey); err != nil {
 		panic(err)
 	}
 
@@ -117,7 +211,15 @@ func main() {
 		&res,
 	)
 	if err != nil {
-		panic(err)
+		mxerr, ok := err.(gomatrix.HTTPError)
+		if ok {
+			fmt.Printf("Server returned HTTP %d\n", mxerr.Code)
+			fmt.Println(mxerr.Message)
+			fmt.Println(mxerr.WrappedError)
+		} else {
+			panic(err)
+		}
+		os.Exit(1)
 	}
 
 	j, err := json.MarshalIndent(res, "", "  ")
@@ -126,4 +228,20 @@ func main() {
 	}
 
 	fmt.Println(string(j))
+}
+
+type tt struct{}
+
+func (t tt) Logf(format string, args ...any) {
+	fmt.Printf(format+"\n", args...)
+}
+func (t tt) Errorf(format string, args ...any) {
+	fmt.Printf(format+"\n", args...)
+}
+func (t tt) Fatalf(format string, args ...any) {
+	fmt.Printf(format+"\n", args...)
+	os.Exit(2)
+}
+func (t tt) TempDir() string {
+	return os.TempDir()
 }

--- a/federationapi/federationapi_test.go
+++ b/federationapi/federationapi_test.go
@@ -314,7 +314,7 @@ func TestRoomsV3URLEscapeDoNot404(t *testing.T) {
 	// TODO: This is pretty fragile, as if anything calls anything on these nils this test will break.
 	// Unfortunately, it makes little sense to instantiate these dependencies when we just want to test routing.
 	federationapi.AddPublicRoutes(processCtx, routers, cfg, &natsInstance, nil, nil, keyRing, nil, &internal.FederationInternalAPI{}, caching.DisableMetrics)
-	baseURL, cancel := test.ListenAndServe(t, routers.Federation, true)
+	baseURL, cancel := test.ListenAndServe(t, routers.Federation, true, 0)
 	defer cancel()
 	serverName := spec.ServerName(strings.TrimPrefix(baseURL, "https://"))
 

--- a/federationapi/routing/join.go
+++ b/federationapi/routing/join.go
@@ -45,6 +45,7 @@ func MakeJoin(
 ) util.JSONResponse {
 	roomVersion, err := rsAPI.QueryRoomVersionForRoom(httpReq.Context(), roomID)
 	if err != nil {
+		util.GetLogger(httpReq.Context()).WithError(err).Error("rsAPI.QueryRoomVersionForRoom failed")
 		return util.JSONResponse{
 			Code: http.StatusInternalServerError,
 			JSON: jsonerror.InternalServerError(),

--- a/test/http.go
+++ b/test/http.go
@@ -49,9 +49,17 @@ func NewRequest(t *testing.T, method, path string, opts ...HTTPRequestOpt) *http
 	return req
 }
 
+// it's a testing.T but implementable for things which don't have one e.g furl
+type testInterface interface {
+	Logf(format string, args ...any)
+	Errorf(format string, args ...any)
+	Fatalf(format string, args ...any)
+	TempDir() string
+}
+
 // ListenAndServe will listen on a random high-numbered port and attach the given router.
 // Returns the base URL to send requests to. Call `cancel` to shutdown the server, which will block until it has closed.
-func ListenAndServe(t *testing.T, router http.Handler, withTLS bool) (apiURL string, cancel func()) {
+func ListenAndServe(t testInterface, router http.Handler, withTLS bool) (apiURL string, cancel func()) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to listen: %s", err)

--- a/test/http.go
+++ b/test/http.go
@@ -59,8 +59,8 @@ type testInterface interface {
 
 // ListenAndServe will listen on a random high-numbered port and attach the given router.
 // Returns the base URL to send requests to. Call `cancel` to shutdown the server, which will block until it has closed.
-func ListenAndServe(t testInterface, router http.Handler, withTLS bool) (apiURL string, cancel func()) {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+func ListenAndServe(t testInterface, router http.Handler, withTLS bool, customPort int) (apiURL string, cancel func()) {
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", customPort))
 	if err != nil {
 		t.Fatalf("failed to listen: %s", err)
 	}


### PR DESCRIPTION
- Allow skipping TLS checks with -k (for localhost dendrites)
- Allow self-hosting server keys (for ephemeral servers)

Tried writing tests, ended up wasting hours, so leaving this as-is for now.

```
./furl             
furl [-k] [-X GET|PUT|POST|DELETE] [-d @filename|{"inline":"json"}] [-M matrix_key.pem] [-O localhost] https://federation-server.url/_matrix/.../
  -M string
    	The private key to use when signing the request (default "matrix_key.pem")
  -O string
    	The server name that the request should originate from. The remote server will use this to request server keys. There MUST be a TLS listener at the .well-known address for this server name, i.e it needs to be pointing to a real homeserver. If blank, furl will self-host this on a random high numbered port, but only if the target is localhost. Use $PORT in request URLs/bodies to substitute the port number in.
  -X string
    	Specify HTTP request method to use (default "GET")
  -d string
    	HTTP JSON body data. If you start the data with the letter @, the rest should be a filename.
  -data string
    	HTTP JSON body data. If you start the data with the letter @, the rest should be a filename.
  -insecure
    	Allow insecure server connections
  -k	Allow insecure server connections
  -key string
    	The private key to use when signing the request (default "matrix_key.pem")
  -origin string
    	The server name that the request should originate from. The remote server will use this to request server keys. There MUST be a TLS listener at the .well-known address for this server name, i.e it needs to be pointing to a real homeserver. If blank, furl will self-host this on a random high numbered port, but only if the target is localhost. Use $PORT in request URLs/bodies to substitute the port number in.
  -request string
    	Specify HTTP request method to use (default "GET")
```

Run a localhost dendrite and then:
```
./create-account -username bob -password somethingsecure                                                                                                                           
INFO[0000] Created account: bob (AccessToken: 1wtvniRKwXFt5xg9I4kOFkKIsOYpaqV_arSW0qLoCcI)

./furl -k -X GET 'https://localhost:8448/_matrix/federation/v1/query/profile?user_id=@bob:localhost:8448'
Self-hosting key... OK on localhost:58189
Will return {"server_keys":[{"old_verify_keys":null,"server_name":"localhost:58189","signatures":{"localhost:58189":{"ed25519:BnkpBy":"hg6S7ewUAoi2chTaeKxy7F+IU4H+31obJW3jMTsReuIgC5RFvyyNVfzRKoB23pRrKNMCQjxiTzAfOa/AXeq/Aw"}},"valid_until_ts":1683214071237,"verify_keys":{"ed25519:BnkpBy":{"key":"F1LHXs0Avb/92NYtknjJP2BRav5ypUYpb5tgzRL9USc"}}}]}
{
  "displayname": "bob"
}

curl -s -XPOST -d '{"preset":"public_chat"}' -H "Authorization: Bearer 1wtvniRKwXFt5xg9I4kOFkKIsOYpaqV_arSW0qLoCcI" 'http://localhost:8008/_matrix/client/v3/createRoom' | jq -r .room_id
!jF4apQQtzudjoHec:localhost:8448

./furl -k -X GET 'https://localhost:8448/_matrix/federation/v1/make_join/%21jF4apQQtzudjoHec:localhost:8448/@alice:localhost:$PORT?ver=10'
Self-hosting key... OK on localhost:58370
Will return {"server_keys":[{"old_verify_keys":null,"server_name":"localhost:58370","signatures":{"localhost:58370":{"ed25519:BnkpBy":"BMXZzKP+cCfmGvlBOjlJXoNErI6J7bFcr3lOLYcs7r0BEh4Yju97ZXXhz5MQ01lX2smRkxrV3OYkvJArYgFAAg"}},"valid_until_ts":1683215160410,"verify_keys":{"ed25519:BnkpBy":{"key":"F1LHXs0Avb/92NYtknjJP2BRav5ypUYpb5tgzRL9USc"}}}]}
{
  "event": {
    "auth_events": [
      "$omhR4QytYKU7QS7THKP2_Or0RZV1E4kHp0oxZc3gUvg",
      "$tK3Ex8iJbpWxbdMsyDazxqeWv2_jFTnQsMkwG2P9jFs",
      "$-qdT0CfNy_d4S45hTWf8hKcQ0sUlbBWJW5HSymXuez4"
    ],
    "content": {
      "membership": "join"
    },
    "depth": 6,
    "prev_events": [
      "$ui6UWJbUcsitW_UPq5ownfYr75LVd22VfeUX3nzF_ZU"
    ],
    "room_id": "!jF4apQQtzudjoHec:localhost:8448",
    "sender": "@alice:localhost:58370",
    "state_key": "@alice:localhost:58370",
    "type": "m.room.member"
  },
  "room_version": "10"
}

./furl -k -p 58370 -d '@signed-e.json' -X PUT 'https://localhost:8448/_matrix/federation/v1/send_join/%21jF4apQQtzudjoHec:localhost:8448/$yNSZ10gHgDmnloGs7LsLraNfUH06O1qfeJP0UW69q-c?ver=10'
Self-hosting key... OK on localhost:58370
Will return {"server_keys":[{"old_verify_keys":null,"server_name":"localhost:58370","signatures":{"localhost:58370":{"ed25519:BnkpBy":"svQ1QGnG39llg+6IzZryK4zC73jCq8eQwrLmOjZ9wqlS1EqpiaGwRQ1qSwX8QrtzcvoLelVImdKQO1cFdbokCg"}},"valid_until_ts":1683215790892,"verify_keys":{"ed25519:BnkpBy":{"key":"F1LHXs0Avb/92NYtknjJP2BRav5ypUYpb5tgzRL9USc"}}}]}
[
  200,
  {
    "auth_chain": [ ... ]
....
```