### PR TITLE
rearrange order of sections about signing keys and configuring dendrite, fix a dead link

### DIFF
--- a/docs/installation/manual/3_signingkey.md
+++ b/docs/installation/manual/3_signingkey.md
@@ -2,7 +2,7 @@
 title: Generating signing keys
 parent: Manual
 grand_parent: Installation
-nav_order: 4
+nav_order: 3
 permalink: /installation/manual/signingkeys
 ---
 

--- a/docs/installation/manual/4_configuration.md
+++ b/docs/installation/manual/4_configuration.md
@@ -2,7 +2,7 @@
 title: Configuring Dendrite
 parent: Manual
 grand_parent: Installation
-nav_order: 3
+nav_order: 4
 permalink: /installation/manual/configuration
 ---
 
@@ -21,7 +21,7 @@ sections:
 
 First of all, you will need to configure the server name of your Matrix homeserver.
 This must match the domain name that you have selected whilst [configuring the domain
-name delegation](domainname#delegation).
+name delegation](../domainname#delegation).
 
 In the `global` section, set the `server_name` to your delegated domain name:
 


### PR DESCRIPTION
I thought I would rearrange these pages since the configuration step requires that a signing key has been generated.