### PR TITLE
Fix backfilling

### DIFF
--- a/roomserver/auth/auth.go
+++ b/roomserver/auth/auth.go
@@ -30,10 +30,6 @@ func IsServerAllowed(
 	serverCurrentlyInRoom bool,
 	authEvents []gomatrixserverlib.PDU,
 ) bool {
-	// In practice should not happen, but avoids unneeded CPU cycles
-	if serverName == "" || len(authEvents) == 0 {
-		return false
-	}
 	historyVisibility := HistoryVisibilityForRoom(authEvents)
 
 	// 1. If the history_visibility was set to world_readable, allow.

--- a/roomserver/internal/perform/perform_backfill.go
+++ b/roomserver/internal/perform/perform_backfill.go
@@ -114,7 +114,7 @@ func (r *Backfiller) backfillViaFederation(ctx context.Context, req *api.Perform
 	if info == nil || info.IsStub() {
 		return fmt.Errorf("backfillViaFederation: missing room info for room %s", req.RoomID)
 	}
-	requester := newBackfillRequester(r.DB, r.FSAPI, r.Querier, req.VirtualHost, r.IsLocalServerName, req.BackwardsExtremities, r.PreferServers, info.RoomVersion, info.RoomNID)
+	requester := newBackfillRequester(r.DB, r.FSAPI, r.Querier, req.VirtualHost, r.IsLocalServerName, req.BackwardsExtremities, r.PreferServers, info.RoomVersion)
 	// Request 100 items regardless of what the query asks for.
 	// We don't want to go much higher than this.
 	// We can't honour exactly the limit as some sytests rely on requesting more for tests to pass
@@ -266,7 +266,6 @@ type backfillRequester struct {
 	eventIDMap              map[string]gomatrixserverlib.PDU
 	historyVisiblity        gomatrixserverlib.HistoryVisibility
 	roomVersion             gomatrixserverlib.RoomVersion
-	roomNID                 types.RoomNID
 }
 
 func newBackfillRequester(
@@ -276,7 +275,6 @@ func newBackfillRequester(
 	isLocalServerName func(spec.ServerName) bool,
 	bwExtrems map[string][]string, preferServers []spec.ServerName,
 	roomVersion gomatrixserverlib.RoomVersion,
-	roomNID types.RoomNID,
 ) *backfillRequester {
 	preferServer := make(map[spec.ServerName]bool)
 	for _, p := range preferServers {
@@ -293,7 +291,6 @@ func newBackfillRequester(
 		bwExtrems:               bwExtrems,
 		preferServer:            preferServer,
 		historyVisiblity:        gomatrixserverlib.HistoryVisibilityShared,
-		roomNID:                 roomNID,
 		roomVersion:             roomVersion,
 	}
 }


### PR DESCRIPTION
This should fix two issues with backfilling:
1. right after creating and joining a room over federation, we are doing a `/backfill` request, which would return redacted events, because the `authEvents` are empty. Even though the spec states that, in the absence of a history visibility event, it should be handled as `shared`.
2. `gomatrixserverlib: unsupported room version ''` - because, well, we were never setting the `roomInfo` field..