### PR TITLE
Fix setting `displayname` and `avatar_url`

### DIFF
--- a/clientapi/routing/profile.go
+++ b/clientapi/routing/profile.go
@@ -104,12 +104,6 @@ func SetAvatarURL(
 	if resErr := httputil.UnmarshalJSONRequest(req, &r); resErr != nil {
 		return *resErr
 	}
-	if r.AvatarURL == "" {
-		return util.JSONResponse{
-			Code: http.StatusBadRequest,
-			JSON: spec.BadJSON("'avatar_url' must be supplied."),
-		}
-	}
 
 	localpart, domain, err := gomatrixserverlib.SplitID('@', userID)
 	if err != nil {
@@ -198,12 +192,6 @@ func SetDisplayName(
 	var r eventutil.UserProfile
 	if resErr := httputil.UnmarshalJSONRequest(req, &r); resErr != nil {
 		return *resErr
-	}
-	if r.DisplayName == "" {
-		return util.JSONResponse{
-			Code: http.StatusBadRequest,
-			JSON: spec.BadJSON("'displayname' must be supplied."),
-		}
 	}
 
 	localpart, domain, err := gomatrixserverlib.SplitID('@', userID)


### PR DESCRIPTION
As per the spec, `displayname` and `avatar_url` may be empty.