### PR TITLE
Fix adding state events to the database

### DIFF
--- a/roomserver/storage/shared/storage.go
+++ b/roomserver/storage/shared/storage.go
@@ -282,17 +282,17 @@ func (d *Database) addState(
 		var found bool
 		for i := len(state) - 1; i >= 0; i-- {
 			found = false
+		blocksLoop:
 			for _, events := range blocks {
 				for _, event := range events {
 					if state[i].EventNID == event {
 						found = true
-						break
+						break blocksLoop
 					}
 				}
 			}
 			if found {
 				state = append(state[:i], state[i+1:]...)
-				i--
 			}
 		}
 	}


### PR DESCRIPTION
When we're adding state to the database, we check which eventNIDs are already in a block, if we already have that eventNID, we remove it from the list. In its current form we would skip over eventNIDs in the case we already found a match (we're decrementing `i` twice)
My theory is, that when we later get the state blocks, we are receiving "too many" eventNIDs (well, yea, we stored too many), which may or may not can result in state resets when comparing different state snapshots. (e.g. when adding state we stored a eventNID by accident because we skipped it, later we add more state and are not adding it because we don't skip it)