### PR TITLE
allow numeric usernames less than MAX_INT64 during registration

### DIFF
--- a/clientapi/routing/register.go
+++ b/clientapi/routing/register.go
@@ -513,13 +513,6 @@ func Register(
 		return handleGuestRegistration(req, r, cfg, userAPI)
 	}
 
-	// Don't allow numeric usernames less than MAX_INT64.
-	if _, err = strconv.ParseInt(r.Username, 10, 64); err == nil {
-		return util.JSONResponse{
-			Code: http.StatusBadRequest,
-			JSON: spec.InvalidUsername("Numeric user IDs are reserved"),
-		}
-	}
 	// Auto generate a numeric username if r.Username is empty
 	if r.Username == "" {
 		nreq := &userapi.QueryNumericLocalpartRequest{

--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -709,6 +709,7 @@ PUT /rooms/:room_id/redact/:event_id/:txn_id is idempotent
 Unnamed room comes with a name summary
 Named room comes with just joined member count summary
 Room summary only has 5 heroes
+registration is idempotent, without username specified
 registration is idempotent, with username specified
 Setting state twice is idempotent
 Joining room twice is idempotent


### PR DESCRIPTION
### Pull Request Checklist

* [ ] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
* [x] I have already signed off privately


I have not added additional unit tests yet, waiting for #3138 .

Fixes one of the sytests in https://github.com/matrix-org/dendrite/issues/1300 .

