### PR TITLE
Fix prev event lookup in syncapi

### DIFF
--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -558,27 +558,28 @@ func (s *OutputRoomEventConsumer) updateStateEvent(event *rstypes.HeaderedEvent)
 	var succeeded bool
 	defer sqlutil.EndTransactionWithCheck(snapshot, &succeeded, &err)
 
-	prevEvent, err := snapshot.GetStateEvent(
-		s.ctx, event.RoomID(), event.Type(), stateKey,
-	)
-	if err != nil {
-		return event, err
-	}
-
 	validRoomID, err := spec.NewRoomID(event.RoomID())
 	if err != nil {
 		return event, err
 	}
 
+	sKeyUser := ""
 	if event.StateKey() != nil {
 		if *event.StateKey() != "" {
 			var sku *spec.UserID
 			sku, err = s.rsAPI.QueryUserIDForSender(s.ctx, *validRoomID, spec.SenderID(stateKey))
 			if err == nil && sku != nil {
-				sKey := sku.String()
-				event.StateKeyResolved = &sKey
+				sKeyUser = sku.String()
+				event.StateKeyResolved = &sKeyUser
 			}
 		}
+	}
+
+	prevEvent, err := snapshot.GetStateEvent(
+		s.ctx, event.RoomID(), event.Type(), sKeyUser,
+	)
+	if err != nil {
+		return event, err
 	}
 
 	userID, err := s.rsAPI.QueryUserIDForSender(s.ctx, *validRoomID, event.SenderID())


### PR DESCRIPTION
The syncapi operates using userID's so when querying for the previous state event we need to lookup the userID from the given senderID before the state query.