### PR TITLE
Add revision to version string

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,2 @@
 bin
 *.wasm
-.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # base installs required dependencies and runs go mod download to cache dependencies
 #
 FROM --platform=${BUILDPLATFORM} docker.io/golang:1.20-alpine AS base
-RUN apk --update --no-cache add bash build-base curl
+RUN apk --update --no-cache add bash build-base curl git
 
 #
 # build creates all needed binaries

--- a/cmd/dendrite/main.go
+++ b/cmd/dendrite/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/matrix-org/dendrite/setup/jetstream"
 	"github.com/matrix-org/dendrite/setup/process"
 	"github.com/matrix-org/gomatrixserverlib/fclient"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
 	"github.com/matrix-org/dendrite/appservice"
@@ -186,6 +187,16 @@ func main() {
 			logrus.WithError(err).Fatalf("Failed to enable MSCs")
 		}
 	}
+
+	upCounter := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "dendrite",
+		Name:      "up",
+		ConstLabels: map[string]string{
+			"version": internal.VersionString(),
+		},
+	})
+	upCounter.Add(1)
+	prometheus.MustRegister(upCounter)
 
 	// Expose the matrix APIs directly rather than putting them under a /api path.
 	go func() {


### PR DESCRIPTION
Since the removal of `build.sh`, we don't include any information about the revision Dendrite was build from. Since go1.18, the revision a binary was build from is automatically included, so we can try to get that instead.

This also adds a `dendrite_up` metric showing the current version (`dendrite_up{version="0.13.1+c796f20"} 1`)

Closes #2993 