### PR TITLE
Use pointer when passing the connection manager around

### DIFF
--- a/cmd/dendrite-demo-pinecone/monolith/monolith.go
+++ b/cmd/dendrite-demo-pinecone/monolith/monolith.go
@@ -126,7 +126,7 @@ func (p *P2PMonolith) SetupPinecone(sk ed25519.PrivateKey) {
 }
 
 func (p *P2PMonolith) SetupDendrite(
-	processCtx *process.ProcessContext, cfg *config.Dendrite, cm sqlutil.Connections, routers httputil.Routers,
+	processCtx *process.ProcessContext, cfg *config.Dendrite, cm *sqlutil.Connections, routers httputil.Routers,
 	port int, enableRelaying bool, enableMetrics bool, enableWebsockets bool) {
 
 	p.port = port

--- a/federationapi/federationapi.go
+++ b/federationapi/federationapi.go
@@ -95,7 +95,7 @@ func AddPublicRoutes(
 func NewInternalAPI(
 	processContext *process.ProcessContext,
 	dendriteCfg *config.Dendrite,
-	cm sqlutil.Connections,
+	cm *sqlutil.Connections,
 	natsInstance *jetstream.NATSInstance,
 	federation fclient.FederationClient,
 	rsAPI roomserverAPI.FederationRoomserverAPI,

--- a/federationapi/storage/postgres/storage.go
+++ b/federationapi/storage/postgres/storage.go
@@ -36,7 +36,7 @@ type Database struct {
 }
 
 // NewDatabase opens a new database
-func NewDatabase(ctx context.Context, conMan sqlutil.Connections, dbProperties *config.DatabaseOptions, cache caching.FederationCache, isLocalServerName func(spec.ServerName) bool) (*Database, error) {
+func NewDatabase(ctx context.Context, conMan *sqlutil.Connections, dbProperties *config.DatabaseOptions, cache caching.FederationCache, isLocalServerName func(spec.ServerName) bool) (*Database, error) {
 	var d Database
 	var err error
 	if d.db, d.writer, err = conMan.Connection(dbProperties); err != nil {

--- a/federationapi/storage/sqlite3/storage.go
+++ b/federationapi/storage/sqlite3/storage.go
@@ -34,7 +34,7 @@ type Database struct {
 }
 
 // NewDatabase opens a new database
-func NewDatabase(ctx context.Context, conMan sqlutil.Connections, dbProperties *config.DatabaseOptions, cache caching.FederationCache, isLocalServerName func(spec.ServerName) bool) (*Database, error) {
+func NewDatabase(ctx context.Context, conMan *sqlutil.Connections, dbProperties *config.DatabaseOptions, cache caching.FederationCache, isLocalServerName func(spec.ServerName) bool) (*Database, error) {
 	var d Database
 	var err error
 	if d.db, d.writer, err = conMan.Connection(dbProperties); err != nil {

--- a/federationapi/storage/storage.go
+++ b/federationapi/storage/storage.go
@@ -30,7 +30,7 @@ import (
 )
 
 // NewDatabase opens a new database
-func NewDatabase(ctx context.Context, conMan sqlutil.Connections, dbProperties *config.DatabaseOptions, cache caching.FederationCache, isLocalServerName func(spec.ServerName) bool) (Database, error) {
+func NewDatabase(ctx context.Context, conMan *sqlutil.Connections, dbProperties *config.DatabaseOptions, cache caching.FederationCache, isLocalServerName func(spec.ServerName) bool) (Database, error) {
 	switch {
 	case dbProperties.ConnectionString.IsSQLite():
 		return sqlite3.NewDatabase(ctx, conMan, dbProperties, cache, isLocalServerName)

--- a/internal/sqlutil/connection_manager.go
+++ b/internal/sqlutil/connection_manager.go
@@ -29,24 +29,26 @@ type Connections struct {
 	processContext *process.ProcessContext
 }
 
-func NewConnectionManager(processCtx *process.ProcessContext, globalConfig config.DatabaseOptions) Connections {
-	return Connections{
+func NewConnectionManager(processCtx *process.ProcessContext, globalConfig config.DatabaseOptions) *Connections {
+	return &Connections{
 		globalConfig:   globalConfig,
 		processContext: processCtx,
 	}
 }
 
 func (c *Connections) Connection(dbProperties *config.DatabaseOptions) (*sql.DB, Writer, error) {
-	writer := NewDummyWriter()
-	if dbProperties.ConnectionString.IsSQLite() {
-		writer = NewExclusiveWriter()
-	}
 	var err error
 	if dbProperties.ConnectionString == "" {
 		// if no connectionString was provided, try the global one
 		dbProperties = &c.globalConfig
 	}
-	if dbProperties.ConnectionString != "" || c.db == nil {
+
+	writer := NewDummyWriter()
+	if dbProperties.ConnectionString.IsSQLite() {
+		writer = NewExclusiveWriter()
+	}
+
+	if dbProperties.ConnectionString != "" && c.db == nil {
 		// Open a new database connection using the supplied config.
 		c.db, err = Open(dbProperties, writer)
 		if err != nil {

--- a/internal/sqlutil/connection_manager_test.go
+++ b/internal/sqlutil/connection_manager_test.go
@@ -6,51 +6,113 @@ import (
 
 	"github.com/matrix-org/dendrite/internal/sqlutil"
 	"github.com/matrix-org/dendrite/setup/config"
+	"github.com/matrix-org/dendrite/setup/process"
 	"github.com/matrix-org/dendrite/test"
 )
 
 func TestConnectionManager(t *testing.T) {
-	test.WithAllDatabases(t, func(t *testing.T, dbType test.DBType) {
-		conStr, close := test.PrepareDBConnectionString(t, dbType)
-		t.Cleanup(close)
-		cm := sqlutil.NewConnectionManager(nil, config.DatabaseOptions{})
 
-		dbProps := &config.DatabaseOptions{ConnectionString: config.DataSource(conStr)}
-		db, writer, err := cm.Connection(dbProps)
-		if err != nil {
-			t.Fatal(err)
-		}
+	t.Run("component defined connection string", func(t *testing.T) {
+		test.WithAllDatabases(t, func(t *testing.T, dbType test.DBType) {
+			conStr, close := test.PrepareDBConnectionString(t, dbType)
+			t.Cleanup(close)
+			cm := sqlutil.NewConnectionManager(nil, config.DatabaseOptions{})
 
-		switch dbType {
-		case test.DBTypeSQLite:
-			_, ok := writer.(*sqlutil.ExclusiveWriter)
-			if !ok {
-				t.Fatalf("expected exclusive writer")
+			dbProps := &config.DatabaseOptions{ConnectionString: config.DataSource(conStr)}
+			db, writer, err := cm.Connection(dbProps)
+			if err != nil {
+				t.Fatal(err)
 			}
-		case test.DBTypePostgres:
-			_, ok := writer.(*sqlutil.DummyWriter)
-			if !ok {
-				t.Fatalf("expected dummy writer")
+
+			switch dbType {
+			case test.DBTypeSQLite:
+				_, ok := writer.(*sqlutil.ExclusiveWriter)
+				if !ok {
+					t.Fatalf("expected exclusive writer")
+				}
+			case test.DBTypePostgres:
+				_, ok := writer.(*sqlutil.DummyWriter)
+				if !ok {
+					t.Fatalf("expected dummy writer")
+				}
 			}
-		}
 
-		// test global db pool
-		dbGlobal, writerGlobal, err := cm.Connection(&config.DatabaseOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !reflect.DeepEqual(db, dbGlobal) {
-			t.Fatalf("expected database connection to be reused")
-		}
-		if !reflect.DeepEqual(writer, writerGlobal) {
-			t.Fatalf("expected database writer to be reused")
-		}
-
-		// test invalid connection string configured
-		cm2 := sqlutil.NewConnectionManager(nil, config.DatabaseOptions{})
-		_, _, err = cm2.Connection(&config.DatabaseOptions{ConnectionString: "http://"})
-		if err == nil {
-			t.Fatal("expected an error but got none")
-		}
+			// reuse existing connection
+			db2, writer2, err := cm.Connection(dbProps)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(db, db2) {
+				t.Fatalf("expected database connection to be reused")
+			}
+			if !reflect.DeepEqual(writer, writer2) {
+				t.Fatalf("expected database writer to be reused")
+			}
+		})
 	})
+
+	t.Run("global connection pool", func(t *testing.T) {
+		test.WithAllDatabases(t, func(t *testing.T, dbType test.DBType) {
+			conStr, close := test.PrepareDBConnectionString(t, dbType)
+			t.Cleanup(close)
+			cm := sqlutil.NewConnectionManager(nil, config.DatabaseOptions{ConnectionString: config.DataSource(conStr)})
+
+			dbProps := &config.DatabaseOptions{}
+			db, writer, err := cm.Connection(dbProps)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			switch dbType {
+			case test.DBTypeSQLite:
+				_, ok := writer.(*sqlutil.ExclusiveWriter)
+				if !ok {
+					t.Fatalf("expected exclusive writer")
+				}
+			case test.DBTypePostgres:
+				_, ok := writer.(*sqlutil.DummyWriter)
+				if !ok {
+					t.Fatalf("expected dummy writer")
+				}
+			}
+
+			// reuse existing connection
+			db2, writer2, err := cm.Connection(dbProps)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(db, db2) {
+				t.Fatalf("expected database connection to be reused")
+			}
+			if !reflect.DeepEqual(writer, writer2) {
+				t.Fatalf("expected database writer to be reused")
+			}
+		})
+	})
+
+	t.Run("shutdown", func(t *testing.T) {
+		test.WithAllDatabases(t, func(t *testing.T, dbType test.DBType) {
+			conStr, close := test.PrepareDBConnectionString(t, dbType)
+			t.Cleanup(close)
+
+			processCtx := process.NewProcessContext()
+			cm := sqlutil.NewConnectionManager(processCtx, config.DatabaseOptions{ConnectionString: config.DataSource(conStr)})
+
+			dbProps := &config.DatabaseOptions{}
+			_, _, err := cm.Connection(dbProps)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			processCtx.ShutdownDendrite()
+			processCtx.WaitForComponentsToFinish()
+		})
+	})
+
+	// test invalid connection string configured
+	cm2 := sqlutil.NewConnectionManager(nil, config.DatabaseOptions{})
+	_, _, err := cm2.Connection(&config.DatabaseOptions{ConnectionString: "http://"})
+	if err == nil {
+		t.Fatal("expected an error but got none")
+	}
 }

--- a/mediaapi/mediaapi.go
+++ b/mediaapi/mediaapi.go
@@ -28,7 +28,7 @@ import (
 // AddPublicRoutes sets up and registers HTTP handlers for the MediaAPI component.
 func AddPublicRoutes(
 	mediaRouter *mux.Router,
-	cm sqlutil.Connections,
+	cm *sqlutil.Connections,
 	cfg *config.Dendrite,
 	userAPI userapi.MediaUserAPI,
 	client *fclient.Client,

--- a/mediaapi/storage/postgres/mediaapi.go
+++ b/mediaapi/storage/postgres/mediaapi.go
@@ -24,7 +24,7 @@ import (
 )
 
 // NewDatabase opens a postgres database.
-func NewDatabase(conMan sqlutil.Connections, dbProperties *config.DatabaseOptions) (*shared.Database, error) {
+func NewDatabase(conMan *sqlutil.Connections, dbProperties *config.DatabaseOptions) (*shared.Database, error) {
 	db, writer, err := conMan.Connection(dbProperties)
 	if err != nil {
 		return nil, err

--- a/mediaapi/storage/sqlite3/mediaapi.go
+++ b/mediaapi/storage/sqlite3/mediaapi.go
@@ -23,7 +23,7 @@ import (
 )
 
 // NewDatabase opens a SQLIte database.
-func NewDatabase(conMan sqlutil.Connections, dbProperties *config.DatabaseOptions) (*shared.Database, error) {
+func NewDatabase(conMan *sqlutil.Connections, dbProperties *config.DatabaseOptions) (*shared.Database, error) {
 	db, writer, err := conMan.Connection(dbProperties)
 	if err != nil {
 		return nil, err

--- a/mediaapi/storage/storage.go
+++ b/mediaapi/storage/storage.go
@@ -27,7 +27,7 @@ import (
 )
 
 // NewMediaAPIDatasource opens a database connection.
-func NewMediaAPIDatasource(conMan sqlutil.Connections, dbProperties *config.DatabaseOptions) (Database, error) {
+func NewMediaAPIDatasource(conMan *sqlutil.Connections, dbProperties *config.DatabaseOptions) (Database, error) {
 	switch {
 	case dbProperties.ConnectionString.IsSQLite():
 		return sqlite3.NewDatabase(conMan, dbProperties)

--- a/relayapi/relayapi.go
+++ b/relayapi/relayapi.go
@@ -53,7 +53,7 @@ func AddPublicRoutes(
 
 func NewRelayInternalAPI(
 	dendriteCfg *config.Dendrite,
-	cm sqlutil.Connections,
+	cm *sqlutil.Connections,
 	fedClient fclient.FederationClient,
 	rsAPI rsAPI.RoomserverInternalAPI,
 	keyRing *gomatrixserverlib.KeyRing,

--- a/relayapi/storage/postgres/storage.go
+++ b/relayapi/storage/postgres/storage.go
@@ -33,7 +33,7 @@ type Database struct {
 
 // NewDatabase opens a new database
 func NewDatabase(
-	conMan sqlutil.Connections,
+	conMan *sqlutil.Connections,
 	dbProperties *config.DatabaseOptions,
 	cache caching.FederationCache,
 	isLocalServerName func(spec.ServerName) bool,

--- a/relayapi/storage/sqlite3/storage.go
+++ b/relayapi/storage/sqlite3/storage.go
@@ -33,7 +33,7 @@ type Database struct {
 
 // NewDatabase opens a new database
 func NewDatabase(
-	conMan sqlutil.Connections,
+	conMan *sqlutil.Connections,
 	dbProperties *config.DatabaseOptions,
 	cache caching.FederationCache,
 	isLocalServerName func(spec.ServerName) bool,

--- a/relayapi/storage/storage.go
+++ b/relayapi/storage/storage.go
@@ -30,7 +30,7 @@ import (
 
 // NewDatabase opens a new database
 func NewDatabase(
-	conMan sqlutil.Connections,
+	conMan *sqlutil.Connections,
 	dbProperties *config.DatabaseOptions,
 	cache caching.FederationCache,
 	isLocalServerName func(spec.ServerName) bool,

--- a/roomserver/roomserver.go
+++ b/roomserver/roomserver.go
@@ -31,7 +31,7 @@ import (
 func NewInternalAPI(
 	processContext *process.ProcessContext,
 	cfg *config.Dendrite,
-	cm sqlutil.Connections,
+	cm *sqlutil.Connections,
 	natsInstance *jetstream.NATSInstance,
 	caches caching.RoomServerCaches,
 	enableMetrics bool,

--- a/roomserver/storage/postgres/storage.go
+++ b/roomserver/storage/postgres/storage.go
@@ -37,7 +37,7 @@ type Database struct {
 }
 
 // Open a postgres database.
-func Open(ctx context.Context, conMan sqlutil.Connections, dbProperties *config.DatabaseOptions, cache caching.RoomServerCaches) (*Database, error) {
+func Open(ctx context.Context, conMan *sqlutil.Connections, dbProperties *config.DatabaseOptions, cache caching.RoomServerCaches) (*Database, error) {
 	var d Database
 	var err error
 	db, writer, err := conMan.Connection(dbProperties)

--- a/roomserver/storage/sqlite3/storage.go
+++ b/roomserver/storage/sqlite3/storage.go
@@ -36,7 +36,7 @@ type Database struct {
 }
 
 // Open a sqlite database.
-func Open(ctx context.Context, conMan sqlutil.Connections, dbProperties *config.DatabaseOptions, cache caching.RoomServerCaches) (*Database, error) {
+func Open(ctx context.Context, conMan *sqlutil.Connections, dbProperties *config.DatabaseOptions, cache caching.RoomServerCaches) (*Database, error) {
 	var d Database
 	var err error
 	db, writer, err := conMan.Connection(dbProperties)

--- a/roomserver/storage/storage.go
+++ b/roomserver/storage/storage.go
@@ -29,7 +29,7 @@ import (
 )
 
 // Open opens a database connection.
-func Open(ctx context.Context, conMan sqlutil.Connections, dbProperties *config.DatabaseOptions, cache caching.RoomServerCaches) (Database, error) {
+func Open(ctx context.Context, conMan *sqlutil.Connections, dbProperties *config.DatabaseOptions, cache caching.RoomServerCaches) (Database, error) {
 	switch {
 	case dbProperties.ConnectionString.IsSQLite():
 		return sqlite3.Open(ctx, conMan, dbProperties, cache)

--- a/setup/monolith.go
+++ b/setup/monolith.go
@@ -61,7 +61,7 @@ func (m *Monolith) AddAllPublicRoutes(
 	processCtx *process.ProcessContext,
 	cfg *config.Dendrite,
 	routers httputil.Routers,
-	cm sqlutil.Connections,
+	cm *sqlutil.Connections,
 	natsInstance *jetstream.NATSInstance,
 	caches *caching.Caches,
 	enableMetrics bool,

--- a/setup/mscs/msc2836/msc2836.go
+++ b/setup/mscs/msc2836/msc2836.go
@@ -105,7 +105,7 @@ func toClientResponse(ctx context.Context, res *MSC2836EventRelationshipsRespons
 
 // Enable this MSC
 func Enable(
-	cfg *config.Dendrite, cm sqlutil.Connections, routers httputil.Routers, rsAPI roomserver.RoomserverInternalAPI, fsAPI fs.FederationInternalAPI,
+	cfg *config.Dendrite, cm *sqlutil.Connections, routers httputil.Routers, rsAPI roomserver.RoomserverInternalAPI, fsAPI fs.FederationInternalAPI,
 	userAPI userapi.UserInternalAPI, keyRing gomatrixserverlib.JSONVerifier,
 ) error {
 	db, err := NewDatabase(cm, &cfg.MSCs.Database)

--- a/setup/mscs/msc2836/storage.go
+++ b/setup/mscs/msc2836/storage.go
@@ -59,14 +59,14 @@ type DB struct {
 }
 
 // NewDatabase loads the database for msc2836
-func NewDatabase(conMan sqlutil.Connections, dbOpts *config.DatabaseOptions) (Database, error) {
+func NewDatabase(conMan *sqlutil.Connections, dbOpts *config.DatabaseOptions) (Database, error) {
 	if dbOpts.ConnectionString.IsPostgres() {
 		return newPostgresDatabase(conMan, dbOpts)
 	}
 	return newSQLiteDatabase(conMan, dbOpts)
 }
 
-func newPostgresDatabase(conMan sqlutil.Connections, dbOpts *config.DatabaseOptions) (Database, error) {
+func newPostgresDatabase(conMan *sqlutil.Connections, dbOpts *config.DatabaseOptions) (Database, error) {
 	d := DB{}
 	var err error
 	if d.db, d.writer, err = conMan.Connection(dbOpts); err != nil {
@@ -144,7 +144,7 @@ func newPostgresDatabase(conMan sqlutil.Connections, dbOpts *config.DatabaseOpti
 	return &d, err
 }
 
-func newSQLiteDatabase(conMan sqlutil.Connections, dbOpts *config.DatabaseOptions) (Database, error) {
+func newSQLiteDatabase(conMan *sqlutil.Connections, dbOpts *config.DatabaseOptions) (Database, error) {
 	d := DB{}
 	var err error
 	if d.db, d.writer, err = conMan.Connection(dbOpts); err != nil {

--- a/setup/mscs/mscs.go
+++ b/setup/mscs/mscs.go
@@ -30,7 +30,7 @@ import (
 )
 
 // Enable MSCs - returns an error on unknown MSCs
-func Enable(cfg *config.Dendrite, cm sqlutil.Connections, routers httputil.Routers, monolith *setup.Monolith, caches *caching.Caches) error {
+func Enable(cfg *config.Dendrite, cm *sqlutil.Connections, routers httputil.Routers, monolith *setup.Monolith, caches *caching.Caches) error {
 	for _, msc := range cfg.MSCs.MSCs {
 		util.GetLogger(context.Background()).WithField("msc", msc).Info("Enabling MSC")
 		if err := EnableMSC(cfg, cm, routers, monolith, msc, caches); err != nil {
@@ -40,7 +40,7 @@ func Enable(cfg *config.Dendrite, cm sqlutil.Connections, routers httputil.Route
 	return nil
 }
 
-func EnableMSC(cfg *config.Dendrite, cm sqlutil.Connections, routers httputil.Routers, monolith *setup.Monolith, msc string, caches *caching.Caches) error {
+func EnableMSC(cfg *config.Dendrite, cm *sqlutil.Connections, routers httputil.Routers, monolith *setup.Monolith, msc string, caches *caching.Caches) error {
 	switch msc {
 	case "msc2836":
 		return msc2836.Enable(cfg, cm, routers, monolith.RoomserverAPI, monolith.FederationAPI, monolith.UserAPI, monolith.KeyRing)

--- a/syncapi/storage/postgres/syncserver.go
+++ b/syncapi/storage/postgres/syncserver.go
@@ -36,7 +36,7 @@ type SyncServerDatasource struct {
 }
 
 // NewDatabase creates a new sync server database
-func NewDatabase(ctx context.Context, cm sqlutil.Connections, dbProperties *config.DatabaseOptions) (*SyncServerDatasource, error) {
+func NewDatabase(ctx context.Context, cm *sqlutil.Connections, dbProperties *config.DatabaseOptions) (*SyncServerDatasource, error) {
 	var d SyncServerDatasource
 	var err error
 	if d.db, d.writer, err = cm.Connection(dbProperties); err != nil {

--- a/syncapi/storage/sqlite3/syncserver.go
+++ b/syncapi/storage/sqlite3/syncserver.go
@@ -36,7 +36,7 @@ type SyncServerDatasource struct {
 
 // NewDatabase creates a new sync server database
 // nolint: gocyclo
-func NewDatabase(ctx context.Context, conMan sqlutil.Connections, dbProperties *config.DatabaseOptions) (*SyncServerDatasource, error) {
+func NewDatabase(ctx context.Context, conMan *sqlutil.Connections, dbProperties *config.DatabaseOptions) (*SyncServerDatasource, error) {
 	var d SyncServerDatasource
 	var err error
 

--- a/syncapi/storage/storage.go
+++ b/syncapi/storage/storage.go
@@ -28,7 +28,7 @@ import (
 )
 
 // NewSyncServerDatasource opens a database connection.
-func NewSyncServerDatasource(ctx context.Context, conMan sqlutil.Connections, dbProperties *config.DatabaseOptions) (Database, error) {
+func NewSyncServerDatasource(ctx context.Context, conMan *sqlutil.Connections, dbProperties *config.DatabaseOptions) (Database, error) {
 	switch {
 	case dbProperties.ConnectionString.IsSQLite():
 		return sqlite3.NewDatabase(ctx, conMan, dbProperties)

--- a/syncapi/syncapi.go
+++ b/syncapi/syncapi.go
@@ -45,7 +45,7 @@ func AddPublicRoutes(
 	processContext *process.ProcessContext,
 	routers httputil.Routers,
 	dendriteCfg *config.Dendrite,
-	cm sqlutil.Connections,
+	cm *sqlutil.Connections,
 	natsInstance *jetstream.NATSInstance,
 	userAPI userapi.SyncUserAPI,
 	rsAPI api.SyncRoomserverAPI,

--- a/userapi/storage/postgres/storage.go
+++ b/userapi/storage/postgres/storage.go
@@ -31,7 +31,7 @@ import (
 )
 
 // NewDatabase creates a new accounts and profiles database
-func NewDatabase(ctx context.Context, conMan sqlutil.Connections, dbProperties *config.DatabaseOptions, serverName spec.ServerName, bcryptCost int, openIDTokenLifetimeMS int64, loginTokenLifetime time.Duration, serverNoticesLocalpart string) (*shared.Database, error) {
+func NewDatabase(ctx context.Context, conMan *sqlutil.Connections, dbProperties *config.DatabaseOptions, serverName spec.ServerName, bcryptCost int, openIDTokenLifetimeMS int64, loginTokenLifetime time.Duration, serverNoticesLocalpart string) (*shared.Database, error) {
 	db, writer, err := conMan.Connection(dbProperties)
 	if err != nil {
 		return nil, err
@@ -140,7 +140,7 @@ func NewDatabase(ctx context.Context, conMan sqlutil.Connections, dbProperties *
 	}, nil
 }
 
-func NewKeyDatabase(conMan sqlutil.Connections, dbProperties *config.DatabaseOptions) (*shared.KeyDatabase, error) {
+func NewKeyDatabase(conMan *sqlutil.Connections, dbProperties *config.DatabaseOptions) (*shared.KeyDatabase, error) {
 	db, writer, err := conMan.Connection(dbProperties)
 	if err != nil {
 		return nil, err

--- a/userapi/storage/sqlite3/storage.go
+++ b/userapi/storage/sqlite3/storage.go
@@ -29,7 +29,7 @@ import (
 )
 
 // NewUserDatabase creates a new accounts and profiles database
-func NewUserDatabase(ctx context.Context, conMan sqlutil.Connections, dbProperties *config.DatabaseOptions, serverName spec.ServerName, bcryptCost int, openIDTokenLifetimeMS int64, loginTokenLifetime time.Duration, serverNoticesLocalpart string) (*shared.Database, error) {
+func NewUserDatabase(ctx context.Context, conMan *sqlutil.Connections, dbProperties *config.DatabaseOptions, serverName spec.ServerName, bcryptCost int, openIDTokenLifetimeMS int64, loginTokenLifetime time.Duration, serverNoticesLocalpart string) (*shared.Database, error) {
 	db, writer, err := conMan.Connection(dbProperties)
 	if err != nil {
 		return nil, err
@@ -137,7 +137,7 @@ func NewUserDatabase(ctx context.Context, conMan sqlutil.Connections, dbProperti
 	}, nil
 }
 
-func NewKeyDatabase(conMan sqlutil.Connections, dbProperties *config.DatabaseOptions) (*shared.KeyDatabase, error) {
+func NewKeyDatabase(conMan *sqlutil.Connections, dbProperties *config.DatabaseOptions) (*shared.KeyDatabase, error) {
 	db, writer, err := conMan.Connection(dbProperties)
 	if err != nil {
 		return nil, err

--- a/userapi/storage/storage.go
+++ b/userapi/storage/storage.go
@@ -34,7 +34,7 @@ import (
 // and sets postgres connection parameters
 func NewUserDatabase(
 	ctx context.Context,
-	conMan sqlutil.Connections,
+	conMan *sqlutil.Connections,
 	dbProperties *config.DatabaseOptions,
 	serverName spec.ServerName,
 	bcryptCost int,
@@ -54,7 +54,7 @@ func NewUserDatabase(
 
 // NewKeyDatabase opens a new Postgres or Sqlite database (base on dataSourceName) scheme)
 // and sets postgres connection parameters.
-func NewKeyDatabase(conMan sqlutil.Connections, dbProperties *config.DatabaseOptions) (KeyDatabase, error) {
+func NewKeyDatabase(conMan *sqlutil.Connections, dbProperties *config.DatabaseOptions) (KeyDatabase, error) {
 	switch {
 	case dbProperties.ConnectionString.IsSQLite():
 		return sqlite3.NewKeyDatabase(conMan, dbProperties)

--- a/userapi/userapi.go
+++ b/userapi/userapi.go
@@ -39,7 +39,7 @@ import (
 func NewInternalAPI(
 	processContext *process.ProcessContext,
 	dendriteCfg *config.Dendrite,
-	cm sqlutil.Connections,
+	cm *sqlutil.Connections,
 	natsInstance *jetstream.NATSInstance,
 	rsAPI rsapi.UserRoomserverAPI,
 	fedClient fedsenderapi.KeyserverFederationAPI,


### PR DESCRIPTION
As otherwise existing connections aren't reused.