### PR TITLE
Extend context timeout on send_join to allow for joining complex rooms

### DIFF
--- a/federationapi/internal/federationclient.go
+++ b/federationapi/internal/federationclient.go
@@ -29,6 +29,8 @@ func (a *FederationInternalAPI) MakeJoin(
 func (a *FederationInternalAPI) SendJoin(
 	ctx context.Context, origin, s spec.ServerName, event gomatrixserverlib.PDU,
 ) (res gomatrixserverlib.SendJoinResponse, err error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Minute*5)
+	defer cancel()
 	ires, err := a.federation.SendJoin(ctx, origin, s, event)
 	if err != nil {
 		return &fclient.RespSendJoin{}, err

--- a/federationapi/internal/federationclient.go
+++ b/federationapi/internal/federationclient.go
@@ -29,8 +29,6 @@ func (a *FederationInternalAPI) MakeJoin(
 func (a *FederationInternalAPI) SendJoin(
 	ctx context.Context, origin, s spec.ServerName, event gomatrixserverlib.PDU,
 ) (res gomatrixserverlib.SendJoinResponse, err error) {
-	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
-	defer cancel()
 	ires, err := a.federation.SendJoin(ctx, origin, s, event)
 	if err != nil {
 		return &fclient.RespSendJoin{}, err


### PR DESCRIPTION
Background federated joins are currently broken since they timeout after 30s. This timeout didn't exist before the refactor and it shouldn't be here.