### PR TITLE
add deployment strategy option to helm chart (re #3021)

### DIFF
--- a/helm/dendrite/templates/deployment.yaml
+++ b/helm/dendrite/templates/deployment.yaml
@@ -26,6 +26,13 @@ spec:
       annotations:
         confighash: secret-{{ .Values.dendrite_config | toYaml | sha256sum | trunc 32 }}
     spec:
+      strategy:
+        type: {{ $.Values.strategy.type }}
+        {{- if eq $.Values.strategy.type "RollingUpdate" }}
+        rollingUpdate:
+          maxSurge: {{ $.Values.strategy.rollingUpdate.maxSurge }}
+          maxUnavailable: {{ $.Values.strategy.rollingUpdate.maxUnavailable }}
+        {{- end }}
       volumes:
       - name: {{ include "dendrite.fullname" . }}-conf-vol
         secret:

--- a/helm/dendrite/values.yaml
+++ b/helm/dendrite/values.yaml
@@ -75,6 +75,16 @@ strategy:
     # -- Maximum number of pods that can be scheduled above the desired number of pods
     maxSurge: 25%
 
+strategy:
+  # -- Strategy to use for rolling updates (e.g. Recreate, RollingUpdate)
+  # If you are using ReadWriteOnce volumes, you should probably use Recreate
+  type: RollingUpdate
+  rollingUpdate:
+    # -- Maximum number of pods that can be unavailable during the update process
+    maxUnavailable: 25%
+    # -- Maximum number of pods that can be scheduled above the desired number of pods
+    maxSurge: 25%
+
 dendrite_config:
   version: 2
   global:


### PR DESCRIPTION
@S7evinK sorry for the spam but any chance we get get this merged into main at some point? It was previously merged in https://github.com/matrix-org/dendrite/pull/3021 into a temp branch that never made it into main. If there is an issue with this being merged let me know.

---

Minor update to the helm chart to allow setting the update strategy as the default `RollingUpdate` one is a bit annoying if using `ReadWriteOnce` volumes for media. Hope this makes sense.

---

### Pull Request Checklist

<!-- Please read
https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [x] ~~I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests~~ Haven't touched any go files.
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

Signed-off-by: `George Antoniadis <george@noodles.gr>` [skip ci]
