### PR TITLE
[helm] Update Ingress hosts to account for IPv6 (server+client) and scheme (client)

### DIFF
--- a/helm/dendrite/Chart.yaml
+++ b/helm/dendrite/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dendrite
-version: "0.13.2"
+version: "0.13.3"
 appVersion: "0.13.2"
 description: Dendrite Matrix Homeserver
 type: application

--- a/helm/dendrite/templates/deployment.yaml
+++ b/helm/dendrite/templates/deployment.yaml
@@ -26,13 +26,6 @@ spec:
       annotations:
         confighash: secret-{{ .Values.dendrite_config | toYaml | sha256sum | trunc 32 }}
     spec:
-      strategy:
-        type: {{ $.Values.strategy.type }}
-        {{- if eq $.Values.strategy.type "RollingUpdate" }}
-        rollingUpdate:
-          maxSurge: {{ $.Values.strategy.rollingUpdate.maxSurge }}
-          maxUnavailable: {{ $.Values.strategy.rollingUpdate.maxUnavailable }}
-        {{- end }}
       volumes:
       - name: {{ include "dendrite.fullname" . }}-conf-vol
         secret:

--- a/helm/dendrite/templates/ingress.yaml
+++ b/helm/dendrite/templates/ingress.yaml
@@ -1,8 +1,8 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "dendrite.fullname" . -}}
 {{- $serverNameHost := .Values.dendrite_config.global.server_name -}}
-{{- $wellKnownServerHost := default $serverNameHost (regexFind "^[^:]+" .Values.dendrite_config.global.well_known_server_name) -}}
-{{- $wellKnownClientHost := default $serverNameHost (regexFind "^[^:]+" .Values.dendrite_config.global.well_known_client_name) -}}
+{{- $wellKnownServerHost := default $serverNameHost (regexFind "^(\\[.+\\])?[^:]*" .Values.dendrite_config.global.well_known_server_name) -}}
+{{- $wellKnownClientHost := default $serverNameHost (regexFind "//(\\[.+\\])?[^:/]*" .Values.dendrite_config.global.well_known_client_name | trimAll "/") -}}
 {{- $allHosts := list $serverNameHost $wellKnownServerHost $wellKnownClientHost | uniq -}}
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1

--- a/helm/dendrite/values.yaml
+++ b/helm/dendrite/values.yaml
@@ -75,16 +75,6 @@ strategy:
     # -- Maximum number of pods that can be scheduled above the desired number of pods
     maxSurge: 25%
 
-strategy:
-  # -- Strategy to use for rolling updates (e.g. Recreate, RollingUpdate)
-  # If you are using ReadWriteOnce volumes, you should probably use Recreate
-  type: RollingUpdate
-  rollingUpdate:
-    # -- Maximum number of pods that can be unavailable during the update process
-    maxUnavailable: 25%
-    # -- Maximum number of pods that can be scheduled above the desired number of pods
-    maxSurge: 25%
-
 dendrite_config:
   version: 2
   global:


### PR DESCRIPTION
This updates the matchers for deriving the host values from the dendrite config. The original version turned out to have 2 complications:
- It did not support IPv6 addresses as host value
- It failed for `well_known_client_host` which is a (base) URL instead of a hostname+port.

I've verified `well_known_server_name` with
```
dendrite.example.net:443
dendrite.example.net
192.168.1.1
192.168.1.1:1324
[dead::beef]:1234
[dead::beef]
[ffff:dead::beef]
```
and `well_known_client_name` with:
```
https://dendrite.example.net:443
https://dendrite.example.net
https://dendrite.example.net/
http://dendrite.example.net:8080/
http://192.168.1.1
http://192.168.1.1:8080/
http://[dead::beef]:1234
http://[dead::beef]/
http://[ffff:dead::beef]
```

Fixes #3175

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [x] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

Signed-off-by: `Omar Pakker <Omar007@users.noreply.github.com>`
