### PR TITLE
[helm chart] Strategy wrongly duplicated at pod level

### DIFF
--- a/helm/dendrite/templates/deployment.yaml
+++ b/helm/dendrite/templates/deployment.yaml
@@ -26,13 +26,6 @@ spec:
       annotations:
         confighash: secret-{{ .Values.dendrite_config | toYaml | sha256sum | trunc 32 }}
     spec:
-      strategy:
-        type: {{ $.Values.strategy.type }}
-        {{- if eq $.Values.strategy.type "RollingUpdate" }}
-        rollingUpdate:
-          maxSurge: {{ $.Values.strategy.rollingUpdate.maxSurge }}
-          maxUnavailable: {{ $.Values.strategy.rollingUpdate.maxUnavailable }}
-        {{- end }}
       volumes:
       - name: {{ include "dendrite.fullname" . }}-conf-vol
         secret:


### PR DESCRIPTION
A pod has no `strategy` field, only a `deployment` does and thus the deployment spec is broken by having `.spec.template.spec.strategy` as well as `.spec.strategy`.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [x] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

Signed-off-by: `Martyn Ranyard <m@rtyn.berlin>`
