### PR TITLE
Add configuration option for sliding sync when hosting /.well-known/matrix/client

### DIFF
--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -53,7 +53,7 @@ type WellKnownSlidingSyncProxy struct {
 }
 
 type WellKnownClientResponse struct {
-	HomeserverName   WellKnownClientHomeserver  `json:"m.homeserver"`
+	Homeserver       WellKnownClientHomeserver  `json:"m.homeserver"`
 	SlidingSyncProxy *WellKnownSlidingSyncProxy `json:"org.matrix.msc3575.proxy,omitempty"`
 }
 
@@ -114,7 +114,7 @@ func Setup(
 		}
 		wkMux.Handle("/client", httputil.MakeExternalAPI("wellknown", func(r *http.Request) util.JSONResponse {
 			response := WellKnownClientResponse{
-				HomeserverName: WellKnownClientHomeserver{cfg.Matrix.WellKnownClientName},
+				Homeserver: WellKnownClientHomeserver{cfg.Matrix.WellKnownClientName},
 			}
 			if cfg.Matrix.WellKnownSlidingSyncProxy != "" {
 				response.SlidingSyncProxy = &WellKnownSlidingSyncProxy{

--- a/setup/config/config_global.go
+++ b/setup/config/config_global.go
@@ -48,6 +48,10 @@ type Global struct {
 	// The server name to delegate client-server communications to, with optional port
 	WellKnownClientName string `yaml:"well_known_client_name"`
 
+	// The server name to delegate sliding sync communications to, with optional port.
+	// Requires `well_known_client_name` to also be configured.
+	WellKnownSlidingSyncProxy string `yaml:"well_known_sliding_sync_proxy"`
+
 	// Disables federation. Dendrite will not be able to make any outbound HTTP requests
 	// to other servers and the federation API will not be exposed.
 	DisableFederation bool `yaml:"disable_federation"`


### PR DESCRIPTION
Adds the `org.matrix.msc3575.proxy` field (used for configuring sliding sync) to /.well-known/matrix/client when Dendrite is serving that endpoint and `well_known_sliding_sync_proxy` has been configured.

ie. Config values of:
``` yaml
global:
    well_known_client_name: https://example.com
    well_known_sliding_sync_proxy: https://syncv3.example.com
```
results in a /.well-known/matrix/client of:
``` json
{
    "m.homeserver": {
        "base_url": "https://example.com"
    },
    "org.matrix.msc3575.proxy": {
        "url": "https://syncv3.example.com"
    }
}
```

If `well_known_sliding_sync_proxy` is not provided, the json provided by /.well-known/matrix/client does not include the proxy field.
ie.
``` json
{
    "m.homeserver": {
        "base_url": "https://example.com"
    }
}
```