### PR TITLE
Move pseudoID ClientEvent hotswapping to a common location

### DIFF
--- a/clientapi/routing/state.go
+++ b/clientapi/routing/state.go
@@ -191,9 +191,16 @@ func OnIncomingStateRequest(ctx context.Context, device *userapi.Device, rsAPI a
 					sk = &skString
 				}
 			}
+			clientEvent, err := synctypes.ToClientEvent(ev, synctypes.FormatAll, func(roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
+				return rsAPI.QueryUserIDForSender(ctx, roomID, senderID)
+			}, sender.String(), sk)
+			if err != nil {
+				util.GetLogger(ctx).WithError(err).Error("Failed converting to ClientEvent")
+				continue
+			}
 			stateEvents = append(
 				stateEvents,
-				synctypes.ToClientEvent(ev, synctypes.FormatAll, sender.String(), sk, ev.Unsigned()),
+				*clientEvent,
 			)
 		}
 	}

--- a/clientapi/routing/state.go
+++ b/clientapi/routing/state.go
@@ -172,28 +172,9 @@ func OnIncomingStateRequest(ctx context.Context, device *userapi.Device, rsAPI a
 			}
 		}
 		for _, ev := range stateAfterRes.StateEvents {
-			sender := spec.UserID{}
-			evRoomID, err := spec.NewRoomID(ev.RoomID())
-			if err != nil {
-				util.GetLogger(ctx).WithError(err).Error("Event roomID is invalid")
-				continue
-			}
-			userID, err := rsAPI.QueryUserIDForSender(ctx, *evRoomID, ev.SenderID())
-			if err == nil && userID != nil {
-				sender = *userID
-			}
-
-			sk := ev.StateKey()
-			if sk != nil && *sk != "" {
-				skUserID, err := rsAPI.QueryUserIDForSender(ctx, *evRoomID, spec.SenderID(*ev.StateKey()))
-				if err == nil && skUserID != nil {
-					skString := skUserID.String()
-					sk = &skString
-				}
-			}
 			clientEvent, err := synctypes.ToClientEvent(ev, synctypes.FormatAll, func(roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
 				return rsAPI.QueryUserIDForSender(ctx, roomID, senderID)
-			}, sender.String(), sk)
+			})
 			if err != nil {
 				util.GetLogger(ctx).WithError(err).Error("Failed converting to ClientEvent")
 				continue

--- a/internal/eventutil/events.go
+++ b/internal/eventutil/events.go
@@ -176,17 +176,9 @@ func RedactEvent(ctx context.Context, redactionEvent, redactedEvent gomatrixserv
 		return fmt.Errorf("RedactEvent: redactionEvent isn't a redaction event, is '%s'", redactionEvent.Type())
 	}
 	redactedEvent.Redact()
-	validRoomID, err := spec.NewRoomID(redactionEvent.RoomID())
-	if err != nil {
-		return err
-	}
-	senderID, err := querier.QueryUserIDForSender(ctx, *validRoomID, redactionEvent.SenderID())
-	if err != nil {
-		return err
-	}
 	clientEvent, err := synctypes.ToClientEvent(redactionEvent, synctypes.FormatSync, func(roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
 		return querier.QueryUserIDForSender(ctx, roomID, senderID)
-	}, senderID.String(), redactionEvent.StateKey())
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/eventutil/events.go
+++ b/internal/eventutil/events.go
@@ -184,7 +184,13 @@ func RedactEvent(ctx context.Context, redactionEvent, redactedEvent gomatrixserv
 	if err != nil {
 		return err
 	}
-	redactedBecause := synctypes.ToClientEvent(redactionEvent, synctypes.FormatSync, senderID.String(), redactionEvent.StateKey(), redactionEvent.Unsigned())
+	clientEvent, err := synctypes.ToClientEvent(redactionEvent, synctypes.FormatSync, func(roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
+		return querier.QueryUserIDForSender(ctx, roomID, senderID)
+	}, senderID.String(), redactionEvent.StateKey())
+	if err != nil {
+		return err
+	}
+	redactedBecause := clientEvent
 	if err := redactedEvent.SetUnsignedField("redacted_because", redactedBecause); err != nil {
 		return err
 	}

--- a/syncapi/routing/getevent.go
+++ b/syncapi/routing/getevent.go
@@ -118,34 +118,9 @@ func GetEvent(
 		}
 	}
 
-	senderUserID, err := rsAPI.QueryUserIDForSender(req.Context(), *roomID, events[0].SenderID())
-	if err != nil || senderUserID == nil {
-		util.GetLogger(req.Context()).WithError(err).WithField("senderID", events[0].SenderID()).WithField("roomID", *roomID).Error("QueryUserIDForSender errored or returned nil-user ID when user should be part of a room")
-		return util.JSONResponse{
-			Code: http.StatusInternalServerError,
-			JSON: spec.Unknown("internal server error"),
-		}
-	}
-
-	sk := events[0].StateKey()
-	if sk != nil && *sk != "" {
-		evRoomID, err := spec.NewRoomID(events[0].RoomID())
-		if err != nil {
-			return util.JSONResponse{
-				Code: http.StatusBadRequest,
-				JSON: spec.BadJSON("roomID is invalid"),
-			}
-		}
-		skUserID, err := rsAPI.QueryUserIDForSender(ctx, *evRoomID, spec.SenderID(*events[0].StateKey()))
-		if err == nil && skUserID != nil {
-			skString := skUserID.String()
-			sk = &skString
-		}
-	}
-
 	clientEvent, err := synctypes.ToClientEvent(events[0], synctypes.FormatAll, func(roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
 		return rsAPI.QueryUserIDForSender(ctx, roomID, senderID)
-	}, senderUserID.String(), sk)
+	})
 	if err != nil {
 		util.GetLogger(req.Context()).WithError(err).WithField("senderID", events[0].SenderID()).WithField("roomID", *roomID).Error("Failed converting to ClientEvent")
 		return util.JSONResponse{

--- a/syncapi/routing/messages.go
+++ b/syncapi/routing/messages.go
@@ -416,17 +416,6 @@ func (r *messagesReq) retrieveEvents(ctx context.Context, rsAPI api.SyncRoomserv
 
 	start = *r.from
 
-	for _, ev := range filteredEvents {
-		if ev.Version() != gomatrixserverlib.RoomVersionPseudoIDs {
-			continue
-		}
-		if ev.Type() != spec.MRoomPowerLevels || !ev.StateKeyEquals("") {
-			continue
-		}
-		// TODO: update power levels
-		// TODO: same thing for /event endpoint?
-	}
-
 	return synctypes.ToClientEvents(gomatrixserverlib.ToPDUs(filteredEvents), synctypes.FormatAll, func(roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
 		return rsAPI.QueryUserIDForSender(ctx, roomID, senderID)
 	}), start, end, nil

--- a/syncapi/routing/messages.go
+++ b/syncapi/routing/messages.go
@@ -416,6 +416,17 @@ func (r *messagesReq) retrieveEvents(ctx context.Context, rsAPI api.SyncRoomserv
 
 	start = *r.from
 
+	for _, ev := range filteredEvents {
+		if ev.Version() != gomatrixserverlib.RoomVersionPseudoIDs {
+			continue
+		}
+		if ev.Type() != spec.MRoomPowerLevels || !ev.StateKeyEquals("") {
+			continue
+		}
+		// TODO: update power levels
+		// TODO: same thing for /event endpoint?
+	}
+
 	return synctypes.ToClientEvents(gomatrixserverlib.ToPDUs(filteredEvents), synctypes.FormatAll, func(roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
 		return rsAPI.QueryUserIDForSender(ctx, roomID, senderID)
 	}), start, end, nil

--- a/syncapi/routing/relations.go
+++ b/syncapi/routing/relations.go
@@ -144,9 +144,17 @@ func Relations(
 				sk = &skString
 			}
 		}
+
+		clientEvent, err := synctypes.ToClientEvent(event.PDU, synctypes.FormatAll, func(roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
+			return rsAPI.QueryUserIDForSender(req.Context(), roomID, senderID)
+		}, sender.String(), sk)
+		if err != nil {
+			util.GetLogger(req.Context()).WithError(err).WithField("senderID", events[0].SenderID()).WithField("roomID", *roomID).Error("Failed converting to ClientEvent")
+			continue
+		}
 		res.Chunk = append(
 			res.Chunk,
-			synctypes.ToClientEvent(event.PDU, synctypes.FormatAll, sender.String(), sk, event.Unsigned()),
+			*clientEvent,
 		)
 	}
 

--- a/syncapi/routing/relations.go
+++ b/syncapi/routing/relations.go
@@ -130,24 +130,9 @@ func Relations(
 	// type if it was specified.
 	res.Chunk = make([]synctypes.ClientEvent, 0, len(filteredEvents))
 	for _, event := range filteredEvents {
-		sender := spec.UserID{}
-		userID, err := rsAPI.QueryUserIDForSender(req.Context(), *roomID, event.SenderID())
-		if err == nil && userID != nil {
-			sender = *userID
-		}
-
-		sk := event.StateKey()
-		if sk != nil && *sk != "" {
-			skUserID, err := rsAPI.QueryUserIDForSender(req.Context(), *roomID, spec.SenderID(*event.StateKey()))
-			if err == nil && skUserID != nil {
-				skString := skUserID.String()
-				sk = &skString
-			}
-		}
-
 		clientEvent, err := synctypes.ToClientEvent(event.PDU, synctypes.FormatAll, func(roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
 			return rsAPI.QueryUserIDForSender(req.Context(), roomID, senderID)
-		}, sender.String(), sk)
+		})
 		if err != nil {
 			util.GetLogger(req.Context()).WithError(err).WithField("senderID", events[0].SenderID()).WithField("roomID", *roomID).Error("Failed converting to ClientEvent")
 			continue

--- a/syncapi/routing/search.go
+++ b/syncapi/routing/search.go
@@ -235,31 +235,11 @@ func Search(req *http.Request, device *api.Device, syncDB storage.Database, fts 
 			profileInfos[userID.String()] = profile
 		}
 
-		sender := spec.UserID{}
-		validRoomID, roomErr := spec.NewRoomID(event.RoomID())
-		if err != nil {
-			logrus.WithError(roomErr).WithField("room_id", event.RoomID()).Warn("failed to query userprofile")
-			continue
-		}
-		userID, err := rsAPI.QueryUserIDForSender(req.Context(), *validRoomID, event.SenderID())
-		if err == nil && userID != nil {
-			sender = *userID
-		}
-
-		sk := event.StateKey()
-		if sk != nil && *sk != "" {
-			skUserID, err := rsAPI.QueryUserIDForSender(req.Context(), *validRoomID, spec.SenderID(*event.StateKey()))
-			if err == nil && skUserID != nil {
-				skString := skUserID.String()
-				sk = &skString
-			}
-		}
-
 		clientEvent, err := synctypes.ToClientEvent(event, synctypes.FormatAll, func(roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
 			return rsAPI.QueryUserIDForSender(ctx, roomID, senderID)
-		}, sender.String(), sk)
+		})
 		if err != nil {
-			util.GetLogger(req.Context()).WithError(err).WithField("senderID", event.SenderID()).WithField("roomID", *validRoomID).Error("Failed converting to ClientEvent")
+			util.GetLogger(req.Context()).WithError(err).WithField("senderID", event.SenderID()).Error("Failed converting to ClientEvent")
 			continue
 		}
 

--- a/syncapi/streams/stream_invite.go
+++ b/syncapi/streams/stream_invite.go
@@ -79,20 +79,11 @@ func (p *InviteStreamProvider) IncrementalSync(
 			user = *sender
 		}
 
-		sk := inviteEvent.StateKey()
-		if sk != nil && *sk != "" {
-			skUserID, err := p.rsAPI.QueryUserIDForSender(ctx, *validRoomID, spec.SenderID(*inviteEvent.StateKey()))
-			if err == nil && skUserID != nil {
-				skString := skUserID.String()
-				sk = &skString
-			}
-		}
-
 		// skip ignored user events
 		if _, ok := req.IgnoredUsers.List[user.String()]; ok {
 			continue
 		}
-		ir, err := types.NewInviteResponse(ctx, p.rsAPI, inviteEvent, user, sk, eventFormat)
+		ir, err := types.NewInviteResponse(ctx, p.rsAPI, inviteEvent, eventFormat)
 		if err != nil {
 			req.Log.WithError(err).Error("failed creating invite response")
 			continue

--- a/syncapi/streams/stream_invite.go
+++ b/syncapi/streams/stream_invite.go
@@ -92,7 +92,11 @@ func (p *InviteStreamProvider) IncrementalSync(
 		if _, ok := req.IgnoredUsers.List[user.String()]; ok {
 			continue
 		}
-		ir := types.NewInviteResponse(inviteEvent, user, sk, eventFormat)
+		ir, err := types.NewInviteResponse(ctx, p.rsAPI, inviteEvent, user, sk, eventFormat)
+		if err != nil {
+			req.Log.WithError(err).Error("failed creating invite response")
+			continue
+		}
 		req.Response.Rooms.Invite[roomID] = ir
 	}
 

--- a/syncapi/synctypes/clientevent.go
+++ b/syncapi/synctypes/clientevent.go
@@ -153,12 +153,10 @@ func ToClientEvent(se gomatrixserverlib.PDU, format ClientEventFormat, userIDFor
 		// TODO: Set Signatures & Hashes fields
 	}
 
-	if format != FormatSyncFederation {
-		if se.Version() == gomatrixserverlib.RoomVersionPseudoIDs {
-			err := updatePseudoIDs(&ce, se, userIDForSender, format)
-			if err != nil {
-				return nil, err
-			}
+	if format != FormatSyncFederation && se.Version() == gomatrixserverlib.RoomVersionPseudoIDs {
+		err := updatePseudoIDs(&ce, se, userIDForSender, format)
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -282,7 +280,7 @@ func updateInviteEvent(userIDForSender spec.UserIDForSender, ev gomatrixserverli
 			return nil, err
 		}
 
-		newState, err := getUpdatedInviteRoomState(userIDForSender, inviteRoomState, ev, *validRoomID, eventFormat)
+		newState, err := GetUpdatedInviteRoomState(userIDForSender, inviteRoomState, ev, *validRoomID, eventFormat)
 		if err != nil {
 			return nil, err
 		}
@@ -306,7 +304,7 @@ type InviteRoomStateEvent struct {
 	Type     string       `json:"type"`
 }
 
-func getUpdatedInviteRoomState(userIDForSender spec.UserIDForSender, inviteRoomState gjson.Result, event gomatrixserverlib.PDU, roomID spec.RoomID, eventFormat ClientEventFormat) (spec.RawJSON, error) {
+func GetUpdatedInviteRoomState(userIDForSender spec.UserIDForSender, inviteRoomState gjson.Result, event gomatrixserverlib.PDU, roomID spec.RoomID, eventFormat ClientEventFormat) (spec.RawJSON, error) {
 	var res spec.RawJSON
 	inviteStateEvents := []InviteRoomStateEvent{}
 	err := json.Unmarshal([]byte(inviteRoomState.Raw), &inviteStateEvents)

--- a/syncapi/synctypes/clientevent.go
+++ b/syncapi/synctypes/clientevent.go
@@ -318,7 +318,9 @@ func GetUpdatedInviteRoomState(userIDForSender spec.UserIDForSender, inviteRoomS
 			if userIDErr != nil {
 				return nil, userIDErr
 			}
-			inviteStateEvents[i].SenderID = userID.String()
+			if userID != nil {
+				inviteStateEvents[i].SenderID = userID.String()
+			}
 
 			if ev.StateKey != nil && *ev.StateKey != "" {
 				userID, senderErr := userIDForSender(roomID, spec.SenderID(*ev.StateKey))

--- a/syncapi/synctypes/clientevent.go
+++ b/syncapi/synctypes/clientevent.go
@@ -90,7 +90,7 @@ func ToClientEvents(serverEvs []gomatrixserverlib.PDU, format ClientEventFormat,
 	return evs
 }
 
-// ToClientEvent converts a single server event to a client event.
+// ToClientEventDefault converts a single server event to a client event.
 // It provides default logic for event.SenderID & event.StateKey -> userID conversions.
 func ToClientEventDefault(userIDQuery spec.UserIDForSender, event gomatrixserverlib.PDU) ClientEvent {
 	ev, err := ToClientEvent(event, FormatAll, userIDQuery)

--- a/syncapi/synctypes/clientevent_test.go
+++ b/syncapi/synctypes/clientevent_test.go
@@ -17,7 +17,6 @@ package synctypes
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -27,7 +26,7 @@ import (
 	"github.com/matrix-org/gomatrixserverlib/spec"
 )
 
-func queryUserIDForSender(ctx context.Context, roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
+func queryUserIDForSender(senderID spec.SenderID) (*spec.UserID, error) {
 	if senderID == "" {
 		return nil, nil
 	}
@@ -116,8 +115,8 @@ func TestToClientEvent(t *testing.T) { // nolint: gocyclo
 	}
 	sk := ""
 	ce, err := ToClientEvent(ev, FormatAll, func(roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
-		return queryUserIDForSender(context.Background(), roomID, senderID)
-	}, userID.String(), &sk)
+		return queryUserIDForSender(senderID)
+	})
 	if err != nil {
 		t.Fatalf("failed to create ClientEvent: %s", err)
 	}
@@ -175,14 +174,9 @@ func TestToClientFormatSync(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create Event: %s", err)
 	}
-	userID, err := spec.NewUserID("@test:localhost", true)
-	if err != nil {
-		t.Fatalf("failed to create userID: %s", err)
-	}
-	sk := ""
 	ce, err := ToClientEvent(ev, FormatSync, func(roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
-		return queryUserIDForSender(context.Background(), roomID, senderID)
-	}, userID.String(), &sk)
+		return queryUserIDForSender(senderID)
+	})
 	if err != nil {
 		t.Fatalf("failed to create ClientEvent: %s", err)
 	}
@@ -226,8 +220,8 @@ func TestToClientEventFormatSyncFederation(t *testing.T) { // nolint: gocyclo
 	}
 	sk := ""
 	ce, err := ToClientEvent(ev, FormatSyncFederation, func(roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
-		return queryUserIDForSender(context.Background(), roomID, senderID)
-	}, userID.String(), &sk)
+		return queryUserIDForSender(senderID)
+	})
 	if err != nil {
 		t.Fatalf("failed to create ClientEvent: %s", err)
 	}

--- a/syncapi/synctypes/clientevent_test.go
+++ b/syncapi/synctypes/clientevent_test.go
@@ -17,6 +17,7 @@ package synctypes
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -25,6 +26,14 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 )
+
+func queryUserIDForSender(ctx context.Context, roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
+	if senderID == "" {
+		return nil, nil
+	}
+
+	return spec.NewUserID(string(senderID), true)
+}
 
 const testSenderID = "testSenderID"
 const testUserID = "@test:localhost"
@@ -106,7 +115,12 @@ func TestToClientEvent(t *testing.T) { // nolint: gocyclo
 		t.Fatalf("failed to create userID: %s", err)
 	}
 	sk := ""
-	ce := ToClientEvent(ev, FormatAll, userID.String(), &sk, ev.Unsigned())
+	ce, err := ToClientEvent(ev, FormatAll, func(roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
+		return queryUserIDForSender(context.Background(), roomID, senderID)
+	}, userID.String(), &sk)
+	if err != nil {
+		t.Fatalf("failed to create ClientEvent: %s", err)
+	}
 
 	verifyEventFields(t,
 		EventFieldsToVerify{
@@ -166,7 +180,12 @@ func TestToClientFormatSync(t *testing.T) {
 		t.Fatalf("failed to create userID: %s", err)
 	}
 	sk := ""
-	ce := ToClientEvent(ev, FormatSync, userID.String(), &sk, ev.Unsigned())
+	ce, err := ToClientEvent(ev, FormatSync, func(roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
+		return queryUserIDForSender(context.Background(), roomID, senderID)
+	}, userID.String(), &sk)
+	if err != nil {
+		t.Fatalf("failed to create ClientEvent: %s", err)
+	}
 	if ce.RoomID != "" {
 		t.Errorf("ClientEvent.RoomID: wanted '', got %s", ce.RoomID)
 	}
@@ -206,7 +225,12 @@ func TestToClientEventFormatSyncFederation(t *testing.T) { // nolint: gocyclo
 		t.Fatalf("failed to create userID: %s", err)
 	}
 	sk := ""
-	ce := ToClientEvent(ev, FormatSyncFederation, userID.String(), &sk, ev.Unsigned())
+	ce, err := ToClientEvent(ev, FormatSyncFederation, func(roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
+		return queryUserIDForSender(context.Background(), roomID, senderID)
+	}, userID.String(), &sk)
+	if err != nil {
+		t.Fatalf("failed to create ClientEvent: %s", err)
+	}
 
 	verifyEventFields(t,
 		EventFieldsToVerify{

--- a/syncapi/types/types.go
+++ b/syncapi/types/types.go
@@ -533,7 +533,7 @@ type InviteResponse struct {
 }
 
 // NewInviteResponse creates an empty response with initialised arrays.
-func NewInviteResponse(ctx context.Context, rsAPI api.QuerySenderIDAPI, event *types.HeaderedEvent, userID spec.UserID, stateKey *string, eventFormat synctypes.ClientEventFormat) (*InviteResponse, error) {
+func NewInviteResponse(ctx context.Context, rsAPI api.QuerySenderIDAPI, event *types.HeaderedEvent, eventFormat synctypes.ClientEventFormat) (*InviteResponse, error) {
 	res := InviteResponse{}
 	res.InviteState.Events = []json.RawMessage{}
 
@@ -554,7 +554,7 @@ func NewInviteResponse(ctx context.Context, rsAPI api.QuerySenderIDAPI, event *t
 	// This is needed for clients to work out *who* sent the invite.
 	inviteEvent, err := synctypes.ToClientEvent(eventNoUnsigned, eventFormat, func(roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
 		return rsAPI.QueryUserIDForSender(ctx, roomID, senderID)
-	}, userID.String(), stateKey)
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/syncapi/types/types_test.go
+++ b/syncapi/types/types_test.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"testing"
@@ -11,8 +12,19 @@ import (
 	"github.com/matrix-org/gomatrixserverlib/spec"
 )
 
-func UserIDForSender(roomID string, senderID string) (*spec.UserID, error) {
-	return spec.NewUserID(senderID, true)
+type FakeRoomserverAPI struct{}
+
+func (f *FakeRoomserverAPI) QueryUserIDForSender(ctx context.Context, roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
+	if senderID == "" {
+		return nil, nil
+	}
+
+	return spec.NewUserID(string(senderID), true)
+}
+
+func (f *FakeRoomserverAPI) QuerySenderIDForUser(ctx context.Context, roomID spec.RoomID, userID spec.UserID) (*spec.SenderID, error) {
+	sender := spec.SenderID(userID.String())
+	return &sender, nil
 }
 
 func TestSyncTokens(t *testing.T) {
@@ -72,14 +84,18 @@ func TestNewInviteResponse(t *testing.T) {
 	skString := skUserID.String()
 	sk := &skString
 
-	res := NewInviteResponse(&types.HeaderedEvent{PDU: ev}, *sender, sk, synctypes.FormatSync)
+	rsAPI := FakeRoomserverAPI{}
+	res, err := NewInviteResponse(context.Background(), &rsAPI, &types.HeaderedEvent{PDU: ev}, *sender, sk, synctypes.FormatSync)
+	if err != nil {
+		t.Fatal(err)
+	}
 	j, err := json.Marshal(res)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if string(j) != expected {
-		t.Fatalf("Invite response didn't contain correct info")
+		t.Fatalf("Invite response didn't contain correct info, \nexpected: %s \ngot: %s", expected, string(j))
 	}
 }
 

--- a/syncapi/types/types_test.go
+++ b/syncapi/types/types_test.go
@@ -73,19 +73,8 @@ func TestNewInviteResponse(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sender, err := spec.NewUserID("@neilalexander:matrix.org", true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	skUserID, err := spec.NewUserID("@neilalexander:dendrite.neilalexander.dev", true)
-	if err != nil {
-		t.Fatal(err)
-	}
-	skString := skUserID.String()
-	sk := &skString
-
 	rsAPI := FakeRoomserverAPI{}
-	res, err := NewInviteResponse(context.Background(), &rsAPI, &types.HeaderedEvent{PDU: ev}, *sender, sk, synctypes.FormatSync)
+	res, err := NewInviteResponse(context.Background(), &rsAPI, &types.HeaderedEvent{PDU: ev}, synctypes.FormatSync)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/userapi/util/notify_test.go
+++ b/userapi/util/notify_test.go
@@ -23,7 +23,7 @@ import (
 	userUtil "github.com/matrix-org/dendrite/userapi/util"
 )
 
-func queryUserIDForSender(ctx context.Context, roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
+func queryUserIDForSender(senderID spec.SenderID) (*spec.UserID, error) {
 	if senderID == "" {
 		return nil, nil
 	}
@@ -108,14 +108,12 @@ func TestNotifyUserCountsAsync(t *testing.T) {
 		}
 
 		// Insert a dummy event
-		sender, err := spec.NewUserID(alice.ID, true)
+		ev, err := synctypes.ToClientEvent(dummyEvent, synctypes.FormatAll, func(roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
+			return queryUserIDForSender(senderID)
+		})
 		if err != nil {
 			t.Error(err)
 		}
-		sk := ""
-		ev, err := synctypes.ToClientEvent(dummyEvent, synctypes.FormatAll, func(roomID spec.RoomID, senderID spec.SenderID) (*spec.UserID, error) {
-			return queryUserIDForSender(context.Background(), roomID, senderID)
-		}, sender.String(), &sk)
 		if err := db.InsertNotification(ctx, aliceLocalpart, serverName, dummyEvent.EventID(), 0, nil, &api.Notification{
 			Event: *ev,
 		}); err != nil {


### PR DESCRIPTION
Fixes a variety of issues where clients were receiving pseudoIDs in places that should be userIDs.
This change makes pseudoIDs work with sliding sync & element x.