### PR TITLE
Fix invitations not sending push notifications

### DIFF
--- a/sytest-whitelist
+++ b/sytest-whitelist
@@ -784,3 +784,7 @@ Invited user can reject local invite after originator leaves
 Guest users can join guest_access rooms
 Forgotten room messages cannot be paginated
 Local device key changes get to remote servers with correct prev_id
+HS provides query metadata
+HS can provide query metadata on a single protocol
+Invites over federation are correctly pushed
+Invites over federation are correctly pushed with name

--- a/userapi/consumers/roomserver.go
+++ b/userapi/consumers/roomserver.go
@@ -463,7 +463,8 @@ func (s *OutputRoomEventConsumer) roomName(ctx context.Context, event *rstypes.H
 
 	// Special case for invites, as we don't store any "current state" for these events,
 	// we need to make sure that, if present, the m.room.name is sent as well.
-	if event.Type() == spec.MRoomMember {
+	if event.Type() == spec.MRoomMember &&
+		gjson.GetBytes(event.Content(), "membership").Str == "invite" {
 		invState := gjson.GetBytes(event.JSON(), "unsigned.invite_room_state")
 		for _, ev := range invState.Array() {
 			if ev.Get("type").Str == spec.MRoomName {

--- a/userapi/consumers/roomserver.go
+++ b/userapi/consumers/roomserver.go
@@ -112,16 +112,16 @@ func (s *OutputRoomEventConsumer) onMessage(ctx context.Context, msgs []*nats.Ms
 			event = output.NewInviteEvent.Event
 		}
 
+		if event == nil {
+			log.Errorf("userapi consumer: expected event")
+			return true
+		}
+
 		log.WithFields(log.Fields{
 			"event_id":   event.EventID(),
 			"event_type": event.Type(),
 		}).Tracef("Received message from roomserver: %#v", output)
 	default:
-		return true
-	}
-
-	if event == nil {
-		log.Errorf("userapi consumer: expected event")
 		return true
 	}
 

--- a/userapi/consumers/roomserver.go
+++ b/userapi/consumers/roomserver.go
@@ -92,16 +92,34 @@ func (s *OutputRoomEventConsumer) Start() error {
 func (s *OutputRoomEventConsumer) onMessage(ctx context.Context, msgs []*nats.Msg) bool {
 	msg := msgs[0] // Guaranteed to exist if onMessage is called
 	// Only handle events we care about
-	if rsapi.OutputType(msg.Header.Get(jetstream.RoomEventType)) != rsapi.OutputTypeNewRoomEvent {
+
+	var event *rstypes.HeaderedEvent
+	var isNewRoomEvent bool
+	switch rsapi.OutputType(msg.Header.Get(jetstream.RoomEventType)) {
+	case rsapi.OutputTypeNewRoomEvent:
+		isNewRoomEvent = true
+		fallthrough
+	case rsapi.OutputTypeNewInviteEvent:
+		var output rsapi.OutputEvent
+		if err := json.Unmarshal(msg.Data, &output); err != nil {
+			// If the message was invalid, log it and move on to the next message in the stream
+			log.WithError(err).Errorf("roomserver output log: message parse failure")
+			return true
+		}
+		if isNewRoomEvent {
+			event = output.NewRoomEvent.Event
+		} else {
+			event = output.NewInviteEvent.Event
+		}
+
+		log.WithFields(log.Fields{
+			"event_id":   event.EventID(),
+			"event_type": event.Type(),
+		}).Tracef("Received message from roomserver: %#v", output)
+	default:
 		return true
 	}
-	var output rsapi.OutputEvent
-	if err := json.Unmarshal(msg.Data, &output); err != nil {
-		// If the message was invalid, log it and move on to the next message in the stream
-		log.WithError(err).Errorf("roomserver output log: message parse failure")
-		return true
-	}
-	event := output.NewRoomEvent.Event
+
 	if event == nil {
 		log.Errorf("userapi consumer: expected event")
 		return true
@@ -110,11 +128,6 @@ func (s *OutputRoomEventConsumer) onMessage(ctx context.Context, msgs []*nats.Ms
 	if s.cfg.Matrix.ReportStats.Enabled {
 		go s.storeMessageStats(ctx, event.Type(), string(event.SenderID()), event.RoomID().String())
 	}
-
-	log.WithFields(log.Fields{
-		"event_id":   event.EventID(),
-		"event_type": event.Type(),
-	}).Tracef("Received message from roomserver: %#v", output)
 
 	metadata, err := msg.Metadata()
 	if err != nil {
@@ -445,6 +458,18 @@ func (s *OutputRoomEventConsumer) roomName(ctx context.Context, event *rstypes.H
 
 		if name != "" {
 			return name, nil
+		}
+	}
+
+	// Special case for invites, as we don't store any "current state" for these events,
+	// we need to make sure that, if present, the m.room.name is sent as well.
+	if event.Type() == spec.MRoomMember {
+		invState := gjson.GetBytes(event.JSON(), "unsigned.invite_room_state")
+		for _, ev := range invState.Array() {
+			if ev.Get("type").Str == spec.MRoomName {
+				name := ev.Get("content.name").Str
+				return name, nil
+			}
 		}
 	}
 


### PR DESCRIPTION
The tests added in https://github.com/matrix-org/sytest/pull/1356 uncovered that we don't consider invitations as events the userapi should handle and thus just don't notify the client about any new invitations received over federation.