### PR TITLE
Use port number instead of name for k8s service port

### DIFF
--- a/helm/dendrite/templates/ingress.yaml
+++ b/helm/dendrite/templates/ingress.yaml
@@ -4,6 +4,7 @@
 {{- $wellKnownServerHost := default $serverNameHost (regexFind "^(\\[.+\\])?[^:]*" .Values.dendrite_config.global.well_known_server_name) -}}
 {{- $wellKnownClientHost := default $serverNameHost (regexFind "//(\\[.+\\])?[^:/]*" .Values.dendrite_config.global.well_known_client_name | trimAll "/") -}}
 {{- $allHosts := list $serverNameHost $wellKnownServerHost $wellKnownClientHost | uniq -}}
+
 {{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 {{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
@@ -56,7 +57,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  name: http
+                  number: {{ $.Values.service.port }}
               {{- else }}
               serviceName: {{ $fullName }}
               servicePort: http
@@ -72,7 +73,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  name: http
+                  number: {{ $.Values.service.port }}
               {{- else }}
               serviceName: {{ $fullName }}
               servicePort: http
@@ -88,7 +89,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  name: http
+                  number: {{ $.Values.service.port }}
               {{- else }}
               serviceName: {{ $fullName }}
               servicePort: http
@@ -105,7 +106,7 @@ spec:
               service:
                 name: {{ $fullName }}
                 port:
-                  name: http
+                  number: {{ $.Values.service.port }}
               {{- else }}
               serviceName: {{ $fullName }}
               servicePort: http

--- a/helm/dendrite/templates/service.yaml
+++ b/helm/dendrite/templates/service.yaml
@@ -14,4 +14,4 @@ spec:
     - name: http
       protocol: TCP
       port: {{ .Values.service.port }}
-      targetPort: 8008
+      targetPort: http


### PR DESCRIPTION
I've found an issue when deploying Dendrite's Helm chart on my local cluster. The template for generating an Ingress resource tries to find the service port using a name (`http`), but the template that generates the Service resource, instead, identifies the resource with a port number.

According to the [Kubernetes ServiceSpec](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/), `ports.targetPort` can be either a number or a string; if it's the latter, it will be looked up as a named port in the pod's container ports.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [x] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately
