### PR TITLE
Allow some content types to be inlined

### DIFF
--- a/mediaapi/routing/download_test.go
+++ b/mediaapi/routing/download_test.go
@@ -1,0 +1,13 @@
+package routing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_dispositionFor(t *testing.T) {
+	assert.Equal(t, "attachment", contentDispositionFor(""), "empty content type")
+	assert.Equal(t, "attachment", contentDispositionFor("image/svg"), "image/svg")
+	assert.Equal(t, "inline", contentDispositionFor("image/jpeg"), "image/jpg")
+}


### PR DESCRIPTION
"Shamelessly" stolen from https://github.com/matrix-org/synapse/pull/15988