### PR TITLE
Return `M_INVALID_PARAM` instead of `M_BAD_JSON` when setting aliases 

### DIFF
--- a/clientapi/routing/directory.go
+++ b/clientapi/routing/directory.go
@@ -55,7 +55,7 @@ func DirectoryRoom(
 	if err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
-			JSON: spec.BadJSON("Room alias must be in the form '#localpart:domain'"),
+			JSON: spec.InvalidParam("Room alias must be in the form '#localpart:domain'"),
 		}
 	}
 
@@ -134,7 +134,7 @@ func SetLocalAlias(
 	if err != nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
-			JSON: spec.BadJSON("Room alias must be in the form '#localpart:domain'"),
+			JSON: spec.InvalidParam("Room alias must be in the form '#localpart:domain'"),
 		}
 	}
 


### PR DESCRIPTION
Part of https://github.com/matrix-org/dendrite/issues/3223 (https://github.com/matrix-org/matrix-spec/pull/1286)

(For `DELETE` we don't validate the alias, but just return a 404 if we can't find it)