### PR TITLE
Optimize `PrevEventIDs` when getting thousands of backwards extremeties

### DIFF
--- a/federationapi/routing/backfill.go
+++ b/federationapi/routing/backfill.go
@@ -95,6 +95,12 @@ func Backfill(
 		}
 	}
 
+	// Enforce a limit of 100 events, as not to hit the DB to hard.
+	// Synapse has a hard limit of 100 events as well.
+	if req.Limit > 100 {
+		req.Limit = 100
+	}
+
 	// Query the Roomserver.
 	if err = rsAPI.PerformBackfill(httpReq.Context(), &req, &res); err != nil {
 		util.GetLogger(httpReq.Context()).WithError(err).Error("query.PerformBackfill failed")

--- a/roomserver/api/perform.go
+++ b/roomserver/api/perform.go
@@ -94,7 +94,11 @@ type PerformBackfillRequest struct {
 // PrevEventIDs returns the prev_event IDs of all backwards extremities, de-duplicated in a lexicographically sorted order.
 func (r *PerformBackfillRequest) PrevEventIDs() []string {
 	// Collect 1k eventIDs, if possible, they may be cleared out below
-	prevEventIDs := make([]string, 0, len(r.BackwardsExtremities)*3)
+	maxPrevEventIDs := len(r.BackwardsExtremities) * 3
+	if maxPrevEventIDs > 2000 {
+		maxPrevEventIDs = 2000
+	}
+	prevEventIDs := make([]string, 0, maxPrevEventIDs)
 	for _, pes := range r.BackwardsExtremities {
 		prevEventIDs = append(prevEventIDs, pes...)
 		if len(prevEventIDs) > 1000 {

--- a/roomserver/api/perform.go
+++ b/roomserver/api/perform.go
@@ -93,11 +93,19 @@ type PerformBackfillRequest struct {
 
 // PrevEventIDs returns the prev_event IDs of all backwards extremities, de-duplicated in a lexicographically sorted order.
 func (r *PerformBackfillRequest) PrevEventIDs() []string {
-	var prevEventIDs []string
+	// Collect 1k eventIDs, if possible, they may be cleared out below
+	prevEventIDs := make([]string, 0, len(r.BackwardsExtremities)*3)
 	for _, pes := range r.BackwardsExtremities {
 		prevEventIDs = append(prevEventIDs, pes...)
+		if len(prevEventIDs) > 1000 {
+			break
+		}
 	}
 	prevEventIDs = util.UniqueStrings(prevEventIDs)
+	// If we still have > 100 eventIDs, only return the first 100
+	if len(prevEventIDs) > 100 {
+		return prevEventIDs[:100]
+	}
 	return prevEventIDs
 }
 

--- a/roomserver/api/perform.go
+++ b/roomserver/api/perform.go
@@ -90,6 +90,10 @@ type PerformBackfillRequest struct {
 	VirtualHost spec.ServerName `json:"virtual_host"`
 }
 
+// limitPrevEventIDs is the maximum of eventIDs we
+// return when calling PrevEventIDs.
+const limitPrevEventIDs = 100
+
 // PrevEventIDs returns the prev_event IDs of either 100 backwards extremities or
 // len(r.BackwardsExtremities). Limited to 100, due to Synapse/Dendrite stopping after reaching
 // this limit. (which sounds sane)
@@ -98,8 +102,8 @@ func (r *PerformBackfillRequest) PrevEventIDs() []string {
 
 	// Create a unique eventID map of either 100 or len(r.BackwardsExtremities).
 	// 100 since Synapse/Dendrite stops after reaching 100 events.
-	if len(r.BackwardsExtremities) > 100 {
-		uniqueIDs = make(map[string]struct{}, 100)
+	if len(r.BackwardsExtremities) > limitPrevEventIDs {
+		uniqueIDs = make(map[string]struct{}, limitPrevEventIDs)
 	} else {
 		uniqueIDs = make(map[string]struct{}, len(r.BackwardsExtremities))
 	}
@@ -109,7 +113,7 @@ outerLoop:
 		for _, evID := range pes {
 			uniqueIDs[evID] = struct{}{}
 			// We found enough unique eventIDs.
-			if len(uniqueIDs) >= 100 {
+			if len(uniqueIDs) >= limitPrevEventIDs {
 				break outerLoop
 			}
 		}

--- a/roomserver/api/perform.go
+++ b/roomserver/api/perform.go
@@ -120,6 +120,7 @@ outerLoop:
 	i := 0
 	for evID := range uniqueIDs {
 		result[i] = evID
+		i++
 	}
 
 	return result

--- a/roomserver/api/perform.go
+++ b/roomserver/api/perform.go
@@ -91,13 +91,13 @@ type PerformBackfillRequest struct {
 }
 
 // PrevEventIDs returns the prev_event IDs of either 100 backwards extremities or
-// len(r.BackwardsExtremities). Limited to 100, due to Synapse stopping after reaching
+// len(r.BackwardsExtremities). Limited to 100, due to Synapse/Dendrite stopping after reaching
 // this limit. (which sounds sane)
 func (r *PerformBackfillRequest) PrevEventIDs() []string {
 	var uniqueIDs map[string]struct{}
 
 	// Create a unique eventID map of either 100 or len(r.BackwardsExtremities).
-	// 100 since Synapse stops after reaching 100 events.
+	// 100 since Synapse/Dendrite stops after reaching 100 events.
 	if len(r.BackwardsExtremities) > 100 {
 		uniqueIDs = make(map[string]struct{}, 100)
 	} else {

--- a/roomserver/api/perform_test.go
+++ b/roomserver/api/perform_test.go
@@ -32,11 +32,11 @@ func generateBackwardsExtremities(b *testing.B, count int) map[string][]string {
 	b.Helper()
 	result := make(map[string][]string, count)
 	for i := 0; i < count; i++ {
-		eventID := randomEventId(int64(i), randomIDCharsCount)
+		eventID := randomEventId(int64(i))
 		result[eventID] = []string{
-			randomEventId(int64(i+1), randomIDCharsCount),
-			randomEventId(int64(i+2), randomIDCharsCount),
-			randomEventId(int64(i+3), randomIDCharsCount),
+			randomEventId(int64(i + 1)),
+			randomEventId(int64(i + 2)),
+			randomEventId(int64(i + 3)),
 		}
 	}
 	return result
@@ -45,9 +45,9 @@ func generateBackwardsExtremities(b *testing.B, count int) map[string][]string {
 const alphanumerics = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 // RandomString generates a pseudo-random string of length n.
-func randomEventId(src int64, n int) string {
+func randomEventId(src int64) string {
 	randSrc := rand.NewSource(src)
-	b := make([]byte, n)
+	b := make([]byte, randomIDCharsCount)
 	for i := range b {
 		b[i] = alphanumerics[randSrc.Int63()%int64(len(alphanumerics))]
 	}

--- a/roomserver/api/perform_test.go
+++ b/roomserver/api/perform_test.go
@@ -26,15 +26,17 @@ func benchPrevEventIDs(b *testing.B, count int) {
 	})
 }
 
+const randomIDCharsCount = 10
+
 func generateBackwardsExtremities(b *testing.B, count int) map[string][]string {
 	b.Helper()
 	result := make(map[string][]string, count)
 	for i := 0; i < count; i++ {
-		eventID := randomEventId(int64(i), 10)
+		eventID := randomEventId(int64(i), randomIDCharsCount)
 		result[eventID] = []string{
-			randomEventId(int64(i+1), 10),
-			randomEventId(int64(i+2), 10),
-			randomEventId(int64(i+3), 10),
+			randomEventId(int64(i+1), randomIDCharsCount),
+			randomEventId(int64(i+2), randomIDCharsCount),
+			randomEventId(int64(i+3), randomIDCharsCount),
 		}
 	}
 	return result

--- a/roomserver/api/perform_test.go
+++ b/roomserver/api/perform_test.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+)
+
+func BenchmarkPrevEventIDs(b *testing.B) {
+	for _, x := range []int64{1, 2, 4, 10, 50, 100, 300, 500, 800, 1000, 2000, 3000, 5000, 10000} {
+		benchPrevEventIDs(b, int(x))
+	}
+}
+
+func benchPrevEventIDs(b *testing.B, count int) {
+	b.Run(fmt.Sprintf("Benchmark%d", count), func(b *testing.B) {
+		bwExtrems := generateBackwardsExtremities(b, count)
+		backfiller := PerformBackfillRequest{
+			BackwardsExtremities: bwExtrems,
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			prevIDs := backfiller.PrevEventIDs()
+			_ = prevIDs
+		}
+	})
+}
+
+func generateBackwardsExtremities(b *testing.B, count int) map[string][]string {
+	b.Helper()
+	result := make(map[string][]string, count)
+	for i := 0; i < count; i++ {
+		eventID := randomEventId(int64(i), 10)
+		result[eventID] = []string{
+			randomEventId(int64(i+1), 10),
+			randomEventId(int64(i+2), 10),
+			randomEventId(int64(i+3), 10),
+		}
+	}
+	return result
+}
+
+const alphanumerics = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+// RandomString generates a pseudo-random string of length n.
+func randomEventId(src int64, n int) string {
+	randSrc := rand.NewSource(src)
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = alphanumerics[randSrc.Int63()%int64(len(alphanumerics))]
+	}
+	return string(b)
+}

--- a/roomserver/api/perform_test.go
+++ b/roomserver/api/perform_test.go
@@ -62,17 +62,20 @@ func randomEventId(src int64) string {
 }
 
 func TestPrevEventIDs(t *testing.T) {
+	// generate 10 backwards extremities
 	bwExtrems := generateBackwardsExtremities(t, 10)
 	backfiller := PerformBackfillRequest{
 		BackwardsExtremities: bwExtrems,
 	}
 
-	// prevIDs as generated for 10 backwards extremities
 	prevIDs := backfiller.PrevEventIDs()
+	// Given how "generateBackwardsExtremities" works, this
+	// generates 12 unique event IDs
 	assert.Equal(t, 12, len(prevIDs))
 
-	// prevIDs as generated for 100 backwards extremities
-	backfiller.BackwardsExtremities = generateBackwardsExtremities(t, 100)
+	// generate 200 backwards extremities
+	backfiller.BackwardsExtremities = generateBackwardsExtremities(t, 200)
 	prevIDs = backfiller.PrevEventIDs()
+	// PrevEventIDs returns at max 100 event IDs
 	assert.Equal(t, 100, len(prevIDs))
 }

--- a/roomserver/api/perform_test.go
+++ b/roomserver/api/perform_test.go
@@ -68,13 +68,11 @@ func TestPrevEventIDs(t *testing.T) {
 	}
 
 	// prevIDs as generated for 10 backwards extremities
-	wantPrevEventIDs := []string{"1ExBQDVcBj", "A9HQt03Ink", "BRUmuwogIq", "BUzb5KBQBO", "Ibyq7BhmYX", "MIMMBA6e9D", "NEQe6xuOjj", "ONRhfKsUOH", "byJR3RCsab", "eCfa30nG7H", "m3OCJNYcS4", "rMWhKXFs9K"}
 	prevIDs := backfiller.PrevEventIDs()
-	assert.Equal(t, wantPrevEventIDs, prevIDs)
+	assert.Equal(t, 12, len(prevIDs))
 
 	// prevIDs as generated for 100 backwards extremities
 	backfiller.BackwardsExtremities = generateBackwardsExtremities(t, 100)
-	wantPrevEventIDs = []string{"0QWd8TuUHD", "159jkpFN68", "19CrIDkTTb", "1ExBQDVcBj", "1kFAed76vN", "2xKOixxmhS", "3ApLwSwkH3", "3wszjJPW9A", "4qUOTgFKxM", "58tM6RUsRu", "5OQIDNOr4M", "5sJVbLeaKw", "6Vg95rTgUX", "6YxCUbAR9y", "6nZZd4kufM", "7REdWyhuE2", "86a1U3dnjy", "8l2IYAMcdF", "A9HQt03Ink", "AXOrOWTA0j", "AvxnvTLm8K", "AwQiSuIEbH", "BRUmuwogIq", "BUzb5KBQBO", "BrHEgialwW", "C4WNO7VSn2", "CBctYVoacn", "CN3mvQ6E6W", "E7nX8EQT1B", "ES4tNDW0wx", "FS9gV2aYvC", "FZCU0siAER", "FjXa7mqfXn", "G4q5qGdMQb", "GCxaYfmh7s", "Gs9MlFL3Fd", "H0Mzqei69C", "HITwTlAE4j", "IZ3P3uFPu6", "Ibyq7BhmYX", "JMqrpZJT9x", "JVVY34qwhB", "JZQagbldw2", "LJfQVtSU6n", "MIMMBA6e9D", "NEQe6xuOjj", "NlDSaJjceb", "ONRhfKsUOH", "OtptJ4GhQ2", "Qn1XPQhpgz", "SE3y6JniXH", "SlHpqJdjXN", "SqeoLYdQvf", "TmyExrsLR8", "Tvw8iGKHOz", "U9PldtLkuE", "UidzU2YW7G", "VkWDn232Qy", "Wbl4KHc2w0", "XL5mt8EKCt", "ZZ659s7Mwy", "ZmC0h0G6Mf", "anjChmyqJJ", "byJR3RCsab", "eCfa30nG7H", "eooGdExorQ", "esVxgLwWeD", "f0hxkMzETL", "fl5rrUR3Un", "gSoogyeREZ", "gc7zclHt95", "h9ncUeqMAD", "ha936wz0tY", "imnKEUbBlK", "lZRAlpDwpN", "lZy9etvZzj", "lwYHvKrxh0", "m3OCJNYcS4", "m8GagfYqOM", "ni3n5Y56zH", "nxz84Ndaqh", "oUJyu78LB6", "q0mUbgGerE", "qjRbAktvKw", "qmzKjSmsFs", "qncDkkqgi7", "rMWhKXFs9K", "sB8pmOdISV", "sXRWyyQlSi", "t4VYOaIWrg", "t97LRflvAD", "tZUvZ2YXy9", "ta1QyRKnUj", "vHmrrLVkpk", "vxxXjxb8lx", "wvU4kvV1WB", "x8k42j3IXJ", "xPcwjlG49n", "yHFB0bx2IA", "ytgBjHKSes"}
 	prevIDs = backfiller.PrevEventIDs()
-	assert.Equal(t, wantPrevEventIDs, prevIDs)
+	assert.Equal(t, 100, len(prevIDs))
 }

--- a/roomserver/api/perform_test.go
+++ b/roomserver/api/perform_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func BenchmarkPrevEventIDs(b *testing.B) {
@@ -26,10 +28,14 @@ func benchPrevEventIDs(b *testing.B, count int) {
 	})
 }
 
+type testLike interface {
+	Helper()
+}
+
 const randomIDCharsCount = 10
 
-func generateBackwardsExtremities(b *testing.B, count int) map[string][]string {
-	b.Helper()
+func generateBackwardsExtremities(t testLike, count int) map[string][]string {
+	t.Helper()
 	result := make(map[string][]string, count)
 	for i := 0; i < count; i++ {
 		eventID := randomEventId(int64(i))
@@ -52,4 +58,22 @@ func randomEventId(src int64) string {
 		b[i] = alphanumerics[randSrc.Int63()%int64(len(alphanumerics))]
 	}
 	return string(b)
+}
+
+func TestPrevEventIDs(t *testing.T) {
+	bwExtrems := generateBackwardsExtremities(t, 10)
+	backfiller := PerformBackfillRequest{
+		BackwardsExtremities: bwExtrems,
+	}
+
+	// prevIDs as generated for 10 backwards extremities
+	wantPrevEventIDs := []string{"1ExBQDVcBj", "A9HQt03Ink", "BRUmuwogIq", "BUzb5KBQBO", "Ibyq7BhmYX", "MIMMBA6e9D", "NEQe6xuOjj", "ONRhfKsUOH", "byJR3RCsab", "eCfa30nG7H", "m3OCJNYcS4", "rMWhKXFs9K"}
+	prevIDs := backfiller.PrevEventIDs()
+	assert.Equal(t, wantPrevEventIDs, prevIDs)
+
+	// prevIDs as generated for 100 backwards extremities
+	backfiller.BackwardsExtremities = generateBackwardsExtremities(t, 100)
+	wantPrevEventIDs = []string{"0QWd8TuUHD", "159jkpFN68", "19CrIDkTTb", "1ExBQDVcBj", "1kFAed76vN", "2xKOixxmhS", "3ApLwSwkH3", "3wszjJPW9A", "4qUOTgFKxM", "58tM6RUsRu", "5OQIDNOr4M", "5sJVbLeaKw", "6Vg95rTgUX", "6YxCUbAR9y", "6nZZd4kufM", "7REdWyhuE2", "86a1U3dnjy", "8l2IYAMcdF", "A9HQt03Ink", "AXOrOWTA0j", "AvxnvTLm8K", "AwQiSuIEbH", "BRUmuwogIq", "BUzb5KBQBO", "BrHEgialwW", "C4WNO7VSn2", "CBctYVoacn", "CN3mvQ6E6W", "E7nX8EQT1B", "ES4tNDW0wx", "FS9gV2aYvC", "FZCU0siAER", "FjXa7mqfXn", "G4q5qGdMQb", "GCxaYfmh7s", "Gs9MlFL3Fd", "H0Mzqei69C", "HITwTlAE4j", "IZ3P3uFPu6", "Ibyq7BhmYX", "JMqrpZJT9x", "JVVY34qwhB", "JZQagbldw2", "LJfQVtSU6n", "MIMMBA6e9D", "NEQe6xuOjj", "NlDSaJjceb", "ONRhfKsUOH", "OtptJ4GhQ2", "Qn1XPQhpgz", "SE3y6JniXH", "SlHpqJdjXN", "SqeoLYdQvf", "TmyExrsLR8", "Tvw8iGKHOz", "U9PldtLkuE", "UidzU2YW7G", "VkWDn232Qy", "Wbl4KHc2w0", "XL5mt8EKCt", "ZZ659s7Mwy", "ZmC0h0G6Mf", "anjChmyqJJ", "byJR3RCsab", "eCfa30nG7H", "eooGdExorQ", "esVxgLwWeD", "f0hxkMzETL", "fl5rrUR3Un", "gSoogyeREZ", "gc7zclHt95", "h9ncUeqMAD", "ha936wz0tY", "imnKEUbBlK", "lZRAlpDwpN", "lZy9etvZzj", "lwYHvKrxh0", "m3OCJNYcS4", "m8GagfYqOM", "ni3n5Y56zH", "nxz84Ndaqh", "oUJyu78LB6", "q0mUbgGerE", "qjRbAktvKw", "qmzKjSmsFs", "qncDkkqgi7", "rMWhKXFs9K", "sB8pmOdISV", "sXRWyyQlSi", "t4VYOaIWrg", "t97LRflvAD", "tZUvZ2YXy9", "ta1QyRKnUj", "vHmrrLVkpk", "vxxXjxb8lx", "wvU4kvV1WB", "x8k42j3IXJ", "xPcwjlG49n", "yHFB0bx2IA", "ytgBjHKSes"}
+	prevIDs = backfiller.PrevEventIDs()
+	assert.Equal(t, wantPrevEventIDs, prevIDs)
 }


### PR DESCRIPTION
Changes how many `PrevEventIDs` we send to other servers when backfilling, capped to 100 events.

Unsure about how representative this benchmark is..
```
goos: linux
goarch: amd64
pkg: github.com/matrix-org/dendrite/roomserver/api
cpu: Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
                            │    old.txt     │               new.txt               │
                            │     sec/op     │   sec/op     vs base                │
PrevEventIDs/Original1-8         264.9n ± 5%   237.4n ± 7%  -10.36% (p=0.000 n=10)
PrevEventIDs/Original10-8        3.101µ ± 4%   1.590µ ± 2%  -48.72% (p=0.000 n=10)
PrevEventIDs/Original100-8       44.32µ ± 2%   12.80µ ± 4%  -71.11% (p=0.000 n=10)
PrevEventIDs/Original500-8     263.835µ ± 4%   7.907µ ± 4%  -97.00% (p=0.000 n=10)
PrevEventIDs/Original1000-8    578.798µ ± 2%   7.620µ ± 2%  -98.68% (p=0.000 n=10)
PrevEventIDs/Original2000-8   1272.039µ ± 2%   8.241µ ± 9%  -99.35% (p=0.000 n=10)
geomean                          43.81µ        3.659µ       -91.65%

                            │    old.txt     │               new.txt                │
                            │      B/op      │     B/op      vs base                │
PrevEventIDs/Original1-8          72.00 ± 0%     48.00 ± 0%  -33.33% (p=0.000 n=10)
PrevEventIDs/Original10-8        1512.0 ± 0%     500.0 ± 0%  -66.93% (p=0.000 n=10)
PrevEventIDs/Original100-8     11.977Ki ± 0%   7.023Ki ± 0%  -41.36% (p=0.000 n=10)
PrevEventIDs/Original500-8     67.227Ki ± 0%   7.023Ki ± 0%  -89.55% (p=0.000 n=10)
PrevEventIDs/Original1000-8   163.227Ki ± 0%   7.023Ki ± 0%  -95.70% (p=0.000 n=10)
PrevEventIDs/Original2000-8   347.227Ki ± 0%   7.023Ki ± 0%  -97.98% (p=0.000 n=10)
geomean                         12.96Ki        1.954Ki       -84.92%

                            │   old.txt   │              new.txt               │
                            │  allocs/op  │ allocs/op   vs base                │
PrevEventIDs/Original1-8       2.000 ± 0%   1.000 ± 0%  -50.00% (p=0.000 n=10)
PrevEventIDs/Original10-8      6.000 ± 0%   2.000 ± 0%  -66.67% (p=0.000 n=10)
PrevEventIDs/Original100-8     9.000 ± 0%   3.000 ± 0%  -66.67% (p=0.000 n=10)
PrevEventIDs/Original500-8    12.000 ± 0%   3.000 ± 0%  -75.00% (p=0.000 n=10)
PrevEventIDs/Original1000-8   14.000 ± 0%   3.000 ± 0%  -78.57% (p=0.000 n=10)
PrevEventIDs/Original2000-8   16.000 ± 0%   3.000 ± 0%  -81.25% (p=0.000 n=10)
geomean                        8.137        2.335       -71.31%
```