### PR TITLE
Allow + in MIDs as per MSC4009

### DIFF
--- a/internal/validate.go
+++ b/internal/validate.go
@@ -38,9 +38,9 @@ var (
 	ErrPasswordTooLong    = fmt.Errorf("password too long: max %d characters", maxPasswordLength)
 	ErrPasswordWeak       = fmt.Errorf("password too weak: min %d characters", minPasswordLength)
 	ErrUsernameTooLong    = fmt.Errorf("username exceeds the maximum length of %d characters", maxUsernameLength)
-	ErrUsernameInvalid    = errors.New("username can only contain characters a-z, 0-9, or '_-./='")
+	ErrUsernameInvalid    = errors.New("username can only contain characters a-z, 0-9, or '_+-./='")
 	ErrUsernameUnderscore = errors.New("username cannot start with a '_'")
-	validUsernameRegex    = regexp.MustCompile(`^[0-9a-z_\-=./]+$`)
+	validUsernameRegex    = regexp.MustCompile(`^[0-9a-z_\-+=./]+$`)
 )
 
 // ValidatePassword returns an error if the password is invalid

--- a/internal/validate_test.go
+++ b/internal/validate_test.go
@@ -130,8 +130,23 @@ func Test_validateUsername(t *testing.T) {
 			domain:    "localhost",
 		},
 		{
+			name:      "special characters are allowed 3",
+			localpart: "+55555555555",
+			domain:    "localhost",
+		},
+		{
 			name:      "not all special characters are allowed",
 			localpart: "notallowed#", // contains #
+			domain:    "localhost",
+			wantErr:   ErrUsernameInvalid,
+			wantJSON: &util.JSONResponse{
+				Code: http.StatusBadRequest,
+				JSON: spec.InvalidUsername(ErrUsernameInvalid.Error()),
+			},
+		},
+		{
+			name:      "not all special characters are allowed 2",
+			localpart: "<notallowed", // contains <
 			domain:    "localhost",
 			wantErr:   ErrUsernameInvalid,
 			wantJSON: &util.JSONResponse{


### PR DESCRIPTION
This PR adds `+` to the username regex, per MSC4009.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [x] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

Signed-off-by: `Matt Strapp <matt@mattstrapp.net>`
