### PR TITLE
Limit filter to `limit/2` for before/after events on `/context`

### DIFF
--- a/syncapi/routing/context.go
+++ b/syncapi/routing/context.go
@@ -164,7 +164,9 @@ func Context(
 	}
 
 	// Limit is split up for before/after events
-	filter.Limit = filter.Limit / 2
+	if limit > 1 {
+		filter.Limit = filter.Limit / 2
+	}
 
 	eventsBefore, err := snapshot.SelectContextBeforeEvent(ctx, id, roomID, filter)
 	if err != nil && err != sql.ErrNoRows {

--- a/syncapi/routing/context.go
+++ b/syncapi/routing/context.go
@@ -159,7 +159,7 @@ func Context(
 	}
 
 	// Limit is split up for before/after events
-	if limit > 1 {
+	if filter.Limit > 1 {
 		filter.Limit = filter.Limit / 2
 	}
 

--- a/syncapi/routing/context.go
+++ b/syncapi/routing/context.go
@@ -109,13 +109,8 @@ func Context(
 		}
 	}
 
-	// Default to a sane state filter limit
-	limit := filter.Limit
-	if limit > 100 {
-		limit = 100
-	}
 	stateFilter := synctypes.StateFilter{
-		Limit:                   limit,
+		Limit:                   filter.Limit,
 		NotSenders:              filter.NotSenders,
 		NotTypes:                filter.NotTypes,
 		Senders:                 filter.Senders,

--- a/syncapi/routing/context.go
+++ b/syncapi/routing/context.go
@@ -109,7 +109,8 @@ func Context(
 		}
 	}
 
-	stateFilter := synctypes.StateFilter{
+	stateFilter := synctypes.DefaultStateFilter()
+	stateFilter = synctypes.StateFilter{
 		NotSenders:              filter.NotSenders,
 		NotTypes:                filter.NotTypes,
 		Senders:                 filter.Senders,

--- a/syncapi/routing/context.go
+++ b/syncapi/routing/context.go
@@ -157,6 +157,9 @@ func Context(
 		}
 	}
 
+	// Limit is split up for before/after events
+	filter.Limit = filter.Limit / 2
+
 	eventsBefore, err := snapshot.SelectContextBeforeEvent(ctx, id, roomID, filter)
 	if err != nil && err != sql.ErrNoRows {
 		logrus.WithError(err).Error("unable to fetch before events")

--- a/syncapi/routing/context.go
+++ b/syncapi/routing/context.go
@@ -109,8 +109,13 @@ func Context(
 		}
 	}
 
-	stateFilter := synctypes.DefaultStateFilter()
-	stateFilter = synctypes.StateFilter{
+	// Default to a sane state filter limit
+	limit := filter.Limit
+	if limit > 100 {
+		limit = 100
+	}
+	stateFilter := synctypes.StateFilter{
+		Limit:                   limit,
 		NotSenders:              filter.NotSenders,
 		NotTypes:                filter.NotTypes,
 		Senders:                 filter.Senders,

--- a/syncapi/syncapi_test.go
+++ b/syncapi/syncapi_test.go
@@ -1136,7 +1136,7 @@ func testContext(t *testing.T, dbType test.DBType) {
 		},
 		{
 			name:             "events are not limited",
-			wantBeforeLength: 7,
+			wantBeforeLength: 5,
 		},
 		{
 			name: "all events are limited",

--- a/syncapi/synctypes/filter.go
+++ b/syncapi/synctypes/filter.go
@@ -128,6 +128,7 @@ func DefaultEventFilter() EventFilter {
 // is provided in the request
 func DefaultStateFilter() StateFilter {
 	return StateFilter{
+		Limit:                   10,
 		NotSenders:              nil,
 		NotTypes:                nil,
 		Senders:                 nil,

--- a/syncapi/synctypes/filter.go
+++ b/syncapi/synctypes/filter.go
@@ -128,7 +128,6 @@ func DefaultEventFilter() EventFilter {
 // is provided in the request
 func DefaultStateFilter() StateFilter {
 	return StateFilter{
-		Limit:                   10,
 		NotSenders:              nil,
 		NotTypes:                nil,
 		Senders:                 nil,


### PR DESCRIPTION
Part of https://github.com/matrix-org/dendrite/issues/3224