### PR TITLE
Reuse existing NATS connection

### DIFF
--- a/setup/jetstream/nats.go
+++ b/setup/jetstream/nats.go
@@ -38,7 +38,12 @@ func (s *NATSInstance) Prepare(process *process.ProcessContext, cfg *config.JetS
 	defer natsLock.Unlock()
 	// check if we need an in-process NATS Server
 	if len(cfg.Addresses) != 0 {
-		return setupNATS(process, cfg, nil)
+		// reuse existing connections
+		if s.nc != nil {
+			return s.js, s.nc
+		}
+		s.js, s.nc = setupNATS(process, cfg, nil)
+		return s.js, s.nc
 	}
 	if s.Server == nil {
 		var err error


### PR DESCRIPTION
If using external NATS, we opened unnecessary connections. This now re-uses existing connections.