### PR TITLE
Take advantage of changes in recent Go versions

### DIFF
--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -255,7 +255,7 @@ func Setup(
 		logrus.Info("Enabling server notices at /_synapse/admin/v1/send_server_notice")
 		serverNotificationSender, err := getSenderDevice(context.Background(), rsAPI, userAPI, cfg)
 		if err != nil {
-			logrus.WithError(err).Fatal("unable to get account for sending sending server notices")
+			logrus.WithError(err).Fatal("unable to get account for sending server notices")
 		}
 
 		synapseAdminRouter.Handle("/admin/v1/send_server_notice/{txnID}",

--- a/cmd/dendrite-demo-pinecone/relay/retriever.go
+++ b/cmd/dendrite-demo-pinecone/relay/retriever.go
@@ -17,13 +17,13 @@ package relay
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	federationAPI "github.com/matrix-org/dendrite/federationapi/api"
 	relayServerAPI "github.com/matrix-org/dendrite/relayapi/api"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/sirupsen/logrus"
-	"go.uber.org/atomic"
 )
 
 const (
@@ -54,7 +54,7 @@ func NewRelayServerRetriever(
 		federationAPI:       federationAPI,
 		relayAPI:            relayAPI,
 		relayServersQueried: make(map[spec.ServerName]bool),
-		running:             *atomic.NewBool(false),
+		running:             atomic.Bool{},
 		quit:                quit,
 	}
 }

--- a/federationapi/queue/destinationqueue.go
+++ b/federationapi/queue/destinationqueue.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/matrix-org/gomatrix"
@@ -26,7 +27,6 @@ import (
 	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/sirupsen/logrus"
-	"go.uber.org/atomic"
 
 	"github.com/matrix-org/dendrite/federationapi/statistics"
 	"github.com/matrix-org/dendrite/federationapi/storage"

--- a/federationapi/queue/queue_test.go
+++ b/federationapi/queue/queue_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -26,7 +27,6 @@ import (
 	"github.com/matrix-org/dendrite/test/testrig"
 	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/matrix-org/gomatrixserverlib/spec"
-	"go.uber.org/atomic"
 	"gotest.tools/v3/poll"
 
 	"github.com/matrix-org/gomatrixserverlib"
@@ -113,8 +113,8 @@ func testSetup(failuresUntilBlacklist uint32, failuresUntilAssumedOffline uint32
 	fc := &stubFederationClient{
 		shouldTxSucceed:      shouldTxSucceed,
 		shouldTxRelaySucceed: shouldTxRelaySucceed,
-		txCount:              *atomic.NewUint32(0),
-		txRelayCount:         *atomic.NewUint32(0),
+		txCount:              atomic.Uint32{},
+		txRelayCount:         atomic.Uint32{},
 	}
 
 	stats := statistics.NewStatistics(db, failuresUntilBlacklist, failuresUntilAssumedOffline, false)

--- a/internal/sqlutil/writer_exclusive.go
+++ b/internal/sqlutil/writer_exclusive.go
@@ -3,8 +3,7 @@ package sqlutil
 import (
 	"database/sql"
 	"errors"
-
-	"go.uber.org/atomic"
+	"sync/atomic"
 )
 
 // ExclusiveWriter implements sqlutil.Writer.

--- a/internal/transactionrequest_test.go
+++ b/internal/transactionrequest_test.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -26,7 +27,6 @@ import (
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/nats-io/nats.go"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/atomic"
 	"gotest.tools/v3/poll"
 
 	"github.com/matrix-org/dendrite/federationapi/producers"
@@ -228,7 +228,7 @@ func TestProcessTransactionRequestEDUTyping(t *testing.T) {
 	ctx := process.NewProcessContext()
 	defer ctx.ShutdownDendrite()
 	txn, js, cfg := createTransactionWithEDU(ctx, edus)
-	received := atomic.NewBool(false)
+	received := atomic.Bool{}
 	onMessage := func(ctx context.Context, msgs []*nats.Msg) bool {
 		msg := msgs[0] // Guaranteed to exist if onMessage is called
 		room := msg.Header.Get(jetstream.RoomID)
@@ -294,7 +294,7 @@ func TestProcessTransactionRequestEDUToDevice(t *testing.T) {
 	ctx := process.NewProcessContext()
 	defer ctx.ShutdownDendrite()
 	txn, js, cfg := createTransactionWithEDU(ctx, edus)
-	received := atomic.NewBool(false)
+	received := atomic.Bool{}
 	onMessage := func(ctx context.Context, msgs []*nats.Msg) bool {
 		msg := msgs[0] // Guaranteed to exist if onMessage is called
 
@@ -371,7 +371,7 @@ func TestProcessTransactionRequestEDUDeviceListUpdate(t *testing.T) {
 	ctx := process.NewProcessContext()
 	defer ctx.ShutdownDendrite()
 	txn, js, cfg := createTransactionWithEDU(ctx, edus)
-	received := atomic.NewBool(false)
+	received := atomic.Bool{}
 	onMessage := func(ctx context.Context, msgs []*nats.Msg) bool {
 		msg := msgs[0] // Guaranteed to exist if onMessage is called
 
@@ -468,7 +468,7 @@ func TestProcessTransactionRequestEDUReceipt(t *testing.T) {
 	ctx := process.NewProcessContext()
 	defer ctx.ShutdownDendrite()
 	txn, js, cfg := createTransactionWithEDU(ctx, edus)
-	received := atomic.NewBool(false)
+	received := atomic.Bool{}
 	onMessage := func(ctx context.Context, msgs []*nats.Msg) bool {
 		msg := msgs[0] // Guaranteed to exist if onMessage is called
 
@@ -512,7 +512,7 @@ func TestProcessTransactionRequestEDUSigningKeyUpdate(t *testing.T) {
 	ctx := process.NewProcessContext()
 	defer ctx.ShutdownDendrite()
 	txn, js, cfg := createTransactionWithEDU(ctx, edus)
-	received := atomic.NewBool(false)
+	received := atomic.Bool{}
 	onMessage := func(ctx context.Context, msgs []*nats.Msg) bool {
 		msg := msgs[0] // Guaranteed to exist if onMessage is called
 
@@ -569,7 +569,7 @@ func TestProcessTransactionRequestEDUPresence(t *testing.T) {
 	ctx := process.NewProcessContext()
 	defer ctx.ShutdownDendrite()
 	txn, js, cfg := createTransactionWithEDU(ctx, edus)
-	received := atomic.NewBool(false)
+	received := atomic.Bool{}
 	onMessage := func(ctx context.Context, msgs []*nats.Msg) bool {
 		msg := msgs[0] // Guaranteed to exist if onMessage is called
 

--- a/setup/base/base.go
+++ b/setup/base/base.go
@@ -28,13 +28,13 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
 	sentryhttp "github.com/getsentry/sentry-go/http"
 	"github.com/matrix-org/gomatrixserverlib/fclient"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"go.uber.org/atomic"
 
 	"github.com/gorilla/mux"
 	"github.com/kardianos/minwinsvc"

--- a/setup/base/sanity_other.go
+++ b/setup/base/sanity_other.go
@@ -1,5 +1,5 @@
-//go:build !linux && !darwin && !netbsd && !freebsd && !openbsd && !solaris && !dragonfly && !aix
-// +build !linux,!darwin,!netbsd,!freebsd,!openbsd,!solaris,!dragonfly,!aix
+//go:build !unix
+// +build !unix
 
 package base
 

--- a/setup/base/sanity_unix.go
+++ b/setup/base/sanity_unix.go
@@ -1,5 +1,5 @@
-//go:build linux || darwin || netbsd || freebsd || openbsd || solaris || dragonfly || aix
-// +build linux darwin netbsd freebsd openbsd solaris dragonfly aix
+//go:build unix
+// +build unix
 
 package base
 


### PR DESCRIPTION
Given that #2714 wasn't merged but we are now at a minimum supported Go version of 1.20 (soon to be 1.21), I wanted to carry over some of the changes. Namely:
- Fix the log typo
- Simplify build constraints for unix
- Use stdlib atomic package

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [x] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

Signed-off-by: `0x1a8510f2 <admin@0x1a8510f2.space>`
