### PR TITLE
Fix: Edited messages appear twice in fulltext search

### DIFF
--- a/clientapi/routing/admin.go
+++ b/clientapi/routing/admin.go
@@ -328,7 +328,7 @@ func AdminPurgeRoom(req *http.Request, rsAPI roomserverAPI.ClientRoomserverAPI) 
 	}
 }
 
-func AdminResetPassword(req *http.Request, cfg *config.ClientAPI, device *api.Device, userAPI api.ClientUserAPI) util.JSONResponse {
+func AdminResetPassword(req *http.Request, cfg *config.ClientAPI, device *api.Device, userAPI userapi.ClientUserAPI) util.JSONResponse {
 	if req.Body == nil {
 		return util.JSONResponse{
 			Code: http.StatusBadRequest,
@@ -423,7 +423,7 @@ func AdminReindex(req *http.Request, cfg *config.ClientAPI, device *api.Device, 
 	}
 }
 
-func AdminMarkAsStale(req *http.Request, cfg *config.ClientAPI, keyAPI api.ClientKeyAPI) util.JSONResponse {
+func AdminMarkAsStale(req *http.Request, cfg *config.ClientAPI, keyAPI userapi.ClientKeyAPI) util.JSONResponse {
 	vars, err := httputil.URLDecodeMapValues(mux.Vars(req))
 	if err != nil {
 		return util.ErrorResponse(err)

--- a/clientapi/routing/pushrules.go
+++ b/clientapi/routing/pushrules.go
@@ -70,7 +70,7 @@ func GetPushRulesByKind(ctx context.Context, scope, kind string, device *userapi
 	}
 	rulesPtr := pushRuleSetKindPointer(ruleSet, pushrules.Kind(kind))
 	// Even if rulesPtr is not nil, there may not be any rules for this kind
-	if rulesPtr == nil || (rulesPtr != nil && len(*rulesPtr) == 0) {
+	if rulesPtr == nil || len(*rulesPtr) == 0 {
 		return errorResponse(ctx, spec.InvalidParam("invalid push rules kind"), "pushRuleSetKindPointer failed")
 	}
 	return util.JSONResponse{

--- a/clientapi/routing/sendevent_test.go
+++ b/clientapi/routing/sendevent_test.go
@@ -265,7 +265,7 @@ func createEvents(eventsJSON []string, roomVer gomatrixserverlib.RoomVersion) ([
 	for i, eventJSON := range eventsJSON {
 		pdu, evErr := roomVerImpl.NewEventFromTrustedJSON([]byte(eventJSON), false)
 		if evErr != nil {
-			return nil, fmt.Errorf("failed to make event: %s", err.Error())
+			return nil, fmt.Errorf("failed to make event: %s", evErr.Error())
 		}
 		ev := types.HeaderedEvent{PDU: pdu}
 		events[i] = &ev

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -634,7 +634,7 @@ func (s *OutputRoomEventConsumer) writeFTS(ev *rstypes.HeaderedEvent, pduPositio
 					if err := s.fts.Delete(srcEventID.Str); err != nil {
 						log.WithFields(log.Fields{
 							"event_id": ev.EventID(),
-							"src_id":   srcEventID,
+							"src_id":   srcEventID.Str,
 						}).WithError(err).Error("Failed to delete edited message from the fulltext index")
 					}
 				}

--- a/syncapi/consumers/roomserver.go
+++ b/syncapi/consumers/roomserver.go
@@ -634,7 +634,7 @@ func (s *OutputRoomEventConsumer) writeFTS(ev *rstypes.HeaderedEvent, pduPositio
 						log.WithFields(log.Fields{
 							"event_id": ev.EventID(),
 							"src_id":   srcEventID,
-						}).WithError(err).Error("Failed to delete edited message from fulltext index")
+						}).WithError(err).Error("Failed to delete edited message from the fulltext index")
 					}
 				}
 			}

--- a/test/testrig/base.go
+++ b/test/testrig/base.go
@@ -71,6 +71,7 @@ func CreateConfig(t *testing.T, dbType test.DBType) (*config.Dendrite, *process.
 			SingleDatabase: false,
 		})
 		cfg.Global.ServerName = "test"
+		cfg.SyncAPI.Fulltext.Enabled = true
 		cfg.SyncAPI.Fulltext.InMemory = true
 		// use a distinct prefix else concurrent postgres/sqlite runs will clash since NATS will use
 		// the file system event with InMemory=true :(


### PR DESCRIPTION
As stated in https://github.com/matrix-org/dendrite/issues/3358 the search response contains both original and edited message.
This PR fixes it by removing of the original message from the fulltext index after indexing the edit message event.
I also made some cosmetic changes/fixes i found in the code

Signed-off-by: `Alexander Dubovikov <d.lexand@gmail.com>`
