### PR TITLE
refactoring user interactive auth

### DIFF
--- a/clientapi/auth/user_interactive.go
+++ b/clientapi/auth/user_interactive.go
@@ -106,9 +106,9 @@ type UserInteractive struct {
 	flows []userInteractiveFlow
 	// Map of login type to implementation
 	types map[string]Type
-	// Map of session ID to completed login types, will need to be extended in future
 
-	mutex    sync.RWMutex
+	mutex sync.RWMutex
+	// Map of session ID to completed login types, will need to be extended in future
 	sessions map[string][]string
 }
 
@@ -160,13 +160,11 @@ func (u *UserInteractive) challenge(sessionID string) *util.JSONResponse {
 	completed := u.sessions[sessionID]
 	u.mutex.RUnlock()
 
-	flows := u.flows
-
 	return &util.JSONResponse{
 		Code: 401,
 		JSON: Challenge{
 			Completed: completed,
-			Flows:     flows,
+			Flows:     u.flows,
 			Session:   sessionID,
 			Params:    make(map[string]interface{}),
 		},


### PR DESCRIPTION
- making members of `auth.UserInteractive` private as they aren't used outside of the package and in order to protect from concurrent writes
- making the mutex protect the sessions only as only they are written to concurrently

This prepares future contributions I plan, in particular adding functionality for multi-stage flows.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [x] I have justified why this PR doesn't need tests: No functionality added or removed, only refactoring tested behaviour.
* [x] I have already signed off privately.