### PR TITLE
Use mautrix for tag events instead of deprecated matrix/go

### DIFF
--- a/clientapi/routing/room_tagging.go
+++ b/clientapi/routing/room_tagging.go
@@ -21,9 +21,9 @@ import (
 	"github.com/matrix-org/dendrite/clientapi/httputil"
 	"github.com/matrix-org/dendrite/clientapi/producers"
 	"github.com/matrix-org/dendrite/userapi/api"
-	"github.com/matrix-org/gomatrix"
 	"github.com/matrix-org/gomatrixserverlib/spec"
 	"github.com/matrix-org/util"
+	"maunium.net/go/mautrix/event"
 )
 
 // GetTags implements GET /_matrix/client/r0/user/{userID}/rooms/{roomID}/tags
@@ -78,7 +78,7 @@ func PutTag(
 		}
 	}
 
-	var properties gomatrix.TagProperties
+	var properties event.Tag
 	if reqErr := httputil.UnmarshalJSONRequest(req, &properties); reqErr != nil {
 		return *reqErr
 	}
@@ -93,7 +93,7 @@ func PutTag(
 	}
 
 	if tagContent.Tags == nil {
-		tagContent.Tags = make(map[string]gomatrix.TagProperties)
+		tagContent.Tags = make(map[string]event.Tag)
 	}
 	tagContent.Tags[tag] = properties
 
@@ -172,7 +172,7 @@ func obtainSavedTags(
 	userID string,
 	roomID string,
 	userAPI api.ClientUserAPI,
-) (tags gomatrix.TagContent, err error) {
+) (tags event.TagEventContent, err error) {
 	dataReq := api.QueryAccountDataRequest{
 		UserID:   userID,
 		RoomID:   roomID,
@@ -199,7 +199,7 @@ func saveTagData(
 	userID string,
 	roomID string,
 	userAPI api.ClientUserAPI,
-	Tag gomatrix.TagContent,
+	Tag event.TagEventContent,
 ) error {
 	newTagData, err := json.Marshal(Tag)
 	if err != nil {

--- a/clientapi/routing/server_notices.go
+++ b/clientapi/routing/server_notices.go
@@ -21,11 +21,11 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/matrix-org/gomatrix"
 	"github.com/matrix-org/gomatrixserverlib/tokens"
 	"github.com/matrix-org/util"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+	"maunium.net/go/mautrix/event"
 
 	"github.com/matrix-org/dendrite/roomserver/types"
 
@@ -176,9 +176,9 @@ func SendServerNotice(
 			roomID = data.RoomID
 
 			// tag the room, so we can later check if the user tries to reject an invite
-			serverAlertTag := gomatrix.TagContent{Tags: map[string]gomatrix.TagProperties{
+			serverAlertTag := event.TagEventContent{Tags: map[string]event.Tag{
 				"m.server_notice": {
-					Order: 1.0,
+					Order: "1.0",
 				},
 			}}
 			if err = saveTagData(req, r.UserID, roomID, userAPI, serverAlertTag); err != nil {


### PR DESCRIPTION
The iOS crashes because dendrite is using an old framework that is deprecated. For reference [look here](https://github.com/matrix-org/matrix-ios-sdk/issues/1857).
This PR just fixes this.

Signed-off-by: `Dario <me@dgrp.es>`
