### PR TITLE
claim to support v1.3 and v1.4

### DIFF
--- a/clientapi/routing/routing.go
+++ b/clientapi/routing/routing.go
@@ -147,6 +147,8 @@ func Setup(
 					"v1.0",
 					"v1.1",
 					"v1.2",
+					"v1.3",
+					"v1.4",
 				}, UnstableFeatures: unstableFeatures},
 			}
 		}),


### PR DESCRIPTION
We already claim to support v1.1 and v1.2 which dendrite supports about as much. Maunium bridges now require v1.4  and will refuse to run otherwise.

i dont think it needs additional tests given the existing test for the endpoint seems to just be if it responds which it still does

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [x] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

Signed-off-by: `Joseph Winkie <jjj333.p.1325@gmail.com>`
