### PR TITLE
add option for credentials file for NATS; more info: https://docs.nat…

### DIFF
--- a/setup/config/config_jetstream.go
+++ b/setup/config/config_jetstream.go
@@ -21,6 +21,9 @@ type JetStream struct {
 	NoLog bool `yaml:"-"`
 	// Disables TLS validation. This should NOT be used in production
 	DisableTLSValidation bool `yaml:"disable_tls_validation"`
+	// A credentials file to be used for authentication, example:
+	// https://docs.nats.io/using-nats/developer/connecting/creds
+	Credentials Path `yaml:"credentials_path"`
 }
 
 func (c *JetStream) Prefixed(name string) string {
@@ -38,6 +41,7 @@ func (c *JetStream) Defaults(opts DefaultOpts) {
 		c.StoragePath = Path("./")
 		c.NoLog = true
 		c.DisableTLSValidation = true
+		c.Credentials = Path("")
 	}
 }
 

--- a/setup/jetstream/nats.go
+++ b/setup/jetstream/nats.go
@@ -102,6 +102,9 @@ func setupNATS(process *process.ProcessContext, cfg *config.JetStream, nc *natsc
 				InsecureSkipVerify: true,
 			}))
 		}
+		if string(cfg.Credentials) != "" {
+			opts = append(opts, natsclient.UserCredentials(string(cfg.Credentials)))
+		}
 		nc, err = natsclient.Connect(strings.Join(cfg.Addresses, ","), opts...)
 		if err != nil {
 			logrus.WithError(err).Panic("Unable to connect to NATS")


### PR DESCRIPTION
Not 100% on how you would want to test this; you would need a NATS server configured with NKey:

https://docs.nats.io/using-nats/developer/connecting/creds

This was tested with Synadia's free NATS SaaS and it does appear to be working, however there's an issue with how NATS is used in general:

```
time="2024-09-10T14:40:05.105105731Z" level=fatal msg="Unable to add in-memory stream" error="nats: account requires a stream config to have max bytes set" stream=DendriteInputRoomEvent subjects="[DendriteInputRoomEvent DendriteInputRoomEvent.>]"
```

I tried creating the topic manually, however dendrite insists on deleting/recreating the topic, so getting this to work is an issue I'm going ot have to deal with later unless somebody gets to it before then. 

If you feel more competent than me and wanna draw from this PR as an example (if you have another way you'd prefer to see this done) go ahead feel free I just wanna see it get done and I'm not particularly good at working with golang.

Signed-off-by: `Paige Thompson <paige@paige.bio>`
