### PR TITLE
Pinecone test image - Explicitly select Alpine golang image

### DIFF
--- a/build/docker/Dockerfile.demo-pinecone
+++ b/build/docker/Dockerfile.demo-pinecone
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.22 AS base
+FROM docker.io/golang:1.22-alpine AS base
 
 #
 # Needs to be separate from the main Dockerfile for OpenShift,


### PR DESCRIPTION
I've noticed when trying to build the Dendrite Pinecone test image, the build fails due to `apk` not being available:

<img width="837" alt="image" src="https://github.com/user-attachments/assets/8b483010-a037-4499-b925-a806ae8a82cb">

Checking out the [Docker Hub](https://hub.docker.com/_/golang/) repo for the `golang` image it looks like this can resovle to `1.22-bookworm`, so this should ensure we get an Alpine-based image for this build.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [x] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

Signed-off-by: `Rhea Danzey <rdanzey@element.io>`
