### PR TITLE
Ensure Helm packages generated end up in docs/ subpath that's hosted

### DIFF
--- a/helm/ct.yaml
+++ b/helm/ct.yaml
@@ -5,3 +5,5 @@ chart-repos:
 chart-dirs:
   - helm
 validate-maintainers: false
+# this should ensure the tarballs are in the appropriate location for GH pages, rather than repo root
+package-path: docs/


### PR DESCRIPTION
I've noticed that Chart Releaser is behaving improperly, and not successfully putting the charts where gh-pages will hots them and generating invalid index.

This change should ensure built charts end up in the `docs/` subpath, which should ensure that `gh-pages` branch isn't getting an invalid `index.yaml` and new charts should be automatically available.

### Pull Request Checklist

* [x] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

Signed-off-by: `Rhea Danzey <rdanzey@element.io>`
