### PR TITLE
Helm chart - Add configuration for image pull secrets

### DIFF
--- a/helm/dendrite/Chart.yaml
+++ b/helm/dendrite/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dendrite
-version: "0.14.2"
+version: "0.14.3"
 appVersion: "0.13.8"
 description: Dendrite Matrix Homeserver
 type: application

--- a/helm/dendrite/templates/deployment.yaml
+++ b/helm/dendrite/templates/deployment.yaml
@@ -110,3 +110,7 @@ spec:
           httpGet:
             path: /_dendrite/monitor/up
             port: http
+      imagePullSecrets:
+      {{- with .Values.imagePullSecrets }}
+      {{ . | toYaml | nindent 6 }}
+      {{- end }}

--- a/helm/dendrite/values.yaml
+++ b/helm/dendrite/values.yaml
@@ -6,6 +6,10 @@ image:
   # -- Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+# -- Configure image pull secrets to use private container registry 
+# https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret
+imagePullSecrets: []
+# - name: your-pull-secret-name
 
 # signing key to use
 signing_key:


### PR DESCRIPTION
This minor change should allow the use of private container images with this chart by specifying image pull secrets.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [x] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

Signed-off-by: `Rhea Danzey <rdanzey@element.io>`
