### PR TITLE
Make OPTIONS method on MSC3916 endpoints available without auth

### DIFF
--- a/internal/httputil/httpapi.go
+++ b/internal/httputil/httpapi.go
@@ -210,6 +210,12 @@ func MakeExternalAPI(metricsName string, f func(*http.Request) util.JSONResponse
 // This is used to serve HTML alongside JSON error messages
 func MakeHTTPAPI(metricsName string, userAPI userapi.QueryAcccessTokenAPI, enableMetrics bool, f func(http.ResponseWriter, *http.Request), checks ...AuthAPIOption) http.Handler {
 	withSpan := func(w http.ResponseWriter, req *http.Request) {
+		if req.Method == http.MethodOptions {
+			util.SetCORSHeaders(w)
+			w.WriteHeader(http.StatusOK) // Maybe http.StatusNoContent?
+			return
+		}
+
 		trace, ctx := internal.StartTask(req.Context(), metricsName)
 		defer trace.EndTask()
 		req = req.WithContext(ctx)


### PR DESCRIPTION
OPTIONS method is usually sent by browser in preflight requests, most of the time we cannot control preflight request to add auth header.

Synapse will return a 204 response directly without authentication for those OPTIONS method.

According to firefox's documentation, both 200 and 204 are acceptable so I think there is no need to change handler in dendrite.

This closes https://github.com/matrix-org/dendrite/issues/3424

No need to add a test because this is just a fix and I have tested on my Cinny Web client personally.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [x] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

Signed-off-by: `arenekosreal <17194552+arenekosreal@users.noreply.github.com>`
