### PR TITLE
Add release trigger for gh-pages rebuild

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,6 +8,12 @@ on:
     paths:
       - 'docs/**' # only execute if we have docs changes
 
+  # Helm charts don't push to repo anymore, they index to GH release files now
+  # as such, docs/** changes won't trigger it, leaving the newly released chart out of the index until gh-pages pipeline runs
+  # we can rebuild when a release is published
+  release:
+    types: [published]
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -8,12 +8,6 @@ on:
     paths:
       - 'docs/**' # only execute if we have docs changes
 
-  # Helm charts don't push to repo anymore, they index to GH release files now
-  # as such, docs/** changes won't trigger it, leaving the newly released chart out of the index until gh-pages pipeline runs
-  # we can rebuild when a release is published
-  release:
-    types: [published]
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -39,3 +39,13 @@ jobs:
           config: helm/cr.yaml
           charts_dir: helm/
           mark_as_latest: false
+
+  invoke_pages_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invoke gh-pages build and deploy
+        env:
+          WORKFLOW_PATH: .github/workflows/gh-pages.yml
+          WORKFLOW_TARGET_REF: "gh-pages"
+        run: |
+          gh workflow run ${WORKFLOW_PATH} --ref ${WORKFLOW_TARGET_REF}


### PR DESCRIPTION
I've noticed that newly released charts don't appear immediately until I manually run the `gh-pages` workflow - Lets see if we can dispatch that on a release event

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [x] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

Signed-off-by: `Rhea Danzey <rdanzey@element.io>`
