### PR TITLE
Helm Chart - Add configuration for node selector / tolerations / affi…

### DIFF
--- a/helm/dendrite/Chart.yaml
+++ b/helm/dendrite/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: dendrite
-version: "0.14.5"
+version: "0.14.6"
 appVersion: "0.13.8"
 description: Dendrite Matrix Homeserver
 type: application

--- a/helm/dendrite/templates/deployment.yaml
+++ b/helm/dendrite/templates/deployment.yaml
@@ -114,3 +114,15 @@ spec:
       {{- with .Values.imagePullSecrets }}
       {{ . | toYaml | nindent 6 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/dendrite/templates/deployment.yaml
+++ b/helm/dendrite/templates/deployment.yaml
@@ -56,6 +56,9 @@ spec:
         args:
           - '--config'
           - '/etc/dendrite/dendrite.yaml'
+        {{- with .Values.extraArgs }}
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         ports:
           - name: http
             containerPort: 8008

--- a/helm/dendrite/templates/jobs.yaml
+++ b/helm/dendrite/templates/jobs.yaml
@@ -98,6 +98,18 @@ spec:
       volumes:
       - name: signing-key
         emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   parallelism: 1
   completions: 1
   backoffLimit: 1

--- a/helm/dendrite/values.yaml
+++ b/helm/dendrite/values.yaml
@@ -77,6 +77,9 @@ persistence:
     #   GKE, AWS & OpenStack)
     storageClass:
 
+# -- Add additional arguments to the dendrite command
+extraArgs: []
+
 # -- Add additional volumes to the Dendrite Pod
 extraVolumes: []
 # ex.

--- a/helm/dendrite/values.yaml
+++ b/helm/dendrite/values.yaml
@@ -100,6 +100,15 @@ strategy:
     # -- Maximum number of pods that can be scheduled above the desired number of pods
     maxSurge: 25%
 
+# -- Node selector configuration
+nodeSelector: {}
+
+# -- Tolerations configuration
+tolerations: {}
+
+# -- Affinity configuration
+affinity: {}
+
 dendrite_config:
   version: 2
   global:


### PR DESCRIPTION
For some experimentation I'm doing, I need to pin Dendrite to a specific node pool. This should be available configuration within the chart ideally, and this should do it in theory.

### Pull Request Checklist

<!-- Please read https://matrix-org.github.io/dendrite/development/contributing before submitting your pull request -->

* [x] I have added Go unit tests or [Complement integration tests](https://github.com/matrix-org/complement) for this PR _or_ I have justified why this PR doesn't need tests
* [x] Pull request includes a [sign off below using a legally identifiable name](https://matrix-org.github.io/dendrite/development/contributing#sign-off) _or_ I have already signed off privately

Signed-off-by: `Rhea Danzey <rdanzey@element.io>`
